### PR TITLE
python3Packages.pytest-xdist: Treat --forked problems on darwin

### DIFF
--- a/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
@@ -3,6 +3,14 @@ pytestXdistHook() {
         "--numprocesses=$NIX_BUILD_CORES"
         "--forked"
     )
+
+    # Using --forked on darwin leads to crashes when fork safety is
+    # enabled. This often happens when urllib tries to request proxy
+    # settings on MacOS through `urllib.request.getproxies()`
+    # - https://github.com/python/cpython/issues/77906
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+    fi
 }
 
 # the flags should be added before pytestCheckHook runs so


### PR DESCRIPTION
We run pytest with `--forked` in nixpkgs, to reduce side effects that
can occur when multiple tests mutate their environment in incompatible
ways.

Forking on macOS 10.13 and later is unsafe when an application does work
between calls to fork() and its followup exec(). This may lead to
crashes when calls into the Objective-C runtime are issued, which will
in turn coredump the Python interpreter.

One good reproducer for this scenario is when the urllib module tries
to lookup proxy configurations in `urllib.request.getproxies()` through
`get_proxies_macos_sysconf` into the native `_scproxy` module.

This is a class of issues that is of course not limited to the urllib
module. The general recommendation is to use `spawn` instead of `fork`,
but we don't have any influence on upstream developers to do one or the
other.

One often cited workaround would be to disable fork safety entirely on
calls to `initialize()`, which is probably a better solution than
running without multithreading (slow) or without the `--forked` (prone
to side effects) mode.

This currently happens on aarch64-linux only, where we use more recent
11.0 SDK version, while x86_64-darwin has been stuck on 10.12 for a
while now.

https://github.com/python/cpython/issues/77906#issuecomment-1093788352
http://www.sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html

Closes: #194290

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
