### PR TITLE
Add note/warning about wipefs if older filesystem signatures were left during installation

### DIFF
--- a/nixos/doc/manual/from_md/installation/installing.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/installing.chapter.xml
@@ -209,6 +209,19 @@ OK
 </programlisting>
         </listitem>
       </orderedlist>
+      <note>
+        <para>
+          It can be recommended to run a <literal>wipefs -a</literal> on
+          the boot ESP partition, in order to remove any left
+          signatures, if any previous mkfs was run on the ESP. Failling
+          to do so will lead to a failure in any bootloader installation
+          during <literal>nixos-install</literal>. GRUB will fail when
+          calling <literal>blkid</literal> with the error
+          <literal>Unknown filesystem</literal>,
+          <literal>systemd-boot</literal> also fails with another kind
+          of error.
+        </para>
+      </note>
       <para>
         Once complete, you can follow with
         <xref linkend="sec-installation-partitioning-formatting" />.

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -157,6 +157,14 @@ update /etc/fstab.
     # parted /dev/sda -- set 3 esp on
     ```
 
+::: {.note}
+It can be recommended to run a `wipefs -a` on the boot ESP partition, in order to
+remove any left signatures, if any previous mkfs was run on the ESP. Failling to
+do so will lead to a failure in any bootloader installation during `nixos-install`.
+GRUB will fail when calling `blkid` with the error `Unknown filesystem`, `systemd-boot`
+also fails with another kind of error.
+:::
+
 Once complete, you can follow with
 [](#sec-installation-partitioning-formatting).
 


### PR DESCRIPTION
###### Description of changes

I've run into a bug where after having create a ZFS pool on `/dev/sda1`, destroyed it and then ran `mkfs.fat` on `/dev/sda1`, no bootloader could be installed, all of my attempt at making `nixos-install` work, bluntly failed when installing the booloader.

Investigating this issue, with the help of folks from NixOS official Matrix, led me to discover that ZFS left signatures, that the `mkfs.fat` didn't overwrite.

Hence, my proposal for this note in the official manual.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
