### PR TITLE
jot: init at 0.1.1

### DIFF
--- a/pkgs/applications/misc/jot/default.nix
+++ b/pkgs/applications/misc/jot/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "jot";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "araekiel";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-CgS9I05Om4JxAbPN0vxh2Y7dftIkVnZkRP7PY4kOfpw=";
+  };
+
+  cargoSha256 = "sha256-8nRO01/hUKT6Jt7/3Sw2+aLU6hITSNl6nn9UEAvfyJY=";
+
+  meta = with lib; {
+    description = "Rapid note management for the terminal";
+    homepage = "https://github.com/araekiel/jot";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/applications/misc/jot/default.nix
+++ b/pkgs/applications/misc/jot/default.nix
@@ -21,5 +21,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/araekiel/jot";
     license = licenses.mit;
     maintainers = with maintainers; [ dit7ya ];
+    mainProgram = "jt";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7975,6 +7975,8 @@ with pkgs;
 
   joplin-desktop = callPackage ../applications/misc/joplin-desktop { };
 
+  jot = callPackage ../applications/misc/jot { };
+
   journaldriver = callPackage ../tools/misc/journaldriver {
     openssl = openssl_1_1;
   };


### PR DESCRIPTION
###### Description of changes

Jot is a feature-stripped version of Obsidian focused on rapid note management through the terminal.
It uses the same format of storage as Obsidian, i.e. markdown files for notes, and local folders for vaults (and sub-folders). 

https://github.com/araekiel/jot

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
