### PR TITLE
maintainers/team-list: Update feature freeze flags on multiple teams

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -15,6 +15,8 @@
   - `scope` describes the scope of the group.
   - `shortName` short human-readable name
   - `enableFeatureFreezePing` will ping this team during the Feature Freeze announcements on releases
+    - There is limited mention capacity in a single post, so this should be reserved for critical components
+      or larger ecosystems within nixpkgs.
   - `githubTeams` will ping specified GitHub teams as well
 
   More fields may be added in the future.

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -38,6 +38,7 @@ with lib.maintainers; {
     ];
     scope = "Maintain ACME-related packages and modules.";
     shortName = "ACME";
+    enableFeatureFreezePing = true;
   };
 
   bazel = {
@@ -90,7 +91,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain Blockchain packages and modules.";
     shortName = "Blockchains";
-    enableFeatureFreezePing = true;
   };
 
   c = {
@@ -111,7 +111,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain packages used in the C3D2 hackspace";
     shortName = "c3d2";
-    enableFeatureFreezePing = true;
   };
 
   cinnamon = {
@@ -202,7 +201,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain Docker and related tools.";
     shortName = "DockerTools";
-    enableFeatureFreezePing = true;
   };
 
   docs = {
@@ -220,7 +218,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain the Emacs editor and packages.";
     shortName = "Emacs";
-    enableFeatureFreezePing = true;
   };
 
   enlightenment = {
@@ -426,6 +423,7 @@ with lib.maintainers; {
     ];
     scope = "Maintain Mate desktop environment and related packages.";
     shortName = "MATE";
+    enableFeatureFreezePing = true;
   };
 
   matrix = {
@@ -448,7 +446,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain Mobile NixOS.";
     shortName = "Mobile";
-    enableFeatureFreezePing = true;
   };
 
   nix = {
@@ -483,7 +480,6 @@ with lib.maintainers; {
       tazjin
       zimbatm
     ];
-    enableFeatureFreezePing = true;
     scope = "Group registration for Numtide team members who collectively maintain packages.";
     shortName = "Numtide team";
   };
@@ -548,7 +544,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain Podman and CRI-O related packages and modules.";
     shortName = "Podman";
-    enableFeatureFreezePing = true;
   };
 
   postgres = {
@@ -557,7 +552,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain the PostgreSQL package and plugins along with the NixOS module.";
     shortName = "PostgreSQL";
-    enableFeatureFreezePing = true;
   };
 
   python = {
@@ -610,7 +604,6 @@ with lib.maintainers; {
     ];
     scope = "Manage the current nixpkgs/NixOS release.";
     shortName = "Release";
-    enableFeatureFreezePing = true;
   };
 
   ruby = {
@@ -699,7 +692,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain the vim and neovim text editors and related packages.";
     shortName = "Vim/Neovim";
-    enableFeatureFreezePing = true;
   };
 
   xfce = {
@@ -708,5 +700,6 @@ with lib.maintainers; {
     ];
     scope = "Maintain Xfce desktop environment and related packages.";
     shortName = "Xfce";
+    enableFeatureFreezePing = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

This updates the selection of teams pinged during feature freeze. The changes are of course subjective and open for discussion. I hope I'm not stepping on anyones toes here!

My thought was too reduce the scope to teams that maintain large ecosystems or critical components within nixpkgs. Most flags were configured by Janne when he first created that tooling. Two flags were enabled by @SuperSandro2000 and @zimbatm, which is why I requested them for review.

Everyone is of course always welcome to check-in regardless and report important issues, that deserve attention.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
