### PR TITLE
python3Packages.mkdocs-jupyter: init at 0.22.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9534,6 +9534,12 @@
     github = "nessdoor";
     githubId = 25993494;
   };
+  net-mist = {
+    email = "archimist.linux@gmail.com";
+    github = "Net-Mist";
+    githubId = 13920346;
+    name = "Sébastien Iooss";
+  };
   netali = {
     name = "Jennifer Graul";
     email = "me@netali.de";

--- a/pkgs/development/python-modules/mkdocs-jupyter/default.nix
+++ b/pkgs/development/python-modules/mkdocs-jupyter/default.nix
@@ -1,0 +1,54 @@
+{ buildPythonPackage
+, fetchpatch
+, fetchPypi
+, ipykernel
+, jupytext
+, lxml
+, mkdocs 
+, mkdocs-material
+, nbconvert
+, pygments
+, pytestCheckHook
+, pytest-cov
+, pyyaml
+, requests
+, stdlib-list
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-jupyter";
+  version = "0.22.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-WFzGm+pMufr2iYExl43JqbIlCR7UtghPWrZWUqXhIYU=";
+  };
+
+  postPatch = ''
+  substituteInPlace mkdocs_jupyter/tests/test_base_usage.py \
+        --replace "[\"mkdocs\"," "[\"${mkdocs.out}/bin/mkdocs\","
+  '';
+
+  propagatedBuildInputs = [
+    nbconvert
+    jupytext
+    mkdocs 
+    mkdocs-material
+    pygments
+    ipykernel
+  ];
+  
+  pythonImportsCheck = [ "mkdocs_jupyter" ];
+
+  checkInputs = [
+    pytest-cov
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Use Jupyter Notebook in mkdocs";
+    homepage = "https://github.com/danielfrg/mkdocs-jupyter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ net-mist ];
+  };
+}

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -39,6 +39,18 @@ buildPythonPackage rec {
       hash = "sha256-kdOmE7BnkRy2lsNQ2OVrEXXZntJUPJ//b139kSsfKmI=";
       excludes = [ "pyproject.toml" ];
     })
+
+    # patch nbconvert/filters/markdown_mistune.py
+    (fetchpatch {
+      name = "clean-up-markdown-parsing.patch";
+      url = "https://github.com/jupyter/nbconvert/commit/4df1f5451c9c3e8121036dfbc7e07f0095f4d524.patch";
+      hash = "sha256-O+VWUaQi8UMCpE9/h/IsrenmEuJ2ac/kBkUBq7GFJTY";
+    })
+    (fetchpatch {
+      name = "fix-markdown-table.patch";
+      url = "https://github.com/jupyter/nbconvert/commit/d3900ed4527f024138dc3a8658c6a1b1dfc43c09.patch";
+      hash = "sha256-AFE1Zhw29JMLB0Sj17zHcOfy7VEFqLekO8NYbyMLrdI=";
+    })
   ];
 
   postPatch = ''
@@ -47,6 +59,9 @@ buildPythonPackage rec {
     # Use mistune 2.x
     substituteInPlace setup.py \
         --replace "mistune>=0.8.1,<2" "mistune>=2.0.3,<3"
+
+    substituteInPlace share/jupyter/nbconvert/templates/lab/base.html.j2 \
+        --replace "{{ output.data['image/svg+xml'] | clean_html }}" "{{ output.data['image/svg+xml'].encode(\"utf-8\") | clean_html }}"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5756,6 +5756,7 @@ in {
   mkdocs-autorefs = callPackage ../development/python-modules/mkdocs-autorefs { };
   mkdocs-drawio-exporter = callPackage ../development/python-modules/mkdocs-drawio-exporter { };
   mkdocs-exclude = callPackage ../development/python-modules/mkdocs-exclude { };
+  mkdocs-jupyter = callPackage ../development/python-modules/mkdocs-jupyter { };
   mkdocs-gitlab = callPackage ../development/python-modules/mkdocs-gitlab-plugin { };
   mkdocs-macros = callPackage ../development/python-modules/mkdocs-macros { };
   mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };


### PR DESCRIPTION
###### Description of changes

mkdocs-jupyter is a mkdocs extension for generating documentation pages from jupyter-notebook document.
When working on mkdocs-jupyter tests, I discover that some tests were failing because of nbconvert, that I patched.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
