### PR TITLE
maintainers: remove flexagoon from hover and dart

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     homepage = "https://www.dartlang.org/";
-    maintainers = with maintainers; [ grburst flexagoon ];
+    maintainers = with maintainers; [ grburst ];
     description = "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
     longDescription = ''
       Dart is a class-based, single inheritance, object-oriented language

--- a/pkgs/development/tools/hover/default.nix
+++ b/pkgs/development/tools/hover/default.nix
@@ -41,7 +41,7 @@ let
       homepage = "https://github.com/go-flutter-desktop/hover";
       license = licenses.bsd3;
       platforms = platforms.linux;
-      maintainers = with maintainers; [ ericdallo flexagoon ];
+      maintainers = with maintainers; [ ericdallo ];
     };
 
     subPackages = [ "." ];


### PR DESCRIPTION
###### Description of changes

I am no longer using NixOS. For now, I'm fine with maintaining other packages where I'm the only maintainer. But Dart and Hover have another people maintaining them, which were more active anyway, so I'm removing myself from those packages.