### PR TITLE
libgtkflow: split into 3 separate derivations

### DIFF
--- a/pkgs/development/libraries/libgflow/default.nix
+++ b/pkgs/development/libraries/libgflow/default.nix
@@ -1,15 +1,18 @@
 {stdenv, lib, vala, meson, ninja, pkg-config, fetchFromGitea, gobject-introspection, glib, gtk3}:
 
 stdenv.mkDerivation rec {
-  pname = "libgtkflow";
-  version = "0.10.0";
+  pname = "libgflow";
+  version = "1.0.4";
+
+  outputs = [ "out" "dev" "devdoc" ];
+  outputBin = "devdoc"; # demo app
 
   src = fetchFromGitea {
     domain = "notabug.org";
     owner = "grindhold";
-    repo = pname;
-    rev = version;
-    hash = "sha256-iTOoga94yjGTowQOM/EvHEDOO9Z3UutPGRgEoI1UWkI=";
+    repo = "libgtkflow";
+    rev = "gflow_${version}";
+    hash = "sha256-JoVq7U5JQ3pRxptR7igWFw7lcBTsgr3aVXxayLqhyFo=";
   };
 
   nativeBuildInputs = [
@@ -25,8 +28,15 @@ stdenv.mkDerivation rec {
     glib
   ];
 
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
   mesonFlags = [
     "-Denable_valadoc=true"
+    "-Denable_gtk3=false"
+    "-Denable_gtk4=false"
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/libgtkflow3/default.nix
+++ b/pkgs/development/libraries/libgtkflow3/default.nix
@@ -1,0 +1,54 @@
+{stdenv, lib, vala, meson, ninja, pkg-config, fetchFromGitea, gobject-introspection, glib, gtk3, libgflow}:
+
+stdenv.mkDerivation rec {
+  pname = "libgtkflow3";
+  version = "1.0.6";
+
+  outputs = [ "out" "dev" "devdoc" ];
+  outputBin = "devdoc"; # demo app
+
+  src = fetchFromGitea {
+    domain = "notabug.org";
+    owner = "grindhold";
+    repo = "libgtkflow";
+    rev = "gtkflow3_${version}";
+    hash = "sha256-JoVq7U5JQ3pRxptR7igWFw7lcBTsgr3aVXxayLqhyFo=";
+  };
+
+  nativeBuildInputs = [
+    vala
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    libgflow
+  ];
+
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
+  mesonFlags = [
+    "-Denable_valadoc=true"
+    "-Denable_gtk4=false"
+    "-Denable_gflow=false"
+  ];
+
+  postPatch = ''
+    rm -r libgflow
+  '';
+
+  meta = with lib; {
+    description = "Flow graph widget for GTK 3";
+    homepage = "https://notabug.org/grindhold/libgtkflow";
+    maintainers = with maintainers; [ grindhold ];
+    license = licenses.lgpl3Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libgtkflow4/default.nix
+++ b/pkgs/development/libraries/libgtkflow4/default.nix
@@ -1,0 +1,54 @@
+{stdenv, lib, vala, meson, ninja, pkg-config, fetchFromGitea, gobject-introspection, glib, gtk4, libgflow}:
+
+stdenv.mkDerivation rec {
+  pname = "libgtkflow4";
+  version = "0.2.6";
+
+  outputs = [ "out" "dev" "devdoc" ];
+  outputBin = "devdoc"; # demo app
+
+  src = fetchFromGitea {
+    domain = "notabug.org";
+    owner = "grindhold";
+    repo = "libgtkflow";
+    rev = "gtkflow4_${version}";
+    hash = "sha256-JoVq7U5JQ3pRxptR7igWFw7lcBTsgr3aVXxayLqhyFo=";
+  };
+
+  nativeBuildInputs = [
+    vala
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk4
+    glib
+    libgflow
+  ];
+
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
+  mesonFlags = [
+    "-Denable_valadoc=true"
+    "-Denable_gtk3=false"
+    "-Denable_gflow=false"
+  ];
+
+  postPatch = ''
+    rm -r libgflow
+  '';
+
+  meta = with lib; {
+    description = "Flow graph widget for GTK 3";
+    homepage = "https://notabug.org/grindhold/libgtkflow";
+    maintainers = with maintainers; [ grindhold ];
+    license = licenses.lgpl3Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -899,7 +899,9 @@ with pkgs;
   ld-is-cc-hook = makeSetupHook { name = "ld-is-cc-hook"; }
     ../build-support/setup-hooks/ld-is-cc-hook.sh;
 
-  libgtkflow = callPackage ../development/libraries/libgtkflow { };
+  libgflow = callPackage ../development/libraries/libgflow { };
+  libgtkflow3 = callPackage ../development/libraries/libgtkflow3 { };
+  libgtkflow4 = callPackage ../development/libraries/libgtkflow4 { };
 
   libredirect = callPackage ../build-support/libredirect { };
 


### PR DESCRIPTION
libgtkflow has of late received a port to gtk4.  as there might be users that only need the gtk3-variant as a dependency for a specific application or the gtk4-variant respectively, i've decided to split the three libraries libgflow libgtkflow3 and libgtkflow4 into their own packages.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
