### PR TITLE
squid: enable tests

### DIFF
--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, perl, openldap, pam, db, cyrus_sasl, libcap
 , expat, libxml2, openssl, pkg-config, systemd
+, cppunit
 }:
 
 stdenv.mkDerivation rec {
@@ -31,6 +32,22 @@ stdenv.mkDerivation rec {
     "--enable-htcp"
   ] ++ lib.optional (stdenv.isLinux && !stdenv.hostPlatform.isMusl)
     "--enable-linux-netfilter";
+
+  doCheck = true;
+  checkInputs = [ cppunit ];
+  preCheck = ''
+    # tests attempt to copy around "/bin/true" to make some things
+    # no-ops but this doesn't work if our "true" is a multi-call
+    # binary, so make our own fake "true" which will work when used
+    # this way
+    echo "#!$SHELL" > fake-true
+    chmod +x fake-true
+    grep -rlF '/bin/true' test-suite/ | while read -r filename ; do
+      substituteInPlace "$filename" \
+        --replace "$(type -P true)" "$(realpath fake-true)" \
+        --replace "/bin/true" "$(realpath fake-true)"
+    done
+  '';
 
   meta = with lib; {
     description = "A caching proxy for the Web supporting HTTP, HTTPS, FTP, and more";


### PR DESCRIPTION
###### Description of changes

This is nice to have seeing as we don't (yet) have a squid nixos test.

Needed a small amount of fiddling due to its misuse of `/bin/true`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
