### PR TITLE
systemd: don't taint on unmerged /usr

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -607,6 +607,7 @@ in {
   systemd-networkd-dhcpserver-static-leases = handleTest ./systemd-networkd-dhcpserver-static-leases.nix {};
   systemd-networkd-ipv6-prefix-delegation = handleTest ./systemd-networkd-ipv6-prefix-delegation.nix {};
   systemd-networkd-vrf = handleTest ./systemd-networkd-vrf.nix {};
+  systemd-no-tainted = handleTest ./systemd-no-tainted.nix {};
   systemd-nspawn = handleTest ./systemd-nspawn.nix {};
   systemd-oomd = handleTest ./systemd-oomd.nix {};
   systemd-shutdown = handleTest ./systemd-shutdown.nix {};

--- a/nixos/tests/systemd-no-tainted.nix
+++ b/nixos/tests/systemd-no-tainted.nix
@@ -1,0 +1,14 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "systemd-no-tainted";
+
+  nodes.machine = { };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    with subtest("systemctl should not report tainted with unmerged-usr"):
+        output = machine.succeed("systemctl status")
+        print(output)
+        assert "Tainted" not in output
+        assert "unmerged-usr" not in output
+  '';
+})

--- a/pkgs/os-specific/linux/systemd/0018-core-don-t-taint-on-unmerged-usr.patch
+++ b/pkgs/os-specific/linux/systemd/0018-core-don-t-taint-on-unmerged-usr.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: oxalica <oxalicc@pm.me>
+Date: Tue, 4 Oct 2022 09:18:07 +0800
+Subject: [PATCH] core: don't taint on unmerged /usr
+
+NixOS has very different approach towards /bin and /sbin - they don't
+really exist (except for /bin/sh and /usr/bin/env, because these are used
+heavily in shebangs around the world). The concept of merged or unmerged
+usr doesn't really apply here at all, it's neither of the two.
+Users don't execute things from /bin or /sbin, there's nothing else in
+there. In all cases, systemd doesn't look things up from /usr/bin or /bin,
+so showing the taint isn't really helpful.
+
+See also: https://github.com/systemd/systemd/issues/24191
+---
+ src/core/manager.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/src/core/manager.c b/src/core/manager.c
+index 33ded94a7c..8847479799 100644
+--- a/src/core/manager.c
++++ b/src/core/manager.c
+@@ -4488,10 +4488,6 @@ char* manager_taint_string(const Manager *m) {
+         if (m->taint_usr)
+                 stage[n++] = "split-usr";
+ 
+-        _cleanup_free_ char *usrbin = NULL;
+-        if (readlink_malloc("/bin", &usrbin) < 0 || !PATH_IN_SET(usrbin, "usr/bin", "/usr/bin"))
+-                stage[n++] = "unmerged-usr";
+-
+         if (access("/proc/cgroups", F_OK) < 0)
+                 stage[n++] = "cgroups-missing";
+ 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -163,6 +163,7 @@ stdenv.mkDerivation {
     ./0015-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
     ./0016-pkg-config-derive-prefix-from-prefix.patch
     ./0017-inherit-systemd-environment-when-calling-generators.patch
+    ./0018-core-don-t-taint-on-unmerged-usr.patch
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let
       oe-core = fetchzip {


### PR DESCRIPTION
###### Description of changes

Fixes #184826
Discussion: https://github.com/systemd/systemd/issues/24191#issuecomment-1209350080

~I'm still running the build. It may take some time.~
`systemd` builds and works as expected.

r? @flokli

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
