### PR TITLE
 Fix fs-uae-launcher Qt wrapping issue

### DIFF
--- a/pkgs/applications/emulators/fs-uae/launcher.nix
+++ b/pkgs/applications/emulators/fs-uae/launcher.nix
@@ -2,8 +2,9 @@
 , stdenv
 , fetchurl
 , gettext
-, makeWrapper
 , python3
+, wrapQtAppsHook
+, fsuae
 }:
 
 stdenv.mkDerivation rec {
@@ -17,8 +18,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     gettext
-    makeWrapper
     python3
+    wrapQtAppsHook
   ];
 
   buildInputs = with python3.pkgs; [
@@ -29,15 +30,19 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "prefix=$(out)" ];
 
-  postInstall = ''
-    wrapProgram $out/bin/fs-uae-launcher --set PYTHONPATH "$PYTHONPATH"
+  dontWrapQtApps = true;
+
+  preFixup = ''
+      wrapQtApp "$out/bin/fs-uae-launcher" --set PYTHONPATH "$PYTHONPATH" \
+        --prefix PATH : ${lib.makeBinPath [ fsuae ]}
   '';
 
   meta = with lib; {
     homepage = "https://fs-uae.net";
     description = "Graphical front-end for the FS-UAE emulator";
-    license = lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     maintainers = with  maintainers; [ sander AndersonTorres ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1510,7 +1510,7 @@ with pkgs;
 
   fsuae = callPackage ../applications/emulators/fs-uae { };
 
-  fsuae-launcher = callPackage ../applications/emulators/fs-uae/launcher.nix { };
+  fsuae-launcher = libsForQt5.callPackage ../applications/emulators/fs-uae/launcher.nix { };
 
   fuse-emulator = callPackage ../applications/emulators/fuse-emulator {};
 


### PR DESCRIPTION
Should fix #161716 



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


