### PR TITLE
invoiceplane: 1.5.11 -> 1.6-beta-1

### DIFF
--- a/nixos/modules/services/web-apps/invoiceplane.nix
+++ b/nixos/modules/services/web-apps/invoiceplane.nix
@@ -36,10 +36,10 @@ let
     version = src.version;
     src = pkgs.invoiceplane;
 
-    patchPhase = ''
+    postPhase = ''
       # Patch index.php file to load additional config file
       substituteInPlace index.php \
-        --replace "require('vendor/autoload.php');" "require('vendor/autoload.php'); \$dotenv = new \Dotenv\Dotenv(__DIR__, 'extraConfig.php'); \$dotenv->load();";
+        --replace "require('vendor/autoload.php');" "require('vendor/autoload.php'); \$dotenv = Dotenv\Dotenv::createImmutable(__DIR__, 'extraConfig.php'); \$dotenv->load();";
     '';
 
     installPhase = ''

--- a/nixos/tests/invoiceplane.nix
+++ b/nixos/tests/invoiceplane.nix
@@ -13,12 +13,12 @@ import ./make-test-python.nix ({ pkgs, ... }:
       services.invoiceplane.webserver = "caddy";
       services.invoiceplane.sites = {
         "site1.local" = {
-          #database.name = "invoiceplane1";
+          database.name = "invoiceplane1";
           database.createLocally = true;
           enable = true;
         };
         "site2.local" = {
-          #database.name = "invoiceplane2";
+          database.name = "invoiceplane2";
           database.createLocally = true;
           enable = true;
         };

--- a/pkgs/servers/web-apps/invoiceplane/default.nix
+++ b/pkgs/servers/web-apps/invoiceplane/default.nix
@@ -2,43 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "invoiceplane";
-  version = "1.5.11";
+  version = "1.6-beta-1";
 
   src = fetchurl {
     url = "https://github.com/InvoicePlane/InvoicePlane/releases/download/v${version}/v${version}.zip";
-    sha256 = "137g0xps4kb3j7f5gz84ql18iggbya6d9dnrfp05g2qcbbp8kqad";
+    sha256 = "sha256-hIbk9zzqbwv2kSFClgPfTObB1YHj7KR4swKjGoN2v2E=";
   };
-
-  patches = [
-
-    # Fix CVE-2021-29024, unauthenticated directory listing
-    # Should be included in a later release > 1.5.11
-    # https://github.com/NixOS/nixpkgs/issues/166655
-    # https://github.com/InvoicePlane/InvoicePlane/pull/754
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/754.patch";
-      sha256 = "sha256-EHXw7Zqli/nA3tPIrhxpt8ueXvDtshz0XRzZT78sdQk=";
-    })
-
-    # Fix CVE-2021-29023, password reset rate-limiting
-    # Should be included in a later release > 1.5.11
-    # https://github.com/NixOS/nixpkgs/issues/166655
-    # https://github.com/InvoicePlane/InvoicePlane/pull/739
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/739.patch";
-      sha256 = "sha256-6ksJjW6awr3lZsDRxa22pCcRGBVBYyV8+TbhOp6HBq0=";
-    })
-
-    # Fix CVE-2021-29022, full path disclosure
-    # Should be included in a later release > 1.5.11
-    # https://github.com/NixOS/nixpkgs/issues/166655
-    # https://github.com/InvoicePlane/InvoicePlane/pull/767
-    #(fetchpatch {
-    #  url = "https://patch-diff.githubusercontent.com/raw/InvoicePlane/InvoicePlane/pull/767.patch";
-    #  sha256 = "sha256-rSWDH8KeHSRWLyQEa7RSwv+8+ja9etTz+6Q9XThuwUo=";
-    #})
-
-  ];
 
   nativeBuildInputs = [ unzip ];
 
@@ -46,7 +15,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/
-    cp -r . $out/
+    cp -r ip/. $out/
   '';
 
   passthru.tests = {


### PR DESCRIPTION
###### Description of changes

Packaging beta version which unbreaks the invoiceplane module and test since the last version doesn't support PHP8

Fixes https://github.com/NixOS/nixpkgs/issues/166655
Fixes https://github.com/NixOS/nixpkgs/pull/193159
Fixes https://github.com/NixOS/nixpkgs/pull/182557

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
