### PR TITLE
hy: 1.0a4 -> 0.24.0

### DIFF
--- a/pkgs/development/python-modules/funcparserlib/default.nix
+++ b/pkgs/development/python-modules/funcparserlib/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , poetry-core
 , python
 , pytestCheckHook
@@ -11,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "funcparserlib";
-  version = "1.0.0a0";
+  version = "1.0.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -20,7 +19,7 @@ buildPythonPackage rec {
     owner = "vlasovskikh";
     repo = pname;
     rev = version;
-    sha256 = "sha256-YfcboKjyc5ASzrp0duu2R6psf51MGZIeZ0owo5QNSnU=";
+    sha256 = "sha256-moWaOzyF/yhDQCLEp7bc0j8wNv7FM7cvvpCwon3j+gI=";
   };
 
   nativeBuildInputs = [
@@ -30,15 +29,6 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
     six
-  ];
-
-  patches = [
-    # Support for poetry-core, https://github.com/vlasovskikh/funcparserlib/pull/73
-    (fetchpatch {
-      name = "support-poetry-core.patch";
-      url = "https://github.com/vlasovskikh/funcparserlib/commit/61ed558fc146b7a30879919325dfa8aae77be556.patch";
-      sha256 = "sha256-tqdR3r4/t7RWBYZeAabaN7oYf6VxkVVz006XICX9rYI=";
-    })
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/hy/default.nix
+++ b/pkgs/development/python-modules/hy/default.nix
@@ -10,8 +10,6 @@
 , pythonOlder
 , rply
 , testers
-, toPythonApplication
-, hyDefinedPythonPackages ? python-packages: [ ] /* Packages like with python.withPackages */
 }:
 
 buildPythonPackage rec {
@@ -37,10 +35,7 @@ buildPythonPackage rec {
   ] ++
   lib.optionals (pythonOlder "3.9") [
     astor
-  ] ++
-  # for backwards compatibility with removed pkgs/development/interpreters/hy
-  # See: https://github.com/NixOS/nixpkgs/issues/171428
-  (hyDefinedPythonPackages python.pkgs);
+  ];
 
   checkInputs = [
     pytestCheckHook
@@ -63,10 +58,10 @@ buildPythonPackage rec {
       package = hy;
       command = "hy -v";
     };
-    # also for backwards compatibility with removed pkgs/development/interpreters/hy
-    withPackages = python-packages: (toPythonApplication hy).override {
-      hyDefinedPythonPackages = python-packages;
-    };
+    # For backwards compatibility with removed pkgs/development/interpreters/hy
+    # Example usage:
+    #   hy.withPackages (ps: with ps; [ hyrule requests ])
+    withPackages = python-packages: python.withPackages (ps: (python-packages ps) ++ [ ps.hy ]);
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/hy/default.nix
+++ b/pkgs/development/python-modules/hy/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "hy";
-  version = "1.0a4";
+  version = "0.24.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "hylang";
     repo = pname;
     rev = version;
-    sha256 = "sha256-MBzp3jqBg/kH233wcgYYHc+Yg9GuOaBsXIfjFDihD1E=";
+    sha256 = "sha256-PmnYOniYqNHGTxpWuAc+zBhOsgRgMMbERHq81KpHheg=";
   };
 
   # https://github.com/hylang/hy/blob/1.0a4/get_version.py#L9-L10
@@ -34,24 +34,26 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     colorama
     funcparserlib
-    rply # TODO: remove on the next release
-  ]
-  ++ lib.optionals (pythonOlder "3.9") [
+  ] ++
+  lib.optionals (pythonOlder "3.9") [
     astor
-  ]
+  ] ++
   # for backwards compatibility with removed pkgs/development/interpreters/hy
   # See: https://github.com/NixOS/nixpkgs/issues/171428
-  ++ (hyDefinedPythonPackages python.pkgs);
+  (hyDefinedPythonPackages python.pkgs);
 
   checkInputs = [
     pytestCheckHook
   ];
 
+  preCheck = ''
+    # For test_bin_hy
+    export PATH="$out/bin:$PATH"
+  '';
+
   disabledTests = [
-    # Don't test the binary
-    "test_bin_hy"
-    "test_hystartup"
-    "est_hy2py_import"
+    "test_circular_macro_require"
+    "test_macro_require"
   ];
 
   pythonImportsCheck = [ "hy" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37099,7 +37099,7 @@ with pkgs;
 
   simplenote = callPackage ../applications/misc/simplenote { };
 
-  hy = python3Packages.hy.withPackages (python-packages: [ ]);
+  hy = with python3Packages; toPythonApplication hy;
 
   wmic-bin = callPackage ../servers/monitoring/plugins/wmic-bin.nix { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Not a downgrade, upstream returned to 0.* version numbers: https://github.com/hylang/hy/releases/tag/0.24.0. `python3Packages.hyrule` was updated in one of the mass Python upgrades.

Also updated `funcparserlib` since `hy` explicitly depends on this specific version (it is the latest, BTW). We could relax the deps instead, but in this case bumping the library was easier (and also removed a patch).

Fixes https://github.com/NixOS/nixpkgs/issues/194527.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
