### PR TITLE
dale: 20181024 -> unstable-2022-04-11

### DIFF
--- a/pkgs/development/compilers/dale/default.nix
+++ b/pkgs/development/compilers/dale/default.nix
@@ -1,30 +1,29 @@
-{ lib, stdenv
+{ lib
 , fetchFromGitHub
 , cmake
 , pkg-config
+, llvmPackages_13
 , libffi
-, llvm_6
 , doCheck ? false
 , perl
 }:
 
-stdenv.mkDerivation {
+llvmPackages_13.stdenv.mkDerivation rec {
   pname = "dale";
-  version = "20181024";
+  version = "unstable-2022-04-11";
 
   src = fetchFromGitHub {
     owner = "tomhrr";
     repo = "dale";
-    rev = "f5db8b486f4e7c423fc25941a8315f1209bc0e54";
-    sha256 = "0v4ajrzrqvf279kd7wsd9flrpsav57lzxlwwimk9vnfwh7xpzf9v";
+    rev = "7386ef2d8912c60c6fb157a1e5cd772e15eaf658";
+    sha256 = "sha256-LNWqrFuEjtL7zuPTBfe4qQWr8IrT/ldQWSeDTK3Wqmo=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config llvm_6.dev ];
-  buildInputs = [ libffi llvm_6 ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libffi llvmPackages_13.llvm ];
 
   inherit doCheck;
   checkInputs = [ perl ];
-
   checkTarget = "tests";
 
   meta = with lib; {
@@ -36,8 +35,5 @@ stdenv.mkDerivation {
     homepage = "https://github.com/tomhrr/dale";
     license = licenses.bsd3;
     maintainers = with maintainers; [ amiloradovsky ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
-    # failed on Darwin: linker couldn't find the FFI lib
-    # failed on AArch64: because LLVM 3.5 is failed there
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
