### PR TITLE
python310Packages.pysdl2: mark broken

### DIFF
--- a/pkgs/development/python-modules/pysdl2/default.nix
+++ b/pkgs/development/python-modules/pysdl2/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/marcusva/py-sdl2";
     license = lib.licenses.publicDomain;
     maintainers = with lib.maintainers; [ pmiddend ];
+    broken = true; # at 2022-09-30, patch fail to apply.
   };
 }


### PR DESCRIPTION
python310Packages.pysdl2: mark broken

![image](https://user-images.githubusercontent.com/5861043/193378658-916dfaf5-16ce-43d8-9926-b9a36c3cd388.png)

logs: https://termbin.com/032g

* I have no interest in fixing this package. I'm only reporting it is broken so it stops showing up in builds. Whoever has an interest in fixing can open a new PR. Thanks for understanding.