### PR TITLE
elmPackages.elm-language-server: 2.4.1 -> 2.5.0

### DIFF
--- a/pkgs/development/compilers/elm/packages/node-composition.nix
+++ b/pkgs/development/compilers/elm/packages/node-composition.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-12_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-14_x"}:
 
 let
   nodeEnv = import ../../../node-packages/node-env.nix {

--- a/pkgs/development/compilers/elm/packages/node-packages.nix
+++ b/pkgs/development/compilers/elm/packages/node-packages.nix
@@ -31,13 +31,13 @@ let
         sha512 = "TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==";
       };
     };
-    "@babel/compat-data-7.18.13" = {
+    "@babel/compat-data-7.19.3" = {
       name = "_at_babel_slash_compat-data";
       packageName = "@babel/compat-data";
-      version = "7.18.13";
+      version = "7.19.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz";
-        sha512 = "5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==";
+        url = "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.3.tgz";
+        sha512 = "prBHMK4JYYK+wDjJF1q99KK4JLL+egWS4nmNqdlMUgCExMZ+iZW0hGhyC3VEbsPjvaN0TBhW//VIFwBrk8sEiw==";
       };
     };
     "@babel/core-7.12.10" = {
@@ -49,13 +49,13 @@ let
         sha512 = "eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==";
       };
     };
-    "@babel/generator-7.18.13" = {
+    "@babel/generator-7.19.3" = {
       name = "_at_babel_slash_generator";
       packageName = "@babel/generator";
-      version = "7.18.13";
+      version = "7.19.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz";
-        sha512 = "CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==";
+        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.19.3.tgz";
+        sha512 = "fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==";
       };
     };
     "@babel/helper-annotate-as-pure-7.18.6" = {
@@ -76,31 +76,31 @@ let
         sha512 = "yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==";
       };
     };
-    "@babel/helper-compilation-targets-7.18.9" = {
+    "@babel/helper-compilation-targets-7.19.3" = {
       name = "_at_babel_slash_helper-compilation-targets";
       packageName = "@babel/helper-compilation-targets";
-      version = "7.18.9";
+      version = "7.19.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz";
-        sha512 = "tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==";
+        url = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz";
+        sha512 = "65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==";
       };
     };
-    "@babel/helper-create-class-features-plugin-7.18.13" = {
+    "@babel/helper-create-class-features-plugin-7.19.0" = {
       name = "_at_babel_slash_helper-create-class-features-plugin";
       packageName = "@babel/helper-create-class-features-plugin";
-      version = "7.18.13";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz";
-        sha512 = "hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==";
+        url = "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz";
+        sha512 = "NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==";
       };
     };
-    "@babel/helper-create-regexp-features-plugin-7.18.6" = {
+    "@babel/helper-create-regexp-features-plugin-7.19.0" = {
       name = "_at_babel_slash_helper-create-regexp-features-plugin";
       packageName = "@babel/helper-create-regexp-features-plugin";
-      version = "7.18.6";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.18.6.tgz";
-        sha512 = "7LcpH1wnQLGrI+4v+nPp+zUvIkF9x0ddv1Hkdue10tg3gmRnLy97DXh4STiOf1qeIInyD69Qv5kKSZzKD8B/7A==";
+        url = "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.19.0.tgz";
+        sha512 = "htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==";
       };
     };
     "@babel/helper-environment-visitor-7.18.9" = {
@@ -121,13 +121,13 @@ let
         sha512 = "eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==";
       };
     };
-    "@babel/helper-function-name-7.18.9" = {
+    "@babel/helper-function-name-7.19.0" = {
       name = "_at_babel_slash_helper-function-name";
       packageName = "@babel/helper-function-name";
-      version = "7.18.9";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz";
-        sha512 = "fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==";
+        url = "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz";
+        sha512 = "WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==";
       };
     };
     "@babel/helper-hoist-variables-7.18.6" = {
@@ -157,13 +157,13 @@ let
         sha512 = "0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==";
       };
     };
-    "@babel/helper-module-transforms-7.18.9" = {
+    "@babel/helper-module-transforms-7.19.0" = {
       name = "_at_babel_slash_helper-module-transforms";
       packageName = "@babel/helper-module-transforms";
-      version = "7.18.9";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz";
-        sha512 = "KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==";
+        url = "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz";
+        sha512 = "3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==";
       };
     };
     "@babel/helper-optimise-call-expression-7.18.6" = {
@@ -175,13 +175,13 @@ let
         sha512 = "HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==";
       };
     };
-    "@babel/helper-plugin-utils-7.18.9" = {
+    "@babel/helper-plugin-utils-7.19.0" = {
       name = "_at_babel_slash_helper-plugin-utils";
       packageName = "@babel/helper-plugin-utils";
-      version = "7.18.9";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz";
-        sha512 = "aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==";
+        url = "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz";
+        sha512 = "40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==";
       };
     };
     "@babel/helper-remap-async-to-generator-7.18.9" = {
@@ -193,13 +193,13 @@ let
         sha512 = "dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==";
       };
     };
-    "@babel/helper-replace-supers-7.18.9" = {
+    "@babel/helper-replace-supers-7.19.1" = {
       name = "_at_babel_slash_helper-replace-supers";
       packageName = "@babel/helper-replace-supers";
-      version = "7.18.9";
+      version = "7.19.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz";
-        sha512 = "dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==";
+        url = "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz";
+        sha512 = "T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==";
       };
     };
     "@babel/helper-simple-access-7.18.6" = {
@@ -238,13 +238,13 @@ let
         sha512 = "XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==";
       };
     };
-    "@babel/helper-validator-identifier-7.18.6" = {
+    "@babel/helper-validator-identifier-7.19.1" = {
       name = "_at_babel_slash_helper-validator-identifier";
       packageName = "@babel/helper-validator-identifier";
-      version = "7.18.6";
+      version = "7.19.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz";
-        sha512 = "MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==";
+        url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz";
+        sha512 = "awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==";
       };
     };
     "@babel/helper-validator-option-7.18.6" = {
@@ -256,22 +256,22 @@ let
         sha512 = "XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==";
       };
     };
-    "@babel/helper-wrap-function-7.18.11" = {
+    "@babel/helper-wrap-function-7.19.0" = {
       name = "_at_babel_slash_helper-wrap-function";
       packageName = "@babel/helper-wrap-function";
-      version = "7.18.11";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.11.tgz";
-        sha512 = "oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==";
+        url = "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.19.0.tgz";
+        sha512 = "txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==";
       };
     };
-    "@babel/helpers-7.18.9" = {
+    "@babel/helpers-7.19.0" = {
       name = "_at_babel_slash_helpers";
       packageName = "@babel/helpers";
-      version = "7.18.9";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz";
-        sha512 = "Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==";
+        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz";
+        sha512 = "DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==";
       };
     };
     "@babel/highlight-7.18.6" = {
@@ -283,22 +283,22 @@ let
         sha512 = "u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==";
       };
     };
-    "@babel/parser-7.18.13" = {
+    "@babel/parser-7.19.3" = {
       name = "_at_babel_slash_parser";
       packageName = "@babel/parser";
-      version = "7.18.13";
+      version = "7.19.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz";
-        sha512 = "dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==";
+        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz";
+        sha512 = "pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==";
       };
     };
