### PR TITLE
perf: Remove the quadratic behavior in haskellPackages.ghcWithPackages

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -132,6 +132,15 @@
       </listitem>
       <listitem>
         <para>
+          Improved performances of
+          <literal>lib.closePropagation</literal> which was previously
+          quadratic. This is used in e.g.
+          <literal>ghcWithPackages</literal>. Please see backward
+          incompatibilities notes below.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           Cinnamon has been updated to 5.4. While at it, the cinnamon
           module now defaults to blueman as bluetooth manager and
           slick-greeter as lightdm greeter to match upstream.
@@ -544,6 +553,12 @@
           instructions</link> and
           <link xlink:href="https://goteleport.com/docs/ver/10.0/changelog/#1000">release
           notes</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>lib.closePropagation</literal> now needs that all
+          gathered sets have an <literal>outPath</literal> attribute.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -52,6 +52,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - Perl has been updated to 5.36, and its core module `HTTP::Tiny` was patched to verify SSL/TLS certificates by default.
 
+- Improved performances of `lib.closePropagation` which was previously quadratic. This is used in e.g. `ghcWithPackages`. Please see backward incompatibilities notes below.
+
 - Cinnamon has been updated to 5.4. While at it, the cinnamon module now defaults to
   blueman as bluetooth manager and slick-greeter as lightdm greeter to match upstream.
 
@@ -181,6 +183,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 - dd-agent package removed along with the `services.dd-agent` module, due to the project being deprecated in favor of `datadog-agent`,  which is available via the `services.datadog-agent` module.
 
 - `teleport` has been upgraded to major version 10. Please see upstream [upgrade instructions](https://goteleport.com/docs/ver/10.0/management/operations/upgrading/) and [release notes](https://goteleport.com/docs/ver/10.0/changelog/#1000).
+
+- `lib.closePropagation` now needs that all gathered sets have an `outPath` attribute.
 
 - lemmy module option `services.lemmy.settings.database.createLocally`
   moved to `services.lemmy.database.createLocally`.

--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -36,7 +36,6 @@ let
       This index includes documentation for many Haskell modules.
     '';
 
-  # TODO: closePropagation is deprecated; replace
   docPackages = lib.closePropagation
     # we grab the doc outputs
     (map (lib.getOutput "doc") packages);


### PR DESCRIPTION
###### Description of changes

This code was using `lib.closePropagation` which internally do a recursion on the dependencies of ghcWithPackages and returns all the haskell dependencies.

`lib.closeProgation` is implemented in pure nix and uses an unique function for list which is quadratic and does "true" equality, which needs deep set comparison.

###### Things done

Instead, we use the `builtins.genericClosure` which is implemented as a builtin and uses a more efficient sorting feature.

Note that `genericClosure` needs a `key` to discriminate the values, we used the `outPath` which is unique and orderable.

On benchmarks, it performs up to 15x time faster.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

# Testing / Benchmark

I've tested this implementation on a large haskell codebase where I'm using nix as a build system. I have something like 250 calls to `ghcWithPackages`. When building everything, `nix build --dry-run` was tacking up to `20s`, now it runs in `1.5s`.

In order to compare, I've created the following benchmark, drop this file (name it `fiz.nix`) at the root of nixpkgs

```nix
let
  pkgs = import ./. { };

  haskellPackages = p:
    with p; [
      ad
      aeson
      AesonBson
      aeson-pretty
      algebraic-graphs
      async
      attoparsec
      barbies
      base
      base16
      base64-bytestring
      base-noprelude
      bazel-runfiles
      binary
      blaze-html
      bson
      bytestring
      case-insensitive
      casing
      cassava
      cereal
      cereal-text
      cereal-unordered-containers
      cereal-uuid
      cereal-vector
      clock
      conduit
      conduit-extra
      containers
      criterion
      cryptohash-sha1
      data-default
      deepseq
      directory
      erf
      exceptions
      extra
      filepath
      foldl
      formatting
      generic-data
      generics-sop
      ghc-prim
      githash
      Glob
      gloss
      hashable
      hedgehog
      hedis
      heredoc
      hmatrix
      hmatrix-nlopt
      hspec
      hspec-core
      hspec-wai
      http-client
      http-conduit
      http-media
      http-types
      hvega
      hxt
      integration
      JuicyPixels
      katip
      KdTree
      lens
      lexer-applicative
      linear
      megaparsec
      mime-types
      mmorph
      monad-classes
      monad-control
      mono-traversable
      mtl
      mwc-random
      openapi3
      optparse-applicative
      optparse-generic
      ordered-containers
      pandoc
      parallel
      parsec
      parser-combinators
      pqueue
      pretty
      pretty-show
      pretty-simple
      primitive
      process
      profunctors
      PyF
      QuickCheck
      quickcheck-instances
      quickcheck-text
      random
      random-fu
      reflection
      regex
      regex-applicative
      regex-compat
      resourcet
      retry
      safe
      safe-exceptions
      scientific
      selda
      semigroups
      servant
      servant-blaze
      servant-client
      servant-client-core
      servant-conduit
      servant-openapi3
      servant-server
      servant-swagger-ui
      singletons
      singletons-th
      split
      splitmix
      srcloc
      statistics
      stm
      storable-tuple
      streaming
      streaming-bytestring
      strict
      string-conv
      tagged
      tardis
      tasty
      tasty-expected-failure
      tasty-golden
      tasty-hedgehog
      tasty-hunit
      tasty-quickcheck
      tasty-wai
      template-haskell
      temporary
      text
      time
      tls
      transformers
      transformers-base
      trie-simple
      tuples-homogenous-h98
      typed-process
      uglymemo
      unicode-transforms
      unix
      unliftio
      unliftio-core
      unordered-containers
      url
      utf8-string
      uuid
      uuid-types
      vector
      vector-algorithms
      versions
      vinyl
      wai
      wai-extra
      warp
      yaml
      zip
      zlib
    ];
in builtins.genList (n:
  pkgs.haskellPackages.ghcWithPackages
  (p: pkgs.lib.lists.take n (haskellPackages p))) 167
```

Then I'm benchmarking with `time nix build -f fiz.nix --dry-run`

Without this change: `18.6s`
With this change: `1.2s`

Note that nix will still announce that it will fetch the same numbers of paths, but before that patch, it generates `94` `ghc-xxx-with-packages.drv` and with this patch it generates `147` distinct derivations. I don't understand why. I suppose that the ordering of the results is changing. I was however able to confirm that it behaves the same (by building my 250 packages and running their test suite).

This change should not (as far as I'm aware) trigger a mass rebuild because it only impacts shell / dynamic environments.