### PR TITLE
python310Packages.tensorflow-datasets: mark broken

### DIFF
--- a/pkgs/development/python-modules/tensorflow-datasets/default.nix
+++ b/pkgs/development/python-modules/tensorflow-datasets/default.nix
@@ -149,5 +149,7 @@ buildPythonPackage rec {
     homepage = "https://www.tensorflow.org/datasets/overview";
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];
+    # ERROR: No matching distribution found for protobuf<4,>=3.12.2
+    broken = true; # at 2022-10-04
   };
 }


### PR DESCRIPTION
python310Packages.tensorflow-datasets: mark broken

  > ERROR: No matching distribution found for protobuf<4,>=3.12.2

  logs: https://termbin.com/6156h
  Arch: `linux-x86_64`.

* Goal is to avoid **false positive** in upstream builds.
  - Please, feel free to propose a fix in a **new** PR.