### PR TITLE
Add support for pname+version to fetchzip/fetchurl

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -57,6 +57,11 @@ in
   # first element of `urls').
   name ? ""
 
+  # for versioned downloads optionally take pname + version.
+  # if name is set that is preferred
+, pname ? ""
+, version ? ""
+
 , # SRI hash.
   hash ? ""
 
@@ -130,12 +135,16 @@ let
     else throw "fetchurl requires a hash for fixed-output derivation: ${lib.concatStringsSep ", " urls_}";
 in
 
-stdenvNoCC.mkDerivation {
-  name =
-    if showURLs then "urls"
-    else if name != "" then name
-    else baseNameOf (toString (builtins.head urls_));
-
+stdenvNoCC.mkDerivation ((
+  if (pname != "" && version != "") then
+    { inherit pname version; }
+  else
+    { name =
+      if showURLs then "urls"
+      else if name != "" then name
+      else baseNameOf (toString (builtins.head urls_));
+    }
+) // {
   builder = ./builder.sh;
 
   nativeBuildInputs = [ curl ] ++ nativeBuildInputs;
@@ -177,4 +186,4 @@ stdenvNoCC.mkDerivation {
 
   inherit meta;
   passthru = { inherit url; } // passthru;
-}
+})

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -58,7 +58,6 @@ in
   name ? ""
 
   # for versioned downloads optionally take pname + version.
-  # if name is set that is preferred
 , pname ? ""
 , version ? ""
 

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -14,6 +14,8 @@
 , extraPostFetch ? ""
 , postFetch ? ""
 , name ? "source"
+, pname ? ""
+, version ? ""
 , nativeBuildInputs ? [ ]
 , # Allows to set the extension for the intermediate downloaded
   # file. This can be used as a hint for the unpackCmdHooks to select
@@ -23,14 +25,23 @@
 
 
 lib.warnIf (extraPostFetch != "") "use 'postFetch' instead of 'extraPostFetch' with 'fetchzip' and 'fetchFromGitHub'."
