### PR TITLE
pattypan: init at 22.03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4377,6 +4377,12 @@
     name = "Fedx sudo";
     matrix = "fedx:matrix.org";
   };
+  fee1-dead = {
+    email = "ent3rm4n@gmail.com";
+    github = "fee1-dead";
+    githubId = 43851243;
+    name = "Deadbeef";
+  };
   fehnomenal = {
     email = "fehnomenal@fehn.systems";
     github = "fehnomenal";

--- a/pkgs/applications/misc/pattypan/default.nix
+++ b/pkgs/applications/misc/pattypan/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, unzip
+, jre
+, jdk
+, ant
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+, glib
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pattypan";
+  version = "22.03";
+
+  src = fetchFromGitHub {
+    owner = "yarl";
+    repo = "pattypan";
+    rev = "v${version}";
+    sha256 = "0qmvlcqhqw5k500v2xdakk340ymgv5amhbfqxib5s4db1w32pi60";
+  };
+
+  nativeBuildInputs = [ copyDesktopItems jdk ant makeWrapper wrapGAppsHook ];
+  buildInputs = [ glib jre ];
+
+  buildPhase = ''
+    runHook preBuild
+    export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+    ant
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/share/java
+    cp pattypan.jar $out/share/java/pattypan.jar
+    makeWrapper ${jre}/bin/java $out/bin/pattypan \
+      --add-flags "-cp $out/share/java/pattypan.jar pattypan.Launcher"
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "Pattypan";
+      genericName = "An uploader for Wikimedia Commons";
+      categories = [ "Utility" ];
+      exec = "pattypan";
+      name = "pattypan";
+    })
+  ];
+
+  meta = with lib; {
+    homepage = "https://commons.wikimedia.org/wiki/Commons:Pattypan";
+    description = "An uploader for Wikimedia Commons";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ fee1-dead ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28371,6 +28371,8 @@ with pkgs;
 
   moe =  callPackage ../applications/editors/moe { };
 
+  pattypan = callPackage ../applications/misc/pattypan {};
+
   praat = callPackage ../applications/audio/praat { };
 
   quvi = callPackage ../applications/video/quvi/tool.nix {


### PR DESCRIPTION
###### Description of changes

Adding pattypan: a Java GUI uploader for Wikimedia Commons. https://github.com/yarl/pattypan

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
