### PR TITLE
phosh-mobile-settings: init at 0.21.1

### DIFF
--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+, desktop-file-utils
+, feedbackd
+, gtk4
+, libadwaita
+, lm_sensors
+, phoc
+, phosh
+, wayland-protocols
+}:
+
+stdenv.mkDerivation rec {
+  pname = "phosh-mobile-settings";
+  version = "0.21.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "guidog";
+    repo = "phosh-mobile-settings";
+    rev = "v${version}";
+    sha256 = "sha256-60AXaKSF8bY+Z3TNlIIa7jZwQ2IkHqCbZ3uIlhkx6i0=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    desktop-file-utils
+    feedbackd
+    gtk4
+    libadwaita
+    lm_sensors
+    phoc
+    phosh
+    wayland-protocols
+  ];
+
+  postInstall = ''
+    # this is optional, but without it phosh-mobile-settings won't know about lock screen plugins
+    ln -s '${phosh}/lib/phosh' "$out/lib/phosh"
+
+    # .desktop files marked `OnlyShowIn=Phosh;` aren't displayed even in our phosh, so remove that.
+    # also make the Exec path absolute.
+    substituteInPlace "$out/share/applications/org.sigxcpu.MobileSettings.desktop" \
+      --replace 'OnlyShowIn=Phosh;' "" \
+      --replace 'Exec=phosh-mobile-settings' "Exec=$out/bin/phosh-mobile-settings"
+  '';
+
+  meta = with lib; {
+    description = "A settings app for mobile specific things";
+    homepage = "https://gitlab.gnome.org/guidog/phosh-mobile-settings";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ colinsane ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10088,6 +10088,8 @@ with pkgs;
 
   phosh = callPackage ../applications/window-managers/phosh { };
 
+  phosh-mobile-settings = callPackage ../applications/window-managers/phosh/phosh-mobile-settings.nix { };
+
   pinentry = libsForQt5.callPackage ../tools/security/pinentry { };
 
   pinentry-curses = (lib.getOutput "curses" pinentry);


### PR DESCRIPTION
###### Description of changes

phosh 0.21.1 release notes referenced phosh-mobile-settings as a "recommended package". it lets one control things like scale-to-fit and lock screen settings.

built on x86_64/aarch64 and manually tested on aarch64 pinephone.

unlike the other desktops, Phosh does not seem to have its own folder for the applications closely tied to it. `phoc`, the Phosh compositor, lives in pkgs/applications/misc so that location probably makes sense for this too.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
