### PR TITLE
devpi-server: 6.2.0 -> 6.7.0

### DIFF
--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -1,49 +1,56 @@
-{ lib, fetchFromGitHub, python3, nginx }:
+{ lib, fetchFromGitHub, buildPythonApplication, isPy27
+, aiohttp
+, appdirs
+, beautifulsoup4
+, defusedxml
+, devpi-common
+, execnet
+, itsdangerous
+, nginx
+, packaging
+, passlib
+, platformdirs
+, pluggy
+, pyramid
+, pytest-flake8
+, pytestCheckHook
+, repoze_lru
+, setuptools
+, strictyaml
+, waitress
+, webtest
+}:
 
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-      # pyramid 2.0 no longer has a 'pyramid.compat' module
-      pyramid = super.pyramid.overridePythonAttrs (oldAttrs: rec {
-        version = "1.10.8";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "sha256-t81mWVvvkvgXZLl23d4rL6jk9fMl4C9l9ux/NwiynPY=";
-        };
-      });
-    };
-  };
 
-in with py.pkgs;
 buildPythonApplication rec {
   pname = "devpi-server";
-  version = "6.2.0";
+  version = "6.7.0";
+
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi";
-    rev = "68ee291ef29a93f6d921d4927aec8d13919b4a4c";
-    sha256 = "1ivd5dy9f2gq07w8n2gywa0n0d9wv8644l53ni9fz7i69jf8q2fm";
+    rev = "server-${version}";
+    hash = "sha256-tevQ/Ocusz2PythGnedP6r4xARgetVosAc8uTD49H3M=";
   };
 
   sourceRoot = "source/server";
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "pluggy>=0.6.0,<1.0" "pluggy>=0.6.0,<2.0"
-  '';
-
   propagatedBuildInputs = [
-    py
+    aiohttp
     appdirs
-    devpi-common
     defusedxml
+    devpi-common
     execnet
     itsdangerous
-    repoze_lru
+    packaging
     passlib
+    platformdirs
     pluggy
     pyramid
+    repoze_lru
+    setuptools
     strictyaml
     waitress
   ] ++ passlib.optional-dependencies.argon2;
@@ -51,10 +58,10 @@ buildPythonApplication rec {
   checkInputs = [
     beautifulsoup4
     nginx
-    pytestCheckHook
     pytest-flake8
+    pytestCheckHook
     webtest
-  ] ++ lib.optionals isPy27 [ mock ];
+  ];
 
   # root_passwd_hash tries to write to store
   # TestMirrorIndexThings tries to write to /var through ngnix

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13372,7 +13372,7 @@ with pkgs;
 
   devpi-client = python3Packages.callPackage ../development/tools/devpi-client {};
 
-  devpi-server = callPackage ../development/tools/devpi-server {};
+  devpi-server = python3Packages.callPackage ../development/tools/devpi-server {};
 
   dictu = callPackage ../development/compilers/dictu { };
 


### PR DESCRIPTION
###### Description of changes

bump devpi-server to 6.7.0, use tag `server-${version}` instead of commit, replace sha256 with hash, remove pyramid override, disable for python2, add new dependencies `aiohttp`, `platformdirs`,`packaging`, `setuptools` andevaluate package in `all-packages` with `python3Packages.callPackage` to make the dependencies overridable.

`devpi-common` is already at `6.7.0`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) - all `devpi-*` tools tested
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
