### PR TITLE
python310Packages.apache-beam: mark broken

### DIFF
--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -165,5 +165,7 @@ buildPythonPackage rec {
     homepage = "https://beam.apache.org/";
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];
+    # ERROR: No matching distribution found for protobuf<4,>=3.12.2
+    broken = true; # at 2022-10-04
   };
 }


### PR DESCRIPTION
python310Packages.apache-beam: mark broken

  ![image](https://user-images.githubusercontent.com/5861043/193862748-fef84f81-ed9a-4118-a21e-810fef95cb9a.png)

  logs: https://termbin.com/3dj9

* Goal is to avoid **false positive** in upstream builds.
  - Please, feel free to propose a fix in a **new** PR.