### PR TITLE
sonic-lineup: mark broken

### DIFF
--- a/pkgs/applications/audio/sonic-lineup/default.nix
+++ b/pkgs/applications/audio/sonic-lineup/default.nix
@@ -2,6 +2,7 @@
 , libid3tag, liblo, libmad, liboggz, libpulseaudio, libsamplerate
 , libsndfile, lrdf, opusfile, portaudio, rubberband, serd, sord, capnproto
 , wrapQtAppsHook, pkg-config
+, libjack2
 }:
 
 stdenv.mkDerivation rec {
@@ -17,6 +18,7 @@ stdenv.mkDerivation rec {
     [ alsa-lib boost bzip2 fftw fftwFloat libfishsound libid3tag liblo
       libmad liboggz libpulseaudio libsamplerate libsndfile lrdf opusfile
       portaudio rubberband serd sord capnproto
+      libjack2
     ];
 
   nativeBuildInputs = [ pkg-config wrapQtAppsHook ];
@@ -34,5 +36,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.vandenoever ];
     platforms = platforms.linux;
+    # undefined reference to `std::__throw_bad_array_new_length()@GLIBCXX_3.4.29'
+    broken = true; # at 2022-09-30
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31395,7 +31395,10 @@ with pkgs;
 
   socialscan = with python3.pkgs; toPythonApplication socialscan;
 
-  sonic-lineup = libsForQt5.callPackage ../applications/audio/sonic-lineup { stdenv = gcc10StdenvCompat; };
+  sonic-lineup = libsForQt5.callPackage ../applications/audio/sonic-lineup {
+    bzip2 = bzip2_1_1;
+    stdenv = gcc10StdenvCompat;
+  };
 
   sonic-visualiser = libsForQt5.callPackage ../applications/audio/sonic-visualiser { };
 


### PR DESCRIPTION
sonic-lineup: mark broken
* Fix bzip2 and jack issue.

undefined reference to `std::__throw_bad_array_new_length()@GLIBCXX_3.4.29

![image](https://user-images.githubusercontent.com/5861043/193368595-e2d41f53-63e6-4c8e-91c2-0728cf412492.png)

logs: https://termbin.com/4i5a