### PR TITLE
elektroid: init at 2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2928,6 +2928,12 @@
       fingerprint = "D68C 8469 5C08 7E0F 733A  28D0 EEB8 D1CE 62C4 DFEA";
     }];
   };
+  dag-h = {
+    email = "dagharju@protonmail.com";
+    github = "dag-h";
+    githubId = 16627772;
+    name = "Dag Harju";
+  };
   dalance = {
     email = "dalance@gmail.com";
     github = "dalance";

--- a/pkgs/applications/misc/elektroid/default.nix
+++ b/pkgs/applications/misc/elektroid/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gtk3
+, wrapGAppsHook
+, autoreconfHook
+, pkg-config
+, gettext
+, json-glib
+, automake
+, autoconf
+, libtool
+, alsa-lib
+, libpulseaudio
+, libsndfile
+, libsamplerate
+, zlib
+, libjson
+, libzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "elektroid";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "dagargo";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "sha256-T7jxtmxlFe5WPC2KYDN6jDHwuVkmA6Y/h9qizZFH5rk=";
+  };
+
+  buildInputs = [
+    wrapGAppsHook
+    autoreconfHook
+    gtk3
+    pkg-config
+    gettext
+    json-glib
+    automake
+    autoconf
+    libtool
+    alsa-lib
+    libpulseaudio
+    libsndfile
+    libsamplerate
+    zlib
+    libjson
+    libzip
+  ];
+
+  meta = with lib; {
+    description = "Transfer application for Elektron devices";
+    homepage = "https://github.com/dagargo/elektroid";
+    maintainers = with maintainers; [ dag-h ];
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/applications/misc/elektroid/default.nix
+++ b/pkgs/applications/misc/elektroid/default.nix
@@ -30,16 +30,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-T7jxtmxlFe5WPC2KYDN6jDHwuVkmA6Y/h9qizZFH5rk=";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     wrapGAppsHook
     autoreconfHook
-    gtk3
     pkg-config
-    gettext
-    json-glib
     automake
     autoconf
     libtool
+  ];
+
+  buildInputs = [
+    gtk3
+    gettext
+    json-glib
     alsa-lib
     libpulseaudio
     libsndfile

--- a/pkgs/applications/misc/elektroid/default.nix
+++ b/pkgs/applications/misc/elektroid/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "dagargo";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256-T7jxtmxlFe5WPC2KYDN6jDHwuVkmA6Y/h9qizZFH5rk=";
   };
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     description = "Transfer application for Elektron devices";
     homepage = "https://github.com/dagargo/elektroid";
     maintainers = with maintainers; [ dag-h ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -462,6 +462,8 @@ with pkgs;
 
   efficient-compression-tool = callPackage ../tools/compression/efficient-compression-tool { };
 
+  elektroid = callPackage ../applications/misc/elektroid { };
+
   evans = callPackage ../development/tools/evans { };
 
   expressvpn = callPackage ../applications/networking/expressvpn { };


### PR DESCRIPTION
###### Description of changes

[Elektroid](https://github.com/dagargo/elektroid) is a management application for Elektron devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
