### PR TITLE
mysql57: use protobuf 3.21, protobuf3_7: remove

### DIFF
--- a/pkgs/development/libraries/protobuf/3.7.nix
+++ b/pkgs/development/libraries/protobuf/3.7.nix
@@ -1,6 +1,0 @@
-{ callPackage, ... }:
-
-callPackage ./generic-v3.nix {
-  version = "3.7.1";
-  sha256 = "00zkijvj80bmhlj8290x4bc416mng2dlbzwc4bkvfmbal1fx93m2";
-}

--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -16,6 +16,10 @@ self = stdenv.mkDerivation rec {
     sha256 = "sha256-ERw6ypGJfkUwOds5GkdSZeAg/ZIcuXMHwACEqI5NYQQ=";
   };
 
+  patches = [
+    ./mysql-5.7-add-protobuf-3.8+-support.patch
+  ];
+
   preConfigure = lib.optionalString stdenv.isDarwin ''
     ln -s /bin/ps $TMPDIR/ps
     export PATH=$PATH:$TMPDIR

--- a/pkgs/servers/sql/mysql/mysql-5.7-add-protobuf-3.8+-support.patch
+++ b/pkgs/servers/sql/mysql/mysql-5.7-add-protobuf-3.8+-support.patch
@@ -1,0 +1,66 @@
+diff --git a/cmake/build_configurations/compiler_options.cmake b/cmake/build_configurations/compiler_options.cmake
+index a935227e523..b4ebd61c5c1 100644
+--- a/cmake/build_configurations/compiler_options.cmake
++++ b/cmake/build_configurations/compiler_options.cmake
+@@ -43,7 +43,7 @@ IF(UNIX)
+ 
+   # Default GCC flags
+   IF(CMAKE_COMPILER_IS_GNUCC)
+-    SET(COMMON_C_FLAGS "-fabi-version=2 -fno-omit-frame-pointer -fno-strict-aliasing")
++    SET(COMMON_C_FLAGS "-fno-omit-frame-pointer -fno-strict-aliasing")
+     # Disable inline optimizations for valgrind testing to avoid false positives
+     IF(WITH_VALGRIND)
+       STRING_PREPEND(COMMON_C_FLAGS "-fno-inline ")
+@@ -68,7 +68,7 @@ IF(UNIX)
+     ENDIF()
+   ENDIF()
+   IF(CMAKE_COMPILER_IS_GNUCXX)
+-    SET(COMMON_CXX_FLAGS               "-fabi-version=2 -fno-omit-frame-pointer -fno-strict-aliasing")
++    SET(COMMON_CXX_FLAGS               "-fno-omit-frame-pointer -fno-strict-aliasing")
+     # GCC 6 has C++14 as default, set it explicitly to the old default.
+     EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
+                     OUTPUT_VARIABLE GXX_VERSION)
+diff --git a/rapid/plugin/x/mysqlxtest_src/mysqlxtest.cc b/rapid/plugin/x/mysqlxtest_src/mysqlxtest.cc
+index 5dc91ba269c..3a45284859f 100644
+--- a/rapid/plugin/x/mysqlxtest_src/mysqlxtest.cc
++++ b/rapid/plugin/x/mysqlxtest_src/mysqlxtest.cc
+@@ -629,12 +629,12 @@ class ErrorDumper : public ::google::protobuf::io::ErrorCollector
+   std::stringstream m_out;
+ 
+ public:
+-  virtual void AddError(int line, int column, const string & message)
++  virtual void AddError(int line, int column, const std::string & message)
+   {
+     m_out << "ERROR in message: line " << line+1 << ": column " << column << ": " << message<<"\n";
+   }
+ 
+-  virtual void AddWarning(int line, int column, const string & message)
++  virtual void AddWarning(int line, int column, const std::string & message)
+   {
+     m_out << "WARNING in message: line " << line+1 << ": column " << column << ": " << message<<"\n";
+   }
+diff --git a/rapid/plugin/x/ngs/include/ngs_common/protocol_protobuf.h b/rapid/plugin/x/ngs/include/ngs_common/protocol_protobuf.h
+index 90f7cc77a39..cf6c607a818 100644
+--- a/rapid/plugin/x/ngs/include/ngs_common/protocol_protobuf.h
++++ b/rapid/plugin/x/ngs/include/ngs_common/protocol_protobuf.h
+@@ -36,7 +36,6 @@
+ #include <google/protobuf/io/tokenizer.h>
+ #include <google/protobuf/io/zero_copy_stream.h>
+ #include <google/protobuf/wire_format_lite.h>
+-#include <google/protobuf/wire_format_lite_inl.h>
+ #include <google/protobuf/dynamic_message.h>
+ 
+ #include "mysqlx_connection.pb.h"
+diff --git a/rapid/plugin/x/ngs/src/protocol_decoder.cc b/rapid/plugin/x/ngs/src/protocol_decoder.cc
+index 298b6a6884c..fae21d18f78 100644
+--- a/rapid/plugin/x/ngs/src/protocol_decoder.cc
++++ b/rapid/plugin/x/ngs/src/protocol_decoder.cc
+@@ -123,7 +123,7 @@ Error_code Message_decoder::parse(Request &request)
+     google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(request.buffer()),
+                                                   static_cast<int>(request.buffer_size()));
+     // variable 'mysqlx_max_allowed_packet' has been checked when buffer was filling by data
+-    stream.SetTotalBytesLimit(static_cast<int>(request.buffer_size()), -1 /*no warnings*/);
++    stream.SetTotalBytesLimit(static_cast<int>(request.buffer_size()));
+     // Protobuf limits the number of nested objects when decoding messages
+     // lets set the value in explicit way (to ensure that is set accordingly with
+     // out stack size)

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -944,6 +944,7 @@ mapAliases ({
   prometheus-dmarc-exporter = dmarc-metrics-exporter; # added 2022-05-31
   prometheus-mesos-exporter = throw "prometheus-mesos-exporter is deprecated and archived by upstream"; # Added 2022-04-05
   prometheus-unifi-exporter = throw "prometheus-unifi-exporter is deprecated and archived by upstream, use unifi-poller instead"; # Added 2022-06-03
+  protobuf3_7 = throw "protobuf3_7 does not receive updates anymore and has been removed"; # Added 2022-10-03
   protobuf3_11 = throw "protobuf3_11 does not receive updates anymore and has been removed"; # Added 2022-09-28
   proxytunnel = throw "proxytunnel has been removed from nixpkgs, because it has not been update upstream since it was added to nixpkgs in 2008 and has therefore bitrotted."; # added 2021-12-15
   pulseaudio-hsphfpd = throw "pulseaudio-hsphfpd upstream has been abandoned"; # Added 2022-03-23

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21351,7 +21351,6 @@ with pkgs;
   protobuf3_19 = callPackage ../development/libraries/protobuf/3.19.nix { };
   protobuf3_17 = callPackage ../development/libraries/protobuf/3.17.nix { };
   protobuf3_8 = callPackage ../development/libraries/protobuf/3.8.nix { };
-  protobuf3_7 = callPackage ../development/libraries/protobuf/3.7.nix { };
 
   protobufc = callPackage ../development/libraries/protobufc { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23621,7 +23621,6 @@ with pkgs;
     inherit (darwin) cctools developer_cmds;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     boost = boost159;
-    protobuf = protobuf3_7;
     openssl = openssl_1_1;
   };
 


### PR DESCRIPTION
###### Description of changes

MySQL 5.7 now uses protobuf 3.21 instead of the oudated and non supported protobuf 3.7. See #193370 for more information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>amarok</li>
    <li>cqrlog</li>
    <li>mysql57</li>
  </ul>
</details>