### PR TITLE
ocamlPackages.ppx_tools: 6.5 → 6.6

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -1,10 +1,9 @@
 { lib, stdenv, fetchFromGitHub, buildDunePackage, ocaml, findlib, cppo }:
 
 let param =
-  let v6_5 = {
-    version = "6.5";
-    sha256 = "sha256:0fwibah2hgllrnbdrmfqil5gr5raf6pb5h2zx6zs1h3d4ykvy8k8";
-    useDune2 = true;
+  let v6_6 = {
+    version = "6.6";
+    sha256 = "sha256-QhuaQ9346a3neoRM4GrOVzjR8fg9ysMZR1VzNgyIQtc=";
     nativeBuildInputs = [cppo];
     buildInputs = [cppo];
   }; in
@@ -28,13 +27,13 @@ let param =
   "4.07" = {
     version = "5.1+4.06.0";
     sha256 = "1ww4cspdpgjjsgiv71s0im5yjkr3544x96wsq1vpdacq7dr7zwiw"; };
-  "4.08" = v6_5;
-  "4.09" = v6_5;
-  "4.10" = v6_5;
-  "4.11" = v6_5;
-  "4.12" = v6_5;
-  "4.13" = v6_5;
-  "4.14" = v6_5;
+  "4.08" = v6_6;
+  "4.09" = v6_6;
+  "4.10" = v6_6;
+  "4.11" = v6_6;
+  "4.12" = v6_6;
+  "4.13" = v6_6;
+  "4.14" = v6_6;
 }.${ocaml.meta.branch};
 in
 
@@ -56,7 +55,7 @@ if lib.versionAtLeast param.version "6.0"
 then
   buildDunePackage {
     inherit pname src meta;
-    inherit (param) version useDune2 buildInputs nativeBuildInputs;
+    inherit (param) version buildInputs nativeBuildInputs;
 
     strictDeps = true;
   }


### PR DESCRIPTION
###### Description of changes

Support for future OCaml: https://github.com/ocaml-ppx/ppx_tools/blob/6.6/CHANGES#L1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
