### PR TITLE
nsync: 1.24.0 -> 1.25.0

### DIFF
--- a/pkgs/development/libraries/nsync/default.nix
+++ b/pkgs/development/libraries/nsync/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nsync";
-  version = "1.24.0";
+  version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = pname;
     rev = version;
-    sha256 = "sha256-jQJtlBDR6efBe1tFOUOZ6awaMTT33qM/GbvbwiWTZxw=";
+    sha256 = "sha256-bdnYrMnBnpnEKGuMlDLILfzgwfu/e5tyMdSDWqreyto=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/nsync/default.nix
+++ b/pkgs/development/libraries/nsync/default.nix
@@ -17,13 +17,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # Needed for case-insensitive filesystems like on macOS
+  # because a file named BUILD exists already.
+  cmakeBuildDir = "build_dir";
+
   meta = {
     homepage = "https://github.com/google/nsync";
     description = "C library that exports various synchronization primitives";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ puffnfresh Luflosi ];
-    # On macOS we get an error for some reason:
-    # > mkdir: cannot create directory 'build': File exists
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/nsync/default.nix
+++ b/pkgs/development/libraries/nsync/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/google/nsync";
     description = "C library that exports various synchronization primitives";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ puffnfresh ];
+    maintainers = with lib.maintainers; [ puffnfresh Luflosi ];
     # On macOS we get an error for some reason:
     # > mkdir: cannot create directory 'build': File exists
     platforms = lib.platforms.linux;


### PR DESCRIPTION
###### Description of changes
https://github.com/google/nsync/releases/tag/1.25.0
Also fix the build on macOS and add myself as a maintainer.
Closes #184404.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).