### PR TITLE
vscode-extensions.chenglou92.rescript-vscode: 1.6.0 -> 1.8.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rescript/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rescript/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, vscode-utils, callPackage }:
 let
-  version = "1.6.0";
+  version = "1.8.1";
   rescript-editor-analysis = callPackage ./rescript-editor-analysis.nix { inherit version; };
   arch =
     if stdenv.isLinux then "linux"
@@ -13,7 +13,7 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
     name = "rescript-vscode";
     publisher = "chenglou92";
     inherit version;
-    sha256 = "sha256-/Nv+uyTkJQVaPKIDRr1P/Z5vsituXpP48/sDn3FUEeA=";
+    sha256 = "sha256-XZG0PRzc3wyAVq9tQeGDlaUZg5YAgkPxJ3NsrdUHoOk=";
   };
   postPatch = ''
     rm -r ${analysisDir}

--- a/pkgs/applications/editors/vscode/extensions/rescript/rescript-editor-analysis.nix
+++ b/pkgs/applications/editors/vscode/extensions/rescript/rescript-editor-analysis.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     owner = "rescript-lang";
     repo = "rescript-vscode";
     rev = version;
-    sha256 = "sha256-O5kZCnhtMcevPTs5UxhIXx124WQf1VvF2WMVHjMEQZc=";
+    sha256 = "sha256-a8otK0BxZbl0nOp4QWQRkjb5fM85JA4nVkLuKAz71xU=";
   };
 
   nativeBuildInputs = [ ocaml dune_3 ];


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/rescript-lang/rescript-vscode/blob/master/CHANGELOG.md#v181

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
