### PR TITLE
gzdoom: fix fluidsynth and IWAD selection menu

### DIFF
--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, openal, fluidsynth
 , soundfont-fluid, libGL, SDL2, bzip2, zlib, libjpeg, libsndfile, libvpx, mpg123
-, game-music-emu, pkg-config, copyDesktopItems, makeDesktopItem }:
+, game-music-emu, pkg-config, copyDesktopItems, makeDesktopItem, gtk3 }:
 
 let
   zmusic = stdenv.mkDerivation rec {
@@ -43,16 +43,17 @@ let
     nativeBuildInputs = [ cmake makeWrapper pkg-config copyDesktopItems ];
     buildInputs = [
       SDL2
-      libGL
-      openal
-      fluidsynth
       bzip2
-      zlib
+      fluidsynth
+      game-music-emu
+      gtk3
+      libGL
       libjpeg
       libsndfile
       libvpx
       mpg123
-      game-music-emu
+      openal
+      zlib
       zmusic
     ];
 
@@ -64,6 +65,8 @@ let
     ];
 
     NIX_CFLAGS_LINK = "-lopenal -lfluidsynth";
+
+    cmakeFlags = [ "-DDYN_GTK=OFF" ];
 
     desktopItems = [
       (makeDesktopItem {

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -16,6 +16,10 @@ let
 
     nativeBuildInputs = [ cmake pkg-config ];
 
+    buildInputs = [ fluidsynth ];
+
+    cmakeFlags = [ "-DDYN_FLUIDSYNTH=OFF" ];
+
     preConfigure = ''
       sed -i \
         -e "s@/usr/share/sounds/sf2/@${soundfont-fluid}/share/soundfonts/@g" \


### PR DESCRIPTION
###### Description of changes

- Fixed fluidsynth dependency
- Fixed GTK-based IWAD selection menu

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).