### PR TITLE
openasar: unstable-2022-08-07 -> unstable-2022-10-02

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/openasar.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/openasar.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openasar";
-  version = "unstable-2022-08-07";
+  version = "unstable-2022-10-02";
 
   src = fetchFromGitHub {
     owner = "GooseMod";
     repo = "OpenAsar";
-    rev = "e0870784008a584229d3094e0988f5da155c7fd7";
-    hash = "sha256-t0b2SFlDDBSQEkOCQME0jsLJ8NvoXROTxoQgnoXM9eQ=";
+    rev = "c72f1a3fc064f61cc5c5a578d7350240e26a27af";
+    hash = "sha256-6V9vLmj5ptMALFV57pMU2IGxNbFNyVcdvnrPgCEaUJ0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Adds [updates to OpenASAR from recent days](https://github.com/GooseMod/OpenAsar/compare/e0870784008a584229d3094e0988f5da155c7fd7...c72f1a3fc064f61cc5c5a578d7350240e26a27af), most notably ones that make it work with Discord 0.0.20 (which broke user mods upon release).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @PedroHLC 