### PR TITLE
comicTagger: init at 1.5.0

### DIFF
--- a/pkgs/applications/misc/comic-tagger/default.nix
+++ b/pkgs/applications/misc/comic-tagger/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pathvalidate
+, text2digits
+, pycountry
+, beautifulsoup4
+, importlib-metadata
+, natsort
+, pillow
+, py7zr
+, requests
+, thefuzz
+, typing-extensions
+, wordninja
+, unrar-cffi
+, pyqt5
+, wrapQtAppsHook
+}:
+
+buildPythonPackage rec {
+  pname = "comicTagger";
+  version = "1.5.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = lib.strings.toLower pname;
+    sha256 = "sha256-D42bGcHwzi2iT7qeTLlX5TXydqc5s+kTrWVioktwJ8s=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+    pathvalidate
+    text2digits
+    pycountry
+    beautifulsoup4
+    importlib-metadata
+    natsort
+    pillow
+    py7zr
+    requests
+    thefuzz
+    typing-extensions
+    wordninja
+    unrar-cffi
+    pyqt5
+  ];
+  buildInputs = [
+  ];
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/comictagger/comictagger";
+    description = "A multi-platform app for writing metadata to digital comics";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ alexnortung ];
+  };
+}

--- a/pkgs/development/python-modules/inflate64/default.nix
+++ b/pkgs/development/python-modules/inflate64/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonAtLeast
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "inflate64";
+  version = "0.3.0";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-gfuOaQ+8uS59Pmdp7Exvv6u4iq3md/YbL0yZh0U4v2Q=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+    setuptools-scm
+  ];
+
+  meta = with lib; {
+    description = "provide Deflater and Inflater class to compress and decompress with Enhanced Deflate compression algorithm";
+    license = licenses.lgpl2Plus;
+  };
+}

--- a/pkgs/development/python-modules/multivolumefile/default.nix
+++ b/pkgs/development/python-modules/multivolumefile/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "multivolumefile";
+  version = "0.2.3";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-oGSNCq+8luWRmNXBfprK1+tTGr6lEDXQjOgGDcrXCdY=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+    setuptools-scm
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/miurahr/multivolume";
+    description = "library to provide a file-object wrapping multiple files as virtually like as a single file";
+    license = licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/development/python-modules/py7zr/default.nix
+++ b/pkgs/development/python-modules/py7zr/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+, pyzstd
+, inflate64
+, pybcj
+, pycryptodomex
+, brotli
+, brotlicffi
+, multivolumefile
+, texttable
+, psutil
+, pyppmd-018
+}:
+
+buildPythonPackage rec {
+  pname = "py7zr";
+  version = "0.20.0";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-InD5IvjQe7ioPSjhxX3XdXCupruHbtjrSHmgOMFJzl4=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+    setuptools-scm
+    pyzstd
+    pybcj
+    inflate64
+    pycryptodomex
+    brotli
+    brotlicffi
+    multivolumefile
+    texttable
+    psutil
+    pyppmd-018
+  ];
+
+  meta = with lib; {
+    homepage = "https://py7zr.readthedocs.io/en/latest/";
+    description = "7zip archive compression, decompression, encryption and decryption";
+    license = licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/development/python-modules/pybcj/default.nix
+++ b/pkgs/development/python-modules/pybcj/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "pybcj";
+  version = "1.0.1";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-i2gu0Iyqv7fAQtS+CD4o3caSr7He/1VnER+IVQcbdcM=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+    setuptools-scm
+  ];
+
+  meta = with lib; {
+    description = "python bindings with BCJ implementation by C language";
+    license = licenses.lgpl2Plus;
+  };
+}
+

