### PR TITLE
systemd: 251.4 -> 251.5

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -571,21 +571,22 @@ stdenv.mkDerivation {
       ];
 
       # { replacement, search, where } -> List[str]
-      mkSubstitute = { replacement, search, where, ignore ? [] }:
+      mkSubstitute = { replacement, search, where, ignore ? [ ] }:
         map (path: "substituteInPlace ${path} --replace '${search}' \"${replacement}\"") where;
-      mkEnsureSubstituted = { replacement, search, where, ignore ? [] }:
-      let
-        ignore' = lib.concatStringsSep "|" (ignore ++ ["^test" "NEWS"]);
-      in ''
-        set +e
-        search=$(grep '${search}' -r | grep -v "${replacement}" | grep -Ev "${ignore'}")
-        set -e
-        if [[ -n "$search" ]]; then
-          echo "Not all references to '${search}' have been replaced. Found the following matches:"
-          echo "$search"
-          exit 1
-        fi
-      '';
+      mkEnsureSubstituted = { replacement, search, where, ignore ? [ ] }:
+        let
+          ignore' = lib.concatStringsSep "|" (ignore ++ [ "^test" "NEWS" ]);
+        in
+        ''
+          set +e
+          search=$(grep '${search}' -r | grep -v "${replacement}" | grep -Ev "${ignore'}")
+          set -e
+          if [[ -n "$search" ]]; then
+            echo "Not all references to '${search}' have been replaced. Found the following matches:"
+            echo "$search"
+            exit 1
+          fi
+        '';
     in
     ''
       mesonFlagsArray+=(-Dntp-servers="0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org")

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -120,7 +120,7 @@ assert withHomed -> withCryptsetup;
 let
   wantCurl = withRemote || withImportd;
   wantGcrypt = withResolved || withImportd;
-  version = "251.4";
+  version = "251.5";
 
   # Bump this variable on every (major) version change. See below (in the meson options list) for why.
   # command:
@@ -137,7 +137,7 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "sha256-lfG6flT1k8LZBAdDK+cF9RjmJMkHMJquMjQK3MINFd8=";
+    sha256 = "sha256-2MEmvFT1D+9v8OazBwjnKc7i/x7i196Eoi8bODk1cM4=";
   };
 
   # On major changes, or when otherwise required, you *must* reformat the patches,


### PR DESCRIPTION
###### Description of changes

systemd: 251.4 -> 251.5

Changes:

