### PR TITLE
librecad: 2.2.0-rc2 -> 2.2.0

### DIFF
--- a/pkgs/applications/misc/librecad/default.nix
+++ b/pkgs/applications/misc/librecad/default.nix
@@ -1,7 +1,6 @@
 { lib
 , boost
 , fetchFromGitHub
-, fetchpatch
 , installShellFiles
 , mkDerivation
 , muparser
@@ -15,38 +14,42 @@
 
 mkDerivation rec {
   pname = "librecad";
-  version = "2.2.0-rc2";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "LibreCAD";
     repo = "LibreCAD";
     rev = version;
-    sha256 = "sha256-RNg7ioMriH4A7V65+4mh8NhsUHs/8IbTt38nVkYilCE=";
+    sha256 = "sha256-horKTegmvcMg4m5NbZ4nzy4J6Ac/6+E5OkiZl0v6TBc=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/LibreCAD/LibreCAD/pull/1465/commits/4edcbe72679f95cb60979c77a348c1522a20b0f4.patch";
-      sha256 = "sha256-P0G2O5sL7Ip860ByxFQ87TfV/lq06wCQnzPxADGqFPs=";
-      name = "CVE-2021-45342.patch";
-    })
+  buildInputs = [
+    boost
+    muparser
+    qtbase
+    qtsvg
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+    qmake
+    qttools
+  ];
+
+  qmakeFlags = [
+    "MUPARSER_DIR=${muparser}"
+    "BOOST_DIR=${boost.dev}"
   ];
 
   postPatch = ''
     substituteInPlace scripts/postprocess-unix.sh \
       --replace /bin/sh ${runtimeShell}
 
-    substituteInPlace librecad/src/lib/engine/rs_system.cpp \
-      --replace /usr/share $out/share
-
     substituteInPlace librecad/src/main/qc_applicationwindow.cpp \
       --replace __DATE__ 0
   '';
 
-  qmakeFlags = [
-    "MUPARSER_DIR=${muparser}"
-    "BOOST_DIR=${boost.dev}"
-  ];
 
   installPhase = ''
     runHook preInstall
@@ -64,20 +67,6 @@ mkDerivation rec {
 
     runHook postInstall
   '';
-
-  buildInputs = [
-    boost
-    muparser
-    qtbase
-    qtsvg
-  ];
-
-  nativeBuildInputs = [
-    installShellFiles
-    pkg-config
-    qmake
-    qttools
-  ];
 
   meta = with lib; {
     description = "2D CAD package based on Qt";


### PR DESCRIPTION
###### Description of changes

https://github.com/LibreCAD/LibreCAD/releases/tag/2.2.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).