### PR TITLE
teleport: 9.1.2 → 10.3.1, enable libfido2 support

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -530,6 +530,16 @@
       </listitem>
       <listitem>
         <para>
+          <literal>teleport</literal> has been upgraded to major version
+          10. Please see upstream
+          <link xlink:href="https://goteleport.com/docs/ver/10.0/management/operations/upgrading/">upgrade
+          instructions</link> and
+          <link xlink:href="https://goteleport.com/docs/ver/10.0/changelog/#1000">release
+          notes</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           lemmy module option
           <literal>services.lemmy.settings.database.createLocally</literal>
           moved to

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -179,6 +179,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - dd-agent package removed along with the `services.dd-agent` module, due to the project being deprecated in favor of `datadog-agent`,  which is available via the `services.datadog-agent` module.
 
+- `teleport` has been upgraded to major version 10. Please see upstream [upgrade instructions](https://goteleport.com/docs/ver/10.0/management/operations/upgrading/) and [release notes](https://goteleport.com/docs/ver/10.0/changelog/#1000).
+
 - lemmy module option `services.lemmy.settings.database.createLocally`
   moved to `services.lemmy.database.createLocally`.
 

--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -14,7 +14,6 @@
 , nixosTests
 
 , withRdpClient ? true
-, withRoleTester ? true
 }:
 let
   # This repo has a private submodule "e" which fetchgit cannot handle without failing.
@@ -22,13 +21,13 @@ let
     owner = "gravitational";
     repo = "teleport";
     rev = "v${version}";
-    sha256 = "sha256-KQfdeMuZ9LJHhEJLMl58Yb0+gxgDT7VcVnK1JxjVZaI=";
+    hash = "sha256-F5v3/eKPLhSxW7FImTbE+QMtfn8w5WVTrxMWhgNr3YA=";
   };
