### PR TITLE
init livekit and livekit-cli

### DIFF
--- a/pkgs/servers/livekit/cli.nix
+++ b/pkgs/servers/livekit/cli.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "livekit-cli";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "livekit";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-euA+MDCqUTAJ4X9D+XQWAs8HKnWOh+KclTdpoQHGADk=";
+  };
+
+  vendorSha256 = "sha256-HZJN4ZjVkk4NDb4/E6BPsgty8oKt7A3eTmJ/qUIaUAY=";
+
+  subPackages = [ "cmd/livekit-cli" ];
+
+  meta = with lib; {
+    description = "Command line interface to LiveKit";
+    homepage = "https://github.com/livekit/livekit-cli";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/servers/livekit/default.nix
+++ b/pkgs/servers/livekit/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+buildGoModule rec {
+  pname = "livekit";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "livekit";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-O+nmPbh5msecYrMcXGzh+JmNXKjHt+M66yMYZ7LRDjc=";
+  };
+
+  vendorSha256 = "sha256-V2svyh/QegO6/03cq8iWBxNMYtt+imFUrTwgLtB19uw=";
+
+  subPackages = [ "cmd/server" ];
+
+  postInstall = ''
+    mv "$out/bin/server" "$out/bin/livekit"
+  '';
+
+  meta = with lib; {
+    description = "Scalable, high-performance WebRTC SFU";
+    homepage = "https://github.com/livekit/livekit";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23231,6 +23231,8 @@ with pkgs;
 
   livekit = callPackage ../servers/livekit { };
 
+  livekit-cli = callPackage ../servers/livekit/cli.nix { };
+
   livepeer = callPackage ../servers/livepeer { };
 
   lwan = callPackage ../servers/http/lwan { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23229,6 +23229,8 @@ with pkgs;
 
   listmonk = callPackage ../servers/mail/listmonk { };
 
+  livekit = callPackage ../servers/livekit { };
+
   livepeer = callPackage ../servers/livepeer { };
 
   lwan = callPackage ../servers/http/lwan { };


### PR DESCRIPTION
###### Description of changes
LiveKit is an open source project that provides scalable, multi-user conferencing based on WebRTC. It's designed to provide everything you need to build real-time video/audio/data capabilities in your applications.

https://github.com/livekit/livekit

https://github.com/livekit/livekit-cli

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
