### PR TITLE
ookla-speedtest: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/tools/networking/ookla-speedtest/default.nix
+++ b/pkgs/tools/networking/ookla-speedtest/default.nix
@@ -2,20 +2,20 @@
 
 let
   pname = "ookla-speedtest";
-  version = "1.1.1";
+  version = "1.2.0";
 
   srcs = rec {
     x86_64-linux = fetchurl {
       url = "https://install.speedtest.net/app/cli/${pname}-${version}-linux-x86_64.tgz";
-      sha256 = "sha256-lwR3/f7k10HnXwiPr2SPm1HHvgQxP7iP+13gfrGjBAw=";
+      sha256 = "sha256-VpBZbFT/m+1j+jcy+BigXbwtsZrTbtaPIcpfZNXP7rc=";
     };
     aarch64-linux = fetchurl {
       url = "https://install.speedtest.net/app/cli/${pname}-${version}-linux-aarch64.tgz";
-      sha256 = "sha256-J2pAhz/hw8okohWAwvxkqpLtNY/8bbYHGhPQOo1DH9k=";
+      sha256 = "sha256-OVPSMdo3g+K/iQS23XJ2fFxuUz4WPTdC/QQ3r/pDG9M=";
     };
     x86_64-darwin = fetchurl {
-      url = "https://install.speedtest.net/app/cli/${pname}-${version}.84-macosx-x86_64.tgz";
-      sha256 = "sha256-FT925OUCortHDH98O0uK+qUOuYuxHoYhb8sai5JnbpQ=";
+      url = "https://install.speedtest.net/app/cli/${pname}-${version}-macosx-universal.tgz";
+      sha256 = "sha256-yfgZIUnryI+GmZmM7Ksc4UQUQEWQfs5vU89Qh39N5m8=";
     };
     aarch64-darwin = x86_64-darwin;
   };


### PR DESCRIPTION
Release notes for 1.2.0 (2022-07-27):
* Cleaned up formatting in human-readable output for additional data within parenthesis (now using `label: value` consistently)
* Compressed result upload data to reduce data usage
* Added support for measuring responsiveness (latency during load)
* Added experimental support for multi-server testing
* Updated third-party dependencies: cURL 7.83.1, mbed TLS 3.1.0, Boost 1.79.0
* Added stability improvements

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
