### PR TITLE
python310Packages.starlette: 0.20.4 -> 0.21.0

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -93,6 +93,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Web framework for building APIs";
     homepage = "https://github.com/tiangolo/fastapi";
+    changelog = "https://github.com/tiangolo/fastapi/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ wd15 ];
   };

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.85.2";
+  version = "0.88.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "tiangolo";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-j3Set+xWNcRqbn90DJOJQhMrJYI3msvWHlFvN1habP0=";
+    hash = "sha256-2rjKmQcehqkL5OnmtLRTvsyUSpK2aUgyE9VLvz+oWNw=";
   };
 
   nativeBuildInputs = [
@@ -77,6 +77,7 @@ buildPythonPackage rec {
 
   disabledTests = [
     "test_get_custom_response"
+    "test_warn_duplicate_operation_id"
     # Failed: DID NOT RAISE <class 'starlette.websockets.WebSocketDisconnect'>
     "test_websocket_invalid_data"
     "test_websocket_no_credentials"

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.23.0";
+  version = "0.23.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "encode";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-j+UsZtk7W5exWGzIrNiELtE9ehoknfsy1W/5vii+9IE=";
+    hash = "sha256-LcFrdaRgFBqcdylCzNlewj/papsg/sZ1FMVxBDLvQWI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.22.0";
+  version = "0.23.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "encode";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-vyGLNQMCWu3zGFF7jRuozVLCqwR1zWBWuYTIDRBncHk=";
+    hash = "sha256-j+UsZtk7W5exWGzIrNiELtE9ehoknfsy1W/5vii+9IE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -76,6 +76,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "The little ASGI framework that shines";
     homepage = "https://www.starlette.io/";
+    changelog = "https://github.com/encode/starlette/releases/tag/${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ wd15 ];
   };

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.21.0";
+  version = "0.22.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "encode";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-wZtlKCD7eE4sCKfhFgWXywACAes8uo4HXkicJAMcgqk=";
+    hash = "sha256-vyGLNQMCWu3zGFF7jRuozVLCqwR1zWBWuYTIDRBncHk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -1,65 +1,51 @@
 { lib
 , stdenv
-, buildPythonPackage
-, fetchFromGitHub
-, fetchpatch
-, aiofiles
+, aiosqlite
 , anyio
-, contextlib2
+, ApplicationServices
+, buildPythonPackage
+, databases
+, fetchFromGitHub
+, hatchling
+, httpx
 , itsdangerous
 , jinja2
-, python-multipart
-, pyyaml
-, requests
-, aiosqlite
-, databases
 , pytestCheckHook
+, python-multipart
 , pythonOlder
+, pyyaml
 , trio
 , typing-extensions
-, ApplicationServices
 }:
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.20.4";
-  format = "setuptools";
+  version = "0.21.0";
+  format = "pyproject";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-vP2TJPn9lRGnLGkO8lUmnsoT6rSnhuWDD3WqNk76SM0=";
+    hash = "sha256-wZtlKCD7eE4sCKfhFgWXywACAes8uo4HXkicJAMcgqk=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/encode/starlette/commit/ab70211f0e1fb7390668bf4891eeceda8d9723a0.diff";
-      excludes = [ "requirements.txt" ]; # conflicts
-      hash = "sha256-UHf4c4YUWp/1I1vD8J0hMewdlfkmluA+FyGf9ZsSv3Y=";
-    })
+  nativeBuildInputs = [
+    hatchling
   ];
 
-  postPatch = ''
-    # remove coverage arguments to pytest
-    sed -i '/--cov/d' setup.cfg
-  '';
-
   propagatedBuildInputs = [
-    aiofiles
     anyio
+    httpx
     itsdangerous
     jinja2
     python-multipart
     pyyaml
-    requests
-  ] ++ lib.optionals (pythonOlder "3.8") [
+  ] ++ lib.optionals (pythonOlder "3.10") [
     typing-extensions
-  ] ++ lib.optionals (pythonOlder "3.7") [
-    contextlib2
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optional stdenv.isDarwin [
     ApplicationServices
   ];
 
@@ -72,7 +58,7 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # asserts fail due to inclusion of br in Accept-Encoding
+    # Asserts fail due to inclusion of br in Accept-Encoding
     "test_websocket_headers"
     "test_request_headers"
   ];
@@ -81,9 +67,15 @@ buildPythonPackage rec {
     "starlette"
   ];
 
+  pytestFlagsArray = [
+    # DeprecationWarning: Please use rfc3986.validators.Validator instead. This method will be eventually removed.
+    "-W"
+    "ignore::DeprecationWarning"
+  ];
+
   meta = with lib; {
-    homepage = "https://www.starlette.io/";
     description = "The little ASGI framework that shines";
+    homepage = "https://www.starlette.io/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ wd15 ];
   };


### PR DESCRIPTION
###### Description of changes
https://github.com/encode/starlette/releases/tag/0.21.0

- switch to httpx
- remove aiofiles which was replaces by anyio
- update disabled
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
