### PR TITLE
go-mockery: 2.9.2 -> 2.14.1

### DIFF
--- a/pkgs/development/tools/go-mockery/default.nix
+++ b/pkgs/development/tools/go-mockery/default.nix
@@ -2,16 +2,29 @@
 
 buildGoModule rec {
   pname = "go-mockery";
-  version = "2.9.2";
+  version = "2.14.1";
 
   src = fetchFromGitHub {
     owner = "vektra";
     repo = "mockery";
     rev = "v${version}";
-    sha256 = "sha256-+r9he3rlANGusv0vIZPSninaouMftRsfJWnm3VngcXU=";
+    sha256 = "sha256-FgDjuiBFzOaT8GlJYI7xNfxC9uhyZtBAIBFXZgW0BDU=";
   };
 
-  vendorSha256 = "sha256-//V3ia3YP1hPgC1ipScURZ5uXU4A2keoG6dGuwaPBcA=";
+  patches = [ ./fix-tests.patch ];
+
+  preCheck = ''
+    substituteInPlace ./pkg/generator_test.go --replace 0.0.0-dev ${version}
+  '';
+
+  ldflags = [
+    "-s" "-w"
+    "-X" "github.com/vektra/mockery/v2/pkg/config.SemVer=v${version}"
+  ];
+
+  CGO_ENABLED = false;
+
+  vendorSha256 = "sha256-+40n7OoP8TLyjj4ehBHOD6/SqzJMCHsISE0FrXUL3Q8=";
 
   meta = with lib; {
     homepage = "https://github.com/vektra/mockery";

--- a/pkgs/development/tools/go-mockery/fix-tests.patch
+++ b/pkgs/development/tools/go-mockery/fix-tests.patch
@@ -1,0 +1,84 @@
+diff --git a/pkg/generator_test.go b/pkg/generator_test.go
+index d480bef..6812a68 100644
+--- a/pkg/generator_test.go
++++ b/pkg/generator_test.go
+@@ -211,7 +211,7 @@ type Requester_Get_Call struct {
+ }
+ 
+ // Get is a helper method to define mock.On call
+-//  - path string
++//   - path string
+ func (_e *Requester_Expecter) Get(path interface{}) *Requester_Get_Call {
+ 	return &Requester_Get_Call{Call: _e.mock.On("Get", path)}
+ }
+@@ -294,8 +294,8 @@ type Expecter_ManyArgsReturns_Call struct {
+ }
+ 
+ // ManyArgsReturns is a helper method to define mock.On call
+-//  - str string
+-//  - i int
++//   - str string
++//   - i int
+ func (_e *Expecter_Expecter) ManyArgsReturns(str interface{}, i interface{}) *Expecter_ManyArgsReturns_Call {
+ 	return &Expecter_ManyArgsReturns_Call{Call: _e.mock.On("ManyArgsReturns", str, i)}
+ }
+@@ -359,7 +359,7 @@ type Expecter_NoReturn_Call struct {
+ }
+ 
+ // NoReturn is a helper method to define mock.On call
+-//  - str string
++//   - str string
+ func (_e *Expecter_Expecter) NoReturn(str interface{}) *Expecter_NoReturn_Call {
+ 	return &Expecter_NoReturn_Call{Call: _e.mock.On("NoReturn", str)}
+ }
+@@ -402,7 +402,7 @@ type Expecter_Variadic_Call struct {
+ }
+ 
+ // Variadic is a helper method to define mock.On call
+-//  - ints ...int
++//   - ints ...int
+ func (_e *Expecter_Expecter) Variadic(ints ...interface{}) *Expecter_Variadic_Call {
+ 	return &Expecter_Variadic_Call{Call: _e.mock.On("Variadic",
+ 		append([]interface{}{}, ints...)...)}
+@@ -449,9 +449,9 @@ type Expecter_VariadicMany_Call struct {
+ }
+ 
+ // VariadicMany is a helper method to define mock.On call
+-//  - i int
+-//  - a string
+-//  - intfs ...interface{}
++//   - i int
++//   - a string
++//   - intfs ...interface{}
+ func (_e *Expecter_Expecter) VariadicMany(i interface{}, a interface{}, intfs ...interface{}) *Expecter_VariadicMany_Call {
+ 	return &Expecter_VariadicMany_Call{Call: _e.mock.On("VariadicMany",
+ 		append([]interface{}{i, a}, intfs...)...)}
+@@ -2397,7 +2397,7 @@ type RequesterGenerics_GenericAnonymousStructs_Call[TAny interface{}, TComparabl
+ }
+ 
+ // GenericAnonymousStructs is a helper method to define mock.On call
+-//  - _a0 struct{Type1 TExternalIntf}
++//   - _a0 struct{Type1 TExternalIntf}
+ func (_e *RequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericAnonymousStructs(_a0 interface{}) *RequesterGenerics_GenericAnonymousStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
+ 	return &RequesterGenerics_GenericAnonymousStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericAnonymousStructs", _a0)}
+ }
+@@ -2446,8 +2446,8 @@ type RequesterGenerics_GenericArguments_Call[TAny interface{}, TComparable compa
+ }
+ 
+ // GenericArguments is a helper method to define mock.On call
+-//  - _a0 TAny
+-//  - _a1 TComparable
++//   - _a0 TAny
++//   - _a1 TComparable
+ func (_e *RequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericArguments(_a0 interface{}, _a1 interface{}) *RequesterGenerics_GenericArguments_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
+ 	return &RequesterGenerics_GenericArguments_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericArguments", _a0, _a1)}
+ }
+@@ -2487,7 +2487,7 @@ type RequesterGenerics_GenericStructs_Call[TAny interface{}, TComparable compara
+ }
+ 
+ // GenericStructs is a helper method to define mock.On call
+-//  - _a0 test.GenericType[TAny,TIntf]
++//   - _a0 test.GenericType[TAny,TIntf]
+ func (_e *RequesterGenerics_Expecter[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]) GenericStructs(_a0 interface{}) *RequesterGenerics_GenericStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric] {
+ 	return &RequesterGenerics_GenericStructs_Call[TAny, TComparable, TSigned, TIntf, TExternalIntf, TGenIntf, TInlineType, TInlineTypeGeneric]{Call: _e.mock.On("GenericStructs", _a0)}
+ }


### PR DESCRIPTION
fixes errors with go 1.18

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/vektra/mockery/releases/tag/v2.14.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
