### PR TITLE
elisp-packages: fix AOT native-comp for several packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -96,7 +96,7 @@ self: let
           ./build.sh -j$NIX_BUILD_CORES
         '';
 
-        postInstall = ''
+        postInstall = (old.postInstall or "") + "\n" + ''
           ./install.sh --prefix=$out
         '';
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -186,7 +186,7 @@ let
             cd -
           '';
 
-          postInstall = ''
+          postInstall = (old.postInstall or "") + "\n" + ''
             install -m=755 -D source/sqlite/emacsql-sqlite \
               $out/share/emacs/site-lisp/elpa/emacsql-sqlite-${old.version}/sqlite/emacsql-sqlite
           '';
@@ -301,7 +301,7 @@ let
             make
             popd
           '';
-          postInstall = ''
+          postInstall = (attrs.postInstall or "") + "\n" + ''
             outd=$(echo $out/share/emacs/site-lisp/elpa/libgit-**)
             mkdir $outd/build
             install -m444 -t $outd/build ./source/src/libegit2.so
@@ -426,7 +426,7 @@ let
             cd -
           '';
 
-          postInstall = ''
+          postInstall = (old.postInstall or "") + "\n" + ''
             mkdir -p $out/bin
             install -m755 -Dt $out/bin ./source/server/telega-server
           '';
@@ -456,7 +456,7 @@ let
             pkgs.libtool
             (pkgs.zeromq.override { enableDrafts = true; })
           ];
-          postInstall = ''
+          postInstall = (old.postInstall or "") + "\n" + ''
             mv $EZMQ_LIBDIR/emacs-zmq.* $out/share/emacs/site-lisp/elpa/zmq-*
             rm -r $out/share/emacs/site-lisp/elpa/zmq-*/src
             rm $out/share/emacs/site-lisp/elpa/zmq-*/Makefile
@@ -533,7 +533,7 @@ let
           ];
           # we need the proper out directory to exist, so we do this in the
           # postInstall instead of postBuild
-          postInstall = ''
+          postInstall = (old.postInstall or "") + "\n" + ''
             pushd source/build >/dev/null
             make
             install -m444 -t $out/share/emacs/site-lisp/elpa/vterm-** ../*.so


### PR DESCRIPTION
Currently, AOT native-comp for emacs packages is implemented[1] in postInstall. These packages override postInstall and do not keep old.postInstall, so they do not do AOT native-comp. This patch fixes this by keeping the old.postInstall in their overrides.

Note that I do not fix emacspeak (@AndersonTorres ) because I have not found an elegant way to do so.

[1]: a7cb8e36ac17526ffc2255c9c48c94be675c4d67

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

I tested vterm and emacsql-sqlite.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
