### PR TITLE
zsa-udev-rules: fix compatibility with new Oryx

### DIFF
--- a/pkgs/os-specific/linux/zsa-udev-rules/50-zsa.rules
+++ b/pkgs/os-specific/linux/zsa-udev-rules/50-zsa.rules
@@ -1,0 +1,30 @@
+# This file has been copied from https://github.com/zsa/wally/wiki/Linux-install#2-create-a-udev-rule-file
+
+# Changes applied:
+# - We need to modify the MODE in all rules from 0664 to 0666 because apps on nixos are not running under logged in user (explanation I got from ZSA devs).
+
+
+# Rules for Oryx web flashing and live training
+KERNEL=="hidraw*", ATTRS{idVendor}=="16c0", MODE="0666", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3297", MODE="0666", GROUP="plugdev"
+
+# Legacy rules for live training over webusb (Not needed for firmware v21+)
+  # Rule for all ZSA keyboards
+  SUBSYSTEM=="usb", ATTR{idVendor}=="3297", GROUP="plugdev"
+  # Rule for the Moonlander
+  SUBSYSTEM=="usb", ATTR{idVendor}=="3297", ATTR{idProduct}=="1969", GROUP="plugdev"
+  # Rule for the Ergodox EZ
+  SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="1307", GROUP="plugdev"
+  # Rule for the Planck EZ
+  SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="6060", GROUP="plugdev"
+
+# Wally Flashing rules for the Ergodox EZ
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789A]?", ENV{MTP_NO_PROBE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789ABCD]?", MODE:="0666"
+KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", MODE:="0666"
+
+# Wally Flashing rules for the Moonlander and Planck EZ
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", \
+    MODE:="0666", \
+    SYMLINK+="stm32_dfu"

--- a/pkgs/os-specific/linux/zsa-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/zsa-udev-rules/default.nix
@@ -4,12 +4,7 @@ stdenv.mkDerivation rec {
   pname = "zsa-udev-rules";
   version = "2.1.3";
 
-  src = fetchFromGitHub {
-    owner = "zsa";
-    repo = "wally";
-    rev = "${version}-linux";
-    sha256 = "mZzXKFKlO/jAitnqzfvmIHp46A+R3xt2gOhVC3qN6gM=";
-  };
+  src = ./.;
 
   # Only copies udevs rules
   dontConfigure = true;
@@ -18,8 +13,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/lib/udev/rules.d
-    cp dist/linux64/50-oryx.rules $out/lib/udev/rules.d/
-    cp dist/linux64/50-wally.rules $out/lib/udev/rules.d/
+    cp 50-zsa.rules $out/lib/udev/rules.d/
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZSA changed the firmware of their keyboards. It now requires different udev rules to work properly. 
They updated their wiki: https://github.com/zsa/wally/wiki/Linux-install#2-create-a-udev-rule-file

On top of that update, we can't use their udev rules as-is because browsers are not running under active user. So we need to change the permissions in udev rules to allow access to everyone (not just the current user).

ZSA asked me to create this PR with 0666 mode.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
