### PR TITLE
coqPackages.simple-io: fix & add tests

### DIFF
--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkCoqDerivation, coq, coq-ext-lib, version ? null }:
+{ lib, callPackage, mkCoqDerivation, coq, coq-ext-lib, version ? null }:
 
 with lib; mkCoqDerivation {
   pname = "simple-io";
@@ -13,10 +13,13 @@ with lib; mkCoqDerivation {
   release."1.3.0".sha256 = "1yp7ca36jyl9kz35ghxig45x6cd0bny2bpmy058359p94wc617ax";
   mlPlugin = true;
   nativeBuildInputs = [ coq.ocamlPackages.cppo ];
-  propagatedBuildInputs = [ coq-ext-lib coq.ocamlPackages.ocamlbuild ];
+  propagatedBuildInputs = [ coq-ext-lib ]
+  ++ (with coq.ocamlPackages; [ ocaml findlib ocamlbuild ]);
 
   doCheck = true;
   checkTarget = "test";
+
+  passthru.tests.HelloWorld = callPackage ./test.nix {};
 
   meta = {
     description = "Purely functional IO for Coq";

--- a/pkgs/development/coq-modules/simple-io/test.nix
+++ b/pkgs/development/coq-modules/simple-io/test.nix
@@ -1,0 +1,21 @@
+{ stdenv, coq, simple-io }:
+
+stdenv.mkDerivation {
+  pname = "coq-simple-io-test";
+  inherit (simple-io) src version;
+  checkInputs = [ coq simple-io ];
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = true;
+
+  checkPhase = ''
+    cd test
+    for p in Argv.v Example.v HelloWorld.v TestExtraction.v TestPervasives.v
+    do
+      [ -f $p ] && echo $p && coqc $p
+    done
+  '';
+
+  installPhase = "touch $out";
+
+}


### PR DESCRIPTION
###### Description of changes

Simple-io is broken; this fixes it (by adding the missing dependency) and add a test to prevent this from happening again.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
