### PR TITLE
exact-audio-copy: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1922,6 +1922,12 @@
     githubId = 2506621;
     name = "Brayden Willenborg";
   };
+  brendanreis = {
+    email = "brendanreis@gmail.com";
+    name = "Brendan Reis";
+    github = "brendanreis";
+    githubId = 10686906;
+  };
   brian-dawn = {
     email = "brian.t.dawn@gmail.com";
     github = "brian-dawn";

--- a/pkgs/applications/audio/exact-audio-copy/default.nix
+++ b/pkgs/applications/audio/exact-audio-copy/default.nix
@@ -71,9 +71,7 @@ let
   };
 in
 symlinkJoin {
-  inherit pname;
-  name = pname;
-  inherit version;
+  name = "${pname}-${version}";
 
   paths = [ wrapper desktopItem ];
 

--- a/pkgs/applications/audio/exact-audio-copy/default.nix
+++ b/pkgs/applications/audio/exact-audio-copy/default.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchurl
+, makeDesktopItem
+, imagemagick
+, p7zip
+, wine
+, writeShellScriptBin
+, symlinkJoin
+, use64 ? false
+}:
+
+let
+  pname = "exact-audio-copy";
+  version = "1.6.0";
+
+  eac_exe = fetchurl {
+    url = "http://www.exactaudiocopy.de/eac-${lib.versions.majorMinor version}.exe";
+    sha256 = "8291d33104ebab2619ba8d85744083e241330a286f5bd7d54c7b0eb08f2b84c1";
+  };
+
+  cygwin_dll = fetchurl {
+    url = "https://cygwin.com/snapshots/x86/cygwin1-20220301.dll.xz";
+    sha256 = "0zxn0r5q69fhciy0mrplhxj1hxwy3sq4k1wdy6n6kyassm4zyz1x";
+  };
+
+  patched_eac = stdenv.mkDerivation {
+    pname = "patched_eac";
+    inherit version;
+
+    nativeBuildInputs = [
+      imagemagick
+      p7zip
+    ];
+
+    buildCommand = ''
+      mkdir -p $out
+      _tmp=$(mktemp -d)
+      cd $_tmp
+      7z x -aoa ${eac_exe}
+      chmod -R 755 .
+      cp ${cygwin_dll} cygwin1.dll.xz
+      xz --decompress cygwin1.dll.xz
+      mv cygwin1.dll CDRDAO/
+      cp -r * $out
+      7z x EAC.exe
+      convert .rsrc/1033/ICON/29.ico -thumbnail 128x128 -alpha on -background none -flatten "$out/eac.ico.128.png"
+    '';
+  };
+
+  wrapper = writeShellScriptBin pname ''
+    export WINEPREFIX="''${EXACT_AUDIO_COPY_HOME:-"''${XDG_DATA_HOME:-"''${HOME}/.local/share"}/exact-audio-copy"}/wine"
+    export WINEARCH=${if use64 then "win64" else "win32"}
+    export WINEDLLOVERRIDES="mscoree=" # disable mono
+    export WINEDEBUG=-all
+    if [ ! -d "$WINEPREFIX" ] ; then
+      mkdir -p "$WINEPREFIX"
+      ${wine}/bin/wineboot -u
+    fi
+
+    exec ${wine}/bin/wine ${patched_eac}/EAC.exe "$@"
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    comment = "Audio Grabber for CDs";
+    desktopName = "Exact Audio Copy";
+    categories = [ "Audio" "AudioVideo" ];
+    icon = "${patched_eac}/eac.ico.128.png";
+  };
+in
+symlinkJoin {
+  inherit pname;
+  name = pname;
+  inherit version;
+
+  paths = [ wrapper desktopItem ];
+
+  meta = with lib; {
+    description = "A precise CD audio grabber for creating perfect quality rips using CD and DVD drives";
+    homepage = "https://www.exactaudiocopy.de/";
+    changelog = "https://www.exactaudiocopy.de/en/index.php/resources/whats-new/whats-new/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.brendanreis ];
+    platforms = wine.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6261,6 +6261,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  exactaudiocopy = callPackage ../applications/audio/exact-audio-copy { };
+
   exempi = callPackage ../development/libraries/exempi {
     stdenv = if stdenv.isDarwin then stdenv
              else if stdenv.isi686 then gcc6Stdenv


### PR DESCRIPTION
###### Description of changes
"Audio grabber" for CDs that is capable of perfect rips.
https://www.exactaudiocopy.de/

I followed the examples set by the Arch AUR PKGBUILD and the winbox package here:
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=exact-audio-copy
https://github.com/NixOS/nixpkgs/blob/350fd0044447ae8712392c6b212a18bdf2433e71/pkgs/tools/admin/winbox/default.nix

This is my first package and it took some time to get it working, so any feedback is greatly appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
