### PR TITLE
[22.05] squid: Address security advisories 2022.1 and 2022.2

### DIFF
--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     perl openldap db cyrus_sasl expat libxml2 openssl
   ] ++ lib.optionals stdenv.isLinux [ libcap pam systemd ];
 
+  enableParallelBuilding = true;
+
   configureFlags = [
     "--enable-ipv6"
     "--disable-strict-error-checking"

--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, perl, openldap, pam, db, cyrus_sasl, libcap
-, expat, libxml2, openssl, pkg-config, systemd
+, expat, libxml2, openssl, pkg-config, systemd, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -10,6 +10,22 @@ stdenv.mkDerivation rec {
     url = "http://www.squid-cache.org/Versions/v5/${pname}-${version}.tar.xz";
     sha256 = "sha256-300xCpFmOuWcKbD4GD8iYjxeb3MYaa95OAWYerlMpBw=";
   };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/squid-cache/squid/security/advisories/GHSA-rcg9-7fqm-83mq
+      # https://www.openwall.com/lists/oss-security/2022/09/23/1
+      name = "CVE-2022-41317.patch";
+      url = "http://www.squid-cache.org/Versions/v5/changesets/SQUID-2022_1.patch";
+      hash = "sha256-lFX7dxEs0Gc1RFJVx5HHsslPQM8pwwAFi/W1Jc7PwK0=";
+    })
+    (fetchpatch {
+      # https://www.openwall.com/lists/oss-security/2022/09/23/2
+      name = "CVE-2022-41318.patch";
+      url = "http://www.squid-cache.org/Versions/v5/changesets/SQUID-2022_2.patch";
+      hash = "sha256-wWXNTTk6K6MMn1+sdHSXwGRqADM4sC1puvwAlmw/fwU=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [


### PR DESCRIPTION
Fixes: CVE-2022-41317, CVE-2022-41318

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
