### PR TITLE
paho-mqtt-c: init at 1.3.11, paho-mqtt-cpp: init at 1.2.0

### DIFF
--- a/pkgs/development/libraries/paho-mqtt-c/default.nix
+++ b/pkgs/development/libraries/paho-mqtt-c/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, cmake, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "paho.mqtt.c";
+  version = "1.3.11";
+
+  src = fetchFromGitHub {
+    owner = "eclipse";
+    repo = "paho.mqtt.c";
+    rev = "v${version}";
+    hash = "sha256-TGCWA9tOOx0rCb/XQWqLFbXb9gOyGS8u6o9fvSRS6xI=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/MQTTVersion.c \
+      --replace "namebuf[60]" "namebuf[120]" \
+      --replace "lib%s" "$out/lib/lib%s"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ openssl ];
+
+  cmakeFlags = [ "-DPAHO_WITH_SSL=TRUE" ];
+
+  meta = with lib; {
+    description = "Eclipse Paho MQTT C Client Library";
+    homepage = "https://www.eclipse.org/paho/";
+    license = licenses.epl20;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/paho-mqtt-cpp/default.nix
+++ b/pkgs/development/libraries/paho-mqtt-cpp/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, cmake, openssl, paho-mqtt-c }:
+
+stdenv.mkDerivation rec {
+  pname = "paho.mqtt.cpp";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "eclipse";
+    repo = "paho.mqtt.cpp";
+    rev = "v${version}";
+    hash = "sha256-tcq0a4X5dKE4rnczRMAVe3Wt43YzUKbxsv9Sk+q+IB8=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ openssl paho-mqtt-c ];
+
+  meta = with lib; {
+    description = "Eclipse Paho MQTT C++ Client Library";
+    homepage = "https://www.eclipse.org/paho/";
+    license = licenses.epl10;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10027,6 +10027,8 @@ with pkgs;
 
   paho-mqtt-c = callPackage ../development/libraries/paho-mqtt-c { };
 
+  paho-mqtt-cpp = callPackage ../development/libraries/paho-mqtt-cpp { };
+
   pakcs = callPackage ../development/compilers/pakcs {
     # Doesn't compile with GHC 9.0 due to whitespace syntax changes
     # see also https://github.com/NixOS/nixpkgs/issues/166108

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10025,6 +10025,8 @@ with pkgs;
 
   pagmo2 = callPackage ../development/libraries/pagmo2 { };
 
+  paho-mqtt-c = callPackage ../development/libraries/paho-mqtt-c { };
+
   pakcs = callPackage ../development/compilers/pakcs {
     # Doesn't compile with GHC 9.0 due to whitespace syntax changes
     # see also https://github.com/NixOS/nixpkgs/issues/166108


### PR DESCRIPTION
###### Description of changes
An [Eclipse Paho](https://www.eclipse.org/paho/) C and C++ client libraries for MQTT:
* paho-mqtt-c [![Packaging status](https://repology.org/badge/tiny-repos/paho.mqtt.c.svg)](https://repology.org/project/paho.mqtt.c/versions)
* paho-mqtt-cpp [![Packaging status](https://repology.org/badge/tiny-repos/paho.mqtt.cpp.svg)](https://repology.org/project/paho.mqtt.cpp/versions)

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
