### PR TITLE
python3Packages.tox: drop toml, use tomli for Python < 3.11

### DIFF
--- a/pkgs/development/python-modules/tox/default.nix
+++ b/pkgs/development/python-modules/tox/default.nix
@@ -4,10 +4,11 @@
 , packaging
 , pluggy
 , py
+, python
 , six
 , virtualenv
 , setuptools-scm
-, toml
+, tomli
 , filelock
 }:
 
@@ -16,7 +17,8 @@ buildPythonPackage rec {
   version = "3.26.0";
 
   buildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ packaging pluggy py six virtualenv toml filelock ];
+  propagatedBuildInputs = [ packaging pluggy py six virtualenv filelock ]
+    ++ lib.optionals (python.pythonOlder "3.11") [ tomli ];
 
   doCheck = false;
 


### PR DESCRIPTION
In version 3.26.0, the tox package switched from using the toml library to using either tomli or the Python 3.11 built-in tomllib one; see e.g. https://github.com/tox-dev/tox/commit/6b76e18fcaa7c9610b642555bcb94aab1d37f2b3

For an example of Tox failing when trying to parse a pyproject.toml file without this change, see the tox-delay.nix file at https://gitlab.com/ppentchev/utf8-locale/-/commit/fb25e83decb3e349fcced0c368cd25e70c263f2b (passing `--arg pkgs 'import <nixpkgs> {}'` to nix-shell)

This is my first attempt to contribute to the Nix ecosystem, so, in all probability, I have not done everything right. Thanks in advance for your time and attention, and keep up the great work!

###### Description of changes

Drop toml from tox's build inputs, add tomli instead for Python < 3.11.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: apache-airflow, devpi-server, privacyIDEA, and skyfield failed for unrelated reasons.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