-    "@babel/plugin-proposal-async-generator-functions-7.18.10" = {
+    "@babel/plugin-proposal-async-generator-functions-7.19.1" = {
       name = "_at_babel_slash_plugin-proposal-async-generator-functions";
       packageName = "@babel/plugin-proposal-async-generator-functions";
-      version = "7.18.10";
+      version = "7.19.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.18.10.tgz";
-        sha512 = "1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==";
+        url = "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.1.tgz";
+        sha512 = "0yu8vNATgLy4ivqMNBIwb1HebCelqN7YX8SL3FDXORv/RqT0zEEWUCH4GH44JsSrvCu6GqnAdR5EBFAPeNBB4Q==";
       };
     };
     "@babel/plugin-proposal-class-properties-7.18.6" = {
@@ -553,13 +553,13 @@ let
         sha512 = "5sDIJRV1KtQVEbt/EIBwGy4T01uYIo4KRB3VUqzkhrAIOGx7AoctL9+Ux88btY0zXdDyPJ9mW+bg+v+XEkGmtw==";
       };
     };
-    "@babel/plugin-transform-classes-7.18.9" = {
+    "@babel/plugin-transform-classes-7.19.0" = {
       name = "_at_babel_slash_plugin-transform-classes";
       packageName = "@babel/plugin-transform-classes";
-      version = "7.18.9";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.18.9.tgz";
-        sha512 = "EkRQxsxoytpTlKJmSPYrsOMjCILacAjtSVkd4gChEe2kXjFCun3yohhW5I7plXJhCemM0gKsaGMcO8tinvCA5g==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz";
+        sha512 = "YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==";
       };
     };
     "@babel/plugin-transform-computed-properties-7.18.9" = {
@@ -661,13 +661,13 @@ let
         sha512 = "Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==";
       };
     };
-    "@babel/plugin-transform-modules-systemjs-7.18.9" = {
+    "@babel/plugin-transform-modules-systemjs-7.19.0" = {
       name = "_at_babel_slash_plugin-transform-modules-systemjs";
       packageName = "@babel/plugin-transform-modules-systemjs";
-      version = "7.18.9";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.18.9.tgz";
-        sha512 = "zY/VSIbbqtoRoJKo2cDTewL364jSlZGvn0LKOf9ntbfxOvjfmyrdtEEOAdswOswhZEb8UH3jDkCKHd1sPgsS0A==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.19.0.tgz";
+        sha512 = "x9aiR0WXAWmOWsqcsnrzGR+ieaTMVyGyffPVA7F8cXAGt/UxefYv6uSHZLkAFChN5M5Iy1+wjE+xJuPt22H39A==";
       };
     };
     "@babel/plugin-transform-modules-umd-7.18.6" = {
@@ -679,13 +679,13 @@ let
         sha512 = "dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==";
       };
     };
-    "@babel/plugin-transform-named-capturing-groups-regex-7.18.6" = {
+    "@babel/plugin-transform-named-capturing-groups-regex-7.19.1" = {
       name = "_at_babel_slash_plugin-transform-named-capturing-groups-regex";
       packageName = "@babel/plugin-transform-named-capturing-groups-regex";
-      version = "7.18.6";
+      version = "7.19.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.18.6.tgz";
-        sha512 = "UmEOGF8XgaIqD74bC8g7iV3RYj8lMf0Bw7NJzvnS9qQhM4mg+1WHKotUIdjxgD2RGrgFLZZPCFPFj3P/kVDYhg==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.1.tgz";
+        sha512 = "oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==";
       };
     };
     "@babel/plugin-transform-new-target-7.18.6" = {
@@ -760,13 +760,13 @@ let
         sha512 = "eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==";
       };
     };
-    "@babel/plugin-transform-spread-7.18.9" = {
+    "@babel/plugin-transform-spread-7.19.0" = {
       name = "_at_babel_slash_plugin-transform-spread";
       packageName = "@babel/plugin-transform-spread";
-      version = "7.18.9";
+      version = "7.19.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.18.9.tgz";
-        sha512 = "39Q814wyoOPtIB/qGopNIL9xDChOE1pNU0ZY5dO0owhiVt/5kFm4li+/bBtwc7QotG0u5EPzqhZdjMtmqBqyQA==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.19.0.tgz";
+        sha512 = "RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==";
       };
     };
     "@babel/plugin-transform-sticky-regex-7.18.6" = {
@@ -850,22 +850,22 @@ let
         sha512 = "TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==";
       };
     };
-    "@babel/traverse-7.18.13" = {
+    "@babel/traverse-7.19.3" = {
       name = "_at_babel_slash_traverse";
       packageName = "@babel/traverse";
-      version = "7.18.13";
+      version = "7.19.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz";
-        sha512 = "N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==";
+        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.3.tgz";
+        sha512 = "qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==";
       };
     };
-    "@babel/types-7.18.13" = {
+    "@babel/types-7.19.3" = {
       name = "_at_babel_slash_types";
       packageName = "@babel/types";
-      version = "7.18.13";
+      version = "7.19.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz";
-        sha512 = "ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==";
+        url = "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz";
+        sha512 = "hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==";
       };
     };
     "@hapi/address-2.1.4" = {
@@ -1165,15 +1165,6 @@ let
         sha512 = "mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==";
       };
     };
-    "@types/json-buffer-3.0.0" = {
-      name = "_at_types_slash_json-buffer";
-      packageName = "@types/json-buffer";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz";
-        sha512 = "3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==";
-      };
-    };
     "@types/json-schema-7.0.11" = {
       name = "_at_types_slash_json-schema";
       packageName = "@types/json-schema";
@@ -1192,22 +1183,22 @@ let
         sha512 = "BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==";
       };
     };
-    "@types/lodash-4.14.184" = {
+    "@types/lodash-4.14.186" = {
       name = "_at_types_slash_lodash";
       packageName = "@types/lodash";
-      version = "4.14.184";
+      version = "4.14.186";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz";
-        sha512 = "RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==";
+        url = "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz";
+        sha512 = "eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==";
       };
     };
-    "@types/minimatch-5.1.0" = {
+    "@types/minimatch-5.1.2" = {
       name = "_at_types_slash_minimatch";
       packageName = "@types/minimatch";
-      version = "5.1.0";
+      version = "5.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.0.tgz";
-        sha512 = "0RJHq5FqDWo17kdHe+SMDJLfxmLaqHbWnqZ6gNKzDvStUlrmx/eKIY17+ifLS1yybo7X86aUshQMlittDOVNnw==";
+        url = "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz";
+        sha512 = "K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==";
       };
     };
     "@types/mkdirp-0.5.2" = {
@@ -1219,13 +1210,13 @@ let
         sha512 = "U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==";
       };
     };
-    "@types/node-18.7.13" = {
+    "@types/node-18.8.0" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "18.7.13";
+      version = "18.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz";
-        sha512 = "46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==";
+        url = "https://registry.npmjs.org/@types/node/-/node-18.8.0.tgz";
+        sha512 = "u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA==";
       };
     };
     "@types/node-8.10.66" = {
@@ -1262,6 +1253,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz";
         sha512 = "85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==";
+      };
+    };
+    "@types/responselike-3.0.0" = {
+      name = "_at_types_slash_responselike";
+      packageName = "@types/responselike";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/responselike/-/responselike-3.0.0.tgz";
+        sha512 = "zfgGLWx5IQOTJgQPD4UfGEhapTKUPC1ra/QCG02y3GUJWrhX05bBf/EfTh3aFj2DKi7cLo+cipXLNclD27tQXQ==";
       };
     };
     "@types/rimraf-2.0.5" = {
@@ -2416,13 +2416,13 @@ let
         sha512 = "VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==";
       };
     };
