### PR TITLE
heptagon: init at 1.05.00

### DIFF
--- a/pkgs/development/compilers/heptagon/default.nix
+++ b/pkgs/development/compilers/heptagon/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, makeWrapper
+, ocamlPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "heptagon";
+  version = "1.05.00";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.inria.fr";
+    owner = "synchrone";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-b4O48MQT3Neh8a1Z5wRgS701w6XrwpsbSMprlqTT+CE=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = with ocamlPackages; [
+    ocaml
+    findlib
+    menhir
+    menhirLib
+    ocamlgraph
+    camlp4
+    ocamlbuild
+    lablgtk
+  ];
+
+  # the heptagon library in lib/heptagon is not executable
+  postInstall = ''
+    find $out/lib/heptagon -type f -exec chmod -x {} \;
+  '';
+
+  postFixup = with ocamlPackages; ''
+    wrapProgram $out/bin/hepts \
+      --prefix CAML_LD_LIBRARY_PATH : "${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2"
+  '';
+
+  meta = with lib; {
+    description = "Compiler for the Heptagon/BZR synchronous programming language";
+    homepage = "https://gitlab.inria.fr/synchrone/heptagon";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ wegank ];
+    mainProgram = "heptc";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14101,6 +14101,8 @@ with pkgs;
     inherit (emacs.pkgs.melpaStablePackages) irony;
   };
 
+  heptagon = callPackage ../development/compilers/heptagon { };
+
   holo-build = callPackage ../tools/package-management/holo-build { };
 
   hugs = callPackage ../development/interpreters/hugs { };


### PR DESCRIPTION
###### Description of changes

This PR features `heptagon`, compiler for the Heptagon/BZR synchronous programming language.

Tested on all major platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
