### PR TITLE
src-cli: init at 4.0.0

### DIFF
--- a/pkgs/development/tools/misc/src-cli/default.nix
+++ b/pkgs/development/tools/misc/src-cli/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "src-cli";
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "sourcegraph";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-cd96ddFtPOMATI0MEMFH399/y7SZeASetVhvRt0P38A=";
+  };
+
+  vendorSha256 = "sha256-ll/Q7hZJngOGG/Jl79KvEIHQ+ARDxFD7KHY3nSokRi0=";
+
+  subPackages = [ "cmd/src" ];
+
+  CGO_ENABLED = 0;
+
+  ldflags = [ "-X github.com/sourcegraph/src-cli/internal/version.BuildTag=${version}" ];
+
+  meta = with lib; {
+    description = "Command line interface to Sourcegraph";
+    homepage = "https://github.com/sourcegraph/src-cli";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+    mainProgram = "src";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21959,6 +21959,8 @@ with pkgs;
 
   sratom = callPackage ../development/libraries/audio/sratom { };
 
+  src-cli = callPackage ../development/tools/misc/src-cli { };
+
   srm = callPackage ../tools/security/srm { };
 
   srt = callPackage ../development/libraries/srt { };


### PR DESCRIPTION
###### Description of changes
src is a command line interface to Sourcegraph
https://github.com/sourcegraph/src-cli

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