-  version = "9.1.2";
+  version = "10.3.1";
 
   rdpClient = rustPlatform.buildRustPackage rec {
-    name = "teleport-rdpclient";
-    cargoSha256 = "sha256-Jz7bB/f4HRxBhSevmfELSrIm+IXUVlADIgp2qWQd5PY=";
+    pname = "teleport-rdpclient";
+    cargoHash = "sha256-Xmabjoq1NXxXemeR06Gg8R/HwdSE+rsxxX645pQ3SuI=";
     inherit version src;
 
     buildAndTestSubdir = "lib/srv/desktop/rdp/rdpclient";
@@ -44,42 +43,28 @@ let
     OPENSSL_NO_VENDOR = "1";
 
     postInstall = ''
-      cp -r target $out
-    '';
-  };
-
-  roleTester = rustPlatform.buildRustPackage {
-    name = "teleport-roletester";
-    inherit version src;
-
-    cargoSha256 = "sha256-gCm4ETbXy6tGJQVSzUkoAWUmKD3poYgkw133LtziASI=";
-    buildAndTestSubdir = "lib/datalog/roletester";
-
-    PROTOC = "${protobuf}/bin/protoc";
-    PROTOC_INCLUDE = "${protobuf}/include";
-
-    postInstall = ''
-      cp -r target $out
+      mkdir -p $out/include
+      cp ${buildAndTestSubdir}/librdprs.h $out/include/
     '';
   };
 
   webassets = fetchFromGitHub {
     owner = "gravitational";
     repo = "webassets";
-    rev = "67e608db77300d8a6cb17709be67f12c1d3271c3";
-    sha256 = "sha256-o4qjXGaNi5XDSUQrUuU+G77EdRnvJ1WUPWrryZU1CUE=";
+    # Submodule rev from https://github.com/gravitational/teleport/tree/v10.3.1
+    rev = "6710dcd0dc19ad101bac3259c463ef940f2ab1f3";
+    hash = "sha256-A13FSpgJODmhugAwy4kqiDw4Rihr//DhQX/bjwaeo2A=";
   };
 in
 buildGoModule rec {
   pname = "teleport";
 
   inherit src version;
-  vendorSha256 = "sha256-UMgWM7KHag99JR4i4mwVHa6yd9aHQ6Dy+pmUijNL4Ew=";
+  vendorHash = "sha256-2Zrd3CbZvxns9lNVtwaaor1mi97IhPc+MRJhj3rU760=";
 
   subPackages = [ "tool/tbot" "tool/tctl" "tool/teleport" "tool/tsh" ];
   tags = [ "webassets_embed" ]
-    ++ lib.optional withRdpClient "desktop_access_rdp"
-    ++ lib.optional withRoleTester "roletester";
+    ++ lib.optional withRdpClient "desktop_access_rdp";
 
   buildInputs = [ openssl ]
     ++ lib.optionals (stdenv.isDarwin && withRdpClient) [ CoreFoundation Security ];
@@ -97,31 +82,26 @@ buildGoModule rec {
   # Reduce closure size for client machines
   outputs = [ "out" "client" ];
 
-  preBuild =
-    let rustDeps = symlinkJoin {
-      name = "teleport-rust-deps";
-      paths = lib.optional withRdpClient rdpClient
-        ++ lib.optional withRoleTester roleTester;
-    };
-    in
-    ''
-      mkdir -p build
-      echo "making webassets"
-      cp -r ${webassets}/* webassets/
-      make lib/web/build/webassets
-
-      cp -r ${rustDeps}/. .
-    '';
+  preBuild = ''
+    mkdir -p build
+    echo "making webassets"
+    cp -r ${webassets}/* webassets/
+    make -j$NIX_BUILD_CORES lib/web/build/webassets
+  '' + lib.optionalString withRdpClient ''
+    ln -s ${rdpClient}/lib/* lib/
+    ln -s ${rdpClient}/include/* lib/srv/desktop/rdp/rdpclient/
+  '';
 
   # Multiple tests fail in the build sandbox
   # due to trying to spawn nixbld's shell (/noshell), etc.
   doCheck = false;
 
   postInstall = ''
-    install -Dm755 -t $client/bin $out/bin/tsh
+    mkdir -p $client/bin
+    mv {$out,$client}/bin/tsh
     # make xdg-open overrideable at runtime
     wrapProgram $client/bin/tsh --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
-    wrapProgram $out/bin/tsh --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
+    ln -s {$client,$out}/bin/tsh
   '';
 
   doInstallCheck = true;

--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -5,6 +5,7 @@
 , makeWrapper
 , symlinkJoin
 , CoreFoundation
+, libfido2
 , openssl
 , pkg-config
 , protobuf
@@ -63,12 +64,12 @@ buildGoModule rec {
   vendorHash = "sha256-2Zrd3CbZvxns9lNVtwaaor1mi97IhPc+MRJhj3rU760=";
 
   subPackages = [ "tool/tbot" "tool/tctl" "tool/teleport" "tool/tsh" ];
-  tags = [ "webassets_embed" ]
+  tags = [ "libfido2" "webassets_embed" ]
     ++ lib.optional withRdpClient "desktop_access_rdp";
 
-  buildInputs = [ openssl ]
+  buildInputs = [ openssl libfido2 ]
     ++ lib.optionals (stdenv.isDarwin && withRdpClient) [ CoreFoundation Security ];
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper pkg-config ];
 
   patches = [
     # https://github.com/NixOS/nixpkgs/issues/120738

--- a/pkgs/servers/teleport/rdpclient.patch
+++ b/pkgs/servers/teleport/rdpclient.patch
@@ -1,17 +1,22 @@
 diff --git a/lib/srv/desktop/rdp/rdpclient/client.go b/lib/srv/desktop/rdp/rdpclient/client.go
-index d191c768f..71117a30d 100644
+index 4357d7aa1..7e21a0076 100644
 --- a/lib/srv/desktop/rdp/rdpclient/client.go
 +++ b/lib/srv/desktop/rdp/rdpclient/client.go
-@@ -56,10 +56,10 @@ package rdpclient
- #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-unknown-linux-gnu/release
- #cgo linux,arm LDFLAGS: -L${SRCDIR}/../../../../../target/arm-unknown-linux-gnueabihf/release
- #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-unknown-linux-gnu/release
+@@ -52,14 +52,9 @@ package rdpclient
+ 
+ /*
+ // Flags to include the static Rust library.
+-#cgo linux,386 LDFLAGS: -L${SRCDIR}/../../../../../target/i686-unknown-linux-gnu/release
+-#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-unknown-linux-gnu/release
+-#cgo linux,arm LDFLAGS: -L${SRCDIR}/../../../../../target/arm-unknown-linux-gnueabihf/release
+-#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-unknown-linux-gnu/release
 -#cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm
-+#cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm -lssl -lcrypto
- #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-apple-darwin/release
- #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-apple-darwin/release
+-#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-apple-darwin/release
+-#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-apple-darwin/release
 -#cgo darwin LDFLAGS: -framework CoreFoundation -framework Security -lrdp_client -lpthread -ldl -lm
-+#cgo darwin LDFLAGS: -framework CoreFoundation -framework Security -lrdp_client -lpthread -ldl -lm -lssl -lcrypto
++#cgo LDFLAGS: -L${SRCDIR}/../../../../../lib -lpthread -ldl -lm -lssl -lcrypto
++#cgo linux LDFLAGS: -l:librdp_client.a
++#cgo darwin LDFLAGS: -framework CoreFoundation -framework Security -lrdp_client
  #include <librdprs.h>
  */
  import "C"


### PR DESCRIPTION
###### Description of changes

Updated version of @06kellyjac’s #190152.

https://goteleport.com/docs/ver/10.0/changelog/
https://goteleport.com/docs/ver/10.0/changelog/#breaking-changes
https://github.com/gravitational/teleport/compare/v9.1.2...v10.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).