### PR TITLE
dictd: add Japanese dbs eng2jpn and jpn2eng

### DIFF
--- a/pkgs/servers/dict/dictd-db.nix
+++ b/pkgs/servers/dict/dictd-db.nix
@@ -56,6 +56,16 @@ in rec {
     url = "mirror://sourceforge/freedict/eng-fra.tar.gz";
     sha256 = "0fi6rrnbqnhc6lq8d0nmn30zdqkibrah0mxfg27hsn9z7alwbj3m";
   }) "eng-fra" "en_UK";
+  jpn2eng = makeDictdDB (fetchurl {
+    url = let version = "0.1";
+          in "mirror://sourceforge/freedict/jpn-eng/${version}/freedict-jpn-eng-${version}.dictd.tar.xz";
+    sha256 = "sha256-juJBoEq7EztLZzOomc7uoZhXVaQPKoUvIxxPLB0xByc=";
+  }) "jpn-eng" "jpn-eng" "ja_JP";
+  eng2jpn = makeDictdDB (fetchurl {
+    url = let version = "2022.04.06";
+          in "https://download.freedict.org/dictionaries/eng-jpn/${version}/freedict-eng-jpn-${version}.dictd.tar.xz";
+    sha256 = "sha256-kfRT2kgbV3XKarCr4mqDRT5A1jR8M8APky5M5MFYatE=";
+  }) "eng-jpn" "eng-jpn" "en_UK";
   mueller_eng2rus_pkg = makeDictdDB (fetchurl {
     url = "mirror://sourceforge/mueller-dict/mueller-dict-3.1.tar.gz";
     sha256 = "04r5xxznvmcb8hkxqbjgfh2gxvbdd87jnhqn5gmgvxxw53zpwfmq";


### PR DESCRIPTION
###### Description of changes

Added freedict dictionaries for Japanese (eng2jpn and jpn2eng) to the dictd-db collection.

Sourceforge does not have the eng2jpn side, so I'm pulling that one from a pinned version on download.freedict.org.

Built via nixpkgs-review:

```console
$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"

$ nix-env --option system x86_64-linux -f /home/ian/.cache/nixpkgs-review/rev-a748f63ca7395046c5856077056fe1033df55018/nixpkgs -qaP --xml --out-path --show-trace --meta
2 packages added:
dictd-db-eng-jpn dictd-db-jpn-eng

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/ian/.cache/nixpkgs-review/rev-a748f63ca7395046c5856077056fe1033df55018/build.nix
2 packages built:
dictdDBs.eng2jpn dictdDBs.jpn2eng
```

Runtime-tested on my nixos system via module config:

```nix
services.dictd = {
  enable = true;
  DBs = with pkgs.dictdDBs; [
    eng2jpn
    jpn2eng
  ];
};
```

Tests:

```console
$ dict -h localhost -D
Databases available:
 dictd-db-eng-jpn English-日本語 (にほんご) FreeDict+WikDict dictionary ver. 2022.04.06
 dictd-db-jpn-eng Japanese-English FreeDict Dictionary ver. 0.1

$ dict -h localhost -d dictd-db-jpn-eng 日本語
1 definition found

From Japanese-English FreeDict Dictionary ver. 0.1 [dictd-db-jpn-eng]:

   [news1]  [nf02]  日本語,  [news1]  [nf02]  にほんご, にっぽんご
  1. (noun (common) (futsuumeishi))
   (nouns which may take the genitive case particle `no')
  {国語・こくご・2}Japanese (language)
  2. (にほんご)
   (noun (common) (futsuumeishi))
   (esp. as a school or university subject)
  Japanese as a second language

$ dict -h localhost -d dictd-db-eng-jpn japanese
2 definitions found

From English-日本語 (にほんご) FreeDict+WikDict dictionary ver. 2022.04.06 [dictd-db-eng-jpn]:

  Japanese //ˌdʒæpəˈniːz// <adj>
  日本の, 日本, 和, 日
  of or relating to Japan

From English-日本語 (にほんご) FreeDict+WikDict dictionary ver. 2022.04.06 [dictd-db-eng-jpn]:

  Japanese //ˌdʒæpəˈniːz// <n>
  1. 日本語, ジャパニーズ
  Japanese language
  2. 日本人, ジャパニーズ
  person of Japan
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
