### PR TITLE
mysql-client: fix fallout from removing this alias

### DIFF
--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -32,7 +32,7 @@ let
       nativeLibs = [ glib gobject-introspection ];
     };
     cl-mysql = pkg: {
-      nativeLibs = [ mysql-client ];
+      nativeLibs = [ mariadb.client ];
     };
     clsql-postgresql = pkg: {
       nativeLibs = [ postgresql.lib ];
@@ -44,7 +44,7 @@ let
       nativeLibs = [ webkitgtk ];
     };
     dbd-mysql = pkg: {
-      nativeLibs = [ mysql-client ];
+      nativeLibs = [ mariadb.client ];
     };
     lla = pkg: {
       nativeLibs = [ openblas ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -743,7 +743,7 @@ mapAliases ({
   mumble_git = throw "'mumble_git' has been renamed to/replaced by 'pkgs.mumble'"; # Converted to throw 2022-09-24
   murmur_git = throw "'murmur_git' has been renamed to/replaced by 'pkgs.murmur'"; # Converted to throw 2022-09-24
   mutt-with-sidebar = mutt; # Added 2022-09-17
-  mysql-client = throw "'mysql-client' has been renamed to/replaced by 'hiPrio'"; # Converted to throw 2022-09-24
+  mysql-client = throw "'mysql-client' has been renamed to/replaced by 'mariadb.client'"; # Converted to throw 2022-09-24
   mysql = throw "'mysql' has been renamed to/replaced by 'mariadb'"; # Converted to throw 2022-09-24
 
   mesa_drivers = throw "'mesa_drivers' has been renamed to/replaced by 'mesa.drivers'"; # Converted to throw 2022-09-24


### PR DESCRIPTION
Removed in commit https://github.com/NixOS/nixpkgs/commit/57b25916f3220dc7e6ee99b645c2dfb80869d1f2 from PR https://github.com/NixOS/nixpkgs/pull/192681.

(The usual checklist doesn't apply, really.)

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
