### PR TITLE
felix-fm: init at 1.2.0

### DIFF
--- a/pkgs/applications/file-managers/felix-fm/default.nix
+++ b/pkgs/applications/file-managers/felix-fm/default.nix
@@ -1,0 +1,25 @@
+{ lib, rustPlatform, fetchFromGitHub, zoxide }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "felix";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "kyoheiu";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "180f2crd134rp3r2333nhc78nzf1n6jryfc7n2qb6ckfkrkzb7zi";
+  };
+
+  cargoSha256 = "sha256-VDIk0xb/p1eqxFFYTFdSnkSuHLnTcVh5tGBuCUj0dnw=";
+
+  checkInputs = [ zoxide ];
+
+  meta = with lib; {
+    description = "A tui file manager with vim-like key mapping";
+    homepage = "https://github.com/kyoheiu/felix";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+    mainProgram = "fx";
+  };
+}

--- a/pkgs/applications/file-managers/felix-fm/default.nix
+++ b/pkgs/applications/file-managers/felix-fm/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "felix";
-  version = "1.1.2";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "kyoheiu";
     repo = pname;
     rev = "v${version}";
-    sha256 = "180f2crd134rp3r2333nhc78nzf1n6jryfc7n2qb6ckfkrkzb7zi";
+    sha256 = "sha256-7WeikYd/mADsp9DQ0jelhuZo5ZiyJrHG9HBg/YLpjZY=";
   };
 
-  cargoSha256 = "sha256-VDIk0xb/p1eqxFFYTFdSnkSuHLnTcVh5tGBuCUj0dnw=";
+  cargoSha256 = "sha256-IUiyDk+TRfODXQ+45ARcFximkLVk32pqvJfn23H0kAw=";
 
   checkInputs = [ zoxide ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1747,6 +1747,8 @@ with pkgs;
     inherit (qt5) wrapQtAppsHook;
   };
 
+  felix-fm = callPackage ../applications/file-managers/felix-fm { };
+
   joshuto = callPackage ../applications/file-managers/joshuto {
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration Foundation;
   };


### PR DESCRIPTION
###### Description of changes

> felix is a tui file manager with vim-like key mapping

https://github.com/kyoheiu/felix

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
