### PR TITLE
python3Packages.sphinx-basic-ng: 0.0.1.a12 -> 1.0.0.beta1

### DIFF
--- a/pkgs/development/python-modules/sphinx-basic-ng/default.nix
+++ b/pkgs/development/python-modules/sphinx-basic-ng/default.nix
@@ -2,29 +2,20 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, fetchpatch
 , sphinx
 }:
 
 buildPythonPackage rec {
   pname = "sphinx-basic-ng";
-  version = "0.0.1.a12";
+  version = "1.0.0.beta1";
   disable = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pradyunsg";
     repo = "sphinx-basic-ng";
     rev = version;
-    sha256 = "sha256-3/a/xHPNO96GEMLgWGTLdFoojVsjNyxYgY1gAZr75S0=";
+    sha256 = "sha256-Zh9KvKs4js+AVSfIk0pAj6Kzq/O2m/MGTF+HCwYJTXk=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-import-error.patch";
-      url = "https://github.com/pradyunsg/sphinx-basic-ng/pull/32/commits/323a0085721b908aa11bc3c36c51e16f517ee023.patch";
-      sha256 = "sha256-/G1wLG/08u2s3YENSKSYekLrV1fUkxDAlxc3crTQNHk=";
-    })
-  ];
 
   propagatedBuildInputs = [
     sphinx


### PR DESCRIPTION
###### Description of changes
https://github.com/pradyunsg/sphinx-basic-ng/releases/tag/1.0.0.beta1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).