### PR TITLE
nixos/filesystems: add automatic nilfs2 detection

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1256,6 +1256,7 @@
   ./tasks/filesystems/f2fs.nix
   ./tasks/filesystems/jfs.nix
   ./tasks/filesystems/nfs.nix
+  ./tasks/filesystems/nilfs2.nix
   ./tasks/filesystems/ntfs.nix
   ./tasks/filesystems/reiserfs.nix
   ./tasks/filesystems/unionfs-fuse.nix

--- a/nixos/modules/tasks/filesystems/nilfs2.nix
+++ b/nixos/modules/tasks/filesystems/nilfs2.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  inInitrd = any (fs: fs == "nilfs2") config.boot.initrd.supportedFilesystems;
+
+  # this file is mandatory for nilfs_cleanerd - can be empty
+  cleaner_conf = pkgs.writeText "nilfs_cleanerd.conf" ''
+    ${concatStringsSep "\n" (attrValues (flip mapAttrs config.boot.nilfs2.cleanerd_conf (name: def:
+      optionalString (def != "")
+        ''
+          ${name} = ${def}
+        '')))}
+  '';
+
+in
+
+{
+  config = mkIf (any (fs: fs == "nilfs2") config.boot.supportedFilesystems) {
+
+    system.fsPackages = [ pkgs.nilfs-utils ];
+
+    boot.initrd.availableKernelModules = mkIf inInitrd [ "nilfs2" ];
+
+    boot.initrd.extraUtilsCommands = mkIf (inInitrd && !config.boot.initrd.systemd.enable)
+      ''
+        copy_bin_and_libs ${pkgs.nilfs-utils}/bin/chcp
+        copy_bin_and_libs ${pkgs.nilfs-utils}/bin/lscp
+        copy_bin_and_libs ${pkgs.nilfs-utils}/bin/mkcp
+        copy_bin_and_libs ${pkgs.nilfs-utils}/bin/mount.nilfs2
+        copy_bin_and_libs ${pkgs.nilfs-utils}/bin/nilfs-clean
+        copy_bin_and_libs ${pkgs.nilfs-utils}/bin/nilfs-resize
+        copy_bin_and_libs ${pkgs.nilfs-utils}/bin/rmcp
+      '';
+
+    environment.etc = {
+      "nilfs_cleanerd.conf".source = cleaner_conf;
+    };
+
+  };
+
+  options = {
+    boot.nilfs2 = {
+      cleanerd_conf = mkOption {
+        type = types.attrsOf types.lines;
+        default = {};
+        example = ''
+        {
+          protection_period = "3600";
+          cleaning_interval = "120";
+        }
+        '';
+        description = lib.mdDoc ''
+          Content of nilfs_cleanerd.conf used to manage garbage collector behavior.
+
+          More information in nilfs_cleanerd.conf man page.
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

This adds a detection for nilfs2 filesystems in mountpoints, and automatically pulls in the kernel module. Without it, you need to add the `nilfs2` kernel module to have a successful stage-1, otherwise you obtain a "device not found" at boot which isn't very helpful. Successfully tested on a laptop using nilfs2 for its root filesystem, no extra configuration required to boot it :rocket: 

fixes #65548

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).