-    "browserslist-4.21.3" = {
+    "browserslist-4.21.4" = {
       name = "browserslist";
       packageName = "browserslist";
-      version = "4.21.3";
+      version = "4.21.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz";
-        sha512 = "898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==";
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz";
+        sha512 = "CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==";
       };
     };
     "buffer-4.9.2" = {
@@ -2477,6 +2477,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz";
         sha512 = "9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==";
+      };
+    };
+    "bufferutil-4.0.6" = {
+      name = "bufferutil";
+      packageName = "bufferutil";
+      version = "4.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz";
+        sha512 = "jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==";
       };
     };
     "builtin-status-codes-3.0.0" = {
@@ -2677,13 +2686,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30001382" = {
+    "caniuse-lite-1.0.30001414" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30001382";
+      version = "1.0.30001414";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001382.tgz";
-        sha512 = "2rtJwDmSZ716Pxm1wCtbPvHtbDWAreTPxXbkc5RkKglow3Ig/4GNGazDI9/BVnXbG/wnv6r3B5FEbkfg9OcTGg==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz";
+        sha512 = "t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==";
       };
     };
     "case-sensitive-paths-webpack-plugin-2.3.0" = {
@@ -3163,13 +3172,13 @@ let
         sha512 = "OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==";
       };
     };
-    "commander-9.4.0" = {
+    "commander-9.4.1" = {
       name = "commander";
       packageName = "commander";
-      version = "9.4.0";
+      version = "9.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz";
-        sha512 = "sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==";
+        url = "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz";
+        sha512 = "5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==";
       };
     };
     "common-tags-1.8.2" = {
@@ -3206,15 +3215,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz";
         sha512 = "Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==";
-      };
-    };
-    "compress-brotli-1.3.8" = {
-      name = "compress-brotli";
-      packageName = "compress-brotli";
-      version = "1.3.8";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz";
-        sha512 = "lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==";
       };
     };
     "compressible-2.0.18" = {
@@ -3406,13 +3406,13 @@ let
         sha512 = "Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==";
       };
     };
-    "core-js-compat-3.25.0" = {
+    "core-js-compat-3.25.4" = {
       name = "core-js-compat";
       packageName = "core-js-compat";
-      version = "3.25.0";
+      version = "3.25.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.0.tgz";
-        sha512 = "extKQM0g8/3GjFx9US12FAgx8KJawB7RCQ5y8ipYLbmfzEzmFRWdDjIlxDx82g7ygcNG85qMVUSRyABouELdow==";
+        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.4.tgz";
+        sha512 = "gCEcIEEqCR6230WroNunK/653CWKhqyCKJ9b+uESqOt/WFJA8B4lTnnQFdpYY5vmBcwJAA90Bo5vXs+CVsf6iA==";
       };
     };
     "core-util-is-1.0.2" = {
@@ -4225,13 +4225,13 @@ let
         sha512 = "WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==";
       };
     };
-    "electron-to-chromium-1.4.228" = {
+    "electron-to-chromium-1.4.270" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.4.228";
+      version = "1.4.270";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.228.tgz";
-        sha512 = "XfDHCvou7CsDMlFwb0WZ1tWmW48e7Sn7VBRyPfZsZZila9esRsJl1trO+OqDNV97GggFSt0ISbWslKXfQkG//g==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.270.tgz";
+        sha512 = "KNhIzgLiJmDDC444dj9vEOpZEgsV96ult9Iff98Vanumn+ShJHd5se8aX6KeVxdc0YQeqdrezBZv89rleDbvSg==";
       };
     };
     "elliptic-6.5.4" = {
@@ -4459,13 +4459,13 @@ let
         sha512 = "7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==";
       };
     };
-    "es-abstract-1.20.1" = {
+    "es-abstract-1.20.3" = {
       name = "es-abstract";
       packageName = "es-abstract";
-      version = "1.20.1";
+      version = "1.20.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz";
-        sha512 = "WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==";
+        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz";
+        sha512 = "AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==";
       };
     };
     "es-array-method-boxes-properly-1.0.0" = {
@@ -4819,13 +4819,13 @@ let
         sha512 = "g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==";
       };
     };
-    "fast-glob-3.2.11" = {
+    "fast-glob-3.2.12" = {
       name = "fast-glob";
       packageName = "fast-glob";
-      version = "3.2.11";
+      version = "3.2.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz";
-        sha512 = "xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==";
+        url = "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz";
+        sha512 = "DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==";
       };
     };
     "fast-json-stable-stringify-2.1.0" = {
@@ -5125,13 +5125,13 @@ let
         sha512 = "SDgHBgV+RCjrYs8aUwCb9rTgbTVuSdzvFmLaChsLre1yf+D64khCW++VYciaByZ8Rm0uKF8R/XEpXuTRSGUM1A==";
       };
     };
-    "follow-redirects-1.15.1" = {
+    "follow-redirects-1.15.2" = {
       name = "follow-redirects";
       packageName = "follow-redirects";
-      version = "1.15.1";
+      version = "1.15.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz";
-        sha512 = "yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==";
+        url = "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz";
+        sha512 = "VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==";
       };
     };
     "for-in-1.0.2" = {
@@ -5404,13 +5404,13 @@ let
         sha512 = "DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==";
       };
     };
-    "get-intrinsic-1.1.2" = {
+    "get-intrinsic-1.1.3" = {
       name = "get-intrinsic";
       packageName = "get-intrinsic";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz";
-        sha512 = "Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==";
+        url = "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz";
+        sha512 = "QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==";
       };
     };
     "get-own-enumerable-property-symbols-3.0.2" = {
@@ -6457,13 +6457,13 @@ let
         sha512 = "NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==";
       };
     };
-    "is-callable-1.2.4" = {
+    "is-callable-1.2.7" = {
       name = "is-callable";
       packageName = "is-callable";
-      version = "1.2.4";
+      version = "1.2.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz";
-        sha512 = "nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==";
+        url = "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz";
+        sha512 = "1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==";
       };
     };
     "is-color-stop-1.1.0" = {
@@ -7195,13 +7195,13 @@ let
         sha512 = "9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==";
       };
     };
-    "keyv-4.4.1" = {
+    "keyv-4.5.0" = {
       name = "keyv";
       packageName = "keyv";
-      version = "4.4.1";
+      version = "4.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/keyv/-/keyv-4.4.1.tgz";
-        sha512 = "PzByhNxfBLnSBW2MZi1DF+W5+qB/7BMpOokewqIvqS8GFtP7xHm2oeGU72Y1fhtfOv/FiEnI4+nyViYDmUChnw==";
+        url = "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz";
+        sha512 = "2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==";
       };
     };
     "killable-1.0.1" = {
@@ -8192,6 +8192,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz";
         sha512 = "PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==";
+      };
+    };
+    "node-gyp-build-4.5.0" = {
+      name = "node-gyp-build";
+      packageName = "node-gyp-build";
+      version = "4.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz";
+        sha512 = "2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==";
       };
     };
     "node-libs-browser-2.2.1" = {
@@ -9220,13 +9229,13 @@ let
         sha512 = "yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==";
       };
     };
