### PR TITLE
postman: 9.25.2 -> 9.31.0

### DIFF
--- a/pkgs/development/web/postman/darwin.nix
+++ b/pkgs/development/web/postman/darwin.nix
@@ -11,12 +11,12 @@ let
   dist = {
     aarch64-darwin = {
       arch = "arm64";
-      sha256 = "62b4b3c63668fa4074b35afe08c212557437ff54c742a500087c74955cec9e04";
+      sha256 = "sha256-zvGWkV92qDsiveS1tvkY6jHIr/Xj3ARSOqov+MCRM+o=";
     };
 
     x86_64-darwin = {
       arch = "64";
-      sha256 = "42160a3c3011f43692fcb28b37dec5f708395318681de960f0cb932cea36021f";
+      sha256 = "sha256-LuXC1ucEsrxqx8wAkBkot2wXbUUVp+FIQPx9/2+tfIw=";
     };
   }.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "postman";
-  version = "9.25.2";
+  version = "9.31.0";
   meta = with lib; {
     homepage = "https://www.getpostman.com";
     description = "API Development Environment";

--- a/pkgs/development/web/postman/linux.nix
+++ b/pkgs/development/web/postman/linux.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "118da102904cd7b04c50d3e2c2daac3fc1228f05e541eacef55e8ecbf73d3896";
+    sha256 = "sha256-ZCfPE+bvPEQjEvUO/FQ1iNR9TG6GtI4vmj6yJ7B62iw=";
     name = "${pname}.tar.gz";
   };
 


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

