### PR TITLE
blightmud: use rustPlatform.bindgenHook, nixpkgs-format

### DIFF
--- a/pkgs/games/blightmud/default.nix
+++ b/pkgs/games/blightmud/default.nix
@@ -1,5 +1,14 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform, pkg-config, alsa-lib, openssl
-, withTTS ? false, llvmPackages, speechd }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, alsa-lib
+, openssl
+, withTTS ? false
+, llvmPackages
+, speechd
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "blightmud";
@@ -20,23 +29,25 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ alsa-lib openssl ] ++ lib.optional withTTS [ speechd ];
 
-  checkFlags = let
-    # Most of Blightmud's unit tests pass without trouble in the isolated
-    # Nixpkgs build env. The following tests need to be skipped.
-    skipList = [
-      "test_connect"
-      "test_gmcp_negotiation"
-      "test_ttype_negotiation"
-      "test_reconnect"
-      "test_is_connected"
-      "test_mud"
-      "test_server"
-      "test_lua_script"
-      "timer_test"
-      "validate_assertion_fail"
-    ];
-    skipFlag = test: "--skip " + test;
-  in builtins.concatStringsSep " " (builtins.map skipFlag skipList);
+  checkFlags =
+    let
+      # Most of Blightmud's unit tests pass without trouble in the isolated
+      # Nixpkgs build env. The following tests need to be skipped.
+      skipList = [
+        "test_connect"
+        "test_gmcp_negotiation"
+        "test_ttype_negotiation"
+        "test_reconnect"
+        "test_is_connected"
+        "test_mud"
+        "test_server"
+        "test_lua_script"
+        "timer_test"
+        "validate_assertion_fail"
+      ];
+      skipFlag = test: "--skip " + test;
+    in
+    builtins.concatStringsSep " " (builtins.map skipFlag skipList);
 
   meta = with lib; {
     description = "A terminal MUD client written in Rust";

--- a/pkgs/games/blightmud/default.nix
+++ b/pkgs/games/blightmud/default.nix
@@ -16,32 +16,9 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = lib.optional withTTS "tts";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config rustPlatform.bindgenHook ];
 
   buildInputs = [ alsa-lib openssl ] ++ lib.optional withTTS [ speechd ];
-
-  # Building the speech-dispatcher-sys crate for TTS support requires setting
-  # LIBCLANG_PATH.
-  LIBCLANG_PATH = lib.optionalString withTTS "${llvmPackages.libclang.lib}/lib";
-
-  preBuild = lib.optionalString withTTS ''
-    # When building w/ TTS the speech-dispatcher-sys crate's build.rs uses
-    # rust-bindgen with libspeechd. This bypasses the normal nixpkgs CC wrapper
-    # so we have to adapt the BINDGEN_EXTRA_CLANG_ARGS env var to compensate. See
-    # this blog post[0] for more information.
-    #
-    # [0]: https://hoverbear.org/blog/rust-bindgen-in-nix/
-
-    export BINDGEN_EXTRA_CLANG_ARGS="$(< ${stdenv.cc}/nix-support/libc-cflags) \
-      $(< ${stdenv.cc}/nix-support/cc-cflags) \
-      -isystem ${llvmPackages.libclang.lib}/lib/clang/${
-        lib.getVersion llvmPackages.clang
-      }/include \
-      -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${
-        lib.getVersion stdenv.cc.cc
-      }/include \
-      -idirafter ${speechd}/include"
-  '';
 
   checkFlags = let
     # Most of Blightmud's unit tests pass without trouble in the isolated

--- a/pkgs/games/blightmud/default.nix
+++ b/pkgs/games/blightmud/default.nix
@@ -6,7 +6,6 @@
 , alsa-lib
 , openssl
 , withTTS ? false
-, llvmPackages
 , speechd
 }:
 


### PR DESCRIPTION
###### Description of changes

By using `rustPlatform.bindgenHook` as a `nativeBuildInput` the Blightmud derivation's custom `LIBCLANG_PATH` and `preBuild` step can be removed outright. See the languages frameworks [Rust hooks docs](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#hooks-hooks) for more information.

For consistency, this branch also runs the Blightmud derivation through `nixpkgs-format`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

