### PR TITLE
[staging-next] python3Packages.protobuf: fix drv version

### DIFF
--- a/pkgs/development/python-modules/sagemaker/default.nix
+++ b/pkgs/development/python-modules/sagemaker/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonRelaxDepsHook
 , attrs
 , boto3
 , google-pasta
@@ -27,6 +28,13 @@ buildPythonPackage rec {
     hash = "sha256-hs71bIoByh5S1ncsku+y4X2i0yU65FknJE05lEmnru4=";
   };
 
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRelaxDeps = [
+    # FIXME: Remove when >= 2.111.0
+    "attrs"
+    "protobuf"
+  ];
+
   propagatedBuildInputs = [
     attrs
     boto3
@@ -40,11 +48,6 @@ buildPythonPackage rec {
     smdebug-rulesconfig
     pandas
   ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "attrs==20.3.0" "attrs>=20.3.0"
-  '';
 
   postFixup = ''
     [ "$($out/bin/sagemaker-upgrade-v2 --help 2>&1 | grep -cim1 'pandas failed to import')" -eq "0" ]

--- a/pkgs/development/tools/misc/nrfutil/default.nix
+++ b/pkgs/development/tools/misc/nrfutil/default.nix
@@ -37,9 +37,12 @@ buildPythonApplication rec {
     nose
   ];
 
+  # Workaround: pythonRelaxDepsHook doesn't work for this.
   postPatch = ''
     mkdir test-reports
-    substituteInPlace requirements.txt --replace "libusb1==1.9.3" "libusb1"
+    substituteInPlace requirements.txt \
+      --replace "libusb1==1.9.3" "libusb1" \
+      --replace "protobuf >=3.17.3, < 4.0.0" "protobuf"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
TL;DR: Currently the `python3Packages.protobuf.version` is 3.21 but its output is actually 4.21, which cause suspicious breakages. This PR targets `staging-next` for the fix.

EDIT: I give up pinning it back to 3.20. Now I did the reverse: just correct version to 4.21 ~and fix build failure of dependent packages by unrestrict the protobuf requirement~. This should be fine according to https://github.com/NixOS/nixpkgs/pull/194112#issuecomment-1272271224

---

OLD ATTEMPT:

protobuf 3.21 coresponds with its python library 4.21, which diverges and causes many breakages. protobuf 3.20 is also the last version having the same version as its python library.

See: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates

Fixes #193997 and tested `electrum`.

Note that this will also break some packages requiring `protobuf >= 4`, like `biliass`. But using 4 breaks  
`touch` (https://github.com/pytorch/pytorch/issues/78362), `electrum` (https://github.com/spesmilo/electrum/issues/7833), `keepkey` (https://github.com/keepkey/python-keepkey/issues/146) and any packages containing a legacy generated `_pb2.py`.
I think pinning to 3.20 would cause less harm.

I'm still running nixpkgs-review to see how it goes.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
