### PR TITLE
python310Packages.distrax: mark broken

### DIFF
--- a/pkgs/development/python-modules/distrax/default.nix
+++ b/pkgs/development/python-modules/distrax/default.nix
@@ -53,5 +53,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/deepmind/distrax";
     license = licenses.asl20;
     maintainers = with maintainers; [ onny ];
+    # 443 unit tests failing, sample:
+    # AttributeError: module 'jax.core' has no attribute 'unitvar'
+    broken = true; # at 2022-10-04
   };
 }


### PR DESCRIPTION
**python310Packages.distrax: mark broken**

My naive fixing attempt went like this:
* 443 unit tests failing, sample:
  > AttributeError: module 'jax.core' has no attribute 'unitvar'

  - After a naive bump of jax to `0.3.21`, fails as:
    - > AttributeError: module 'jax' has no attribute '_src'
       - breaks `chex-0.1.4` as => logs: https://termbin.com/aq8ey
         - `chex-0.1.5` is available. But a single unit test errors as:
             >`AssertsChexifyTest.test_uninspected_checks`
             > chex/_src/asserts_chexify_test.py:179: AssertionError
             logs: https://termbin.com/17y2
           - On skipping `test_uninspected_checks`, `chex` & `jax`  builds. But `distrax` fails:
             > AttributeError: module 'jax.core' has no attribute 'unitvar'

             logs: https://termbin.com/14ty2

* Goal is to avoid **false positive** in upstream builds.
  - Please, feel free to propose a fix in a **new** PR.