### PR TITLE
sbcl: refactor separate 2.*.nix into single file

### DIFF
--- a/pkgs/development/compilers/sbcl/2.0.8.nix
+++ b/pkgs/development/compilers/sbcl/2.0.8.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.0.8";
-  sha256 = "1xwrwvps7drrpyw3wg5h3g2qajmkwqs9gz0fdw1ns9adp7vld390";
-}

--- a/pkgs/development/compilers/sbcl/2.0.9.nix
+++ b/pkgs/development/compilers/sbcl/2.0.9.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.0.9";
-  sha256 = "17wvrcwgp45z9b6arik31fjnz7908qhr5ackxq1y0gqi1hsh1xy4";
-}

--- a/pkgs/development/compilers/sbcl/2.1.1.nix
+++ b/pkgs/development/compilers/sbcl/2.1.1.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.1.1";
-  sha256 = "15wa66sachhzgvg5n35vihmkpasg100lh561c1d1bdrql0p8kbd9";
-}

--- a/pkgs/development/compilers/sbcl/2.1.10.nix
+++ b/pkgs/development/compilers/sbcl/2.1.10.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.1.10";
-  sha256 = "0f5ihj486m7ghh3nc0jlnqa656sbqcmhdv32syz2rjx5b47ky67b";
-}

--- a/pkgs/development/compilers/sbcl/2.1.11.nix
+++ b/pkgs/development/compilers/sbcl/2.1.11.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.1.11";
-  sha256 = "1zgypmn19c58pv7j33ga7m1l7lzghj70w3xbybpgmggxwwflihdz";
-}

--- a/pkgs/development/compilers/sbcl/2.1.2.nix
+++ b/pkgs/development/compilers/sbcl/2.1.2.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.1.2";
-  sha256 = "sha256:02scrqyp2izsd8xjm2k5j5lhn4pdhd202jlcb54ysmcqjd80awdp";
-}

--- a/pkgs/development/compilers/sbcl/2.1.9.nix
+++ b/pkgs/development/compilers/sbcl/2.1.9.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.1.9";
-  sha256 = "189gjqzdz10xh3ybiy4ch1r98bsmkcb4hpnrmggd4y2g5kqnyx4y";
-}

--- a/pkgs/development/compilers/sbcl/2.2.4.nix
+++ b/pkgs/development/compilers/sbcl/2.2.4.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.2.4";
-  sha256 = "sha256-/N0lHLxl9/gI7QrXckaEjRvhZqppoX90mWABhLelcgI=";
-}

--- a/pkgs/development/compilers/sbcl/2.2.6.nix
+++ b/pkgs/development/compilers/sbcl/2.2.6.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.2.6";
-  sha256 = "sha256-PiMEjI+oJvuRMiC+sqw2l9vFwM3y6J/tjbOe0XEjBKA=";
-}

--- a/pkgs/development/compilers/sbcl/2.2.9.nix
+++ b/pkgs/development/compilers/sbcl/2.2.9.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "2.2.9";
-  sha256 = "sha256-fr69bSAj//cHewNy+hFx+IBSm97GEE8gmDKXwv63wXI=";
-}

--- a/pkgs/development/compilers/sbcl/2.x.nix
+++ b/pkgs/development/compilers/sbcl/2.x.nix
@@ -1,5 +1,3 @@
-{ version, sha256 }:
-
 { lib, stdenv, fetchurl, fetchpatch, writeText, sbclBootstrap, zstd
 , sbclBootstrapHost ? "${sbclBootstrap}/bin/sbcl --disable-debugger --no-userinit --no-sysinit"
 , threadSupport ? (stdenv.hostPlatform.isx86 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system)
@@ -11,7 +9,53 @@
 , purgeNixReferences ? false
 , coreCompression ? lib.versionAtLeast version "2.2.6"
 , texinfo
+, version
 }:
