### PR TITLE
lib.lazyFunction: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -71,7 +71,7 @@ let
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare
-      functionArgs setFunctionArgs isFunction toFunction
+      functionArgs setFunctionArgs isFunction toFunction lazyFunction
       toHexString toBaseDigits inPureEvalMode;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -141,6 +141,19 @@ runTests {
     expected = { x = false; };
   };
 
+  testLazyFunction1 = {
+    expr = fix (lazyFunction ({ a, b, d }: { a = b; b = 1; c = 2; }));
+    expected = { a = 1; b = 1; c = 2; };
+  };
+
+  testLazyFunctionNeedsDocumentationUpdate = {
+    expr = fix (lazyFunction (args@{ a, ... }: { a = "a"; b = args?b; }));
+    # if b is true, change this test case, but also update the documentation
+    # to say that it is now supported, and which Nix implementations support it
+    # (if relevant).
+    expected = { a = "a"; b = false; };
+  };
+
 # STRINGS
 
   testConcatMapStrings = {

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -472,21 +472,30 @@ rec {
     else k: v;
 
   /*
-    Make a function lazy in its arguments.
+    Make a function lazy in its argument.
 
-    Normally when you call a function like `{ a, b }: { r = foo a b; }`,
+    Normally when you call a function `f` like `{ a, b }: { r = foo a b; }`,
     the attribute names of the argument must be evaluated before the evaluator
     can return a the (partially evaluated) function body (`{ r = ...; }`).
 
-    `lazyFunction` uses reflection on the passed in function and it only works
-    for functions defined with a "set pattern".
+    `lazyFunction` wraps this kind of function in such a way that this strict
+    behavior is cancelled out. With the example `f` above, `lazyFunction f` returns
+    `arg: f { a = arg.a; b = arg.b; }`.
 
-    It makes a function like `{ a, b }: { r = foo a b; }` behave like
-    `args: { r = foo args.a args.b; }`.
+    You can see that this wrapper function always satisfies `f`'s parameter
+    attributes `a` and `b`, but the expressions for them may still fail later.
+    For example `arg` may not contain an attribute `a`, or not even be an
+    attribute set.
+
+    Limitations:
+
+    `lazyFunction` only works for functions that are either defined using the
+    "set pattern" Nix syntax, or returned from `lib` functions that preserve
+    function argument metadata
 
     It is not compatible with ellipsis patterns, `{ ... }:`, because only the
     explicitly declared parameters are passed through. For example, the
-    following will not work: `lazyFunction(args@{ a, ... }: args.b)`;
+    following will not work: `lazyFunction(arg@{ a, ... }: arg.b)`;
     even if the caller provides `b`.
 
     It also removes the checks against unexpected arguments.
@@ -497,10 +506,10 @@ rec {
   */
   lazyFunction = f:
     setFunctionArgs
-      (args:
+      (arg:
         f
           (mapAttrs
-            (k: _: args.${k})
+            (k: _: arg.${k})
             (functionArgs f)
           )
       )


### PR DESCRIPTION
###### Description of changes

Adds a function that makes attrset-matching functions lazy using reflection.
This is similar to what the module system does for module arguments, but not powerful enough to abstract that.

This isn't used in nixpkgs yet, but may be used in #193336; however, I'd like for this to be reviewed separately.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @infinisil