### PR TITLE
emacs.pkgs.voicemacs: init at unstable-2022-02-16

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -160,6 +160,8 @@
 
   urweb-mode = callPackage ./urweb-mode { };
 
+  voicemacs = callPackage ./voicemacs { };
+
   # Packages made the classical callPackage way
 
   ebuild-mode = callPackage ./ebuild-mode { };

--- a/pkgs/applications/editors/emacs/elisp-packages/voicemacs/add-missing-require.patch
+++ b/pkgs/applications/editors/emacs/elisp-packages/voicemacs/add-missing-require.patch
@@ -1,0 +1,38 @@
+From eb9fefe7eddee0b22c7c1104eb9133ed595c55f9 Mon Sep 17 00:00:00 2001
+From: adisbladis <adisbladis@gmail.com>
+Date: Fri, 23 Sep 2022 14:52:34 +1200
+Subject: [PATCH] Add missing (require)'s
+
+---
+ voicemacs-server.el | 2 ++
+ voicemacs.el        | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/voicemacs-server.el b/voicemacs-server.el
+index edfe74c..04ffdf2 100644
+--- a/voicemacs-server.el
++++ b/voicemacs-server.el
+@@ -1,5 +1,7 @@
+ (require 'cl-lib)
+ (require 'json-rpc-server)
++(require 'f)
++(require 'porthole)
+ 
+ 
+ (defvar voicemacs--update-response-timeout 3
+diff --git a/voicemacs.el b/voicemacs.el
+index b93e80b..d790636 100644
+--- a/voicemacs.el
++++ b/voicemacs.el
+@@ -18,6 +18,8 @@
+   (require 'voicemacs-extend-company))
+ 
+ 
++(require 'yasnippet)
++
+ (voicemacs-define-sync voicemacs
+   :update t
+   :enable nil
+-- 
+2.37.2
+

--- a/pkgs/applications/editors/emacs/elisp-packages/voicemacs/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/voicemacs/default.nix
@@ -1,0 +1,50 @@
+{ trivialBuild
+, lib
+, fetchFromGitHub
+, avy
+, json-rpc-server
+, f
+, nav-flash
+, helm
+, cl-lib
+, porthole
+, default-text-scale
+, bind-key
+, yasnippet
+, company
+, company-quickhelp
+}:
+
+trivialBuild {
+  pname = "voicemacs";
+  version = "unstable-2022-02-16";
+
+  src = fetchFromGitHub {
+    owner = "jcaw";
+    repo = "voicemacs";
+    rev = "d91de2a31c68ab083172ade2451419d6bd7bb389";
+    sha256 = "sha256-/MBB2R9/V0aYZp15e0vx+67ijCPp2iPlgxe262ldmtc=";
+  };
+
+  patches = [ ./add-missing-require.patch ];
+
+  packageRequires = [
+    avy
+    json-rpc-server
+    f
+    nav-flash
+    helm
+    cl-lib
+    porthole
+    default-text-scale
+    bind-key
+    yasnippet
+    company-quickhelp
+  ];
+
+  meta = {
+    description = "Voicemacs is a set of utilities for controlling Emacs by voice";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
