### PR TITLE
prometheus-pushgateway: 1.4.0 -> 1.4.3

### DIFF
--- a/pkgs/servers/monitoring/prometheus/pushgateway.nix
+++ b/pkgs/servers/monitoring/prometheus/pushgateway.nix
@@ -1,42 +1,31 @@
-{ lib, go, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, testers, prometheus-pushgateway }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "pushgateway";
-  version = "1.4.0";
-  rev = "v${version}";
-
-  goPackagePath = "github.com/prometheus/pushgateway";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "prometheus";
     repo = "pushgateway";
-    sha256 = "sha256-230JgG+TtAuopkkcUda+0hl8E6WXOtTUygWoyorLiEU=";
+    rev = "v${version}";
+    sha256 = "sha256-fSp173/ubeXw44IHVnuyYAYnTCrHcsq7GRwPlH05kJY=";
   };
 
-  buildUser = "nix@nixpkgs";
-  buildDate = "19700101-00:00:00";
+  vendorSha256 = "sha256-abl2L8+QY2khLnsjXWWnzs9ewbFWctiJgHE29BRR2gU=";
 
   ldflags = [
-    "-X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Version=${version}"
-    "-X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Revision=${rev}"
-    "-X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Branch=${rev}"
-    "-X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.BuildUser=${buildUser}"
-    "-X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.BuildDate=${buildDate}"
-    "-X main.goVersion=${lib.getVersion go}"
+    "-s"
+    "-w"
+    "-X github.com/prometheus/common/version.Version=${version}"
+    "-X github.com/prometheus/common/version.Revision=${version}"
+    "-X github.com/prometheus/common/version.Branch=${version}"
+    "-X github.com/prometheus/common/version.BuildUser=nix@nixpkgs"
+    "-X github.com/prometheus/common/version.BuildDate=19700101-00:00:00"
   ];
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    export PATH=$PATH:$out/bin
-
-    pushgateway --help
-
-    # Make sure our -X options were included in the build
-    for s in ${version} ${rev} ${buildUser} ${buildDate}; do
-      pushgateway --version 2>&1 | fgrep -q -- "$s" || { echo "pushgateway --version output missing $s"; exit 1; }
-    done
-  '';
+  passthru.tests.version = testers.testVersion {
+    package = prometheus-pushgateway;
+  };
 
   meta = with lib; {
     description = "Allows ephemeral and batch jobs to expose metrics to Prometheus";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
