### PR TITLE
fm: init at unstable-2022-06-08

### DIFF
--- a/pkgs/applications/file-managers/fm/default.nix
+++ b/pkgs/applications/file-managers/fm/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkgs,
+  libpanel
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "fm";
+  version = "unstable-2022-06-08";
+
+  src = fetchFromGitHub {
+    owner = "euclio";
+    repo = pname;
+    rev = "3b78759dacdd5e5a375a3046bc4f41027388affe";
+    sha256 = "sha256-NRHhuwcIAuYcHm05uRojeDOYzdsGW9JxLik69p4DA5M=";
+  };
+
+  cargoSha256 = "sha256-su1SWjXG9/h6BU7/pnP4fJ7+MpVqVN8cBZphDjfNoTU=";
+
+  buildInputs = with pkgs; [
+    glib
+    libpanel
+    libadwaita
+    gtksourceview5
+    gtk4
+  ];
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "Small, general purpose file manager built with GTK4";
+    homepage = "https://github.com/euclio/fm";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1747,6 +1747,8 @@ with pkgs;
     inherit (qt5) wrapQtAppsHook;
   };
 
+  fm = callPackage ../applications/file-managers/fm { };
+
   joshuto = callPackage ../applications/file-managers/joshuto {
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration Foundation;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Small, general purpose file manager built with GTK4. 
https://github.com/euclio/fm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
