### PR TITLE
mullvad-vpn: remove myself from maintainers

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.gpl3Only;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ Br1ght0ne ymarkus flexagoon ];
+    maintainers = with maintainers; [ Br1ght0ne ymarkus ];
   };
 
 }


### PR DESCRIPTION
###### Description of changes

I am no longer using MullvadVPN, neither am I using NixOS. So there's no reason for me to be a mullvad nixpkg maintainer.