### PR TITLE
wesher: init at 0.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14027,6 +14027,13 @@
     github = "twitchyliquid64";
     githubId = 6328589;
   };
+  tylerjl = {
+    email = "tyler+nixpkgs@langlois.to";
+    github = "tylerjl";
+    githubId = 1733846;
+    matrix = "@ty:tjll.net";
+    name = "Tyler Langlois";
+  };
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";

--- a/pkgs/servers/wesher/default.nix
+++ b/pkgs/servers/wesher/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "wesher";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "costela";
+    repo = "wesher";
+    rev = "v${version}";
+    sha256 = "sha256-EIajvcBhS5G9dJzRgXhnD1QKOAhmzngdyCU4L7itT8U=";
+  };
+
+  vendorSha256 = "sha256-BZzhBC4C0OoAxUEDROkggCQF35C9Z4+0/Jk0ZD8Hz1s=";
+
+  ldflags = [
+    "-s" "-w" "-X main.version=${version}"
+  ];
+
+  meta = with lib; {
+    description = "Wireguard overlay mesh network manager";
+    homepage = "https://github.com/costela/wesher";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ tylerjl ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24502,6 +24502,8 @@ with pkgs;
 
   webmetro = callPackage ../servers/webmetro { };
 
+  wesher = callPackage ../servers/wesher { };
+
   wishlist = callPackage ../servers/wishlist { };
 
   wsdd = callPackage ../servers/wsdd { };


### PR DESCRIPTION
###### Description of changes

[Wesher](https://github.com/costela/wesher) is a very simple wireguard mesh daemon. Think of it as a local-only, clustered, and zero-config Tailscale. I've been running wesher in my homelab using this package for a few months so I think it's good to go into the main package set.

I also tossed in my name into `maintainers-list.nix`. Hopefully I can continue to contribute and help out!

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- ~[ ] Tested, as applicable:~
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- ~[ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~[22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)~
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
  - ~[ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes~
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