-    "postcss-8.4.16" = {
+    "postcss-8.4.17" = {
       name = "postcss";
       packageName = "postcss";
-      version = "8.4.16";
+      version = "8.4.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz";
-        sha512 = "ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==";
+        url = "https://registry.npmjs.org/postcss/-/postcss-8.4.17.tgz";
+        sha512 = "UNxNOLQydcOFi41yHNMcKRZ39NeXlr8AxGuZJsdub8vIb12fHzcq37DTU/QtbI6WLxNg2gF9Z+8qtRwTj1UI1Q==";
       };
     };
     "postcss-calc-7.0.5" = {
@@ -10093,13 +10102,13 @@ let
         sha512 = "zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==";
       };
     };
-    "regenerate-unicode-properties-10.0.1" = {
+    "regenerate-unicode-properties-10.1.0" = {
       name = "regenerate-unicode-properties";
       packageName = "regenerate-unicode-properties";
-      version = "10.0.1";
+      version = "10.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz";
-        sha512 = "vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==";
+        url = "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz";
+        sha512 = "d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==";
       };
     };
     "regenerator-runtime-0.11.1" = {
@@ -10156,13 +10165,13 @@ let
         sha512 = "fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==";
       };
     };
-    "regexpu-core-5.1.0" = {
+    "regexpu-core-5.2.1" = {
       name = "regexpu-core";
       packageName = "regexpu-core";
-      version = "5.1.0";
+      version = "5.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.1.0.tgz";
-        sha512 = "bb6hk+xWd2PEOkj5It46A16zFMs2mv86Iwpdu94la4S3sJ7C973h2dHpYKwIBGaWSO7cIRJ+UX0IeMaWcO4qwA==";
+        url = "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.1.tgz";
+        sha512 = "HrnlNtpvqP1Xkb28tMhBUO2EbyUHdQlsnlAhzWcwHy8WJR53UWr7/MAvqrsQKMbV4qdpv03oTMG8iIhfsPFktQ==";
       };
     };
     "registry-auth-token-4.2.2" = {
@@ -10183,22 +10192,22 @@ let
         sha512 = "8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==";
       };
     };
-    "regjsgen-0.6.0" = {
+    "regjsgen-0.7.1" = {
       name = "regjsgen";
       packageName = "regjsgen";
-      version = "0.6.0";
+      version = "0.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz";
-        sha512 = "ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==";
+        url = "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz";
+        sha512 = "RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==";
       };
     };
-    "regjsparser-0.8.4" = {
+    "regjsparser-0.9.1" = {
       name = "regjsparser";
       packageName = "regjsparser";
-      version = "0.8.4";
+      version = "0.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz";
-        sha512 = "J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==";
+        url = "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz";
+        sha512 = "dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==";
       };
     };
     "relateurl-0.2.7" = {
@@ -10579,6 +10588,15 @@ let
         sha512 = "aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==";
       };
     };
+    "safe-regex-test-1.0.0" = {
+      name = "safe-regex-test";
+      packageName = "safe-regex-test";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz";
+        sha512 = "JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==";
+      };
+    };
     "safename-1.0.2" = {
       name = "safename";
       packageName = "safename";
@@ -10685,15 +10703,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz";
         sha512 = "b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==";
-      };
-    };
-    "semver-7.0.0" = {
-      name = "semver";
-      packageName = "semver";
-      version = "7.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz";
-        sha512 = "+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==";
       };
     };
     "semver-7.3.7" = {
@@ -10939,13 +10948,13 @@ let
         sha512 = "wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==";
       };
     };
-    "simple-git-3.13.0" = {
+    "simple-git-3.14.1" = {
       name = "simple-git";
       packageName = "simple-git";
-      version = "3.13.0";
+      version = "3.14.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-3.13.0.tgz";
-        sha512 = "VYrs3joeHvWGcN3K135RpGpPjm4AHYeOrclwew6LlfHgq6ozQYIW2yMnmjf4PCgVOuSYCbXkdUjyiFawuJz8MA==";
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-3.14.1.tgz";
+        sha512 = "1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==";
       };
     };
     "simple-swizzle-0.2.2" = {
@@ -11632,13 +11641,13 @@ let
         sha512 = "qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==";
       };
     };
-    "supports-hyperlinks-2.2.0" = {
+    "supports-hyperlinks-2.3.0" = {
       name = "supports-hyperlinks";
       packageName = "supports-hyperlinks";
-      version = "2.2.0";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz";
-        sha512 = "6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==";
+        url = "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz";
+        sha512 = "RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==";
       };
     };
     "supports-preserve-symlinks-flag-1.0.0" = {
@@ -12082,13 +12091,13 @@ let
         sha512 = "/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==";
       };
     };
-    "typescript-4.7.4" = {
+    "typescript-4.8.4" = {
       name = "typescript";
       packageName = "typescript";
-      version = "4.7.4";
+      version = "4.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz";
-        sha512 = "C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==";
+        url = "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz";
+        sha512 = "QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==";
       };
     };
     "uglify-es-3.3.10" = {
@@ -12172,13 +12181,13 @@ let
         sha512 = "7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==";
       };
     };
-    "unicode-property-aliases-ecmascript-2.0.0" = {
+    "unicode-property-aliases-ecmascript-2.1.0" = {
       name = "unicode-property-aliases-ecmascript";
       packageName = "unicode-property-aliases-ecmascript";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz";
-        sha512 = "5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==";
+        url = "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz";
+        sha512 = "6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==";
       };
     };
     "union-value-1.0.1" = {
@@ -12298,13 +12307,13 @@ let
         sha512 = "1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==";
       };
     };
-    "update-browserslist-db-1.0.5" = {
+    "update-browserslist-db-1.0.9" = {
       name = "update-browserslist-db";
       packageName = "update-browserslist-db";
-      version = "1.0.5";
+      version = "1.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz";
-        sha512 = "dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==";
+        url = "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz";
+        sha512 = "/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==";
       };
     };
     "upgrade-1.1.0" = {
@@ -12386,6 +12395,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/use/-/use-3.1.1.tgz";
         sha512 = "cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==";
+      };
+    };
+    "utf-8-validate-5.0.9" = {
+      name = "utf-8-validate";
+      packageName = "utf-8-validate";
+      version = "5.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz";
+        sha512 = "Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==";
       };
     };
     "util-0.10.3" = {
@@ -12505,58 +12523,58 @@ let
         sha512 = "2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==";
       };
     };
-    "vscode-jsonrpc-6.0.0" = {
+    "vscode-jsonrpc-8.0.2" = {
       name = "vscode-jsonrpc";
       packageName = "vscode-jsonrpc";
-      version = "6.0.0";
+      version = "8.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz";
-        sha512 = "wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==";
+        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz";
+        sha512 = "RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==";
       };
     };
-    "vscode-languageserver-7.0.0" = {
+    "vscode-languageserver-8.0.2" = {
       name = "vscode-languageserver";
       packageName = "vscode-languageserver";
-      version = "7.0.0";
+      version = "8.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz";
-        sha512 = "60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==";
+        url = "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz";
+        sha512 = "bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==";
       };
     };
-    "vscode-languageserver-protocol-3.16.0" = {
+    "vscode-languageserver-protocol-3.17.2" = {
       name = "vscode-languageserver-protocol";
       packageName = "vscode-languageserver-protocol";
-      version = "3.16.0";
+      version = "3.17.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz";
-        sha512 = "sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==";
+        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz";
+        sha512 = "8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==";
       };
     };
-    "vscode-languageserver-textdocument-1.0.4" = {
+    "vscode-languageserver-textdocument-1.0.7" = {
       name = "vscode-languageserver-textdocument";
       packageName = "vscode-languageserver-textdocument";
-      version = "1.0.4";
+      version = "1.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz";
-        sha512 = "/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==";
+        url = "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz";
+        sha512 = "bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==";
       };
     };
