### PR TITLE
python3Packages.dlib: split name to pname&version

### DIFF
--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -4,7 +4,7 @@
 }:
 
 buildPythonPackage {
-  inherit (dlib) name src nativeBuildInputs buildInputs meta;
+  inherit (dlib) pname version src nativeBuildInputs buildInputs meta;
 
   # although AVX can be enabled, we never test with it. Some Hydra machines
   # fail because of this, however their build results are probably used on hardware

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -6,6 +6,16 @@
 buildPythonPackage {
   inherit (dlib) pname version src nativeBuildInputs buildInputs meta;
 
+  patches = [ ./build-cores.patch ];
+
+  checkInputs = [ pytest more-itertools ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "more-itertools<6.0.0" "more-itertools" \
+      --replace "pytest==3.8" "pytest"
+  '';
+
   # although AVX can be enabled, we never test with it. Some Hydra machines
   # fail because of this, however their build results are probably used on hardware
   # with AVX support.
@@ -17,16 +27,6 @@ buildPythonPackage {
     "--set USE_SSE4_INSTRUCTIONS=${if sse4Support then "yes" else "no"}"
     "--set USE_AVX_INSTRUCTIONS=${if avxSupport then "yes" else "no"}"
   ];
-
-  patches = [ ./build-cores.patch ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "more-itertools<6.0.0" "more-itertools" \
-      --replace "pytest==3.8" "pytest"
-  '';
-
-  checkInputs = [ pytest more-itertools ];
 
   dontUseCmakeConfigure = true;
 }


### PR DESCRIPTION
###### Description of changes

This adds a version attribute to `python3Packages.dlib`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
