### PR TITLE
cjdns: hot-fix after python39->python310

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5125,8 +5125,9 @@ with pkgs;
 
   cilium-cli = callPackage ../applications/networking/cluster/cilium { };
 
-  cjdns = callPackage ../tools/networking/cjdns { };
-  cjdns-tools = callPackage ../tools/admin/cjdns-tools { };
+  # TODO: remove the python3 override
+  # 2022-09-30: cjdns fails to build after the python3=python310 bump
+  cjdns = callPackage ../tools/networking/cjdns { python3 = python39; };
 
   cjson = callPackage ../development/libraries/cjson { };
 


### PR DESCRIPTION
###### Description of changes

CJDNS has been failing to build, apparently since the `python3 = python310;` bump: cf. [last successful build](https://hydra.nixos.org/build/180048690#tabs-summary), [first failing build](https://hydra.nixos.org/build/180156993#tabs-summary)

This overrides cjdns to use `python39`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux

###### Notify the maintainers

@ehmry 


P.S. Is there a better tooling to locate the offending patch, than `BAD=2a3df3e7406c07bcf4849fe6a28cbb8002f91e36 ; GOOD=7eb78c6d040df835a754d2abed7760c4da0d5cf0 ; nix-diff $(nix path-info --derivation github:NixOS/nixpkgs/$GOOD#cjdns) $(nix path-info --derivation github:NixOS/nixpkgs/$BAD#cjdns)`?