### PR TITLE
add puae retroarch core

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -40,6 +40,7 @@
 , xxd
 , xz
 , zlib
+, fetchpatch
 }:
 
 let
@@ -725,6 +726,17 @@ in
     description = "Port of ProSystem to libretro";
     license = lib.licenses.gpl2Only;
     makefile = "Makefile";
+  };
+
+  puae = mkLibRetroCore {
+    core = "puae";
+    description = "Amiga emulator based on WinUAE";
+    license = lib.licenses.gpl2Only;
+    makefile = "Makefile";
+    patches = fetchpatch {
+        url = "https://github.com/libretro/libretro-uae/commit/90ba4c9bb940e566781c3590553270ad69cf212e.patch";
+        sha256 = "sha256-9xkRravvyFZc0xsIj0OSm2ux5BqYogfQ1TDnH9l6jKw=";
+    };
   };
 
   quicknes = mkLibRetroCore {

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -376,6 +376,12 @@
         "rev": "fbf62c3dacaac694f7ec26cf9be10a51b27271e7",
         "sha256": "Opb6CUeT/bnaTg4MJo7DNsVyaPa73PLbIor25HHWzZ0="
     },
+    "puae": {
+        "owner": "libretro",
+        "repo": "libretro-uae",
+        "rev": "1b7dd443ff89d667d99f8c44454a91ed59bcabd9",
+        "sha256": "YJiZEtB0rBFffEZj/hB7zEFBUp02kCzblq4CtCmygKo="
+    },
     "quicknes": {
         "owner": "libretro",
         "repo": "QuickNES_Core",

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -71,6 +71,7 @@ CORES = {
     "ppsspp": {"repo": "ppsspp", "owner": "hrydgard", "fetch_submodules": True},
     "prboom": {"repo": "libretro-prboom"},
     "prosystem": {"repo": "prosystem-libretro"},
+    "puae": {"repo": "libretro-uae"},
     "quicknes": {"repo": "QuickNES_Core"},
     "sameboy": {"repo": "sameboy"},
     "scummvm": {"repo": "scummvm"},


### PR DESCRIPTION
PUAE is a libretro core for Amiga emulation.
[Commodore - Amiga (PUAE) - Libretro Docs](https://docs.libretro.com/library/puae/#external-links)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