-    "vscode-languageserver-types-3.16.0" = {
+    "vscode-languageserver-types-3.17.2" = {
       name = "vscode-languageserver-types";
       packageName = "vscode-languageserver-types";
-      version = "3.16.0";
+      version = "3.17.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz";
-        sha512 = "k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==";
+        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz";
+        sha512 = "zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==";
       };
     };
-    "vscode-uri-3.0.3" = {
+    "vscode-uri-3.0.6" = {
       name = "vscode-uri";
       packageName = "vscode-uri";
-      version = "3.0.3";
+      version = "3.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz";
-        sha512 = "EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==";
+        url = "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.6.tgz";
+        sha512 = "fmL7V1eiDBFRRnu+gfRWTzyPpNIHJTc4mWnFkwBUmO9U3KPgJAmTx7oxi2bl/Rh6HLdU7+4C9wlj0k2E4AdKFQ==";
       };
     };
     "watchpack-1.7.5" = {
@@ -12595,13 +12613,13 @@ let
         sha512 = "XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==";
       };
     };
-    "web-tree-sitter-0.20.5" = {
+    "web-tree-sitter-0.20.7" = {
       name = "web-tree-sitter";
       packageName = "web-tree-sitter";
-      version = "0.20.5";
+      version = "0.20.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.5.tgz";
-        sha512 = "mpXlqIeEBE5Q71cnBnt8w6XKhIiKmllPECqsIFBtMvzcfCxA8+614iyMJXBCQo95Vs3y1zORLqiLJn25pYZ4Tw==";
+        url = "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.7.tgz";
+        sha512 = "flC9JJmTII9uAeeYpWF8hxDJ7bfY+leldQryetll8Nv4WgI+MXc6h7TiyAZASWl9uC9TvmfdgOjZn1DAQecb3A==";
       };
     };
     "webpack-4.44.2" = {
@@ -13607,6 +13625,7 @@ in
       sources."body-parser-1.20.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
+      sources."bufferutil-4.0.6"
       sources."bytes-3.1.2"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
@@ -13652,7 +13671,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."fsevents-2.3.2"
       sources."function-bind-1.1.1"
-      sources."get-intrinsic-1.1.2"
+      sources."get-intrinsic-1.1.3"
       sources."get-stream-4.1.0"
       sources."glob-7.2.3"
       sources."glob-parent-5.1.2"
@@ -13689,6 +13708,7 @@ in
       sources."minimist-1.2.6"
       sources."ms-2.0.0"
       sources."negotiator-0.6.3"
+      sources."node-gyp-build-4.5.0"
       sources."normalize-path-3.0.0"
       sources."normalize-url-4.5.1"
       sources."object-inspect-1.12.2"
@@ -13746,6 +13766,7 @@ in
       sources."type-is-1.6.18"
       sources."unpipe-1.0.0"
       sources."url-parse-lax-3.0.0"
+      sources."utf-8-validate-5.0.9"
       sources."utils-merge-1.0.1"
       sources."vary-1.1.2"
       sources."which-2.0.2"
@@ -13765,10 +13786,10 @@ in
   "@elm-tooling/elm-language-server" = nodeEnv.buildNodePackage {
     name = "_at_elm-tooling_slash_elm-language-server";
     packageName = "@elm-tooling/elm-language-server";
-    version = "2.4.1";
+    version = "2.5.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@elm-tooling/elm-language-server/-/elm-language-server-2.4.1.tgz";
-      sha512 = "v8WU/LOrksaR1IO3WkcH5KCfS1ExDDNSE8Aqz/SYMlkZ4RF2aU418Pm54ppdiVX5AOTgHjc6U6mp5LXZocoEqw==";
+      url = "https://registry.npmjs.org/@elm-tooling/elm-language-server/-/elm-language-server-2.5.0.tgz";
+      sha512 = "rHMqPaj3rvCmKqfF8oGtJ4CT8FVb35LhVjqIedlVRDlJ4JRPTyDdLITAgSdyaFErLAVxtQcNr56AWubeluZSCQ==";
     };
     dependencies = [
       sources."@nodelib/fs.scandir-2.1.5"
@@ -13784,7 +13805,7 @@ in
       sources."escape-string-regexp-4.0.0"
       sources."execa-5.1.1"
       sources."fast-diff-1.2.0"
-      sources."fast-glob-3.2.11"
+      sources."fast-glob-3.2.12"
       sources."fastq-1.13.0"
       sources."fill-range-7.0.1"
       sources."fsevents-2.3.2"
@@ -13824,13 +13845,13 @@ in
       sources."ts-debounce-4.0.0"
       sources."tslib-1.14.1"
       sources."tsyringe-4.7.0"
-      sources."vscode-jsonrpc-6.0.0"
-      sources."vscode-languageserver-7.0.0"
-      sources."vscode-languageserver-protocol-3.16.0"
-      sources."vscode-languageserver-textdocument-1.0.4"
-      sources."vscode-languageserver-types-3.16.0"
-      sources."vscode-uri-3.0.3"
-      sources."web-tree-sitter-0.20.5"
+      sources."vscode-jsonrpc-8.0.2"
+      sources."vscode-languageserver-8.0.2"
+      sources."vscode-languageserver-protocol-3.17.2"
+      sources."vscode-languageserver-textdocument-1.0.7"
+      sources."vscode-languageserver-types-3.17.2"
+      sources."vscode-uri-3.0.6"
+      sources."web-tree-sitter-0.20.7"
       sources."which-2.0.2"
     ];
     buildInputs = globalBuildInputs;
@@ -13885,7 +13906,7 @@ in
       })
       sources."fill-range-7.0.1"
       sources."finalhandler-1.1.2"
-      sources."follow-redirects-1.15.1"
+      sources."follow-redirects-1.15.2"
       sources."fresh-0.5.2"
       sources."fsevents-2.3.2"
       sources."get-stream-4.1.0"
@@ -13979,7 +14000,7 @@ in
       sources."chokidar-3.5.3"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
-      sources."commander-9.4.0"
+      sources."commander-9.4.1"
       sources."cross-spawn-7.0.3"
       sources."elm-solve-deps-wasm-1.0.1"
       sources."fill-range-7.0.1"
@@ -14035,10 +14056,9 @@ in
       sources."@szmarczak/http-timer-4.0.6"
       sources."@types/cacheable-request-6.0.2"
       sources."@types/http-cache-semantics-4.0.1"
-      sources."@types/json-buffer-3.0.0"
       sources."@types/keyv-3.1.4"
-      sources."@types/node-18.7.13"
-      sources."@types/responselike-1.0.0"
+      sources."@types/node-18.8.0"
+      sources."@types/responselike-3.0.0"
       sources."cacheable-lookup-2.0.1"
       sources."cacheable-request-7.0.2"
       sources."caw-2.0.1"
@@ -14047,7 +14067,6 @@ in
           sources."mimic-response-1.0.1"
         ];
       })
-      sources."compress-brotli-1.3.8"
       sources."config-chain-1.1.13"
       sources."decompress-response-5.0.0"
       sources."defer-to-connect-2.0.1"
@@ -14067,7 +14086,7 @@ in
       sources."isurl-1.0.0"
       sources."json-buffer-3.0.1"
       sources."jsonfile-4.0.0"
