### PR TITLE
nautilus-open-any-terminal: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/tools/misc/nautilus-open-any-terminal/default.nix
+++ b/pkgs/tools/misc/nautilus-open-any-terminal/default.nix
@@ -15,13 +15,13 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "nautilus-open-any-terminal";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "Stunkymonkey";
     repo = pname;
     rev = version;
-    sha256 = "sha256-PF6DVpiAPL9NG4jK6wDqdqYw+26Nks/bGEbbaV/5aIs=";
+    sha256 = "sha256-EAI60Mw+OTPfjOS6lkGMul7QvTR7NXyNfevWY2JP1yI=";
   };
 
   patches = [ ./hardcode-gsettings.patch ];

--- a/pkgs/tools/misc/nautilus-open-any-terminal/hardcode-gsettings.patch
+++ b/pkgs/tools/misc/nautilus-open-any-terminal/hardcode-gsettings.patch
@@ -2,20 +2,20 @@ diff --git a/nautilus_open_any_terminal/open_any_terminal_extension.py b/nautilu
 index b02a995..a616399 100644
 --- a/nautilus_open_any_terminal/open_any_terminal_extension.py
 +++ b/nautilus_open_any_terminal/open_any_terminal_extension.py
-@@ -125,9 +125,10 @@ def set_terminal_args(*args):
+@@ -205,9 +205,10 @@ def set_terminal_args(*args):
  
- class OpenAnyTerminalShortcutProvider(GObject.GObject, Nautilus.LocationWidgetProvider):
-     def __init__(self):
--        source = Gio.SettingsSchemaSource.get_default()
--        if source.lookup(GSETTINGS_PATH, True):
--            self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
-+        source = Gio.SettingsSchemaSource.new_from_directory("@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True)
-+        if True:
-+            _schema = source.lookup(GSETTINGS_PATH, False)
-+            self._gsettings = Gio.Settings.new_full(_schema, None, None);
-             self._gsettings.connect("changed", self._bind_shortcut)
-             self._create_accel_group()
-         self._window = None
+     class OpenAnyTerminalShortcutProvider(GObject.GObject, Nautilus.LocationWidgetProvider):
+         def __init__(self):
+-            source = Gio.SettingsSchemaSource.get_default()
+-            if source.lookup(GSETTINGS_PATH, True):
+-                self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
++            source = Gio.SettingsSchemaSource.new_from_directory("@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True)
++            if True:
++                _schema = source.lookup(GSETTINGS_PATH, False)
++                self._gsettings = Gio.Settings.new_full(_schema, None, None);
+                 self._gsettings.connect("changed", self._bind_shortcut)
+                 self._create_accel_group()
+             self._window = None
 @@ -232,9 +233,10 @@ class OpenAnyTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
          return items
  
@@ -28,5 +28,4 @@ index b02a995..a616399 100644
 +    _schema = source.lookup(GSETTINGS_PATH, False)
 +    _gsettings = Gio.Settings.new_full(_schema, None, None);
      _gsettings.connect("changed", set_terminal_args)
-     value = _gsettings.get_string(GSETTINGS_TERMINAL)
-     if value in TERM_PARAMS:
+     set_terminal_args()


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
