### PR TITLE
luajit: 2.0.5-2022-03-13, 2.1.0-2022-04-05 -> 2.0.5-2022-09-13, 2.1.0-2022-10-04

### DIFF
--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -2,10 +2,10 @@
 callPackage ./default.nix {
   sourceVersion = { major = "2"; minor = "0"; patch = "5"; };
   inherit self passthruFun;
-  version = "2.0.5-2022-03-13";
-  rev = "93a65d3cc263aef2d2feb3d7ff2206aca3bee17e";
+  version = "2.0.5-2022-09-13";
+  rev = "46e62cd963a426e83a60f691dcbbeb742c7b3ba2";
   isStable = true;
-  hash = "sha256-Gp7OdfxBGkW59zxWUml2ugPABLUv2SezMiDblA/FZ7g=";
+  hash = "sha256-/XR9+6NjXs2TrUVKJNkH2h970BkDNFqMDJTWcy/bswU=";
   extraMeta = { # this isn't precise but it at least stops the useless Hydra build
     platforms = with lib; filter (p: !hasPrefix "aarch64-" p)
       (platforms.linux ++ platforms.darwin);

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -2,8 +2,8 @@
 callPackage ./default.nix {
   sourceVersion = { major = "2"; minor = "1"; patch = "0"; };
   inherit self passthruFun;
-  version = "2.1.0-2022-04-05";
-  rev = "5e3c45c43bb0e0f1f2917d432e9d2dba12c42a6e";
+  version = "2.1.0-2022-10-04";
+  rev = "6c4826f12c4d33b8b978004bc681eb1eef2be977";
   isStable = false;
-  hash = "sha256-Q+34hJDgyCqmtThHbxR16Nn7zhq4Ql142No2rO57HL0=";
+  hash = "sha256-GMgoSVHrfIuLdk8mW9XgdemNFsAkkQR4wiGGjaAXAKg=";
 }


### PR DESCRIPTION
###### Description of changes

Various bugfixes.

*luajit_2_0*
https://github.com/LuaJIT/LuaJIT/compare/93a65d3cc263aef2d2feb3d7ff2206aca3bee17e...46e62cd963a426e83a60f691dcbbeb742c7b3ba2

*luajit_2_1*
https://github.com/LuaJIT/LuaJIT/compare/5e3c45c43bb0e0f1f2917d432e9d2dba12c42a6e...6c4826f12c4d33b8b978004bc681eb1eef2be977

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