--- a/pkgs/development/python-modules/pyppmd/018.nix
+++ b/pkgs/development/python-modules/pyppmd/018.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "pyppmd";
+  version = "0.18.3";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-bHTOKCEwROM6WVJ5AZ6NcVEtXYGIgm0QbfkIPyswBsQ=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+    setuptools-scm
+  ];
+
+  meta = with lib; {
+    homepage = "http://github.com/miurahr/pyppmd";
+    description = "provides classes and functions for compressing and decompressing text data, using PPM compression algorithm which has several variations of implementations";
+    license = licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/development/python-modules/pyppmd/default.nix
+++ b/pkgs/development/python-modules/pyppmd/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "pyppmd";
+  version = "1.0.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-B1yb0pfjsKh9166ryn/uZoIYrL5p7MHGURBkVY3ohA8=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+    setuptools-scm
+  ];
+
+  meta = with lib; {
+    homepage = "http://github.com/miurahr/pyppmd";
+    description = "provides classes and functions for compressing and decompressing text data, using PPM compression algorithm which has several variations of implementations";
+    license = licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/development/python-modules/pyzstd/default.nix
+++ b/pkgs/development/python-modules/pyzstd/default.nix
@@ -1,0 +1,22 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pyzstd";
+  version = "0.15.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-rE7atdOVU0Po9/KH5izSiCkH1GvLpLQGoen4SqKIdHI=";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/animalize/pyzstd";
+    description = "Python bindings to Zstandard (zstd) compression library";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/text2digits/default.nix
+++ b/pkgs/development/python-modules/text2digits/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "text2digits";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-oB2NyNVxediIulid9A4Ccw878t2JKrIsN1OOR5lyi7I=";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = ''Converts text such as "twenty three" to number/digit "23" in any sentence'';
+    homepage = "https://github.com/ShailChoksi/text2digits";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/thefuzz/default.nix
+++ b/pkgs/development/python-modules/thefuzz/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "thefuzz";
+  version = "0.19.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = pname;
+    sha256 = "sha256-b3Em2y8silQhKwXjp0DkX0KRxJfXXSB1Fyj2Nbt0qj0=";
+  };
+
+  doCheck = false;
+  # checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/seatgeek/thefuzz";
+    description = "Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences";
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/development/python-modules/unrar-cffi/default.nix
+++ b/pkgs/development/python-modules/unrar-cffi/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, pytest-runner
+, cffi
+}:
+
+buildPythonPackage rec {
+  pname = "unrar-cffi";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-nebZB8ByhyS+B6z8tHnq3yaS8QOcp88t8mirtd+vS10=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+    setuptools-scm
+    pytest-runner
+    cffi
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/keredson/wordninja";
+    description = "unrar library functionality through a zipfile-like interface";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/wordninja/default.nix
+++ b/pkgs/development/python-modules/wordninja/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "wordninja";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-GhzH7BRq0Z1vcZQe6CrvPTEiFwDw2L+EQTbPjfedKBo=";
+  };
+
+  doCheck = false;
+  propagatedBuildInputs = [
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/keredson/wordninja";
+    description = "Probabilistically split concatenated words using NLP based on English Wikipedia unigram frequencies";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25644,6 +25644,8 @@ with pkgs;
 
   comic-relief = callPackage ../data/fonts/comic-relief {};
 
+  comicTagger = python3Packages.callPackage ../applications/misc/comic-tagger { };
+
   comixcursors = callPackage ../data/icons/comixcursors {};
 
   corefonts = callPackage ../data/fonts/corefonts { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4527,6 +4527,8 @@ in {
 
   infinity = callPackage ../development/python-modules/infinity { };
 
+  inflate64 = callPackage ../development/python-modules/inflate64 { };
+
   inflect = callPackage ../development/python-modules/inflect { };
 
   inflection = callPackage ../development/python-modules/inflection { };
@@ -5965,6 +5967,8 @@ in {
 
   multitasking = callPackage ../development/python-modules/multitasking { };
 
+  multivolumefile = callPackage ../development/python-modules/multivolumefile { };
+
   munch = callPackage ../development/python-modules/munch { };
 
   munkres = callPackage ../development/python-modules/munkres { };
@@ -6350,6 +6354,8 @@ in {
   nvchecker = callPackage ../development/python-modules/nvchecker { };
 
   nxt-python = callPackage ../development/python-modules/nxt-python { };
+
+  py7zr = callPackage ../development/python-modules/py7zr { };
 
   python-nvd3 = callPackage ../development/python-modules/python-nvd3 { };
 
@@ -7114,6 +7120,8 @@ in {
 
   pyzbar = callPackage ../development/python-modules/pyzbar { };
 
+  pyzstd = callPackage ../development/python-modules/pyzstd { };
+
   pkutils = callPackage ../development/python-modules/pkutils { };
 
   plac = callPackage ../development/python-modules/plac { };
@@ -7525,6 +7533,8 @@ in {
   pybalboa = callPackage ../development/python-modules/pybalboa { };
 
   pybase64 = callPackage ../development/python-modules/pybase64 { };
+
+  pybcj = callPackage ../development/python-modules/pybcj { };
 
   pybids = callPackage ../development/python-modules/pybids { };
 
@@ -8319,6 +8329,10 @@ in {
   pyplatec = callPackage ../development/python-modules/pyplatec { };
 
   pyppeteer = callPackage ../development/python-modules/pyppeteer { };
+
+  pyppmd = callPackage ../development/python-modules/pyppmd { };
+
+  pyppmd-018 = callPackage ../development/python-modules/pyppmd/018.nix { };
 
   pypresence = callPackage ../development/python-modules/pypresence { };
 
@@ -11020,6 +11034,8 @@ in {
     cudnnSupport = false;
   };
 
+  thefuzz = callPackage ../development/python-modules/thefuzz { };
+
   thermobeacon-ble = callPackage ../development/python-modules/thermobeacon-ble { };
 
   thermopro-ble = callPackage ../development/python-modules/thermopro-ble { };
@@ -11505,6 +11521,8 @@ in {
 
   unrardll = callPackage ../development/python-modules/unrardll { };
 
+  unrar-cffi = callPackage ../development/python-modules/unrar-cffi { };
+
   unrpa = callPackage ../development/python-modules/unrpa { };
 
   untangle = callPackage ../development/python-modules/untangle { };
@@ -11894,6 +11912,8 @@ in {
   wordcloud = callPackage ../development/python-modules/wordcloud { };
 
   wordfreq = callPackage ../development/python-modules/wordfreq { };
+
+  wordninja = callPackage ../development/python-modules/wordninja { };
 
   worldengine = callPackage ../development/python-modules/worldengine { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10963,6 +10963,8 @@ in {
 
   testfixtures = callPackage ../development/python-modules/testfixtures { };
 
+  text2digits = callPackage ../development/python-modules/text2digits { };
+
   textfsm = callPackage ../development/python-modules/textfsm { };
 
   textile = callPackage ../development/python-modules/textile { };


### PR DESCRIPTION
###### Description of changes

This PR aims to add the comicTagger package.
Although I might need some help to finish it up.
I am currently getting the following error when I try to run the binary from `./result`

```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

[1]    357634 abort (core dumped)  ./result/bin/comictagger
```

Tests can still be added for the individual dependencies

closes #183011

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
