### PR TITLE
usbreset: init at unstable-2018-09-21

### DIFF
--- a/pkgs/os-specific/linux/usbreset/default.nix
+++ b/pkgs/os-specific/linux/usbreset/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, lib, ... }:
+stdenv.mkDerivation rec {
+  pname = "usbreset";
+  version = "unstable-2018-09-21";
+
+  src = fetchFromGitHub {
+    owner = "jkulesza";
+    repo = pname;
+    rev = "7cad37246bdb116d92be05f458605b72cd8a70c7";
+    sha256 = "sha256:04hihfs8nrf53zi6kbbzfwp2aiqjddjrrq5fic2v3s4q1kx7wq16";
+  };
+
+  buildPhase = ''
+    cc usbreset.c -o usbreset
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp usbreset $out/bin/usbreset
+    chmod +x $out/bin/usbreset
+  '';
+
+  meta = {
+    description = "Linux USB Device Reset Application";
+    homepage = "https://github.com/jkulesza/usbreset";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ cheriimoya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25446,6 +25446,8 @@ with pkgs;
   usbrelay = callPackage ../os-specific/linux/usbrelay { };
   usbrelayd = callPackage ../os-specific/linux/usbrelay/daemon.nix { };
 
+  usbreset = callPackage ../os-specific/linux/usbreset { };
+
   usbtop = callPackage ../os-specific/linux/usbtop { };
 
   usbutils = callPackage ../os-specific/linux/usbutils { };


### PR DESCRIPTION
###### Description of changes

This package allows to reset usb devices. This helps in some cases if other tools fail to reset e.g. internal wifi or bluetooth adapters connected via usb.

https://github.com/jkulesza/usbreset

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
