### PR TITLE
nututils: init at unstable-2020-11-06

### DIFF
--- a/pkgs/by-name/nu/nututils/package.nix
+++ b/pkgs/by-name/nu/nututils/package.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, lib
+, fetchgit
+}:
+stdenv.mkDerivation rec {
+  pname = "nututils";
+  version = "unstable-2020-11-06";
+
+  src = fetchgit {
+    url = "https://git.ffmpeg.org/nut.git";
+    rev = "12f6a7af3e0f34fd957cf078b66f072d3dc695b3";
+    hash = "sha256-MlBSIQd3JklrtnImDmta72jpaBQbMOWHDEwgklYV9PE=";
+  };
+
+  sourceRoot = "${src.name}/src/trunk";
+  patches = [ ./prefix.patch ];
+  dontConfigure = true;
+  makeFlags = [ "prefix=$(out)" ];
+  installTargets = "install-nututils";
+
+  meta = {
+    description = "Utils for the NUT video container format";
+    homepage = "https://git.ffmpeg.org/gitweb/nut.git";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.quag ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/nu/nututils/prefix.patch
+++ b/pkgs/by-name/nu/nututils/prefix.patch
@@ -1,0 +1,10 @@
+diff --git a/config.mak b/config.mak
+index 7d88c34..65aa7b1 100644
+--- a/config.mak
++++ b/config.mak
+@@ -1,5 +1,3 @@
+-PREFIX = /usr/local
+-prefix = $(DESTDIR)$(PREFIX)
+ 
+ #CFLAGS += -DDEBUG
+ 


### PR DESCRIPTION
###### Description of changes
Command line utils for parsing, indexing and merging nut video containers. The nut container format is like mkv, avi, or mp4, and contains streams of video, audio, and subtitles. Ffmpeg (among others) developed the nut container format, and it provides the widest support for codecs the best support for seeking and error recovery.

https://git.ffmpeg.org/gitweb/nut.git/tree/HEAD:/src/trunk
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