+
+let
+  versionMap = {
+    "2.0.8" = {
+      sha256 = "1xwrwvps7drrpyw3wg5h3g2qajmkwqs9gz0fdw1ns9adp7vld390";
+    };
+
+    "2.0.9" = {
+      sha256 = "17wvrcwgp45z9b6arik31fjnz7908qhr5ackxq1y0gqi1hsh1xy4";
+    };
+
+    "2.1.1" = {
+      sha256 = "15wa66sachhzgvg5n35vihmkpasg100lh561c1d1bdrql0p8kbd9";
+    };
+
+    "2.1.2" = {
+      sha256 = "sha256:02scrqyp2izsd8xjm2k5j5lhn4pdhd202jlcb54ysmcqjd80awdp";
+    };
+
+    "2.1.9" = {
+      sha256 = "189gjqzdz10xh3ybiy4ch1r98bsmkcb4hpnrmggd4y2g5kqnyx4y";
+    };
+
+    "2.1.10" = {
+      sha256 = "0f5ihj486m7ghh3nc0jlnqa656sbqcmhdv32syz2rjx5b47ky67b";
+    };
+
+    "2.1.11" = {
+      sha256 = "1zgypmn19c58pv7j33ga7m1l7lzghj70w3xbybpgmggxwwflihdz";
+    };
+
+    "2.2.4" = {
+      sha256 = "sha256-/N0lHLxl9/gI7QrXckaEjRvhZqppoX90mWABhLelcgI=";
+    };
+
+    "2.2.6" = {
+      sha256 = "sha256-PiMEjI+oJvuRMiC+sqw2l9vFwM3y6J/tjbOe0XEjBKA=";
+    };
+
+    "2.2.9" = {
+      sha256 = "sha256-fr69bSAj//cHewNy+hFx+IBSm97GEE8gmDKXwv63wXI=";
+    };
+  };
+
+in with versionMap.${version};
 
 stdenv.mkDerivation rec {
   pname = "sbcl";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14874,16 +14874,16 @@ with pkgs;
   sagittarius-scheme = callPackage ../development/compilers/sagittarius-scheme {};
 
   sbclBootstrap = callPackage ../development/compilers/sbcl/bootstrap.nix {};
-  sbcl_2_0_8 = callPackage ../development/compilers/sbcl/2.0.8.nix {};
-  sbcl_2_0_9 = callPackage ../development/compilers/sbcl/2.0.9.nix {};
-  sbcl_2_1_1 = callPackage ../development/compilers/sbcl/2.1.1.nix {};
-  sbcl_2_1_2 = callPackage ../development/compilers/sbcl/2.1.2.nix {};
-  sbcl_2_1_9 = callPackage ../development/compilers/sbcl/2.1.9.nix {};
-  sbcl_2_1_10 = callPackage ../development/compilers/sbcl/2.1.10.nix {};
-  sbcl_2_1_11 = callPackage ../development/compilers/sbcl/2.1.11.nix {};
-  sbcl_2_2_4 = callPackage ../development/compilers/sbcl/2.2.4.nix {};
-  sbcl_2_2_6 = callPackage ../development/compilers/sbcl/2.2.6.nix {};
-  sbcl_2_2_9 = callPackage ../development/compilers/sbcl/2.2.9.nix {};
+  sbcl_2_0_8 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.0.8"; };
+  sbcl_2_0_9 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.0.9"; };
+  sbcl_2_1_1 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.1"; };
+  sbcl_2_1_2 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.2"; };
+  sbcl_2_1_9 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.9"; };
+  sbcl_2_1_10 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.10"; };
+  sbcl_2_1_11 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.11"; };
+  sbcl_2_2_4 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.4"; };
+  sbcl_2_2_6 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.6"; };
+  sbcl_2_2_9 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.9"; };
   sbcl = sbcl_2_2_9;
 
   roswell = callPackage ../development/tools/roswell { };


### PR DESCRIPTION
###### Description of changes
Inspired by scala’s 2.x.nix, a bit lower in the same all-packages.nix file, I have combined all the separate SBCL build declarations into a single 2.x.nix file which you can call with the version as an argument.

Benefits:

- Less clutter in the filesystem
- Less indirection
- Cleaner overview of available versions

This yields no rebuilds on my machine.

The merge base for this PR should be master, but I've set it to staging anyway because this PR would otherwise conflict with another recently merged PR in staging (#193991).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