```
654ae8c1e4 base-filesystem.c: add trailing zero byte for s390x entry
e4a19eef33 basic/missing_loop.h: fix missing lo_flags LO_FLAGS_DIRECT_IO
24238be484 mount-util: fix error code
1b1ad8c79f udev: certainly restart event for previously locked device
7dacfb3fb4 stub: Use EfiLoaderCode for kernel memory
eaeaf4f6ef network: do not silently stop to process configuration on activation failure
bb803856bc bus: use inline trace argument for ANONYMOUS auth
6349062326 Fix ObjectManager interface emitted for non-manager objects
c90ab07fa0 test-bus-objects: Test interfaces added/removed signal interfaces
e32fe1b457 Fix GetManagedObjects returning ObjectManager interface for non-manager objects
efd8e39f4a test-bus-objects: Test GetManagedObjects interfaces are correct
344efd022a coredump: when parsing json, optionally copy the string first
de08edca17 systemctl: color ignored exit status in yellow, not red
1531a496e3 manager: make clear internal Dump() logic is debugging only.
c4fd38f7d2 man: document the Dump() calls of the PID 1 D-Bus interface, and what they are
140fee4627 resolve: do not cache mDNS goodbye packet
1a2d93a770 kbd-model-map: correct variants for cz-qwerty to include comma
9d1ebb2247 resolve: persist DNSOverTLS configuration in state file
3137ac6ef5 udev: support by-path devlink for multipath nvme block devices
c948091cc5 run: make --working-directory= work for --scope too
7bb204620d kbd-model-map: add a mapping for switched czech qwerty/us
e5157050d1 test: add more test cases for mkdir_p_safe() and mkdir_p_root()
b3a9f7b5cb mkdir: chase_symlinks_and_stat() does not return 0
0bfdc91807 units: make sure that initrd-switch-root.service pulls in .target
45fb64c54b units: add dependency ordering for emergency.service conflicts
6535813084 units: add ordering dependencies on initrd-switch-root.target
09c90224f1 units/systemd-network-generator.service: add forgotten ordering for shutdown
1dd723a3b8 units: reorder/split unit dependency blocks
054cad0097 man: explicitly document that "reboot -f" is different from "systemctl reboot -f"
c5b0ae86b1 watchdog: use /dev/watchdog0 only if it exists
ac805eac15 journalctl: respect --quiet flag during file concistency verification
c1d729795d xdg-autostart-service: expand tilde in Exec lines
35c5f5d688 unit: drop ProtectClock=yes from systemd-udevd.service
175ba30cf6 busctl: Fix warning about invaild introspection data
6c7b91372d udev/rules,hwdb: filter out mostly meaningless default strings
8b89e677e9 units: prolong the stop timeout for homed
202a79e7c5 homed: don't wait indefinitely for workers on exit
44660d2e12 man: fix static bridge example
e0dde8a14f log: don't attempt to duplicate closed fd
254b77e73c condition: fix device-tree firmware path
96da39ddb1 udev-util: minor cleanups for on_ac_power()
3345520512 docs: fix incorrect env var name for credentials directory
49f9fa87b2 shell-completion: drop unused $mode
1e29d934de oomd: fix off-by-one when dumping kill candidates
b00cb050c8 on-ac-power: ignore devices with scope==Device
9886011356 on-ac-power: rework logic
1fc74d251e sd-device: add helper to read a unsigned int attribute
6d4c138534 shared/udev-util: say "ignoring device", not "ignoring"
cd2fad2300 virt: Support detection of Apple Virtualization.framework guests
6e47e75c86 virt: align tables
951e99231e check-os-release.py compatible with Python < 3.8
d572a74163 core/mount: adjust deserialized state based on /proc/self/mountinfo
2e372afc35 Allow uneven length BootXXXX variables
8ad143e684 gpt: fix native uuids for s390x
2bb9a0a29b udev: fix inversed inequality for timeout of retrying event
cf67d5ed1b bash-completion: add systemd-sysext support
ada437cfb1 sysext: add missing COMMAND to the help output and man synopsis
58bc1e8e04 hostname: make chassis type actually obtained from ACPI when nothing from DMI
4ffde70981 booctl: do not say uuids differ if one of the uuids is unset
5219a99ccb bash-completion: autocomplete cgroup names in systemd-cgtop
9f2f391153 sysusers: add fsync for passwd (#24324)
c966377c51 dhcp6: do not append ORO option when no option requested
97474b03e7 dhcp6: gracefully handle NoBinding error
c67a388aef udev/cdrom_id: check last track info
52c631b02e firstboot: fix can't overwrite timezone
f279a6f4d1 cryptenroll: fix memory leak
66b060225d sd-device-enumerator: drop noisy log messages
6e1acfe818 sd-device-monitor: actually refuse to send invalid devices
81339c45e8 sd-device-monitor: fix inversed condition
1760559918 resolvctl: only remove protocol after last dot when mangling ifname for resolvconf
a3348ba748 oom: drop invalid %m in the log message
b3dd66f32b meson: Test correct efi linker for supported args
f9d936b865 sysusers: properly process user entries with an explicit GID
ec5a46ca34 sysusers: only check whether the requested GID is available
037b1a8acc dhcp: fix potential buffer overflow
ed2955f8fe udev-util: assume system is running on AC power when no battery found
37b54927d3 Fix issue with system time set back (#24131)
4fdca1ab9e shared/generator: Ensure growfs unit runs after repart
32f9d70f8b manager: optionally, do a full preset on first boot
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
