### PR TITLE
onnnxruntime, python3Packages.onnxruntime: improve packaging

### DIFF
--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -15,10 +15,17 @@
 , boost
 , oneDNN
 , gtest
-, pythonSupport ? true
+, pythonSupport ? false
 , nsync
 , flatbuffers
 }:
+
+# Python Support
+#
+# When enabling Python support a wheel is made and stored in a `dist` output.
+# This wheel is then installed in a separate derivation.
+
+assert pythonSupport -> lib.versionOlder protobuf.version "3.20";
 
 let
   # prefetch abseil
@@ -58,26 +65,26 @@ stdenv.mkDerivation rec {
     setuptools
     wheel
     pip
+    pythonOutputDistHook
   ]);
 
   buildInputs = [
     libpng
     zlib
-    protobuf
     howard-hinnant-date
     nlohmann_json
     boost
     oneDNN
-  ] ++ lib.optionals pythonSupport ([
-    flatbuffers
+    protobuf
+  ] ++ lib.optionals pythonSupport [
     nsync
-  ] ++ (with python3Packages; [
-    numpy
-    pybind11
-  ]));
+    python3Packages.numpy
+    python3Packages.pybind11
+  ];
 
   # TODO: build server, and move .so's to lib output
-  outputs = [ "out" "dev" ] ++ lib.optionals pythonSupport [ "python" ];
+  # Python's wheel is stored in a separate dist output
+  outputs = [ "out" "dev" ] ++ lib.optionals pythonSupport [ "dist" ];
 
   enableParallelBuilding = true;
 
@@ -116,9 +123,14 @@ stdenv.mkDerivation rec {
       ../include/onnxruntime/core/framework/provider_options.h \
       ../include/onnxruntime/core/providers/cpu/cpu_provider_factory.h \
       ../include/onnxruntime/core/session/onnxruntime_*.h
-  '' + lib.optionalString pythonSupport ''
-    pip install dist/*.whl --no-index --no-warn-script-location --prefix="$python" --no-cache --no-deps
   '';
+
+  passthru = {
+    inherit protobuf;
+    tests = lib.optionalAttrs pythonSupport {
+      python = python3Packages.onnxruntime;
+    };
+  };
 
   meta = with lib; {
     description = "Cross-platform, high performance scoring engine for ML models";

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, autoPatchelfHook
+, pythonRelaxDepsHook
+, onnxruntime
+, coloredlogs
+, numpy
+, packaging
+, oneDNN
+
+}:
+
+# onnxruntime requires an older protobuf.
+# Doing an override in protobuf in the python-packages set
+# can give you a functioning Python package but note not
+# all Python packages will be compatible then.
+#
+# Because protobuf is not always needed we remove it
+# as a runtime dependency from our wheel.
+#
+# We do include here the non-Python protobuf so the shared libs
+# link correctly. If you do also want to include the Python
+# protobuf, you can add it to your Python env, but be aware
+# the version likely mismatches with what is used here.
+
+buildPythonPackage {
+  inherit (onnxruntime) pname version;
+  format = "wheel";
+  src = onnxruntime.dist;
+
+  unpackPhase = ''
+    cp -r $src dist
+    chmod +w dist
+  '';
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pythonRelaxDepsHook
+  ];
+
+  # This project requires fairly large dependencies such as sympy which we really don't always need.
+  pythonRemoveDeps = [
+    "flatbuffers"
+    "protobuf"
+    "sympy"
+  ];
+
+  # Libraries are not linked correctly.
+  buildInputs = [
+    oneDNN
+    onnxruntime.protobuf
+  ];
+
+  propagatedBuildInputs = [
+    coloredlogs
+    # flatbuffers
+    numpy
+    packaging
+    # protobuf
+    # sympy
+  ];
+
+  meta = onnxruntime.meta // { maintainers = with lib.maintainers; [ fridh ]; };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6407,10 +6407,12 @@ in {
 
   onnxconverter-common = callPackage ../development/python-modules/onnxconverter-common { };
 
-  onnxruntime = (toPythonModule (pkgs.onnxruntime.override {
-    python3Packages = self;
-    pythonSupport = true;
-  })).python;
+  onnxruntime = callPackage ../development/python-modules/onnxruntime {
+    onnxruntime = pkgs.onnxruntime.override {
+      python3Packages = self;
+      pythonSupport = true;
+    };
+  };
 
   onvif-zeep-async = callPackage ../development/python-modules/onvif-zeep-async { };
 


### PR DESCRIPTION
The Python bindings to onnxruntime were added by me in #193188.

Adding Python support this way is not a good way. Here a wheel was created (which is fine) and installed in a python output. The propagated-build-inputs file is put in the dev output. That's fine, except that stdenv.mkDerivation does not automatically add dev when python is included, because other outputs are only added when no output is explicitly selected. This means that when you want to use these bindings in another Python package, pip will complain it cannot find the dependencies of the bindings.

In this PR, the onnxruntime derivation outputs a wheel in the dist output. Then, in python-packages.nix we have a separate onnxruntime package which installs the bindings.

The Python bindings have quite some dependencies which, depending on your use case, are not required. Thus the dependency relax hook is used to remove some of these dependencies.

Note there is also an issue with protobuf versions. The onnxruntime bindings require an older protobuf and Python protobuf which we cannot offer. Thus protobuf is also removed as Python dependency.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
