### PR TITLE
commitizen: 2.29.2 -> 2.35.0 

### DIFF
--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -16,32 +16,18 @@
 , termcolor
 , tomlkit
 , typing-extensions
-, chardet
-
-, argcomplete, fetchPypi
+, argcomplete
 }:
-
-let
-  # NOTE: Upstream requires argcomplete <2, so we make it here.
-  argcomplete_1 = argcomplete.overrideAttrs (old: rec {
-    version = "1.12.3";
-    src = fetchPypi {
-      inherit (old) pname;
-      inherit version;
-      sha256 = "sha256-LH2//YwEXqU0kh5jsL5v5l6IWZmQ2NxAisjFQrcqVEU=";
-    };
-  });
-in
 
 buildPythonApplication rec {
   pname = "commitizen";
-  version = "2.29.2";
+  version = "2.35.0";
 
   src = fetchFromGitHub {
     owner = "commitizen-tools";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-4mK+GA1rfctJkMv4ZMfXE/qih/9fF0kwT6bIcLVB/Bk=";
+    hash = "sha256-9ek6m5k01sGVHwqWXjWYDsPmIeAgK+H23D9sF5hjrf0=";
     deepClone = true;
   };
 
@@ -50,7 +36,6 @@ buildPythonApplication rec {
   nativeBuildInputs = [ poetry ];
 
   propagatedBuildInputs = [
-    chardet
     termcolor
     questionary
     colorama
@@ -58,76 +43,41 @@ buildPythonApplication rec {
     tomlkit
     jinja2
     pyyaml
-    argcomplete_1
+    argcomplete
     typing-extensions
     packaging
   ];
 
   doCheck = true;
+
   checkInputs = [
     pytestCheckHook
     pytest-freezegun
     pytest-mock
     pytest-regressions
-    argcomplete_1
+    argcomplete
     git
   ];
 
-  # NB: These require full git history
+  # the tests require a functional git installation
+  # which requires a valid HOME directory.
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+
+    git config --global user.name "Nix Builder"
+    git config --global user.email "nix-builder@nixos.org"
+    git init .
+  '';
+
+  # NB: These tests require complex GnuPG setup
   disabledTests = [
-    "test_breaking_change_content_v1"
-    "test_breaking_change_content_v1_beta"
-    "test_breaking_change_content_v1_multiline"
-    "test_bump_command_increment_option"
-    "test_bump_command_prelease"
-    "test_bump_dry_run"
-    "test_bump_files_only"
-    "test_bump_local_version"
-    "test_bump_major_increment"
-    "test_bump_minor_increment"
-    "test_bump_on_git_with_hooks_no_verify_disabled"
+    "test_bump_minor_increment_signed"
+    "test_bump_minor_increment_signed_config_file"
     "test_bump_on_git_with_hooks_no_verify_enabled"
-    "test_bump_patch_increment"
+    "test_bump_on_git_with_hooks_no_verify_disabled"
     "test_bump_pre_commit_changelog"
     "test_bump_pre_commit_changelog_fails_always"
-    "test_bump_tag_exists_raises_exception"
-    "test_bump_when_bumpping_is_not_support"
-    "test_bump_when_version_inconsistent_in_version_files"
-    "test_bump_with_changelog_arg"
-    "test_bump_with_changelog_config"
-    "test_bump_with_changelog_to_stdout_arg"
-    "test_bump_with_changelog_to_stdout_dry_run_arg"
-    "test_changelog_config_flag_increment"
-    "test_changelog_config_start_rev_option"
-    "test_changelog_from_rev_first_version_from_arg"
-    "test_changelog_from_rev_latest_version_dry_run"
-    "test_changelog_from_rev_latest_version_from_arg"
-    "test_changelog_from_rev_range_version_not_found"
-    "test_changelog_from_rev_single_version_not_found"
-    "test_changelog_from_rev_version_range_from_arg"
-    "test_changelog_from_rev_version_range_including_first_tag"
-    "test_changelog_from_rev_version_with_big_range_from_arg"
-    "test_changelog_from_start"
-    "test_changelog_from_version_zero_point_two"
-    "test_changelog_hook"
-    "test_changelog_incremental_angular_sample"
-    "test_changelog_incremental_keep_a_changelog_sample"
-    "test_changelog_incremental_keep_a_changelog_sample_with_annotated_tag"
-    "test_changelog_incremental_newline_separates_new_content_from_old"
-    "test_changelog_incremental_with_release_candidate_version"
-    "test_changelog_is_persisted_using_incremental"
-    "test_changelog_multiple_incremental_do_not_add_new_lines"
-    "test_changelog_replacing_unreleased_using_incremental"
-    "test_changelog_with_different_cz"
-    "test_changelog_with_filename_as_empty_string"
-    "test_get_commits"
-    "test_get_commits_author_and_email"
     "test_get_commits_with_signature"
-    "test_get_latest_tag_name"
-    "test_invalid_subject_is_skipped"
-    "test_is_staging_clean_when_updating_file"
-    "test_none_increment_should_not_call_git_tag_and_error_code_is_not_zero"
-    "test_prevent_prerelease_when_no_increment_detected"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -84,6 +84,6 @@ buildPythonApplication rec {
     description = "Tool to create committing rules for projects, auto bump versions, and generate changelogs";
     homepage = "https://github.com/commitizen-tools/commitizen";
     license = licenses.mit;
-    maintainers = with maintainers; [ lovesegfault ];
+    maintainers = with maintainers; [ lovesegfault anthonyroussel ];
   };
 }


### PR DESCRIPTION
###### Description of changes

* Bump commitizen from 2.29.2 to 2.35.0
  * https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md#v2350-2022-09-23

* Remove argcomplete 1.12.3 dependency override
* Remove unused fetchPypi argument
* Fix most of the tests requiring a Git setup
* Exclude some tests requiring a complex GnuPG setup
* Add myself anthonyroussel to maintainers

Also fix the failing commitizen build since the latest staging-next PR has been merged into master, see https://github.com/NixOS/nixpkgs/pull/191339

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
