### PR TITLE
python3Packages.hdbscan: Patch out runtime Cython dependency

### DIFF
--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -9,6 +9,7 @@
 , fetchPypi
 , joblib
 , six
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -28,7 +29,8 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [ cython ];
+  pythonRemoveDeps = [ "cython" ];
+  nativeBuildInputs = [ pythonRelaxDepsHook cython ];
   propagatedBuildInputs = [ numpy scipy scikit-learn joblib six ];
   preCheck = ''
     cd hdbscan/tests

--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -44,6 +44,9 @@ buildPythonPackage rec {
     "test_approx_predict_diff_clusters"
     # another flaky test https://github.com/scikit-learn-contrib/hdbscan/issues/421
     "test_hdbscan_boruvka_balltree_matches"
+    # more flaky tests https://github.com/scikit-learn-contrib/hdbscan/issues/570
+    "test_hdbscan_boruvka_balltree"
+    "test_hdbscan_best_balltree_metric"
   ];
 
   pythonImportsCheck = [ "hdbscan" ];


### PR DESCRIPTION
###### Description of changes

Upstream declares a dependency on Cython at runtime, but that's not a true requirements. Remove it so that derivations depending on this one can build without pip complaining that Cython cannot be found.

Building an internal `buildPythonPackage` derivation that depends on hdbscan results in this error:

```
ERROR: Could not find a version that satisfies the requirement cython>=0.27 (from hdbscan) (from versions: none)
ERROR: No matching distribution found for cython>=0.27
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

hdbscan's `checkPhase` indicates that everything is OK. I've run the tests of my internal package with this change overlayed in, and those tests all passed, too.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
