### PR TITLE
python310Packages.wxPython: mark broken

### DIFF
--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -74,6 +74,8 @@ buildPythonPackage rec {
     description = "Cross platform GUI toolkit for Python, Phoenix version";
     homepage = "http://wxpython.org/";
     license = lib.licenses.wxWindows;
+    # mv: cannot stat 'dist': No such file or directory
+    broken = true; # at 2022-09-30
   };
 
 }

--- a/pkgs/development/python-modules/wxPython/4.1.nix
+++ b/pkgs/development/python-modules/wxPython/4.1.nix
@@ -94,10 +94,11 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Cross platform GUI toolkit for Python, Phoenix version";
     homepage = "http://wxpython.org/";
     license = licenses.wxWindows;
     maintainers = with maintainers; [ tfmoraes ];
+    # mv: cannot stat 'dist': No such file or directory
+    broken = true; # at 2022-09-30
   };
 }


### PR DESCRIPTION
python310Packages.wxPython: mark broken

* $ nix build .#python310Packages.wxPython_4_0
  ![image](https://user-images.githubusercontent.com/5861043/193377991-a41faca6-a838-4d53-b8b0-1fea4ee40a56.png)
  logs: https://termbin.com/d0xy

* $ nix build .#python310Packages.wxPython_4_1
  ![image](https://user-images.githubusercontent.com/5861043/193378011-cdbb08e7-6f37-4340-9137-c1a9e231833b.png)
  logs: https://termbin.com/1er04

**Packages should be marked broken while are broken to avoid false positives in upstream builds.**

Notice:
1. Anyone fixing it can remove the broken mark.
2. There is no gain from delaying marking broken a **known to be broken** package.

ping @tfmoraes