### PR TITLE
python3Packages.flask-limiter: fix src non-reproducibility

### DIFF
--- a/pkgs/development/python-modules/flask-limiter/default.nix
+++ b/pkgs/development/python-modules/flask-limiter/default.nix
@@ -24,7 +24,10 @@ buildPythonPackage rec {
     owner = "alisaifee";
     repo = "flask-limiter";
     rev = version;
-    sha256 = "sha256-JjksKwSMWzcslXCs977/Wlq1wDMaACxm8e6Ub+r3wPg=";
+    sha256 = "sha256-M5JKpTTARNSp8jBv/ObqF08YTWcpgHzJMmBq5xDti5E=";
+    # unreproducible git_refnames in flask_limiter/_version.py
+    # https://github.com/NixOS/nixpkgs/issues/84312
+    forceFetchGit = true;
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Fixes another case of #84312

```diff
diff -aru prev/flask_limiter/_version.py new/flask_limiter/_version.py
--- prev/flask_limiter/_version.py	1969-12-31 19:00:01.000000000 -0500
+++ new/flask_limiter/_version.py	1969-12-31 19:00:01.000000000 -0500
@@ -24,9 +24,9 @@
     # setup.py/versioneer.py will grep for the variable names, so they must
     # each be defined on a line of their own. _version.py will just call
     # get_keywords().
-    git_refnames = " (tag: 2.6.2, stable)"
-    git_full = "f56d9c0af9930ee58d706bf7aabdf8751ded12e0"
-    git_date = "2022-08-24 09:35:12 -0700"
+    git_refnames = "$Format:%d$"
+    git_full = "$Format:%H$"
+    git_date = "$Format:%ci$"
     keywords = {"refnames": git_refnames, "full": git_full, "date": git_date}
     return keywords
 ```
```
error: hash mismatch in fixed-output derivation '/nix/store/x6gyxa3fbra4sa06wq43hvmf3g5isz6z-source.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-M5JKpTTARNSp8jBv/ObqF08YTWcpgHzJMmBq5xDti5E=
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
