### PR TITLE
file-roller: remove unzip

### DIFF
--- a/pkgs/desktops/gnome/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome/apps/file-roller/default.nix
@@ -21,7 +21,6 @@
 , libarchive
 , libnotify
 , nautilus
-, unzip
 }:
 
 stdenv.mkDerivation rec {
@@ -67,13 +66,6 @@ stdenv.mkDerivation rec {
     chmod +x postinstall.py # patchShebangs requires executable file
     patchShebangs postinstall.py
     patchShebangs data/set-mime-type-entry.py
-  '';
-
-  preFixup = ''
-    # Workaround because of https://gitlab.gnome.org/GNOME/file-roller/issues/40
-    gappsWrapperArgs+=(
-      --prefix PATH : ${lib.makeBinPath [ unzip ]}
-    )
   '';
 
   passthru = {


### PR DESCRIPTION
###### Description of changes
 Unzip can't handle the filename encoding correctly and fails extracting some files.

Test file: [测试.txt.zip](https://github.com/NixOS/nixpkgs/files/9692632/txt.zip)

No matter 7zip, busybox, unzipNLS or bsdtar can extract the file correctly so look like unzip is just the worst choice. Busybox and unzipNLS can't display the filename correctly though.

@jtojnar Does the issue still exsit?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
