### PR TITLE
j2cli: add builders

### DIFF
--- a/pkgs/development/python-modules/j2cli/default.nix
+++ b/pkgs/development/python-modules/j2cli/default.nix
@@ -1,4 +1,5 @@
 { lib
+, pkgs
 , buildPythonPackage
 , fetchPypi
 , jinja2
@@ -18,6 +19,8 @@ buildPythonPackage rec {
   doCheck = false; # tests aren't installed thus aren't found, so skip
   propagatedBuildInputs = [ jinja2 pyyaml setuptools ];
 
+  passthru = import ./generators.nix { inherit lib pkgs; };
+
   meta = with lib; {
     homepage = "https://github.com/kolypto/j2cli";
     description = "Jinja2 Command-Line Tool";
@@ -26,7 +29,7 @@ buildPythonPackage rec {
       J2Cli is a command-line tool for templating in shell-scripts,
       leveraging the Jinja2 library.
     '';
-    maintainers = with maintainers; [ rushmorem SuperSandro2000 ];
+    maintainers = with maintainers; [ rushmorem SuperSandro2000 pbsds ];
   };
 
 }

--- a/pkgs/development/python-modules/j2cli/generators.nix
+++ b/pkgs/development/python-modules/j2cli/generators.nix
@@ -1,0 +1,73 @@
+{ lib
+, pkgs
+}:
+
+rec {
+
+  # A selection of j2cli-based builders.
+  # These builders largely follow the format of pkgs.writeText{,File,Dir}
+
+  generateFile =
+    args_@{ name # derivation name
+          , data # j2cli data
+          , template  # j2cli template
+          , destination ? "" # $out suffix
+          , executable ? false # whether result is marked executable
+          , ...
+          }:
+    let
+      args = builtins.removeAttrs args_ [ "name" "data" "template" "destination" "executable" ];
+
+      dataFile = (pkgs.formats.json { }).generate "${name}-data.json" data;
+
+      templateFile = pkgs.writeText "${name}-template.j2" template;
+
+      dest = lib.escapeShellArg "${destination}";
+
+    in pkgs.runCommand name args ''
+      ${lib.optionalString (destination != "") ''
+        mkdir -p "$( dirname "$out"${dest} )"
+      ''}
+
+      ${pkgs.j2cli}/bin/j2 ${templateFile} ${dataFile} -f json -o "$out"${destination}
+
+      ${lib.optionalString executable ''
+        chmod +x "$out"${destination}
+      ''}
+    '';
+
+
+  # simpler version
+
+  generate = name: data: template:
+    generateFile { inherit name data template; };
+
+
+  # simple version inside a directory
+
+  generateDir = name: data: template:
+    generateFile {
+      inherit name data template;
+      destination = "/${name}";
+    };
+
+
+  # executable version
+
+  generateScript = name: data: template:
+    generateFile {
+      inherit name data template;
+      executable = true;
+    };
+
+
+  # executable version inside /bin
+
+  generateScriptBin = name: data: template:
+    generateFile {
+      inherit name data template;
+      executable = true;
+      destination = "/bin/${name}";
+    };
+
+}


### PR DESCRIPTION
###### Description of changes

This change adds the following builders, whose naming is inspired by `pkgs.writeText`:

* `pkgs.j2cli.generateFile :: { name: String, data: Attrs, template: String, destination: String ? "", executable: Bool ? false} -> Derivation`
* `pkgs.j2cli.generate :: String -> Attrs -> String -> Derivation`
* `pkgs.j2cli.generateDir :: String -> Attrs -> String -> Derivation`
* `pkgs.j2cli.generateScript :: String -> Attrs -> String -> Derivation`
* `pkgs.j2cli.generateScriptBin :: String -> Attrs -> String -> Derivation`

Example usage:

```nix
pkgs.j2cli.generateDir "index.html" {
  urls  = lib.mapAttrsToList (k: v: k) config.services.nginx.virtualHosts;
} ''
  <DOCTYPE html>
  {{ for url in urls }}
    <a href="{{ url }}">{{ url }}</a><br>
  {{ endfor }}
''
```

**Something i will need help with:**

* Where I may document these
* Bikeshedding the function names

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

I thought i had seen an other package defining builders in its passthu, but i am now unable to find it, as i do not  remember the package name.