### PR TITLE
maigret: 0.4.3 -> 0.4.4

### DIFF
--- a/pkgs/tools/security/maigret/default.nix
+++ b/pkgs/tools/security/maigret/default.nix
@@ -1,19 +1,21 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , python3
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maigret";
-  version = "0.4.3";
+  version = "0.4.4";
 
   src = fetchFromGitHub {
     owner = "soxoj";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-0Ni4rXVu3ZQyHBvD3IpV0i849CnumLj+n6/g4sMhHEs=";
+    hash = "sha256-Z8SnA7Z5+oKW0AOaNf+c/zR30lrPFmXaxxKkbnDXNNs=";
   };
 
+  nativeBuildInputs = [ python3.pkgs.pythonRelaxDepsHook ];
   propagatedBuildInputs = with python3.pkgs; [
     aiodns
     aiohttp
@@ -24,6 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     beautifulsoup4
     certifi
     chardet
+    cloudscraper
     colorama
     future
     html5lib
@@ -60,14 +63,8 @@ python3.pkgs.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  postPatch = ''
-    # Remove all version pinning
-    sed -i -e "s/==[0-9.]*//" requirements.txt
-
-    # We are not build for Python < 3.7
-    substituteInPlace requirements.txt \
-      --replace "future-annotations" ""
-  '';
+  pythonRelaxDeps = true;
+  pythonRemoveDeps = [ "future-annotations" ];
 
   pytestFlagsArray = [
     # DeprecationWarning: There is no current event loop
@@ -82,6 +79,10 @@ python3.pkgs.buildPythonApplication rec {
     "test_pdf_report"
     "test_self_check_db_negative_enabled"
     "test_self_check_db_positive_enable"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # AsyncioProgressbarExecutor is slower on darwin than it should be,
+    # Upstream issue: https://github.com/soxoj/maigret/issues/679
+    "test_asyncio_progressbar_executor"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes

New upstream version with less false positives.

Use `pythonRelaxDepsHook` to fix the issue with the `Remove all version pinning` regex failing to unpin `soupsieve==2.3.2.post1`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
