### PR TITLE
losslesscut: 3.43.0 -> 3.46.2

### DIFF
--- a/pkgs/applications/video/losslesscut-bin/appimage.nix
+++ b/pkgs/applications/video/losslesscut-bin/appimage.nix
@@ -5,7 +5,7 @@ let
   nameRepo = "lossless-cut";
   nameCamel = "LosslessCut";
   name = "${pname}-${version}";
-  nameSource = "${nameCamel}-linux.AppImage";
+  nameSource = "${nameCamel}-linux-x86_64.AppImage";
   nameExecutable = "losslesscut";
   owner = "mifi";
   src = fetchurl {

--- a/pkgs/applications/video/losslesscut-bin/default.nix
+++ b/pkgs/applications/video/losslesscut-bin/default.nix
@@ -1,9 +1,9 @@
 { callPackage, stdenvNoCC, lib }:
 let
-  version = "3.43.0";
-  appimage = callPackage ./appimage.nix { inherit version; sha256 = "1xfr3i4gsi13wj374yr5idhgs0q71s4h33yxdr7b7xjdg2gb8lp1"; };
-  dmg = callPackage ./dmg.nix { inherit version; sha256 = "1axki47hrxx5m0hrmjpxcya091lahqfnh2pd3zhn5dd496slq8an"; };
-  windows = callPackage ./windows.nix { inherit version; sha256 = "1v00gym18hjxxm42dfqmw7vhwh8lgjz2jgv6fmg234npr3d43py5"; };
+  version = "3.46.2";
+  appimage = callPackage ./appimage.nix { inherit version; sha256 = "sha256-p+HscYsChR90JHdYjurY4OOHgveGXbJomz1klBCsF2Q="; };
+  dmg = callPackage ./dmg.nix { inherit version; sha256 = "sha256-350MHWwyjCdvIv6W6lX6Hr6PLDiAwO/e+KW0yKi/Yoc="; };
+  windows = callPackage ./windows.nix { inherit version; sha256 = "sha256-48ifhvIWSPmmnBnW8tP7NeWPIWJYWNqGP925O50CAwQ="; };
 in (
   if stdenvNoCC.isDarwin then dmg
   else if stdenvNoCC.isCygwin then windows

--- a/pkgs/applications/video/losslesscut-bin/dmg.nix
+++ b/pkgs/applications/video/losslesscut-bin/dmg.nix
@@ -4,7 +4,7 @@ let
   pname = "losslesscut";
   nameRepo = "lossless-cut";
   nameCamel = "LosslessCut";
-  nameSource = "${nameCamel}-mac.dmg";
+  nameSource = "${nameCamel}-mac-x64.dmg";
   nameApp = nameCamel + ".app";
   owner = "mifi";
   src = fetchurl {

--- a/pkgs/applications/video/losslesscut-bin/windows.nix
+++ b/pkgs/applications/video/losslesscut-bin/windows.nix
@@ -1,7 +1,7 @@
 { stdenvNoCC
 , lib
 , fetchurl
-, unzip
+, p7zip
 , version
 , sha256
 , useMklink ? false
@@ -11,8 +11,8 @@ let
   pname = "losslesscut";
   nameRepo = "lossless-cut";
   nameCamel = "LosslessCut";
-  nameSourceBase = "${nameCamel}-win";
-  nameSource = "${nameSourceBase}.zip";
+  nameSourceBase = "${nameCamel}-win-x64";
+  nameSource = "${nameSourceBase}.7z";
   nameExecutable = "${nameCamel}.exe";
   owner = "mifi";
   getSymlinkCommand = if (customSymlinkCommand != null) then customSymlinkCommand
@@ -27,10 +27,10 @@ in stdenvNoCC.mkDerivation {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [ p7zip ];
 
   unpackPhase = ''
-    unzip $src -d ${nameSourceBase}
+    7z x $src -o${nameSourceBase}
   '';
 
   sourceRoot = nameSourceBase;


### PR DESCRIPTION
###### Description of changes
Upstream changelog:
- [`3.43.0` => `3.44.0`](https://github.com/mifi/lossless-cut/releases/tag/v3.44.0)
- [`3.44.0` => `3.45.0`](https://github.com/mifi/lossless-cut/releases/tag/v3.45.0)
- [`3.45.0` => `3.46.2`](https://github.com/mifi/lossless-cut/releases/tag/v3.46.2)

###### Things done

I could only test the Linux version, but this MR also covers Mac and Windows versions.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
