### PR TITLE
nixos/s3fs-fuse: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1043,6 +1043,7 @@
   ./services/network-filesystems/orangefs/client.nix
   ./services/network-filesystems/orangefs/server.nix
   ./services/network-filesystems/rsyncd.nix
+  ./services/network-filesystems/s3fs-fuse.nix
   ./services/network-filesystems/samba-wsdd.nix
   ./services/network-filesystems/samba.nix
   ./services/network-filesystems/saunafs.nix

--- a/nixos/modules/services/network-filesystems/s3fs-fuse.nix
+++ b/nixos/modules/services/network-filesystems/s3fs-fuse.nix
@@ -1,0 +1,104 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.s3fs-fuse;
+
+  mountModule = lib.types.submodule {
+    options = {
+      mountPoint = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          The point where to mount the s3 filesystem. (second argument to s3fs)
+        '';
+        example = ''
+          "/mnt/s3"
+        '';
+      };
+
+      bucket = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          The name of the bucket you want to mount. (first argument to s3fs)
+        '';
+      };
+
+      useChattr = lib.mkEnableOption null // {
+        description = ''
+          Whether to use chattr to make the mount point immutable.
+          This is useful to prevent files being written to the mount point when it is not mounted.
+        '';
+      };
+
+      options = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          The options passed to the s3fs command
+        '';
+        example = ''
+          [
+            "passwd_file=/root/.passwd-s3fs"
+            "use_path_request_style"
+            "allow_other"
+            "url=https://s3.example.com/"
+          ]
+        '';
+      };
+    };
+  };
+in
+{
+  options = {
+    services.s3fs-fuse = {
+      enable = lib.mkEnableOption "s3fs-fuse mounts";
+
+      package = lib.mkPackageOption pkgs "s3fs" { example = [ "s3fs-fuse" ]; };
+
+      mounts = lib.mkOption {
+        type = lib.types.attrsOf mountModule;
+        description = ''
+          A set of the s3 filesystems you want to mount.
+          The name of the attribute is only used for naming the running service.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    systemd.services = lib.mapAttrs' (
+      name: mountSet:
+      let
+        mount = mountSet.mountPoint;
+        inherit (mountSet) bucket options;
+      in
+      lib.nameValuePair "s3fs-${name}" {
+        description = "S3FS mount";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStartPre =
+            [
+              "${pkgs.coreutils}/bin/mkdir -m 0500 -pv ${mount}"
+            ]
+            ++ lib.optional mountSet.useChattr (
+              "${pkgs.e2fsprogs}/bin/chattr +i ${mount}" # make mount point immutable so that it is not accidentally deleted
+            );
+          ExecStart =
+            "${cfg.package}/bin/s3fs ${bucket} ${mount} -f "
+            + lib.concatMapStringsSep " " (opt: "-o ${opt}") options;
+          ExecStopPost = "-${pkgs.fuse}/bin/fusermount -u ${mount}";
+          KillMode = "process";
+          Restart = "on-failure";
+        };
+      }
+    ) cfg.mounts;
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ alexnortung ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pull requests adds the module `services.s3fs-fuse`.
It is a systemd service based on the `s3fs-fuse` package.

The service configuration was inspired by a [discourse discussion](https://discourse.nixos.org/t/how-to-setup-s3fs-mount/6283) a couple years ago.

This module has been tested on my local system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
