### PR TITLE
nixos/hidpi: Harmonise default with documented recommendations

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -209,6 +209,11 @@ In addition to numerous new and upgraded packages, this release has the followin
     [headscale's example configuration](https://github.com/juanfont/headscale/blob/main/config-example.yaml)
     can be directly written as attribute-set in Nix within this option.
 
+- `hardware.video.hidpi` now provides defaults that are consistent with `fontconfig`'s documentation:
+  - antialiasing and font hinting are disabled, as they have no visible effects at high pixel densities;
+  - subpixel order isn't set: it was irrelevant with the above disabled, and the module *cannot* know the correct
+    setting for the user's screen.
+
 - `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates. This is now extensively documented in the NixOS manual.
 
 - `services.grafana` listens only on localhost by default again. This was changed to upstreams default of `0.0.0.0` by accident in the freeform setting conversion.

--- a/nixos/modules/hardware/video/hidpi.nix
+++ b/nixos/modules/hardware/video/hidpi.nix
@@ -13,6 +13,7 @@ with lib;
 
 
     # Disable font anti-aliasing, hinting, and sub-pixel rendering by default
+    # See recommendations in fonts/fontconfig.nix
     fonts.fontconfig = {
       antialias = mkDefault false;
       hinting.enable = mkDefault false;

--- a/nixos/modules/hardware/video/hidpi.nix
+++ b/nixos/modules/hardware/video/hidpi.nix
@@ -15,10 +15,7 @@ with lib;
     # Disable font anti-aliasing, hinting, and sub-pixel rendering by default
     fonts.fontconfig.antialias = mkDefault false;
     fonts.fontconfig.hinting.enable = mkDefault false;
-    fonts.fontconfig.subpixel = {
-      rgba = mkDefault "none";
-      lcdfilter = mkDefault "none";
-    };
+    fonts.fontconfig.subpixel.lcdfilter = mkDefault "none";
 
     # TODO Find reasonable defaults X11 & wayland
   };

--- a/nixos/modules/hardware/video/hidpi.nix
+++ b/nixos/modules/hardware/video/hidpi.nix
@@ -12,8 +12,8 @@ with lib;
     boot.loader.systemd-boot.consoleMode = mkDefault "1";
 
 
-    # Grayscale anti-aliasing for fonts
-    fonts.fontconfig.antialias = mkDefault true;
+    # Disable font anti-aliasing & sub-pixel rendering by default
+    fonts.fontconfig.antialias = mkDefault false;
     fonts.fontconfig.subpixel = {
       rgba = mkDefault "none";
       lcdfilter = mkDefault "none";

--- a/nixos/modules/hardware/video/hidpi.nix
+++ b/nixos/modules/hardware/video/hidpi.nix
@@ -13,9 +13,11 @@ with lib;
 
 
     # Disable font anti-aliasing, hinting, and sub-pixel rendering by default
-    fonts.fontconfig.antialias = mkDefault false;
-    fonts.fontconfig.hinting.enable = mkDefault false;
-    fonts.fontconfig.subpixel.lcdfilter = mkDefault "none";
+    fonts.fontconfig = {
+      antialias = mkDefault false;
+      hinting.enable = mkDefault false;
+      subpixel.lcdfilter = mkDefault "none";
+    };
 
     # TODO Find reasonable defaults X11 & wayland
   };

--- a/nixos/modules/hardware/video/hidpi.nix
+++ b/nixos/modules/hardware/video/hidpi.nix
@@ -12,8 +12,9 @@ with lib;
     boot.loader.systemd-boot.consoleMode = mkDefault "1";
 
 
-    # Disable font anti-aliasing & sub-pixel rendering by default
+    # Disable font anti-aliasing, hinting, and sub-pixel rendering by default
     fonts.fontconfig.antialias = mkDefault false;
+    fonts.fontconfig.hinting.enable = mkDefault false;
     fonts.fontconfig.subpixel = {
       rgba = mkDefault "none";
       lcdfilter = mkDefault "none";


### PR DESCRIPTION
###### Description of changes

In the NixOS `hidpi` module:
- Disable anti-aliasing and font hinting, as per documented recommendations for hiDPI screens;
- Don't set subpixel order (irrelevant with subpixel rendering disabled)
- Minor refactor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - ~~x86_64-darwin~~
  - ~~aarch64-darwin~~
- ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
- [x] Tested, manually (no applicable NixOS tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
