### PR TITLE
nixos/vmware-guest: refactor platform restriction

### DIFF
--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -23,7 +23,7 @@ in
 
   config = mkIf cfg.enable {
     assertions = [ {
-      assertion = pkgs.stdenv.hostPlatform.isx86;
+      assertion = pkgs.stdenv.hostPlatform.isx86 || (pkgs.stdenv.hostPlatform.isAarch64 && !cfg.headless);
       message = "VMWare guest is not currently supported on ${pkgs.stdenv.hostPlatform.system}";
     } ];
 


### PR DESCRIPTION
PR for #147650

Allow headless aarch64 guests.

It seems xf86inputvmmouse does not build on aarch64-linux, which is used only with graphical configurations (i.e., when headless is `false`).

###### Description of changes

This PR loosens the module assertion logic, allowing configuration like this to proceed: `isAarch64 && !cfg.headless`.

###### Things done

Untested!

I don't have an aarch64 VMWare host to test this. Hoping someone from the issue can try it.


