### PR TITLE
sbcl: bootstrap x86-64-darwin 1.2.11 -> 2.2.9

### DIFF
--- a/pkgs/development/compilers/sbcl/bootstrap.nix
+++ b/pkgs/development/compilers/sbcl/bootstrap.nix
@@ -8,9 +8,9 @@ let
       sha256 = "sha256-H0ALigXcWIypdA+fTf7jERscwbb7QIAfcoxCtGDh0RU=";
     };
     x86_64-darwin = {
-      version = "1.2.11";
+      version = "2.2.9";
       system = "x86-64-darwin";
-      sha256 = "0lh4gpvi8hl6g6b9321g5pwh8sk3218i7h4lx7p3vd9z0cf3lz85";
+      sha256 = "sha256-b1BLkoLIOELAYBYA9eBmMgm1OxMxJewzNP96C9ADfKY=";
     };
     x86_64-linux = {
       version = "1.3.16";


### PR DESCRIPTION

###### Description of changes

> N.B.: This does **not** update or change any actual SBCL version. It only concerns the *bootstrap* version, which is used to compile the final version.

Update the binary used to bootstrap SBCL versions on Darwin (Mac OS) x86-64 systems (i.e. Intel, i.e. non-ARM) from 1.2.11 (released in 2015) to 2.2.9 (released September 2022). Generally, the more recent the bootstrap binary, the fewer the problems. This bootstrap binary can be used to compile other SBCL versions (for this target) from source. Those don’t have binary releases by the SBCL team.

This is useful because building SBCL 2.x from source, using the binary release of 1.2.11, on this system configuration, ended up in an endless loop. See also this thread on the Mac ports forum, where people are having the same issue:

https://trac.macports.org/ticket/64621

Now that SBCL has released a more recent binary build for this system, the problem is solved.

Ironically, this SBCL version is so recent, actual SBCL versions in nixpkgs haven't even been updated to this version yet, so it will always be used to compile a lower version. But that's ok :) it can be solved separately.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
