### PR TITLE
python310Packages.ibeacon-ble: init at 0.7.3, python310Packages.kegtron-ble: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/ibeacon-ble/default.nix
+++ b/pkgs/development/python-modules/ibeacon-ble/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, home-assistant-bluetooth
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "ibeacon-ble";
+  version = "0.7.3";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "Bluetooth-Devices";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-+DPbIIarEAaH1bNzo+FvLp0QpNUPhaJ8nPLdKJKfz0k=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    home-assistant-bluetooth
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --cov=ibeacon_ble --cov-report=term-missing:skip-covered" ""
+  '';
+
+  pythonImportsCheck = [
+    "ibeacon_ble"
+  ];
+
+  meta = with lib; {
+    description = "Library for iBeacon BLE devices";
+    homepage = "https://github.com/Bluetooth-Devices/ibeacon-ble";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/kegtron-ble/default.nix
+++ b/pkgs/development/python-modules/kegtron-ble/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, bluetooth-data-tools
+, bluetooth-sensor-state-data
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, sensor-state-data
+}:
+
+buildPythonPackage rec {
+  pname = "kegtron-ble";
+  version = "0.4.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "Bluetooth-Devices";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-O5I5shW8nL2RAQptS2Bp/GI/4L6o0xXXmwYvRq0MM8o=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    bluetooth-data-tools
+    bluetooth-sensor-state-data
+    sensor-state-data
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --cov=kegtron_ble --cov-report=term-missing:skip-covered" ""
+  '';
+
+  pythonImportsCheck = [
+    "kegtron_ble"
+  ];
+
+  meta = with lib; {
+    description = "Library for Kegtron BLE devices";
+    homepage = "https://github.com/Bluetooth-Devices/kegtron-ble";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4399,6 +4399,8 @@ in {
 
   iaqualink = callPackage ../development/python-modules/iaqualink { };
 
+  ibeacon-ble = callPackage ../development/python-modules/ibeacon-ble { };
+
   ibis = callPackage ../development/python-modules/ibis { };
 
   ibis-framework = callPackage ../development/python-modules/ibis-framework { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4988,6 +4988,8 @@ in {
 
   keepkey = callPackage ../development/python-modules/keepkey { };
 
+  kegtron-ble = callPackage ../development/python-modules/kegtron-ble { };
+
   keras-applications = callPackage ../development/python-modules/keras-applications { };
 
   keras = callPackage ../development/python-modules/keras { };


### PR DESCRIPTION
###### Description of changes

- Library for iBeacon BLE devices - https://github.com/Bluetooth-Devices/ibeacon-ble
- Library for Kegtron BLE devices - homepage = "https://github.com/Bluetooth-Devices/kegtron-ble
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
