### PR TITLE
fortune-mod: create fortuneExtensions

### DIFF
--- a/pkgs/tools/misc/fortune/extensions/blag-fortune.nix
+++ b/pkgs/tools/misc/fortune/extensions/blag-fortune.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchgit, fortune }:
+
+stdenv.mkDerivation rec {
+  pname = "blag-fortune";
+  version = "2022-07-16";
+
+  # We use fetchurl instead of fetchFromGitHub because the release pack has some
+  # special files.
+  src = fetchgit {
+    url = "https://notabug.org/PangolinTurtle/BLAG-fortune.git";
+    rev = "b07fb0312f";
+    sha256 = "sha256-Fi8o+hd2frBXXfzjwiJC7/2ZjdEc8vJbB7bSh9n3Vx0=";
+  };
+
+  # NOTE: this is needed for strfile in installPhase
+  buildInputs = [ fortune ];
+
+  installPhase = ''
+  cat people/* anarchism
+  strfile anarchism
+  install -D -t $out/share/fortunes anarchism
+  install -D -t $out/share/fortunes anarchism.dat
+  '';
+
+
+  meta = with lib; {
+    mainProgram = "blag-fortune";
+    description = "Ongoing project to have English language political fortunes in BLAG";
+    homepage = "https://notabug.org/PangolinTurtle/BLAG-fortune";
+    license = licenses.publicDomain;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ cafkafk ];
+  };
+}

--- a/pkgs/tools/misc/fortune/extensions/default.nix
+++ b/pkgs/tools/misc/fortune/extensions/default.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+with pkgs;
+
+{
+  blag-fortune = callPackage ./blag-fortune.nix {};
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6586,6 +6586,8 @@ with pkgs;
 
   fortune = callPackage ../tools/misc/fortune { };
 
+  fortuneExtensions = recurseIntoAttrs fortune.extensions;
+
   fox = callPackage ../development/libraries/fox {
     libpng = libpng12;
     inherit (darwin.apple_sdk.frameworks) CoreServices;


### PR DESCRIPTION
The fortune-mod program is a true unix classic, being 43 years old, originally released in 1979.

It has a significant cultural relevance in the unix sphere.

As such it has in it's long history had several extensions made.

This pull requests seeks to create a framework in nixpkgs for dealing with these extensions.

What has been done:
- created most code for handling extensions
- created the blag-fortune extension (not done)

The blag-fortune extension serves only to be a demo to be an example for other contributers as to how one would package an extension to fortune-mod

This is still a work in progress, and I would be grateful if anyone more experienced with the nix language would help me get this fully working.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
