### PR TITLE
python310Packages.elegy: mark broken

### DIFF
--- a/pkgs/development/python-modules/elegy/default.nix
+++ b/pkgs/development/python-modules/elegy/default.nix
@@ -82,5 +82,10 @@ buildPythonPackage rec {
     homepage = "https://github.com/poets-ai/elegy";
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];
+    # ERROR: Package 'elegy' requires a different Python: 3.10.7 not in '<3.10,>=3.7'
+    # See: https://github.com/poets-ai/elegy/blob/master/pyproject.toml#L20
+    # On unlocking Python version, several units tests fail. Such as:
+    # AttributeError: module 'jax' has no attribute 'tree_multimap'
+    broken = true; # at 2022-10-04
   };
 }


### PR DESCRIPTION
python310Packages.elegy: mark broken

* ERROR: Package 'elegy' requires a different Python: 3.10.7 not in '<3.10,>=3.7'
  ![image](https://user-images.githubusercontent.com/5861043/193832438-b0e33175-afe3-4c26-8290-aa22f685f363.png)
  logs: https://termbin.com/3tmg

* On unlocking python version (`--replace 'python = ">=3.7,<3.10"' "" \`), unit tests fail as:
  > AttributeError: module 'jax' has no attribute 'tree_multimap'
  - Despite bumping `jax` to `0.3.21` (details at #194429), errors repeats.
  ![image](https://user-images.githubusercontent.com/5861043/193835405-ac4c95b6-bd04-4db2-9e4e-9f242c1400fc.png)
  logs: https://termbin.com/ng6q

* Goal is to avoid **false positive** in upstream builds.
  - Please, feel free to propose a fix in a **new** PR.