### PR TITLE
nodejs: add back newer bypass-xcrun patch

### DIFF
--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -96,13 +96,13 @@ final: prev: {
     nativeBuildInputs = with pkgs; [
       pkg-config
     ] ++ lib.optionals stdenv.isDarwin [
-      xcbuild
       darwin.apple_sdk.frameworks.CoreText
     ];
     buildInputs = with pkgs; [
       pixman
       cairo
       pango
+      giflib
     ];
   };
 
@@ -147,14 +147,13 @@ final: prev: {
   # ../../applications/video/epgstation
   epgstation = prev."epgstation-../../applications/video/epgstation".override (oldAttrs: {
     buildInputs = [ pkgs.postgresql ];
-    nativeBuildInputs = [ final.node-pre-gyp final.node-gyp-build pkgs.which ] ++ lib.optionals stdenv.isDarwin [ pkgs.xcbuild ];
+    nativeBuildInputs = [ final.node-pre-gyp final.node-gyp-build pkgs.which ];
     meta = oldAttrs.meta // { platforms = lib.platforms.none; };
   });
 
   # NOTE: this is a stub package to fetch npm dependencies for
   # ../../applications/video/epgstation/client
   epgstation-client = prev."epgstation-client-../../applications/video/epgstation/client".override (oldAttrs: {
-    nativeBuildInputs = lib.optionals stdenv.isDarwin [ pkgs.xcbuild ];
     meta = oldAttrs.meta // { platforms = lib.platforms.none; };
   });
 
@@ -222,11 +221,7 @@ final: prev: {
   });
 
   joplin = prev.joplin.override {
-    nativeBuildInputs = with pkgs; [
-      pkg-config
-    ] ++ lib.optionals stdenv.isDarwin [
-      xcbuild
-    ];
+    nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = with pkgs; [
       # required by sharp
       # https://sharp.pixelplumbing.com/install
@@ -290,10 +285,6 @@ final: prev: {
         installShellCompletion --cmd $cmd --bash <(./bin/$cmd --completion)
       done
     '';
-  };
-
-  mastodon-bot = prev.mastodon-bot.override {
-    nativeBuildInputs = lib.optionals stdenv.isDarwin [ pkgs.xcbuild ];
   };
 
   mermaid-cli = prev."@mermaid-js/mermaid-cli".override (
@@ -513,11 +504,7 @@ final: prev: {
   };
 
   thelounge-plugin-giphy = prev.thelounge-plugin-giphy.override {
-    nativeBuildInputs = [
-      final.node-pre-gyp
-    ] ++ lib.optionals stdenv.isDarwin [
-      pkgs.xcbuild
-    ];
+    nativeBuildInputs = [ final.node-pre-gyp ];
   };
 
   thelounge-theme-flat-blue = prev.thelounge-theme-flat-blue.override {

--- a/pkgs/development/web/nodejs/bypass-darwin-xcrun-node16.patch
+++ b/pkgs/development/web/nodejs/bypass-darwin-xcrun-node16.patch
@@ -1,0 +1,41 @@
+Avoids needing xcrun or xcodebuild in PATH for native package builds
+
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
+index a75d8ee..476440d 100644
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
+@@ -522,7 +522,13 @@ class XcodeSettings:
+         # Since the CLT has no SDK paths anyway, returning None is the
+         # most sensible route and should still do the right thing.
+         try:
+-            return GetStdoutQuiet(["xcrun", "--sdk", sdk, infoitem])
++            #return GetStdoutQuiet(["xcrun", "--sdk", sdk, infoitem])
++            return {
++                "--show-sdk-platform-path": "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform",
++                "--show-sdk-path": "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
++                "--show-sdk-build-version": "19A547",
++                "--show-sdk-version": "10.15"
++            }[infoitem]
+         except GypError:
+             pass
+ 
+@@ -1499,7 +1505,8 @@ def XcodeVersion():
+     version = ""
+     build = ""
+     try:
+-        version_list = GetStdoutQuiet(["xcodebuild", "-version"]).splitlines()
++        #version_list = GetStdoutQuiet(["xcodebuild", "-version"]).splitlines()
++        version_list = []
+         # In some circumstances xcodebuild exits 0 but doesn't return
+         # the right results; for example, a user on 10.7 or 10.8 with
+         # a bogus path set via xcode-select
+@@ -1510,7 +1517,8 @@ def XcodeVersion():
+         version = version_list[0].split()[-1]  # Last word on first line
+         build = version_list[-1].split()[-1]  # Last word on last line
+     except GypError:  # Xcode not installed so look for XCode Command Line Tools
+-        version = CLTVersion()  # macOS Catalina returns 11.0.0.0.1.1567737322
++        #version = CLTVersion()  # macOS Catalina returns 11.0.0.0.1.1567737322
++        version = "11.0.0.0.1.1567737322"
+         if not version:
+             raise GypError("No Xcode or CLT version detected!")
+     # Be careful to convert "4.2.3" to "0423" and "11.0.0" to "1100":

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -123,7 +123,6 @@ let
           --replace "/usr/bin/env" "${coreutils}/bin/env"
       done
     '' + optionalString stdenv.isDarwin ''
-      sed -i 's/raise.*No Xcode or CLT version detected.*/version = "7.0.0"/' tools/gyp/pylib/gyp/xcode_emulation.py
       sed -i -e "s|tr1/type_traits|type_traits|g" \
              -e "s|std::tr1|std|" src/util.h
     '';
@@ -176,8 +175,6 @@ let
       Libs: -L$libv8/lib -lv8 -pthread -licui18n
       Cflags: -I$libv8/include
       EOF
-    '' + optionalString (stdenv.isDarwin && enableNpm) ''
-      sed -i 's/raise.*No Xcode or CLT version detected.*/version = "7.0.0"/' $out/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
     '';
 
     passthru.updateScript = import ./update.nix {

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -12,6 +12,7 @@ in
     sha256 = "sha256-ZyH+tBUtVtLGs1jOOXq9Wn8drwnuLiXFAhubTT+GozA=";
     patches = [
       ./disable-darwin-v8-system-instrumentation.patch
+      ./bypass-darwin-xcrun-node16.patch
       # Fix npm silently fail without a HOME directory https://github.com/npm/cli/issues/4996
       (fetchpatch {
         url = "https://github.com/npm/cli/commit/9905d0e24c162c3f6cc006fa86b4c9d0205a4c6f.patch";

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -20,5 +20,6 @@ buildNodejs {
     })
 
     ./disable-darwin-v8-system-instrumentation.patch
+    ./bypass-darwin-xcrun-node16.patch
   ];
 }


### PR DESCRIPTION
###### Description of changes

See discussion in #193533

This was a Node.js patch we'd been carrying for a while but it got dropped/forgotten with the v16 update. With `nodePackages` now being on Node.js v18, some packages fail because bundled `node-gyp` is looking for Xcode and this patch was intended to fake version data to prevent that

I made a new patch file instead of reusing the Node.js v14 patch file since between v14 and v16 because the xcode_emulation.py file was refactored

I tested this with `bitwarden-cli` in GitHub Actions to see if it resolves the need for xcbuild in `nodePackages`, since I don't actually have a Mac. It seemed to work there and I assume it will work for other similarly affected packages as well

This is my first staging PR so let me know if I need to do anything else for it. Thanks!

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).