### PR TITLE
home-assistant-cli: 0.9.4 -> 0.9.5

### DIFF
--- a/pkgs/servers/home-assistant/cli.nix
+++ b/pkgs/servers/home-assistant/cli.nix
@@ -1,28 +1,18 @@
 { lib
+, fetchFromGitHub
 , python3
 }:
 
-let
-  python = python3.override {
-    packageOverrides = self: super: {
-      click = super.click.overrideAttrs (oldAttrs: rec {
-        version = "8.0.4";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "sha256-hFjXsSh8X7EoyQ4jOBz5nc3nS+r2x/9jhM6E1v4JCts=";
-        };
-      });
-    };
-  };
-in
-
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "homeassistant-cli";
-  version = "0.9.4";
+  version = "0.9.5";
+  format = "setuptools";
 
-  src = python3.pkgs.fetchPypi {
-    inherit pname version;
-    sha256 = "03kiyqpp3zf8rg30d12h4fapihh0rqwpv5p8jfxb3iq0chfmjx2f";
+  src = fetchFromGitHub {
+    owner = "home-assistant-ecosystem";
+    repo = "home-assistant-cli";
+    rev = version;
+    hash = "sha256-gtyW5FnpzUv/3TuBZ0LJXPxeQAkl7bf8M+K6RNATVm0=";
   };
 
   postPatch = ''
@@ -30,7 +20,7 @@ python.pkgs.buildPythonApplication rec {
     sed -i "s/'\(.*\)\(==\|>=\).*'/'\1'/g" setup.py
   '';
 
-  propagatedBuildInputs = with python.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     aiohttp
     click
     click-log
@@ -44,17 +34,23 @@ python.pkgs.buildPythonApplication rec {
     tabulate
   ];
 
-  # Completion needs to be ported to work with click > 8.0
-  # https://github.com/home-assistant-ecosystem/home-assistant-cli/issues/367
+  # TODO: Completion needs to be adapted after support for latest click was added
+  # $ source <(_HASS_CLI_COMPLETE=bash_source hass-cli) # for bash
+  # $ source <(_HASS_CLI_COMPLETE=zsh_source hass-cli)  # for zsh
+  # $ eval (_HASS_CLI_COMPLETE=fish_source hass-cli)    # for fish
   #postInstall = ''
   #  mkdir -p "$out/share/bash-completion/completions" "$out/share/zsh/site-functions"
   #  $out/bin/hass-cli completion bash > "$out/share/bash-completion/completions/hass-cli"
   #  $out/bin/hass-cli completion zsh > "$out/share/zsh/site-functions/_hass-cli"
   #'';
 
-  checkInputs = with python.pkgs; [
+  checkInputs = with python3.pkgs; [
     pytestCheckHook
     requests-mock
+  ];
+
+  pythonImportsCheck = [
+    "homeassistant_cli"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
https://github.com/home-assistant-ecosystem/home-assistant-cli/releases/tag/0.9.5
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