-      sources."keyv-4.4.1"
+      sources."keyv-4.5.0"
       sources."lowercase-keys-2.0.0"
       sources."lru-cache-6.0.0"
       sources."mimic-response-2.1.0"
@@ -14355,40 +14374,40 @@ in
     dependencies = [
       sources."@babel/cli-7.12.10"
       sources."@babel/code-frame-7.18.6"
-      sources."@babel/compat-data-7.18.13"
+      sources."@babel/compat-data-7.19.3"
       sources."@babel/core-7.12.10"
-      sources."@babel/generator-7.18.13"
+      sources."@babel/generator-7.19.3"
       sources."@babel/helper-annotate-as-pure-7.18.6"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.18.9"
-      (sources."@babel/helper-compilation-targets-7.18.9" // {
+      (sources."@babel/helper-compilation-targets-7.19.3" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
       })
-      sources."@babel/helper-create-class-features-plugin-7.18.13"
-      sources."@babel/helper-create-regexp-features-plugin-7.18.6"
+      sources."@babel/helper-create-class-features-plugin-7.19.0"
+      sources."@babel/helper-create-regexp-features-plugin-7.19.0"
       sources."@babel/helper-environment-visitor-7.18.9"
       sources."@babel/helper-explode-assignable-expression-7.18.6"
-      sources."@babel/helper-function-name-7.18.9"
+      sources."@babel/helper-function-name-7.19.0"
       sources."@babel/helper-hoist-variables-7.18.6"
       sources."@babel/helper-member-expression-to-functions-7.18.9"
       sources."@babel/helper-module-imports-7.18.6"
-      sources."@babel/helper-module-transforms-7.18.9"
+      sources."@babel/helper-module-transforms-7.19.0"
       sources."@babel/helper-optimise-call-expression-7.18.6"
-      sources."@babel/helper-plugin-utils-7.18.9"
+      sources."@babel/helper-plugin-utils-7.19.0"
       sources."@babel/helper-remap-async-to-generator-7.18.9"
-      sources."@babel/helper-replace-supers-7.18.9"
+      sources."@babel/helper-replace-supers-7.19.1"
       sources."@babel/helper-simple-access-7.18.6"
       sources."@babel/helper-skip-transparent-expression-wrappers-7.18.9"
       sources."@babel/helper-split-export-declaration-7.18.6"
       sources."@babel/helper-string-parser-7.18.10"
-      sources."@babel/helper-validator-identifier-7.18.6"
+      sources."@babel/helper-validator-identifier-7.19.1"
       sources."@babel/helper-validator-option-7.18.6"
-      sources."@babel/helper-wrap-function-7.18.11"
-      sources."@babel/helpers-7.18.9"
+      sources."@babel/helper-wrap-function-7.19.0"
+      sources."@babel/helpers-7.19.0"
       sources."@babel/highlight-7.18.6"
-      sources."@babel/parser-7.18.13"
-      sources."@babel/plugin-proposal-async-generator-functions-7.18.10"
+      sources."@babel/parser-7.19.3"
+      sources."@babel/plugin-proposal-async-generator-functions-7.19.1"
       sources."@babel/plugin-proposal-class-properties-7.18.6"
       sources."@babel/plugin-proposal-dynamic-import-7.18.6"
       sources."@babel/plugin-proposal-export-namespace-from-7.18.9"
@@ -14417,7 +14436,7 @@ in
       sources."@babel/plugin-transform-async-to-generator-7.18.6"
       sources."@babel/plugin-transform-block-scoped-functions-7.18.6"
       sources."@babel/plugin-transform-block-scoping-7.18.9"
-      sources."@babel/plugin-transform-classes-7.18.9"
+      sources."@babel/plugin-transform-classes-7.19.0"
       sources."@babel/plugin-transform-computed-properties-7.18.9"
       sources."@babel/plugin-transform-destructuring-7.18.13"
       sources."@babel/plugin-transform-dotall-regex-7.18.6"
@@ -14429,9 +14448,9 @@ in
       sources."@babel/plugin-transform-member-expression-literals-7.18.6"
       sources."@babel/plugin-transform-modules-amd-7.18.6"
       sources."@babel/plugin-transform-modules-commonjs-7.18.6"
-      sources."@babel/plugin-transform-modules-systemjs-7.18.9"
+      sources."@babel/plugin-transform-modules-systemjs-7.19.0"
       sources."@babel/plugin-transform-modules-umd-7.18.6"
-      sources."@babel/plugin-transform-named-capturing-groups-regex-7.18.6"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.19.1"
       sources."@babel/plugin-transform-new-target-7.18.6"
       sources."@babel/plugin-transform-object-super-7.18.6"
       sources."@babel/plugin-transform-parameters-7.18.8"
@@ -14440,7 +14459,7 @@ in
       sources."@babel/plugin-transform-reserved-words-7.18.6"
       sources."@babel/plugin-transform-runtime-7.12.10"
       sources."@babel/plugin-transform-shorthand-properties-7.18.6"
-      sources."@babel/plugin-transform-spread-7.18.9"
+      sources."@babel/plugin-transform-spread-7.19.0"
       sources."@babel/plugin-transform-sticky-regex-7.18.6"
       sources."@babel/plugin-transform-template-literals-7.18.9"
       sources."@babel/plugin-transform-typeof-symbol-7.18.9"
@@ -14450,8 +14469,8 @@ in
       sources."@babel/preset-modules-0.1.5"
       sources."@babel/runtime-7.12.5"
       sources."@babel/template-7.18.10"
-      sources."@babel/traverse-7.18.13"
-      sources."@babel/types-7.18.13"
+      sources."@babel/traverse-7.19.3"
+      sources."@babel/types-7.19.3"
       sources."@hapi/address-2.1.4"
       sources."@hapi/bourne-1.3.2"
       sources."@hapi/hoek-8.5.1"
@@ -14468,8 +14487,8 @@ in
       sources."@types/html-minifier-terser-5.1.2"
       sources."@types/http-proxy-1.17.9"
       sources."@types/json-schema-7.0.11"
-      sources."@types/minimatch-5.1.0"
-      sources."@types/node-18.7.13"
+      sources."@types/minimatch-5.1.2"
+      sources."@types/node-18.8.0"
       sources."@types/parse-json-4.0.0"
       sources."@types/q-1.5.5"
       sources."@types/source-list-map-0.1.2"
@@ -14621,7 +14640,7 @@ in
         ];
       })
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.21.3"
+      sources."browserslist-4.21.4"
       sources."buffer-4.9.2"
       sources."buffer-from-1.1.2"
       sources."buffer-indexof-1.1.1"
@@ -14638,7 +14657,7 @@ in
       sources."camel-case-4.1.2"
       sources."camelcase-5.3.1"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001382"
+      sources."caniuse-lite-1.0.30001414"
       sources."case-sensitive-paths-webpack-plugin-2.3.0"
       sources."caseless-0.12.0"
       (sources."chalk-2.4.2" // {
@@ -14737,11 +14756,7 @@ in
         ];
       })
       sources."core-js-2.6.12"
