### PR TITLE
pythonPackage.pypcap: 1.2.3 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/pypcap/default.nix
+++ b/pkgs/development/python-modules/pypcap/default.nix
@@ -2,31 +2,21 @@
 , buildPythonPackage
 , dpkt
 , fetchFromGitHub
-, fetchpatch
 , libpcap
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pypcap";
-  version = "1.2.3";
-
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "pynetwork";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1zscfk10jpqwxgc8d84y8bffiwr92qrg2b24afhjwiyr352l67cf";
+    # No release was tagged and PyPI doesn't contain tests.
+    rev = "968859f0ffb5b7c990506dffe82457b7de23a026";
+    sha256 = "sha256-NfyEC3qEBm6TjebcDIsoz8tJWaJ625ZFPfx7AMyynWE=";
   };
-
-  patches = [
-    # Support for Python 3.9, https://github.com/pynetwork/pypcap/pull/102
-    (fetchpatch {
-      name = "support-python-3.9.patch";
-      url = "https://github.com/pynetwork/pypcap/pull/102/commits/e22f5d25f0d581d19ef337493434e72cd3a6ae71.patch";
-      sha256 = "0n1syh1vcplgsf6njincpqphd2w030s3b2jyg86d7kbqv1w5wk0l";
-    })
-  ];
 
   postPatch = ''
     # Add the path to libpcap in the nix-store


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump pypcap to its latest release 1.3.0:
- https://github.com/pynetwork/pypcap/blob/master/Changelog.md#pypcap-130-2022-09-05
- https://pypi.org/project/pypcap/1.3.0/
- https://github.com/pynetwork/pypcap/pull/109

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
