### PR TITLE
nixos/nixpkgs: make `nixpkgs.config` mergeable

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -348,6 +348,10 @@ checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survive
 # because of an `extendModules` bug, issue 168767.
 checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-imports.nix
 
+checkConfigOutput '^24$' config.result.test ./override-fn-type.nix
+checkConfigOutput '^25$' config.result.test2 ./override-fn-type.nix
+checkConfigOutput '^1$' config.result.test3 ./override-fn-type.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/override-fn-type.nix
+++ b/lib/tests/modules/override-fn-type.nix
@@ -1,0 +1,34 @@
+{ lib, config, ... }: with lib; {
+  options.packageOverrides = mkOption {
+    default = const {};
+    type = types.overrideFnType;
+  };
+  options.result = mkOption {
+    type = types.attrs;
+  };
+  config = mkMerge [
+    {
+      packageOverrides = pkgs: {
+        test = pkgs.num + 1;
+      };
+    }
+    {
+      packageOverrides = pkgs: {
+        test2 = pkgs.test + 1;
+      };
+    }
+    {
+      packageOverrides = mkAfter (pkgs: {
+        test3 = 1;
+      });
+    }
+    {
+      packageOverrides = pkgs: {
+        test3 = 2;
+      };
+    }
+    {
+      result = config.packageOverrides { num = 23; };
+    }
+  ];
+}

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -14,34 +14,6 @@ let
     then f x
     else f;
 
-  mergeConfig = lhs_: rhs_:
-    let
-      lhs = optCall lhs_ { inherit pkgs; };
-      rhs = optCall rhs_ { inherit pkgs; };
-    in
-    recursiveUpdate lhs rhs //
-    optionalAttrs (lhs ? packageOverrides) {
-      packageOverrides = pkgs:
-        optCall lhs.packageOverrides pkgs //
-        optCall (attrByPath ["packageOverrides"] ({}) rhs) pkgs;
-    } //
-    optionalAttrs (lhs ? perlPackageOverrides) {
-      perlPackageOverrides = pkgs:
-        optCall lhs.perlPackageOverrides pkgs //
-        optCall (attrByPath ["perlPackageOverrides"] ({}) rhs) pkgs;
-    };
-
-  configType = mkOptionType {
-    name = "nixpkgs-config";
-    description = "nixpkgs config";
-    check = x:
-      let traceXIfNot = c:
-            if c x then true
-            else lib.traceSeqN 1 x false;
-      in traceXIfNot isConfig;
-    merge = args: foldr (def: mergeConfig def.value) {};
-  };
-
   overlayType = mkOptionType {
     name = "nixpkgs-overlay";
     description = "nixpkgs overlay";
@@ -156,7 +128,7 @@ in
         ''
           { allowBroken = true; allowUnfree = true; }
         '';
-      type = configType;
+      type = types.submodule ../../../pkgs/top-level/config.nix;
       description = lib.mdDoc ''
         The configuration of the Nix Packages collection.  (For
         details, see the Nixpkgs documentation.)  It allows you to set

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -131,8 +131,24 @@ let
     checkMeta = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Whether to check that the `meta` attribute of derivations are correct during evaluation time.
+      '';
+    };
+
+    packageOverrides = mkOption {
+      default = const {};
+      type = types.overrideFnType;
+      description = lib.mdDoc ''
+        **Not recommended.** Use `overlays` instead!
+      '';
+    };
+
+    perlPackageOverrides = mkOption {
+      default = const {};
+      type = types.overrideFnType;
+      description = lib.mdDoc ''
+        A function that takes the final set of Perl packages and returns an attribute set of packages to add or change.
       '';
     };
   };


### PR DESCRIPTION
###### Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/194056
Alternative implementation to https://github.com/NixOS/nixpkgs/pull/80582

`nixpkgs.config` is now a freeform-type which imports the
`<nixpkgs/pkgs/top-level/config.nix>`-module. This brings the following
benefits:

* Proper merging (to a certain degree, more details later) of several
  `nixpkgs.config` declarations.

* `allowUnfree` and friends appear in the NixOS manual.

To be precise, this means that something like this is now possible:

    {
      nixpkgs = mkMerge [
        { allowUnfree = false; }
        { allowUnfree = mkForce true; }
      ];
    }

Previously this would lead to a bogus attr-set, namely

    { _type = "override"; content = true; priority = 50; }

since no merging for this option-type was implemented.

This however has certain limitations. For instance

    nixpkgs.config.allowUnfree = mkForce false;

works fine whereas

    nixpkgs.config.virtualbox.enableExtensionPack = mkForce true;

doesn't. This is because we use `types.raw` inside the config-module for
`nixpkgs` which doesn't merge undeclared attribute-sets (such as
`virtualbox`). This is because we don't know if any attribute-set is
actually mergeable, for further details see the previous discussion[1].

A basic type has been implemented for the (actually deprecated)
mechanisms `packageOverrides`/`perlPackageOverrides`. This one basically
applies the `pkgs` argument onto each definition of this function, so
e.g. the following expression

    {
      nixpkgs.config = mkMerge [
        { packageOverrides = pkgs: { randomattr = 23; }; }
        { packageOverrides = pkgs: { randomattr = pkgs.randomattr + 19; }; }
      ];
    }

adds an attribute `randomattr` of value `42` to `_module.args.pkgs`.

[1] https://github.com/NixOS/nixpkgs/pull/194207#issuecomment-1267002199

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
