### PR TITLE
openai-whisper: 2022.09-23 -> 2022.09-30

### DIFF
--- a/pkgs/development/python-modules/openai-whisper/default.nix
+++ b/pkgs/development/python-modules/openai-whisper/default.nix
@@ -1,6 +1,10 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
+, substituteAll
+
+# runtime
+, ffmpeg
 
 # propagates
 , numpy
@@ -16,21 +20,22 @@
 
 buildPythonPackage rec {
   pname = "whisper";
-  version = "unstable-2022-09-23";
+  version = "unstable-2022-09-30";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = pname;
-    rev = "8cf36f3508c9acd341a45eb2364239a3d81458b9";
-    hash = "sha256-2RH8eM/SezqFJltelv5AjQEGpqXm980u57vrlkTEUvQ=";
+    rev = "60132ade70e00b843d93542fcb37b58c0d8bf9e7";
+    hash = "sha256-4mhlCvewA0bVo5bq2sbSEKHq99TQ6jUauiCUkdRSdas=";
   };
 
-  postPatch = ''
-    # Rely on the ffmpeg path already patched into the ffmpeg-python library
-    substituteInPlace whisper/audio.py \
-      --replace 'run(cmd="ffmpeg",' 'run('
-  '';
+  patches = [
+    (substituteAll {
+      src = ./ffmpeg-path.patch;
+      inherit ffmpeg;
+    })
+  ];
 
   propagatedBuildInputs = [
     numpy

--- a/pkgs/development/python-modules/openai-whisper/ffmpeg-path.patch
+++ b/pkgs/development/python-modules/openai-whisper/ffmpeg-path.patch
@@ -1,0 +1,13 @@
+diff --git a/whisper/audio.py b/whisper/audio.py
+index a6074e8..da18350 100644
+--- a/whisper/audio.py
++++ b/whisper/audio.py
+@@ -41,7 +41,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
+         out, _ = (
+             ffmpeg.input(file, threads=0)
+             .output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=sr)
+-            .run(cmd=["ffmpeg", "-nostdin"], capture_stdout=True, capture_stderr=True)
++            .run(cmd=["@ffmpeg@/bin/ffmpeg", "-nostdin"], capture_stdout=True, capture_stderr=True)
+         )
+     except ffmpeg.Error as e:
+         raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
