### PR TITLE
bitwuzla: build with SymFPU 

### DIFF
--- a/pkgs/applications/science/logic/bitwuzla/default.nix
+++ b/pkgs/applications/science/logic/bitwuzla/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bitwuzla";
-  version = "unstable-2022-08-07";
+  version = "unstable-2022-10-03";
 
   src = fetchFromGitHub {
     owner = "bitwuzla";
     repo = "bitwuzla";
-    rev = "b6fb61736a5cf70cd0b35ec4aeeadf23971610ce";
-    hash = "sha256-T5VnnWrcZ8K1NjFf5eeg0TRpXBLRCxC67v8zWPwYF/Y=";
+    rev = "3bc0f9f1aca04afabe1aff53dd0937924618b2ad";
+    hash = "sha256-UXZERl7Nedwex/oUrcf6/GkDSgOQ537WDYm117RfvWo=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-    "-DUSE_SYMFPU=ON"
     "-DPicoSAT_INCLUDE_DIR=${lib.getDev picosat}/include/picosat"
     "-DBtor2Tools_INCLUDE_DIR=${lib.getDev btor2tools}/include/btor2parser"
     "-DBtor2Tools_LIBRARIES=${lib.getLib btor2tools}/lib/libbtor2parser${stdenv.hostPlatform.extensions.sharedLibrary}"

--- a/pkgs/applications/science/logic/bitwuzla/default.nix
+++ b/pkgs/applications/science/logic/bitwuzla/default.nix
@@ -5,6 +5,7 @@
 , cmake
 , lingeling
 , btor2tools
+, symfpu
 , gtest
 , gmp
 , cadical
@@ -35,12 +36,14 @@ stdenv.mkDerivation rec {
     picosat
     minisat
     btor2tools
+    symfpu
     gmp
     zlib
   ] ++ lib.optional withLingeling lingeling;
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
+    "-DUSE_SYMFPU=ON"
     "-DPicoSAT_INCLUDE_DIR=${lib.getDev picosat}/include/picosat"
     "-DBtor2Tools_INCLUDE_DIR=${lib.getDev btor2tools}/include/btor2parser"
     "-DBtor2Tools_LIBRARIES=${lib.getLib btor2tools}/lib/libbtor2parser${stdenv.hostPlatform.extensions.sharedLibrary}"


### PR DESCRIPTION
###### Description of changes

This builds Bitwuzla with floating point support. SymFPU has recently become a hard requirement, so I've included a version bump to simplify.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
