### PR TITLE
ocamlPackages.caqti: 1.8.0 → 1.9.1

### DIFF
--- a/pkgs/development/ocaml-modules/caqti/async.nix
+++ b/pkgs/development/ocaml-modules/caqti/async.nix
@@ -2,7 +2,6 @@
 
 buildDunePackage {
   pname = "caqti-async";
-  useDune2 = true;
   inherit (caqti) version src;
 
   propagatedBuildInputs = [ async_kernel async_unix caqti core_kernel ];

--- a/pkgs/development/ocaml-modules/caqti/default.nix
+++ b/pkgs/development/ocaml-modules/caqti/default.nix
@@ -1,19 +1,16 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml
+{ lib, fetchurl, buildDunePackage, ocaml
 , cppo, logs, ptime, uri, bigstringaf
 , re, cmdliner, alcotest }:
 
 buildDunePackage rec {
   pname = "caqti";
-  version = "1.8.0";
-  useDune2 = true;
+  version = "1.9.1";
 
-  minimumOCamlVersion = "4.04";
+  minimalOCamlVersion = "4.04";
 
-  src = fetchFromGitHub {
-    owner = "paurkedal";
-    repo = "ocaml-${pname}";
-    rev = "v${version}";
-    sha256 = "sha256-8uKlrq9j1Z3QzkCyoRIn2j6wCdGyo7BY7XlbFHN1xVE=";
+  src = fetchurl {
+    url = "https://github.com/paurkedal/ocaml-caqti/releases/download/v${version}/caqti-v${version}.tbz";
+    sha256 = "sha256-PQBgJBNx3IcE6/vyNIf26a2xStU22LBhff8eM6UPaJ4=";
   };
 
   nativeBuildInputs = [ cppo ];

--- a/pkgs/development/ocaml-modules/caqti/driver-mariadb.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-mariadb.nix
@@ -2,7 +2,6 @@
 
 buildDunePackage {
   pname = "caqti-driver-mariadb";
-  useDune2 = true;
   inherit (caqti) version src;
 
   propagatedBuildInputs = [ caqti mariadb ];

--- a/pkgs/development/ocaml-modules/caqti/driver-postgresql.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-postgresql.nix
@@ -2,7 +2,6 @@
 
 buildDunePackage {
   pname = "caqti-driver-postgresql";
-  useDune2 = true;
   inherit (caqti) version src;
 
   propagatedBuildInputs = [ caqti postgresql ];

--- a/pkgs/development/ocaml-modules/caqti/driver-sqlite3.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-sqlite3.nix
@@ -2,7 +2,6 @@
 
 buildDunePackage {
   pname = "caqti-driver-sqlite3";
-  useDune2 = true;
   inherit (caqti) version src;
 
   propagatedBuildInputs = [ caqti ocaml_sqlite3 ];

--- a/pkgs/development/ocaml-modules/caqti/dynload.nix
+++ b/pkgs/development/ocaml-modules/caqti/dynload.nix
@@ -2,7 +2,6 @@
 
 buildDunePackage {
   pname = "caqti-dynload";
-  useDune2 = true;
   inherit (caqti) version src;
 
   propagatedBuildInputs = [ caqti ];

--- a/pkgs/development/ocaml-modules/caqti/lwt.nix
+++ b/pkgs/development/ocaml-modules/caqti/lwt.nix
@@ -2,7 +2,6 @@
 
 buildDunePackage {
   pname = "caqti-lwt";
-  useDune2 = true;
   inherit (caqti) version src;
 
   propagatedBuildInputs = [ caqti logs lwt ];

--- a/pkgs/development/ocaml-modules/caqti/type-calendar.nix
+++ b/pkgs/development/ocaml-modules/caqti/type-calendar.nix
@@ -2,9 +2,7 @@
 
 buildDunePackage {
   pname = "caqti-type-calendar";
-  version = "1.2.0";
-  useDune2 = true;
-  inherit (caqti) src;
+  inherit (caqti) src version;
 
   propagatedBuildInputs = [ calendar caqti ];
 


### PR DESCRIPTION
###### Description of changes

Fixes & improvements: https://github.com/paurkedal/ocaml-caqti/blob/v1.9.1/CHANGES.md#v191---2022-09-21

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
