### PR TITLE
arduino-language-server: init at 0.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1541,6 +1541,12 @@
     githubId = 576355;
     name = "Bas van Dijk";
   };
+  BattleCh1cken = {
+    email = "BattleCh1cken@larkov.de";
+    github = "BattleCh1cken";
+    githubId = 75806385;
+    name = "Felix Hass";
+  };
   Baughn = {
     email = "sveina@gmail.com";
     github = "Baughn";

--- a/pkgs/development/embedded/arduino/arduino-language-server/default.nix
+++ b/pkgs/development/embedded/arduino/arduino-language-server/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "arduino-language-server";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "arduino";
+    repo = "arduino-language-server";
+    rev = version;
+    hash = "sha256-FnkXtjktj22LCkmFPxzQ72qiVBC1WR/ZiwMsmZPL578=";
+  };
+
+  subPackages = [ "." ];
+
+  vendorHash = "sha256-Xa26ilo95sQ/6dGvl4gB2bb0vzWXr+WPKLezAnZPeqM=";
+
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/arduino/arduino-language-server/version.versionString=${version}"
+    "-X github.com/arduino/arduino-language-server/version.commit=unknown"
+  ] ++ lib.optionals stdenv.isLinux [ "-extldflags '-static'" ];
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "An Arduino Language Server based on Clangd to Arduino code autocompletion";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ BattleCh1cken ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2063,6 +2063,8 @@ with pkgs;
   arduino-core = callPackage ../development/embedded/arduino/arduino-core/chrootenv.nix { };
   arduino-core-unwrapped = callPackage ../development/embedded/arduino/arduino-core { };
 
+  arduino-language-server = callPackage ../development/embedded/arduino/arduino-language-server { };
+
   arduino-mk = callPackage ../development/embedded/arduino/arduino-mk {};
 
   apio = python3Packages.callPackage ../development/embedded/fpga/apio { };


### PR DESCRIPTION
###### Description of changes
Packaged the arduino-language server
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/arduino/arduino-language-server

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
