### PR TITLE
tzdata: enable cross-compilation for Windows

### DIFF
--- a/pkgs/data/misc/tzdata/0001-Add-exe-extension-for-MS-Windows-binaries.patch
+++ b/pkgs/data/misc/tzdata/0001-Add-exe-extension-for-MS-Windows-binaries.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index a9a989e..4da737b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -579,8 +579,8 @@ install:	all $(DATA) $(REDO) $(MANS)
+ 			-t '$(DESTDIR)$(TZDEFAULT)'
+ 		cp -f $(TABDATA) '$(DESTDIR)$(TZDIR)/.'
+ 		cp tzselect '$(DESTDIR)$(BINDIR)/.'
+-		cp zdump '$(DESTDIR)$(ZDUMPDIR)/.'
+-		cp zic '$(DESTDIR)$(ZICDIR)/.'
++		cp zdump.exe '$(DESTDIR)$(ZDUMPDIR)/.'
++		cp zic.exe '$(DESTDIR)$(ZICDIR)/.'
+ 		cp libtz.a '$(DESTDIR)$(LIBDIR)/.'
+ 		$(RANLIB) '$(DESTDIR)$(LIBDIR)/libtz.a'
+ 		cp -f newctime.3 newtzset.3 '$(DESTDIR)$(MANDIR)/man3/.'

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
+  patches = lib.optionals stdenv.hostPlatform.isWindows [
+    ./0001-Add-exe-extension-for-MS-Windows-binaries.patch
+  ];
+
   outputs = [ "out" "bin" "man" "dev" ];
   propagatedBuildOutputs = [];
 
@@ -34,22 +38,17 @@ stdenv.mkDerivation rec {
     "CFLAGS+=-DZIC_BLOAT_DEFAULT=\\\"fat\\\""
     "cc=${stdenv.cc.targetPrefix}cc"
     "AR=${stdenv.cc.targetPrefix}ar"
+  ] ++ lib.optionals stdenv.hostPlatform.isWindows [
+    "CFLAGS+=-DHAVE_DIRECT_H"
+    "CFLAGS+=-DHAVE_SYMLINK=0"
+    "CFLAGS+=-DRESERVE_STD_EXT_IDS"
   ];
-
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   doCheck = false; # needs more tools
 
-  installFlags = [ "ZIC=./zic-native" ];
-
-  preInstall = ''
-     mv zic.o zic.o.orig
-     mv zic zic.orig
-     make $makeFlags cc=${stdenv.cc.nativePrefix}cc AR=${stdenv.cc.nativePrefix}ar zic
-     mv zic zic-native
-     mv zic.o.orig zic.o
-     mv zic.orig zic
-  '';
+  installFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "zic=${buildPackages.tzdata.bin}/bin/zic"
+  ];
 
   postInstall =
     ''


### PR DESCRIPTION
###### Description of changes

Cross-compilation from Linux to Windows failed (e.g. `nix-build -A pkgsCross.mingwW64.tzdata`). This PR addresses these issues to fix cross-compilation for Windows:

  * Additional make flags are needed since some functions do not exist  
    or have different names or parameters on Windows.

  * When compiling for Windows, GCC implicitly adds a `.exe` suffix to    
    the output file name. A patch is needed for the `install` target    
    to locate and install the correct files.    
    
  * The tzdata Makefile contains `zic` and `ZIC` variables. The former    
    refers to the path of the program to execute, while the latter    
    invokes the former with additional arguments (it is defined as    
    `ZIC=$(zic) $(ZFLAGS)`, `ZFLAGS` is normally empty).    
    
    Previously, `ZIC` was overridden, potentially loosing `ZFLAGS`    
    arguments. This commit changes it to override `zic` instead.    
    
  * The `zic` program is built and installed as part of the package and    
    also executed during the build to translate time-related files. When    
    cross-compiling it means that two executables need to be compiled:    
    one to get installed and run on the host platform, and another to    
    run on the build platform. Instead of renaming files and building a    
    temporary executable for the build platform, this commit references    
    the build platform's `tzdata.bin` package and runs its `zic`    
    program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Successfully tested `zic.exe` with `wine`. It produces the same output as the native `zic`.
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Ping maintainers: @ajs124 @fpletz 

In principle, it would be nice to avoid the patch and fix the upstream. However, I don't know an easy way to check for cross-compilation and the GCC output file suffix dependent on the host platform. GNU autotools provide [EXEEXT](https://www.gnu.org/software/automake/manual/html_node/EXEEXT.html) for this reason, but tzdata uses a pure Makefile.