### PR TITLE
ipaexfont: use mkDerivation

### DIFF
--- a/pkgs/data/fonts/ipaexfont/default.nix
+++ b/pkgs/data/fonts/ipaexfont/default.nix
@@ -13,7 +13,11 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
+
     install -D -m 644 -t "$out/share/fonts/truetype" *.ttf
+
+    runHook postInstall
   '';
 
   outputHashMode = "recursive";

--- a/pkgs/data/fonts/ipaexfont/default.nix
+++ b/pkgs/data/fonts/ipaexfont/default.nix
@@ -1,16 +1,23 @@
-{ lib, fetchzip }:
+{ lib, stdenv, fetchzip }:
 
-fetchzip {
-  name = "ipaexfont-004.01";
+stdenv.mkDerivation {
+  pname = "ipaexfont";
+  version = "4.01";
 
-  url = "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip";
+  src = fetchzip {
+    url = "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip";
+    hash = "sha256-/87qJIb+v4qrtDy+ApfXxh59reOk+6RhGqFN98mc+8Q=";
+  };
 
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/opentype
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -D -m 644 -t "$out/share/fonts/truetype" *.ttf
   '';
 
-  sha256 = "0wp369kri33kb1mmiq4lpl9i4xnacw9fj63ycmkmlkq64s8qnjnx";
+  outputHashMode = "recursive";
+  outputHash = "sha256-11NYDZ3umJqU+oqkfJgrmNHb5nJmOM0ShuAmhCZ+fb4=";
 
   meta = with lib; {
     description = "Japanese font package with Mincho and Gothic fonts";


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/issues/103997#issuecomment-1258186428

Changed `$out/share/fonts/opentype` to `$out/share/fonts/truetype` as the font is in .ttf format.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
