### PR TITLE
python3Packages.msrest: 0.6.21 -> 0.7.1 Fixes build issue with azure-mgmt-subscription

### DIFF
--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -7,7 +7,6 @@
 , aiohttp
 , flask
 , mock
-, msrest
 , pytest
 , pytest-asyncio
 , pytest-trio
@@ -39,7 +38,6 @@ buildPythonPackage rec {
     aiohttp
     flask
     mock
-    msrest
     pytest
     pytest-trio
     pytest-asyncio
@@ -78,6 +76,11 @@ buildPythonPackage rec {
     "tests/testserver_tests/"
     # requires missing pytest plugin
     "tests/async_tests/test_rest_asyncio_transport.py"
+    # needs msrest, which cannot be included in checkInputs due to circular dependency new in msrest 0.7.1
+    # azure-core needs msrest which needs azure-core
+    "tests/test_polling.py"
+    "tests/async_tests/test_base_polling_async.py"
+    "tests/async_tests/test_polling_async.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -1,6 +1,7 @@
 { lib
 , aiodns
 , aiohttp
+, azure-core
 , buildPythonPackage
 , certifi
 , fetchFromGitHub
@@ -16,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "msrest";
-  version = "0.6.21";
+  version = "0.7.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -24,11 +25,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Azure";
     repo = "msrest-for-python";
-    rev = "v${version}";
-    hash = "sha256-IlBwlVQ/v+vJmCWNbFZKGL6a9K09z4AYrPm3kwaA/nI=";
+    # no tag for 0.7.1
+    rev = "2d8fd04f68a124d0f3df7b81584accc3270b1afc";
+    hash = "sha256-1EXXXflhDeU+erdI+NsWxSX76ooDTl3+MyQwRzm2xV0=";
   };
 
   propagatedBuildInputs = [
+    azure-core
     aiodns
     aiohttp
     certifi

--- a/pkgs/development/python-modules/vsts/default.nix
+++ b/pkgs/development/python-modules/vsts/default.nix
@@ -16,6 +16,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ msrest ];
 
+  postPatch = ''
+    substituteInPlace setup.py --replace "msrest>=0.6.0,<0.7.0" "msrest"
+  '';
+
   # Tests are highly impure
   checkPhase = ''
     ${python.interpreter} -c 'import vsts.version; print(vsts.version.VERSION)'


### PR DESCRIPTION
###### Description of changes

This updates `msrest` to the [newest version](https://github.com/Azure/msrest-for-python). 
Due to a change upstream, `msrest` now depends on  `azure-core`. This leads to a circular dependency, since `azure-core` depends (for the checks) on `msrest`. Therefore, `msrest` was removed from `checkInputs` in `azure-core`

Also, the update is necessary for `pgadmin4` to build again. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
