### PR TITLE
Sort /etc/.clean to reduce spurious file changes

### DIFF
--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -137,7 +137,7 @@ foreach my $fn (@oldCopied) {
 
 # Rewrite /etc/.clean.
 close CLEAN;
-write_file("/etc/.clean", map { "$_\n" } @copied);
+write_file("/etc/.clean", map { "$_\n" } sort @copied);
 
 # Create /etc/NIXOS tag if not exists.
 # When /etc is not on a persistent filesystem, it will be wiped after reboot,


### PR DESCRIPTION
Without sorting, the contents of `/etc/.clean` change on almost every nixos-rebuild due to Perl's nondeterministic hash key ordering.

If this patch is merged, /etc/.clean will only change when the file contents actually change.