### PR TITLE
f3: fix build on darwin

### DIFF
--- a/pkgs/tools/filesystems/f3/default.nix
+++ b/pkgs/tools/filesystems/f3/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub
-, parted, systemd ? null
+, parted, systemd, argp-standalone
 }:
 
 stdenv.mkDerivation rec {
@@ -22,10 +22,8 @@ stdenv.mkDerivation rec {
      done
   '';
 
-  buildInputs = [
-    parted
-  ]
-  ++ lib.optional stdenv.isLinux systemd;
+  buildInputs = lib.optional stdenv.isLinux [ systemd parted ]
+  ++ lib.optional stdenv.isDarwin [ argp-standalone ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes

 - parted is broken on darwin, but is not needed for the executables built on darwin anyway (f3read/f3write), so we can move it to the linux dep
 - argp.h is needed, include argp-standalone for it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---
Let me know if there's a more correct way to ensure that `argp.h` is avaliable. Using `isDarwin` to pull in `argp-standalone` feels somewhat indirect.