-(fetchurl (let
+
+(let
   tmpFilename =
     if extension != null
     then "download.${extension}"
     else baseNameOf (if url != "" then url else builtins.head urls);
-in {
-  inherit name;
+in
 
+fetchurl ((
+  if (pname != "" && version != "") then
+    {
+      name = "${name}-${version}";
+      inherit pname version;
+    }
+  else
+    { inherit name; }
+) // {
   recursiveHash = true;
 
   downloadToTemp = true;

--- a/pkgs/data/fonts/cooper-hewitt/default.nix
+++ b/pkgs/data/fonts/cooper-hewitt/default.nix
@@ -1,13 +1,15 @@
 { lib, fetchzip }:
 
-fetchzip {
-  name = "cooper-hewitt-2014-06-09";
+fetchzip rec {
+  pname = "cooper-hewitt";
+  version = "unstable-2014-06-09";
 
-  url = "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip";
+  url = "https://web.archive.org/web/20221004145117/https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype/
+    mv $out/*.otf $out/share/fonts/opentype
+    find $out -maxdepth 1 ! -type d -exec rm {} +
   '';
 
   sha256 = "01iwqmjvqkc6fmc2r0486vk06s6f51n9wxzl1pf9z48n0igj4gqd";

--- a/pkgs/data/fonts/cooper-hewitt/default.nix
+++ b/pkgs/data/fonts/cooper-hewitt/default.nix
@@ -1,20 +1,16 @@
-{ lib, stdenv, fetchzip }:
+{ lib, fetchzip }:
 
-stdenv.mkDerivation {
-  pname = "cooper-hewitt";
-  version = "unstable-2014-06-09";
+fetchzip {
+  name = "cooper-hewitt-2014-06-09";
 
-  src = fetchzip {
-    url = "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip";
-    hash = "sha256-bTlEXQeYNNspvnNdvQhJn6CNBrcSKYWuNWF/N6+3Vb0=";
-  };
+  url = "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip";
 
-  dontConfigure = true;
-  dontBuild = true;
-
-  installPhase = ''
-    install -D -m 644 -t "$out/share/fonts/opentype" *.otf
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype/
   '';
+
+  sha256 = "01iwqmjvqkc6fmc2r0486vk06s6f51n9wxzl1pf9z48n0igj4gqd";
 
   meta = with lib; {
     homepage = "https://www.cooperhewitt.org/open-source-at-cooper-hewitt/cooper-hewitt-the-typeface-by-chester-jenkins/";

--- a/pkgs/data/fonts/freefont-ttf/default.nix
+++ b/pkgs/data/fonts/freefont-ttf/default.nix
@@ -1,16 +1,18 @@
 { lib, fetchzip }:
 
 fetchzip rec {
-  name = "freefont-ttf-20120503";
+  pname = "freefont-ttf";
+  version = "20120503";
 
-  url = "mirror://gnu/freefont/${name}.zip";
+  url = "mirror://gnu/freefont/freefont-ttf-${version}.zip";
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    mkdir -p $out/share/fonts/truetype
+    mv $out/*.ttf $out/share/fonts/truetype
+    find $out -maxdepth 1 ! -type d -exec rm {} +
   '';
 
-  sha256 = "0h0x2hhr7kvjiycf7fv800xxwa6hcpiz54bqx06wsqc7z61iklvd";
+  sha256 = "sha256-bdMZg/mHYc0N6HiR8uNl0CjeOwBou+OYj3LPkyEUHUA=";
 
   meta = {
     description = "GNU Free UCS Outline Fonts";

--- a/pkgs/data/fonts/ubuntu-font-family/default.nix
+++ b/pkgs/data/fonts/ubuntu-font-family/default.nix
@@ -1,26 +1,28 @@
 { lib, fetchzip }:
 
-fetchzip {
-  name = "ubuntu-font-family-0.83";
+fetchzip rec {
+  pname = "ubuntu-font-family";
+  version = "0.83";
 
-  url = "https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip";
+  url = "https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-${version}.zip";
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/ubuntu
+    mkdir -p $out/share/fonts/ubuntu
+    mv $out/*.ttf $out/share/fonts/ubuntu
+    find $out -maxdepth 1 ! -type d -exec rm {} +
   '';
 
   sha256 = "090y665h4kf2bi623532l6wiwkwnpd0xds0jr7560xwfwys1hiqh";
 
-  meta = {
+  meta = with lib; {
     description = "Ubuntu Font Family";
     longDescription = "The Ubuntu typeface has been specially
     created to complement the Ubuntu tone of voice. It has a
     contemporary style and contains characteristics unique to
     the Ubuntu brand that convey a precise, reliable and free attitude.";
     homepage = "http://font.ubuntu.com/";
-    license = lib.licenses.free;
-    platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.antono ];
+    license = licenses.free;
+    platforms = platforms.all;
+    maintainers = [ maintainers.antono ];
   };
 }

--- a/pkgs/data/fonts/ubuntu-font-family/default.nix
+++ b/pkgs/data/fonts/ubuntu-font-family/default.nix
@@ -1,30 +1,26 @@
-{ lib, stdenv, fetchzip }:
+{ lib, fetchzip }:
 
-stdenv.mkDerivation rec {
-  pname = "ubuntu-font-family";
-  version = "0.83";
+fetchzip {
+  name = "ubuntu-font-family-0.83";
 
-  src = fetchzip {
-    url = "https://assets.ubuntu.com/v1/fad7939b-${pname}-${version}.zip";
-    hash = "sha256-FAg1xn8Gcbwmuvqtg9SquSet4oTT9nqE+Izeq7ZMVcA=";
-  };
+  url = "https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip";
 
-  installPhase = ''
-    install -D -m 644 -t "$out/share/fonts/truetype" *.ttf
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/ubuntu
   '';
 
-  outputHashMode = "recursive";
-  outputHash = "sha256-EEcYtOeOd2DKyRLo1kG7lk8euaFilCFMXMJNAosxHiQ=";
+  sha256 = "090y665h4kf2bi623532l6wiwkwnpd0xds0jr7560xwfwys1hiqh";
 
-  meta = with lib; {
+  meta = {
     description = "Ubuntu Font Family";
     longDescription = "The Ubuntu typeface has been specially
     created to complement the Ubuntu tone of voice. It has a
     contemporary style and contains characteristics unique to
     the Ubuntu brand that convey a precise, reliable and free attitude.";
     homepage = "http://font.ubuntu.com/";
-    license = licenses.free;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ antono ];
+    license = lib.licenses.free;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.antono ];
   };
 }


### PR DESCRIPTION
###### Description of changes

After this commit the font was in a double fixed output derivation wrapped which is unnecessary. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
