### PR TITLE
go-jsonnet: fix aarch64-darwin build

### DIFF
--- a/pkgs/development/compilers/go-jsonnet/default.nix
+++ b/pkgs/development/compilers/go-jsonnet/default.nix
@@ -1,4 +1,9 @@
-{ lib, buildGoModule, fetchFromGitHub, testers }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, fetchpatch
+, testers
+}:
 
 let self = buildGoModule rec {
   pname = "go-jsonnet";
@@ -6,12 +11,20 @@ let self = buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "google";
-    repo = "go-jsonnet";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-o/IjXskGaMhvQmTsAS745anGBMI2bwHf/EOEp57H8LU=";
+    hash = "sha256-o/IjXskGaMhvQmTsAS745anGBMI2bwHf/EOEp57H8LU=";
   };
 
-  vendorSha256 = "sha256-fZBhlZrLcC4xj5uvb862lBOczGnJa9CceS3D8lUhBQo=";
+  patches = [
+    (fetchpatch {
+      name = "update-x-sys-for-go-1.18-on-aarch64-darwin.patch";
+      url = "https://github.com/google/go-jsonnet/commit/7032dd729f7e684dcfb2574f4fe99499165ef9cb.patch";
+      hash = "sha256-emUcuE9Q4qkXFXLyLvLHjzrKAaQhjcSWLNafABvHxhM=";
+    })
+  ];
+
+  vendorHash = "sha256-H4vLVXpuPkECB15LHoS9N9IwUD7Fzccshwbo5hjeXXc=";
 
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes

Fixes a known issue in which golang.org/x/sys has to be updated when building using Go 1.18+ on aarch64-darwin. I verified locally that this works with Go 1.18 and Go 1.19.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
