### PR TITLE
hakuneko: initial x86_64-darwin support

### DIFF
--- a/pkgs/tools/misc/hakuneko/darwin.nix
+++ b/pkgs/tools/misc/hakuneko/darwin.nix
@@ -1,0 +1,28 @@
+{ fetchurl
+, stdenv
+, lib
+, undmg
+, src
+, pname
+, version
+, meta
+, desktopName
+}:
+stdenv.mkDerivation rec {
+  inherit pname version src meta desktopName;
+
+  nativeBuildInputs = [
+    undmg
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r "${desktopName}.app" "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+}

--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -8,67 +8,12 @@
 , stdenv
 , lib
 , wrapGAppsHook
+, callPackage
 }:
 let
-  desktopItem = makeDesktopItem {
-    desktopName = "HakuNeko Desktop";
-    genericName = "Manga & Anime Downloader";
-    categories = [ "Network" "FileTransfer" ];
-    exec = "hakuneko";
-    icon = "hakuneko-desktop";
-    name = "hakuneko-desktop";
-  };
-in
-stdenv.mkDerivation rec {
-  pname = "hakuneko";
   version = "6.1.7";
-
-  src = {
-    "x86_64-linux" = fetchurl {
-      url = "https://github.com/manga-download/hakuneko/releases/download/v${version}/hakuneko-desktop_${version}_linux_amd64.deb";
-      sha256 = "06bb17d7a06bb0601053eaaf423f9176f06ff3636cc43ffc024438e1962dcd02";
-    };
-    "i686-linux" = fetchurl {
-      url = "https://github.com/manga-download/hakuneko/releases/download/v${version}/hakuneko-desktop_${version}_linux_i386.deb";
-      sha256 = "32017d26bafffaaf0a83dd6954d3926557014af4022a972371169c56c0e3d98b";
-    };
-  }."${stdenv.hostPlatform.system}";
-
-  dontBuild = true;
-  dontConfigure = true;
-  dontPatchELF = true;
-  dontWrapGApps = true;
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-    dpkg
-    makeWrapper
-    wrapGAppsHook
-  ];
-
-  buildInputs = atomEnv.packages;
-
-  unpackPhase = ''
-    # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
-    dpkg --fsys-tarfile $src | tar --extract
-  '';
-
-  installPhase = ''
-    cp -R usr "$out"
-    # Overwrite existing .desktop file.
-    cp "${desktopItem}/share/applications/hakuneko-desktop.desktop" \
-       "$out/share/applications/hakuneko-desktop.desktop"
-  '';
-
-  runtimeDependencies = [
-    (lib.getLib udev)
-  ];
-
-  postFixup = ''
-    makeWrapper $out/lib/hakuneko-desktop/hakuneko $out/bin/hakuneko \
-      "''${gappsWrapperArgs[@]}"
-  '';
-
+  pname = "hakuneko";
+  desktopName = "HakuNeko Desktop";
   meta = with lib; {
     description = "Manga & Anime Downloader";
     homepage = "https://sourceforge.net/projects/hakuneko/";
@@ -80,6 +25,30 @@ stdenv.mkDerivation rec {
     platforms = [
       "x86_64-linux"
       "i686-linux"
+      "x86_64-darwin"
+      # hakuneko has no arm64 macos build yet
     ];
   };
+  src = {
+    "x86_64-darwin" = fetchurl {
+      url = "https://github.com/manga-download/hakuneko/releases/download/v${version}/hakuneko-desktop_${version}_macos_amd64.dmg";
+      sha256 = "sha256-XuRVzi+bzr31mBgtzLRtv2ZjfXiSD85iZ7MOfbFw+Yc=";
+    };
+    "x86_64-linux" = fetchurl {
+      url = "https://github.com/manga-download/hakuneko/releases/download/v${version}/hakuneko-desktop_${version}_linux_amd64.deb";
+      sha256 = "06bb17d7a06bb0601053eaaf423f9176f06ff3636cc43ffc024438e1962dcd02";
+    };
+    "i686-linux" = fetchurl {
+      url = "https://github.com/manga-download/hakuneko/releases/download/v${version}/hakuneko-desktop_${version}_linux_i386.deb";
+      sha256 = "32017d26bafffaaf0a83dd6954d3926557014af4022a972371169c56c0e3d98b";
+    };
+  }."${stdenv.hostPlatform.system}";
+
+  package =
+    if stdenv.isLinux
+    then ./linux.nix
+    else ./darwin.nix;
+in
+callPackage package {
+    inherit src version meta pname desktopName;
 }

--- a/pkgs/tools/misc/hakuneko/linux.nix
+++ b/pkgs/tools/misc/hakuneko/linux.nix
@@ -1,0 +1,65 @@
+{ atomEnv
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, makeDesktopItem
+, makeWrapper
+, udev
+, stdenv
+, lib
+, wrapGAppsHook
+, src
+, pname
+, meta
+, version
+, desktopName
+}:
+let
+  desktopItem = makeDesktopItem {
+    inherit desktopName;
+    genericName = "Manga & Anime Downloader";
+    categories = [ "Network" "FileTransfer" ];
+    exec = pname;
+    icon = pname + "-desktop";
+    name = pname + "-desktop";
+  };
+in
+stdenv.mkDerivation rec {
+  inherit pname version src meta;
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontPatchELF = true;
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  buildInputs = atomEnv.packages;
+
+  unpackPhase = ''
+    # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
+    dpkg --fsys-tarfile $src | tar --extract
+  '';
+
+  installPhase = ''
+    cp -R usr "$out"
+    # Overwrite existing .desktop file.
+    cp "${desktopItem}/share/applications/${pname}-desktop.desktop" \
+       "$out/share/applications/${pname}-desktop.desktop"
+  '';
+
+  runtimeDependencies = [
+    (lib.getLib udev)
+  ];
+
+  postFixup = ''
+    makeWrapper $out/lib/${pname}-desktop/${pname} $out/bin/${pname} \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