-      (sources."core-js-compat-3.25.0" // {
-        dependencies = [
-          sources."semver-7.0.0"
-        ];
-      })
+      sources."core-js-compat-3.25.4"
       sources."core-util-is-1.0.3"
       sources."cosmiconfig-5.2.1"
       (sources."create-ecdh-4.0.4" // {
@@ -14754,13 +14769,22 @@ in
       sources."cross-spawn-7.0.3"
       sources."crypto-browserify-3.12.0"
       sources."css-color-names-0.0.4"
-      sources."css-declaration-sorter-4.0.1"
+      (sources."css-declaration-sorter-4.0.1" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
       (sources."css-loader-4.3.0" // {
         dependencies = [
           sources."camelcase-6.3.0"
           sources."loader-utils-2.0.2"
           sources."lru-cache-6.0.0"
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."semver-7.3.7"
+          sources."source-map-0.6.1"
           sources."yallist-4.0.0"
         ];
       })
@@ -14773,11 +14797,29 @@ in
       })
       sources."css-what-6.1.0"
       sources."cssesc-3.0.0"
-      sources."cssnano-4.1.11"
-      sources."cssnano-preset-default-4.0.8"
+      (sources."cssnano-4.1.11" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."cssnano-preset-default-4.0.8" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
       sources."cssnano-util-get-arguments-4.0.0"
       sources."cssnano-util-get-match-4.0.0"
-      sources."cssnano-util-raw-cache-4.0.1"
+      (sources."cssnano-util-raw-cache-4.0.1" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
       sources."cssnano-util-same-parent-4.0.1"
       (sources."csso-4.2.0" // {
         dependencies = [
@@ -14838,7 +14880,7 @@ in
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.4.228"
+      sources."electron-to-chromium-1.4.270"
       (sources."elliptic-6.5.4" // {
         dependencies = [
           sources."bn.js-4.12.0"
@@ -14856,7 +14898,7 @@ in
           sources."chalk-4.1.2"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
-          sources."commander-9.4.0"
+          sources."commander-9.4.1"
           sources."glob-8.0.3"
           sources."has-flag-4.0.0"
           sources."minimatch-5.1.0"
@@ -14876,7 +14918,7 @@ in
       sources."entities-2.2.0"
       sources."errno-0.1.8"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.20.1"
+      sources."es-abstract-1.20.3"
       sources."es-array-method-boxes-properly-1.0.0"
       sources."es-to-primitive-1.2.1"
       sources."escalade-3.1.1"
@@ -15005,7 +15047,7 @@ in
       sources."find-up-4.1.0"
       sources."firstline-1.3.1"
       sources."flush-write-stream-1.1.1"
-      sources."follow-redirects-1.15.1"
+      sources."follow-redirects-1.15.2"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -15024,7 +15066,7 @@ in
       sources."functions-have-names-1.2.3"
       sources."gensync-1.0.0-beta.2"
       sources."get-caller-file-1.0.3"
-      sources."get-intrinsic-1.1.2"
+      sources."get-intrinsic-1.1.3"
       sources."get-own-enumerable-property-symbols-3.0.2"
       sources."get-stream-4.1.0"
       sources."get-symbol-description-1.0.0"
@@ -15104,7 +15146,13 @@ in
       sources."https-browserify-1.0.0"
       sources."i-0.3.7"
       sources."iconv-lite-0.4.24"
-      sources."icss-utils-4.1.1"
+      (sources."icss-utils-4.1.1" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
       sources."ieee754-1.2.1"
       sources."iferr-0.1.5"
       sources."ignore-3.3.10"
@@ -15148,7 +15196,7 @@ in
       sources."is-binary-path-2.1.0"
       sources."is-boolean-object-1.1.2"
       sources."is-buffer-1.1.6"
-      sources."is-callable-1.2.4"
+      sources."is-callable-1.2.7"
       sources."is-color-stop-1.1.0"
       sources."is-core-module-2.10.0"
       sources."is-data-descriptor-1.0.0"
@@ -15400,28 +15448,65 @@ in
         ];
       })
       sources."posix-character-classes-0.1.1"
-      (sources."postcss-7.0.39" // {
+      sources."postcss-8.4.17"
+      (sources."postcss-calc-7.0.5" // {
         dependencies = [
           sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."source-map-0.6.1"
         ];
       })
-      sources."postcss-calc-7.0.5"
       (sources."postcss-colormin-4.0.3" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-convert-values-4.0.1" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
-      sources."postcss-discard-comments-4.0.2"
-      sources."postcss-discard-duplicates-4.0.2"
-      sources."postcss-discard-empty-4.0.1"
-      sources."postcss-discard-overridden-4.0.1"
-      sources."postcss-flexbugs-fixes-4.2.1"
+      (sources."postcss-discard-comments-4.0.2" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."postcss-discard-duplicates-4.0.2" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."postcss-discard-empty-4.0.1" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."postcss-discard-overridden-4.0.1" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."postcss-flexbugs-fixes-4.2.1" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
       (sources."postcss-loader-4.1.0" // {
         dependencies = [
           sources."cosmiconfig-7.0.1"
@@ -15438,103 +15523,192 @@ in
       })
       (sources."postcss-merge-longhand-4.0.11" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-merge-rules-4.0.3" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-selector-parser-3.1.2"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-minify-font-values-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-minify-gradients-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-minify-params-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-minify-selectors-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-selector-parser-3.1.2"
+          sources."source-map-0.6.1"
         ];
       })
-      sources."postcss-modules-extract-imports-2.0.0"
-      sources."postcss-modules-local-by-default-3.0.3"
-      sources."postcss-modules-scope-2.2.0"
-      sources."postcss-modules-values-3.0.0"
-      sources."postcss-normalize-charset-4.0.1"
+      (sources."postcss-modules-extract-imports-2.0.0" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."postcss-modules-local-by-default-3.0.3" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."postcss-modules-scope-2.2.0" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."postcss-modules-values-3.0.0" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."postcss-normalize-charset-4.0.1" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
       (sources."postcss-normalize-display-values-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-normalize-positions-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-normalize-repeat-style-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-normalize-string-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-normalize-timing-functions-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-normalize-unicode-4.0.1" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-normalize-url-4.0.1" // {
         dependencies = [
           sources."normalize-url-3.3.0"
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-normalize-whitespace-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
       (sources."postcss-ordered-values-4.1.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
-      sources."postcss-reduce-initial-4.0.3"
+      (sources."postcss-reduce-initial-4.0.3" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
       (sources."postcss-reduce-transforms-4.0.2" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
-      (sources."postcss-safe-parser-5.0.2" // {
-        dependencies = [
-          sources."postcss-8.4.16"
-        ];
-      })
+      sources."postcss-safe-parser-5.0.2"
       sources."postcss-selector-parser-6.0.10"
       (sources."postcss-svgo-4.0.3" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-value-parser-3.3.1"
+          sources."source-map-0.6.1"
         ];
       })
-      sources."postcss-unique-selectors-4.0.1"
+      (sources."postcss-unique-selectors-4.0.1" // {
+        dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
+          sources."source-map-0.6.1"
+        ];
+      })
       sources."postcss-value-parser-4.2.0"
       sources."prepend-http-1.0.4"
       sources."pretty-bytes-5.6.0"
@@ -15627,14 +15801,14 @@ in
         ];
       })
       sources."regenerate-1.4.2"
-      sources."regenerate-unicode-properties-10.0.1"
+      sources."regenerate-unicode-properties-10.1.0"
       sources."regenerator-runtime-0.13.9"
       sources."regenerator-transform-0.15.0"
       sources."regex-not-1.0.2"
       sources."regexp.prototype.flags-1.4.3"
-      sources."regexpu-core-5.1.0"
-      sources."regjsgen-0.6.0"
-      (sources."regjsparser-0.8.4" // {
+      sources."regexpu-core-5.2.1"
+      sources."regjsgen-0.7.1"
+      (sources."regjsparser-0.9.1" // {
         dependencies = [
           sources."jsesc-0.5.0"
         ];
@@ -15675,6 +15849,7 @@ in
       })
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
+      sources."safe-regex-test-1.0.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."schema-utils-2.7.1"
@@ -15842,7 +16017,10 @@ in
       })
       (sources."stylehacks-4.0.3" // {
         dependencies = [
+          sources."picocolors-0.2.1"
+          sources."postcss-7.0.39"
           sources."postcss-selector-parser-3.1.2"
+          sources."source-map-0.6.1"
         ];
       })
       sources."supports-color-5.5.0"
