### PR TITLE
wordbook: init at unstable-2022-11-02

### DIFF
--- a/pkgs/applications/misc/wordbook/default.nix
+++ b/pkgs/applications/misc/wordbook/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, fetchFromGitHub
+, python3
+, meson
+, ninja
+, pkg-config
+, glib
+, gtk4
+, libadwaita
+, librsvg
+, espeak-ng
+, gobject-introspection
+, wrapGAppsHook4
+, appstream-glib
+, desktop-file-utils
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "wordbook";
+  version = "unstable-2022-11-02";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "fushinari";
+    repo = "Wordbook";
+    rev = "2d79e9e9ef21ba4b54d0b46c764a1481a06f0f1b";
+    hash = "sha256-ktusZEQ7m8P0kiH09r3XC6q9bQCWVCn543IMLKmULDo=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    appstream-glib
+    desktop-file-utils
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    librsvg
+    libadwaita
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+    wn
+  ];
+
+  # prevent double wrapping
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      --prefix PATH ":" "${lib.makeBinPath [ espeak-ng ]}"
+      "''${gappsWrapperArgs[@]}"
+    )
+  '';
+
+  meta = with lib; {
+    description = "Offline English-English dictionary application built for GNOME";
+    homepage = "https://github.com/fushinari/Wordbook";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/development/python-modules/wn/default.nix
+++ b/pkgs/development/python-modules/wn/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, flit-core
+, requests
+, tomli
+}:
+
+buildPythonPackage rec {
+  pname = "wn";
+  version = "0.9.2";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-TghCKPKLxRTpvojmZi8tPGmU/D2W+weZl64PArAwDCE=";
+  };
+
+  nativeBuildInputs = [ flit-core ];
+
+  propagatedBuildInputs = [
+    requests
+    tomli
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "wn" ];
+
+  meta = with lib; {
+    description = "A modern, interlingual wordnet interface for Python";
+    homepage = "https://github.com/goodmami/wn";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32344,6 +32344,8 @@ with pkgs;
 
   cl-wordle = callPackage ../games/cl-wordle { };
 
+  wordbook = callPackage ../applications/misc/wordbook { };
+
   wordnet = callPackage ../applications/misc/wordnet {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11844,6 +11844,8 @@ in {
 
   wled = callPackage ../development/python-modules/wled { };
 
+  wn = callPackage ../development/python-modules/wn { };
+
   woob = callPackage ../development/python-modules/woob { };
 
   woodblock = callPackage ../development/python-modules/woodblock { };


### PR DESCRIPTION
###### Description of changes

https://github.com/fushinari/Wordbook

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
