### PR TITLE
basiliskii: unstable-2022-04-05 -> 2022-09-30

### DIFF
--- a/pkgs/applications/emulators/basiliskii/default.nix
+++ b/pkgs/applications/emulators/basiliskii/default.nix
@@ -1,13 +1,13 @@
 { stdenv, lib, fetchFromGitHub, autoconf, automake, pkg-config, SDL2, gtk2 }:
 stdenv.mkDerivation {
   pname = "basiliskii";
-  version = "unstable-2022-04-05";
+  version = "unstable-2022-09-30";
 
   src = fetchFromGitHub {
     owner = "kanjitalk755";
     repo = "macemu";
-    rev = "d4baa318e49a29d7ea5fc71a637191d6c470546f";
-    sha256 = "jBKTC2fIPJ6mSkMABNxcd2ujXJ+duCXw291iz5ZmiVg=";
+    rev = "2fa17a0783cf36ae60b77b5ed930cda4dc1824af";
+    sha256 = "+jkns6H2YjlewbUzgoteGSQYWJL+OWVu178aM+BtABM=";
   };
   sourceRoot = "source/BasiliskII/src/Unix";
   patches = [ ./remove-redhat-6-workaround-for-scsi-sg.h.patch ];


### PR DESCRIPTION
###### Description of changes

The project does not have a changelog, but here are the recent commits: [https://github.com/kanjitalk755/macemu/commits/master](https://github.com/kanjitalk755/macemu/commits/master). Note: the git repo has two separate emulators, Basilisk (this package) and SheepShaver (not included in this package).

The changes include: XDG dir support, SDL 1.2 build fixes, and updated the default key-codes.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
