### PR TITLE
rustPlatform.buildRustPackage: support `finalAttrs` style

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -296,8 +296,10 @@ else let
        "nativeCheckInputs" "nativeInstallCheckInputs"
        "__darwinAllowLocalNetworking"
        "__impureHostDeps" "__propagatedImpureHostDeps"
-       "sandboxProfile" "propagatedSandboxProfile"]
-       ++ lib.optional (__structuredAttrs || envIsExportable) "env"))
+       "sandboxProfile" "propagatedSandboxProfile"
+       "removeFromBuilderEnv"]
+       ++ lib.optional (__structuredAttrs || envIsExportable) "env"
+       ++ (attrs.removeFromBuilderEnv or [])))
     // (lib.optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
       name =
         let

--- a/pkgs/tools/text/difftastic/default.nix
+++ b/pkgs/tools/text/difftastic/default.nix
@@ -3,7 +3,6 @@
 , rustPlatform
 , fetchFromGitHub
 , testers
-, difftastic
 }:
 
 let
@@ -14,14 +13,14 @@ let
   };
 in
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "difftastic";
   version = "0.46.0";
 
   src = fetchFromGitHub {
     owner = "wilfred";
-    repo = pname;
-    rev = version;
+    repo = "difftastic";
+    rev = finalAttrs.version;
     sha256 = "sha256-uXSmEJUpcw/PQ5I9nR1b6N1fcOdCSCM4KF0XnGNJkME=";
   };
 
@@ -37,14 +36,14 @@ rustPlatform.buildRustPackage rec {
       -p1 < ${mimallocPatch}
   '';
 
-  passthru.tests.version = testers.testVersion { package = difftastic; };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     description = "A syntax-aware diff";
     homepage = "https://github.com/Wilfred/difftastic";
-    changelog = "https://github.com/Wilfred/difftastic/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/Wilfred/difftastic/blob/${finalAttrs.version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ ethancedwards8 figsoda ];
     mainProgram = "difft";
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

This PR explores supporting the new `finalAttrs` derivation style for `buildRustPackage`, similar to what is suggested in https://github.com/NixOS/nixpkgs/pull/119942#issuecomment-1014718769. It is basically an extended version of #179392, and in particular also would close #107070.

A few notes:

 - This change should be entirely opt-in and cause no rebuilds.
 - This PR adds an ad-hoc way to prevent some attrs (called "intermediate args" here) to be passed to the underlying derivation call by specifying `removeFromBuilderEnv`. Another option would be to allow an arbitrary function (similar to `apply` in the module system), but that might be too powerful/confusing. Also see https://github.com/NixOS/nixpkgs/pull/194475#discussion_r1163670441.
 - Rust packages can be incrementally converted and then enjoy the benefits outlined in #119942
   
   As an example, I converted `difftastic` to the new style, such that changing its version is now much DRYer:
   ```nix
   pkgs.difftastic.overrideAttrs (oldAttrs: {
     version = "0.37.0";
     src = oldAttrs.src.overrideAttrs (_: {
       outputHash = "sha256-LwDoIvhZj/1fHg2eWgadwTcegeOKPpY8aCAugLfKtDE=";
     });
     cargoHash = "sha256-j7PVzGCButQhxVXVrtWhT6a6F1SLNe0jAy8oGqr9NvQ=";
     cargoLock = null;
     postPatch = "";
   })   
   ```
    Also note that `passthru.tests.version` then automatically points to the new package. 
 - The "overlay" in `buildRustPackage` has a few curiosities, i.e. we have to be careful to avoid `infinite recursion` errors:

     - It is not possible to use the `{ a ? "", ...}@finalAttrs` syntax. Even `{...}@finalAttrs` causes `infinite recursion`.
     - Asserts involving attributes from `finalAttrs` have to be "hidden" inside of values. Right now, I moved them to the respective attributes/variables; another option would be to put them into a dedicated `asserts` attribute, i.e. `asserts = assert (all asserts here); "";`.
   
   Maybe there are better solutions for these problems around, but they don't seem too terrible.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
