### PR TITLE
xorg: remove xlibsWrapper attribute, use top-level one instead

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -64,6 +64,7 @@
 , systemd
 , taglib
 , unzip
+, xlibsWrapper
 , xorg
 , zlib
 , chromecastSupport ? true, libmicrodns, protobuf
@@ -149,6 +150,7 @@ stdenv.mkDerivation rec {
     srt
     systemd
     taglib
+    xlibsWrapper
     zlib
   ]
   ++ (with xorg; [
@@ -156,7 +158,6 @@ stdenv.mkDerivation rec {
     libXv
     libXvMC
     xcbutilkeysyms
-    xlibsWrapper
   ])
   ++ optional (!stdenv.hostPlatform.isAarch && !onlyLibVLC) live555
   ++ optional jackSupport libjack2

--- a/pkgs/applications/video/xine-ui/default.nix
+++ b/pkgs/applications/video/xine-ui/default.nix
@@ -12,6 +12,7 @@
 , readline
 , shared-mime-info
 , xine-lib
+, xlibsWrapper
 , xorg
 }:
 
@@ -46,6 +47,7 @@ stdenv.mkDerivation rec {
     ncurses
     readline
     xine-lib
+    xlibsWrapper
   ] ++ (with xorg; [
     libXext
     libXft
@@ -54,7 +56,6 @@ stdenv.mkDerivation rec {
     libXtst
     libXv
     libXxf86vm
-    xlibsWrapper
     xorgproto
   ]);
 

--- a/pkgs/desktops/gnome-2/platform/libgnomeui/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libgnomeui/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, libxml2, xorg, glib, pango
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, libxml2, xlibsWrapper, glib, pango
 , intltool, libgnome, libgnomecanvas, libbonoboui, GConf, libtool
 , gnome_vfs, libgnome-keyring, libglade }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config intltool ];
   buildInputs =
-    [ xorg.xlibsWrapper libxml2 GConf pango glib libgnome-keyring libglade libtool ];
+    [ xlibsWrapper libxml2 GConf pango glib libgnome-keyring libglade libtool ];
 
   propagatedBuildInputs = [ libgnome libbonoboui libgnomecanvas gnome_vfs ];
 }

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, pkg-config
 , libsndfile, libtool, makeWrapper, perlPackages
-, xorg, libcap, alsa-lib, glib, dconf
+, xlibsWrapper, xorg, libcap, alsa-lib, glib, dconf
 , avahi, libjack2, libasyncns, lirc, dbus
 , sbc, bluez5, udev, openssl, fftwFloat
 , soxr, speexdsp, systemd, webrtc-audio-processing
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (!libOnly) (
       [ libasyncns webrtc-audio-processing ]
       ++ lib.optional jackaudioSupport libjack2
-      ++ lib.optionals x11Support [ xorg.xlibsWrapper xorg.libXtst xorg.libXi ]
+      ++ lib.optionals x11Support [ xlibsWrapper xorg.libXtst xorg.libXi ]
       ++ lib.optional useSystemd systemd
       ++ lib.optionals stdenv.isLinux [ alsa-lib udev ]
       ++ lib.optional airtunesSupport openssl

--- a/pkgs/tools/typesetting/ted/default.nix
+++ b/pkgs/tools/typesetting/ted/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, zlib, pcre, xorg, libjpeg, libtiff, libpng, gtk2, libpaper, makeWrapper, ghostscript }:
+{ lib, stdenv, fetchurl, pkg-config, zlib, pcre, xlibsWrapper, xorg, libjpeg, libtiff, libpng, gtk2, libpaper, makeWrapper, ghostscript }:
 
 stdenv.mkDerivation rec {
   pname = "ted";
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
-  buildInputs = [ zlib pcre xorg.xlibsWrapper xorg.libXpm libjpeg libtiff libpng gtk2 libpaper ];
+  buildInputs = [ zlib pcre xlibsWrapper xorg.libXpm libjpeg libtiff libpng gtk2 libpaper ];
 
   meta = with lib; {
     description = "An easy rich text processor";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24111,7 +24111,7 @@ with pkgs;
     libdrm = if stdenv.isLinux then libdrm else null;
     abiCompat = config.xorg.abiCompat # `config` because we have no `xorg.override`
       or (if stdenv.isDarwin then "1.18" else null); # 1.19 needs fixing on Darwin
-  }) // { inherit xlibsWrapper; } );
+  }));
 
   xorg-autoconf = callPackage ../development/tools/misc/xorg-autoconf { };
 


### PR DESCRIPTION
###### Description of changes

xorg: remove xlibsWrapper attribute, use top-level one instead

I noticed this attribute when tried to override `xorg` scope via
overlay:

    final: prev {
      xorg = prev.xorg.overrideScope' (f: p: {
        libXfont2 = p.libXfont2.overrideAttrs (oa: {
          patches = (oa.patches or []) ++ [
            ../libXfont2/nofollow.patch
          ];
        });
      }) // { inherit (prev) xlibsWrapper; };
    }

As a result I got unexpected `pulseaudio` build failures:

    $ nix build --no-link -f. pulseaudio
    error: attribute 'xlibsWrapper' missing

           at pkgs/servers/pulseaudio/default.nix:79:37:

               78|       ++ lib.optional jackaudioSupport libjack2
               79|       ++ lib.optionals x11Support [ xorg.xlibsWrapper xorg.libXtst xorg.libXi ]
                 |                                     ^
               80|       ++ lib.optional useSystemd systemd

Previous changes in this branch remove references to xorg.xlibsWrapper
in favour of xlibsWrapper. Let's remove injection of this attribute into
`xorg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
