### PR TITLE
python3Packages.wxPython{4_0,4_1}: fixes build, #194354

### DIFF
--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , pkg-config
 , which
 , cairo
@@ -25,6 +26,7 @@
 buildPythonPackage rec {
   pname = "wxPython";
   version = "4.0.7.post2";
+  format = "other";
 
   src = fetchPypi {
     inherit pname version;
@@ -33,7 +35,7 @@ buildPythonPackage rec {
 
   doCheck = false;
 
-  nativeBuildInputs = [ pkg-config which doxygen ]
+  nativeBuildInputs = [ pkg-config which doxygen setuptools ]
   ++ (if stdenv.isDarwin then [ wxmac ] else [ wxGTK ]);
 
   buildInputs = [ ncurses libintl ]

--- a/pkgs/development/python-modules/wxPython/4.1.nix
+++ b/pkgs/development/python-modules/wxPython/4.1.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchPypi
 , buildPythonPackage
+, setuptools
 , which
 , pkg-config
 , python
@@ -33,6 +34,7 @@ buildPythonPackage rec {
   pname = "wxPython";
   version = "4.1.1";
   disabled = isPy27;
+  format = "other";
 
   src = fetchPypi {
     inherit pname version;
@@ -48,6 +50,7 @@ buildPythonPackage rec {
     doxygen
     wxGTK.gtk
     pkg-config
+    setuptools
   ] ++ lib.optionals stdenv.isLinux [
     autoPatchelfHook
   ];


### PR DESCRIPTION
###### Description of changes

No wheels are built and so the hook can't put the dist folder in the dist output. The `"other"` format does not add the hook and thus it won't try to move the folder.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
