### PR TITLE
artem: init at 1.1.5

### DIFF
--- a/pkgs/applications/graphics/artem/default.nix
+++ b/pkgs/applications/graphics/artem/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, pkg-config
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "artem";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "finefindus";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1jax39gizlcbqnkjckxwm5h0wdk5dk8dasaj9wxv7yidbcbgj4zh";
+  };
+
+  cargoSha256 = "sha256-n2NOWrgcMVHpNCHL7r8+Kl1e01XYadaNM7UdE8fQo1U=";
+
+  nativeBuildInputs = [ installShellFiles pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  OPENSSL_NO_VENDOR = 1;
+
+  checkFlags = [
+    # require internet access
+    "--skip=arguments::input::url_input"
+    "--skip=full_file_compare_url"
+
+    # flaky
+    "--skip=full_file_compare_html"
+  ];
+
+  postInstall = ''
+    installManPage $releaseDir/build/artem-*/out/artem.1
+    installShellCompletion $releaseDir/build/artem-*/out/artem.{bash,fish} \
+      --zsh $releaseDir/build/artem-*/out/_artem
+  '';
+
+  meta = with lib; {
+    description = "A small CLI program to convert images to ASCII art";
+    homepage = "https://github.com/finefindus/artem";
+    changelog = "https://github.com/finefindus/artem/blob/v${version}/CHANGELOG.md";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26768,6 +26768,8 @@ with pkgs;
 
   arkade = callPackage ../applications/networking/cluster/arkade { };
 
+  artem = callPackage ../applications/graphics/artem { };
+
   asuka = callPackage ../applications/networking/browsers/asuka {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

> artem is a small CLI program to convert images to ASCII art

https://github.com/finefindus/artem

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
