### PR TITLE
python3Packages.spectral-cube: fix dependencies

### DIFF
--- a/pkgs/development/python-modules/pyregion/default.nix
+++ b/pkgs/development/python-modules/pyregion/default.nix
@@ -30,11 +30,16 @@ buildPythonPackage rec {
     astropy
   ];
 
-  # Upstream patch needed for the test to pass
+  # Upstream patches needed for the tests to pass
+  # See https://github.com/astropy/pyregion/pull/157/
   patches = [
     (fetchpatch {
-      url = "https://github.com/astropy/pyregion/pull/157.patch";
-      sha256 = "sha256-FMPpwwbtCR8FDZWbD3Cmat7vu6AhyUezu2TOpUfujJE=";
+      url = "https://github.com/astropy/pyregion/pull/157/commits/082649730d353a0d0c0ee9619be1aa501aabba62.patch";
+      sha256 = "sha256-4mHZt3S29ZfK+QKavm6DLBwVxGl/ga7W7GEcQ5ewxuo=";
+    })
+    (fetchpatch {
+      url = "https://github.com/astropy/pyregion/pull/157/commits/c448a465dd56887979da62aec6138fc89bb37b19.patch";
+      sha256 = "sha256-GEtvScmVbAdE4E5Xx0hNOPommvzcnJ3jNZpBmY3PbyE=";
     })
   ];
 

--- a/pkgs/development/python-modules/pyregion/default.nix
+++ b/pkgs/development/python-modules/pyregion/default.nix
@@ -13,15 +13,15 @@
 
 buildPythonPackage rec {
   pname = "pyregion";
-  version = "2.0";
+  version = "2.1.1";
 
   # pypi src contains cython-produced .c files which don't compile
   # with python3.9
   src = fetchFromGitHub {
     owner = "astropy";
     repo = pname;
-    rev = version;
-    sha256 = "1izar7z606czcyws9s8bjbpb1xhqshpv5009rlpc92hciw7jv4kg";
+    rev = "v${version}";
+    sha256 = "sha256-xo+XbBJ2HKql9rd7Ma84JofRg8M4u6vmz44Qo8JhEBc=";
   };
 
   propagatedBuildInputs = [
@@ -33,9 +33,8 @@ buildPythonPackage rec {
   # Upstream patch needed for the test to pass
   patches = [
     (fetchpatch {
-      name = "conftest-astropy-3-fix.patch";
-      url = "https://github.com/astropy/pyregion/pull/136.patch";
-      sha256 = "13yxjxiqnhjy9gh24hvv6pnwx7qic2mcx3ccr1igjrc3f881d59m";
+      url = "https://github.com/astropy/pyregion/pull/157.patch";
+      sha256 = "sha256-FMPpwwbtCR8FDZWbD3Cmat7vu6AhyUezu2TOpUfujJE=";
     })
   ];
 

--- a/pkgs/development/python-modules/reproject/default.nix
+++ b/pkgs/development/python-modules/reproject/default.nix
@@ -2,7 +2,6 @@
 , astropy
 , astropy-extension-helpers
 , astropy-healpix
-, astropy-helpers
 , buildPythonPackage
 , cython
 , fetchPypi
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     astropy-extension-helpers
-    astropy-helpers
     cython
     setuptools-scm
   ];
@@ -36,7 +34,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     astropy
     astropy-healpix
-    astropy-helpers
     numpy
     scipy
   ];
@@ -46,9 +43,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  preCheck = ''
-    cd build/lib*
-  '';
+  pytestFlagsArray = [
+    "build/lib*"
+    # Avoid failure due to user warning: Distutils was imported before Setuptools
+    "-p no:warnings"
+  ];
 
   pythonImportsCheck = [
     "reproject"


### PR DESCRIPTION
###### Description of changes

Fix python3Packages.spectral-cube dependencies.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