@@ -15942,7 +16120,7 @@ in
       sources."unicode-canonical-property-names-ecmascript-2.0.0"
       sources."unicode-match-property-ecmascript-2.0.0"
       sources."unicode-match-property-value-ecmascript-2.0.0"
-      sources."unicode-property-aliases-ecmascript-2.0.0"
+      sources."unicode-property-aliases-ecmascript-2.1.0"
       sources."union-value-1.0.1"
       sources."uniq-1.0.1"
       sources."uniqs-2.0.0"
@@ -15962,7 +16140,7 @@ in
         ];
       })
       sources."upath-1.2.0"
-      sources."update-browserslist-db-1.0.5"
+      sources."update-browserslist-db-1.0.9"
       sources."uri-js-4.4.1"
       sources."urix-0.1.0"
       (sources."url-0.11.0" // {
@@ -16230,7 +16408,7 @@ in
       sources."supports-color-7.2.0"
       sources."temp-0.9.4"
       sources."ts-union-2.3.0"
-      sources."typescript-4.7.4"
+      sources."typescript-4.8.4"
       sources."which-1.3.1"
       sources."wrappy-1.0.2"
     ];
@@ -16268,8 +16446,8 @@ in
       sources."@types/debug-0.0.30"
       sources."@types/get-port-3.2.0"
       sources."@types/glob-5.0.37"
-      sources."@types/lodash-4.14.184"
-      sources."@types/minimatch-5.1.0"
+      sources."@types/lodash-4.14.186"
+      sources."@types/minimatch-5.1.2"
       sources."@types/mkdirp-0.5.2"
       sources."@types/node-8.10.66"
       sources."@types/rimraf-2.0.5"
@@ -16295,6 +16473,7 @@ in
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
       sources."buffer-from-1.1.2"
+      sources."bufferutil-4.0.6"
       sources."bytes-3.1.2"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
@@ -16358,7 +16537,7 @@ in
         ];
       })
       sources."extend-shallow-2.0.1"
-      sources."fast-glob-3.2.11"
+      sources."fast-glob-3.2.12"
       sources."fastq-1.13.0"
       sources."fill-range-7.0.1"
       sources."finalhandler-1.1.2"
@@ -16368,7 +16547,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."fsevents-2.3.2"
       sources."function-bind-1.1.1"
-      sources."get-intrinsic-1.1.2"
+      sources."get-intrinsic-1.1.3"
       sources."get-port-3.2.0"
       sources."get-stream-4.1.0"
       sources."glob-7.2.3"
@@ -16426,6 +16605,7 @@ in
       sources."ms-2.0.0"
       sources."negotiator-0.6.3"
       sources."nice-try-1.0.5"
+      sources."node-gyp-build-4.5.0"
       sources."normalize-path-3.0.0"
       sources."normalize-url-4.5.1"
       sources."object-hash-2.2.0"
@@ -16519,6 +16699,7 @@ in
       sources."universalify-2.0.0"
       sources."unpipe-1.0.0"
       sources."url-parse-lax-3.0.0"
+      sources."utf-8-validate-5.0.9"
       sources."utils-merge-1.0.1"
       sources."vary-1.1.2"
       sources."which-2.0.2"
@@ -16538,19 +16719,18 @@ in
   elm-review = nodeEnv.buildNodePackage {
     name = "elm-review";
     packageName = "elm-review";
-    version = "2.7.4";
+    version = "2.7.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elm-review/-/elm-review-2.7.4.tgz";
-      sha512 = "D6J3Gx1JCuNiTk7QeXbRkywLhEtOWqvZKyZoihxQdYlxUqVICwvQf2qaP0d1QunpQKY22iQQpzyEn0PAczNn7Q==";
+      url = "https://registry.npmjs.org/elm-review/-/elm-review-2.7.5.tgz";
+      sha512 = "i9K8G99fiS4MkU2P3Tjk7BfN2PFPRPFBgcugQODrIDAjm1PtGCueFDkzBpaCDDuqkrC3Dy4KEYrnGPlCCdcO8Q==";
     };
     dependencies = [
       sources."@sindresorhus/is-4.6.0"
       sources."@szmarczak/http-timer-4.0.6"
       sources."@types/cacheable-request-6.0.2"
       sources."@types/http-cache-semantics-4.0.1"
-      sources."@types/json-buffer-3.0.0"
       sources."@types/keyv-3.1.4"
-      sources."@types/node-18.7.13"
+      sources."@types/node-18.8.0"
       sources."@types/responselike-1.0.0"
       sources."ansi-escapes-4.3.2"
       sources."ansi-regex-5.0.1"
@@ -16574,7 +16754,6 @@ in
       sources."clone-response-1.0.3"
       sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
-      sources."compress-brotli-1.3.8"
       sources."concat-map-0.0.1"
       sources."cross-spawn-7.0.3"
       sources."debug-4.3.4"
@@ -16621,7 +16800,7 @@ in
       sources."isexe-2.0.0"
       sources."json-buffer-3.0.1"
       sources."jsonfile-6.1.0"
-      sources."keyv-4.4.1"
+      sources."keyv-4.5.0"
       sources."kleur-3.0.3"
       sources."locate-path-5.0.0"
       sources."log-symbols-4.1.0"
@@ -16663,7 +16842,7 @@ in
       sources."string_decoder-1.3.0"
       sources."strip-ansi-6.0.1"
       sources."supports-color-7.2.0"
-      sources."supports-hyperlinks-2.2.0"
+      sources."supports-hyperlinks-2.3.0"
       sources."temp-0.9.4"
       sources."terminal-link-2.1.1"
       sources."to-regex-range-5.0.1"
@@ -16701,7 +16880,7 @@ in
       sources."lru-cache-6.0.0"
       sources."ms-2.1.2"
       sources."semver-7.3.7"
-      sources."simple-git-3.13.0"
+      sources."simple-git-3.14.1"
       sources."upath-2.0.1"
       sources."yallist-4.0.0"
     ];


### PR DESCRIPTION
###### Description of changes

I ran `./generate-node-packages.sh`.
Which upgraded elm-lsp from 2.4.1 to 2.5.0, but also updated lots of other things.   
But i git diff - grepped for the other packages in `node-packages.json` and none of them got changed it seems.  

###### Things done

```
./generate-node-packages.sh
```
Then changed to root and built it with:
```
nix build '.#elmPackages.elm-language-server'
```
then added it to my lsp config in vim:
```
        "elmLS": {
            "command": "/nix/store/bzy3mrn7ik1nqaxjb7q3fy8kcz678caf-_at_elm-tooling_slash_elm-language-server-2.5.0/bin/elm-language-server",
            "filetypes": ["elm"],
            "rootPatterns": ["elm.json"],
            "initializationOptions": {
                "elmFormatPath": "elm-format",
                "elmTestPath": "elm-test",
                "elmReviewPath": "elm-review"
            }
        }

```
And it seems to work fine.


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
