### PR TITLE
pythonPackages.pysdl2: fix build by fixing patch

### DIFF
--- a/pkgs/development/python-modules/pysdl2/PySDL2-dll.patch
+++ b/pkgs/development/python-modules/pysdl2/PySDL2-dll.patch
@@ -1,8 +1,8 @@
 diff --git a/sdl2/dll.py b/sdl2/dll.py
-index 6e30259..12e1f7d 100644
+index 2413329..f460bf6 100644
 --- a/sdl2/dll.py
 +++ b/sdl2/dll.py
-@@ -145,7 +145,7 @@ class DLL(object):
+@@ -235,7 +235,7 @@ class DLL(object):
      """Function wrapper around the different DLL functions. Do not use or
      instantiate this one directly from your user code.
      """
@@ -11,49 +11,31 @@ index 6e30259..12e1f7d 100644
          self._dll = None
          self._deps = None
          self._libname = libinfo
-@@ -157,11 +157,12 @@ class DLL(object):
-             "SDL2_image": 2001,
-             "SDL2_gfx": 1003
+@@ -247,11 +247,7 @@ class DLL(object):
+             "SDL2_image": (2, 0, 1),
+             "SDL2_gfx": (1, 0, 3)
          }
 -        foundlibs = _findlib(libnames, path)
 -        dllmsg = "PYSDL2_DLL_PATH: %s" % (os.getenv("PYSDL2_DLL_PATH") or "unset")
 -        if len(foundlibs) == 0:
 -            raise RuntimeError("could not find any library for %s (%s)" %
 -                               (libinfo, dllmsg))
-+        #foundlibs = _findlib(libnames, path)
-+        #dllmsg = "PYSDL2_DLL_PATH: %s" % (os.getenv("PYSDL2_DLL_PATH") or "unset")
-+        #if len(foundlibs) == 0:
-+        #    raise RuntimeError("could not find any library for %s (%s)" %
-+        #                       (libinfo, dllmsg))
 +        foundlibs = [ libfile ]
          for libfile in foundlibs:
              try:
                  self._dll = CDLL(libfile)
-@@ -185,19 +186,19 @@ class DLL(object):
+@@ -276,9 +272,6 @@ class DLL(object):
                                 (foundlibs, libinfo))
          if _using_ms_store_python():
              self._deps = _preload_deps(libinfo, self._libfile)
 -        if path is not None and sys.platform in ("win32",) and \
 -            path in self._libfile:
 -            os.environ["PATH"] = "%s;%s" % (path, os.environ["PATH"])
-+        #if path is not None and sys.platform in ("win32",) and \
-+        #    path in self._libfile:
-+        #    os.environ["PATH"] = "%s;%s" % (path, os.environ["PATH"])
  
      def bind_function(self, funcname, args=None, returns=None, added=None):
          """Binds the passed argument and return value types to the specified
-         function. If the version of the loaded library is older than the
-         version where the function was added, an informative exception will
-         be raised if the bound function is called.
-         
-         Args:
-             funcname (str): The name of the function to bind.
-             args (List or None, optional): The data types of the C function's 
-                 arguments. Should be 'None' if function takes no arguments.
-             returns (optional): The return type of the bound C function. Should
-                 be 'None' if function returns 'void'.
-@@ -288,7 +289,7 @@ def nullfunc(*args):
-     return
+@@ -359,7 +352,7 @@ class DLL(object):
+ # Once the DLL class is defined, try loading the main SDL2 library
  
  try:
 -    dll = DLL("SDL2", ["SDL2", "SDL2-2.0", "SDL2-2.0.0"], os.getenv("PYSDL2_DLL_PATH"))
@@ -62,10 +44,10 @@ index 6e30259..12e1f7d 100644
      raise ImportError(exc)
  
 diff --git a/sdl2/sdlgfx.py b/sdl2/sdlgfx.py
-index 090752e..a8a7488 100644
+index 015eeaf..d6ce52f 100644
 --- a/sdl2/sdlgfx.py
 +++ b/sdl2/sdlgfx.py
-@@ -50,8 +50,7 @@ __all__ = [
+@@ -27,8 +27,7 @@ __all__ = [
  
  
  try:
@@ -76,32 +58,25 @@ index 090752e..a8a7488 100644
      raise ImportError(exc)
  
 diff --git a/sdl2/sdlimage.py b/sdl2/sdlimage.py
-index a6884e8..95d96df 100644
+index a702136..dcdea51 100644
 --- a/sdl2/sdlimage.py
 +++ b/sdl2/sdlimage.py
-@@ -32,15 +32,14 @@ __all__ = [
-     "IMG_LoadXCF_RW", "IMG_LoadWEBP_RW", "IMG_LoadXPM_RW",
-     "IMG_LoadXV_RW", "IMG_ReadXPMFromArray",
-     "IMG_GetError", "IMG_SetError", "IMG_SaveJPG", "IMG_SaveJPG_RW",
--    
-+
-     # Python Functions
-     "get_dll_file"
- ]
+@@ -30,9 +30,7 @@ __all__ = [
  
  
  try:
--    dll = DLL("SDL2_image", ["SDL2_image", "SDL2_image-2.0"],
--              os.getenv("PYSDL2_DLL_PATH"))
+-    dll = DLL(
+-        "SDL2_image", ["SDL2_image", "SDL2_image-2.0"], os.getenv("PYSDL2_DLL_PATH")
+-    )
 +    dll = DLL("SDL2_image", "@sdl2_image@")
  except RuntimeError as exc:
      raise ImportError(exc)
  
 diff --git a/sdl2/sdlmixer.py b/sdl2/sdlmixer.py
-index 9ad9b85..1c36289 100644
+index 5f2163c..23d95b0 100644
 --- a/sdl2/sdlmixer.py
 +++ b/sdl2/sdlmixer.py
-@@ -76,8 +76,7 @@ __all__ = [
+@@ -50,8 +50,7 @@ __all__ = [
  ]
  
  try:
@@ -112,10 +87,10 @@ index 9ad9b85..1c36289 100644
      raise ImportError(exc)
  
 diff --git a/sdl2/sdlttf.py b/sdl2/sdlttf.py
-index 9c2d951..bd5a16a 100644
+index 7c5f7db..61814cd 100644
 --- a/sdl2/sdlttf.py
 +++ b/sdl2/sdlttf.py
-@@ -54,8 +54,7 @@ __all__ = [
+@@ -41,8 +41,7 @@ __all__ = [
  
  
  try:

--- a/pkgs/development/python-modules/pysdl2/default.nix
+++ b/pkgs/development/python-modules/pysdl2/default.nix
@@ -3,11 +3,13 @@
 buildPythonPackage rec {
   pname = "PySDL2";
   version = "0.9.14";
+
   # The tests use OpenGL using find_library, which would have to be
   # patched; also they seem to actually open X windows and test stuff
   # like "screensaver disabling", which would have to be cleverly
   # sandboxed. Disable for now.
   doCheck = false;
+  pythonImportsCheck = [ "sdl2" ];
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Description of changes

The PySDL2-dll.patch did not apply after the last package bump. This commit both fixes the patch and introduces a pythonImportsCheck.

Closes #193814.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
