### PR TITLE
epgstation.updateScript: Fix eval and clean up

### DIFF
--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -1,14 +1,11 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, gitUpdater
-, writers
 , makeWrapper
 , bash
 , nodejs
 , gzip
-, jq
-, yq
+, callPackage
 }:
 
 let
@@ -33,7 +30,8 @@ let
   });
 
   server = nodejs.pkgs.epgstation.override (drv: {
-    inherit src;
+    # NOTE: updateScript relies on version matching the src.
+    inherit version src;
 
     # This is set to false to keep devDependencies at build time. Build time
     # dependencies are pruned afterwards.
@@ -108,17 +106,7 @@ let
 
     # NOTE: this may take a while since it has to update all packages in
     # nixpkgs.nodePackages
-    passthru.updateScript = import ./update.nix {
-      inherit lib;
-      inherit (src.meta) homepage;
-      inherit
-        pname
-        version
-        gitUpdater
-        writers
-        jq
-        yq;
-    };
+    passthru.updateScript = callPackage ./update.nix { };
 
     # nodePackages.epgstation is a stub package to fetch npm dependencies and
     # its meta.platforms is made empty to prevent users from installing it

--- a/pkgs/applications/video/epgstation/update.nix
+++ b/pkgs/applications/video/epgstation/update.nix
@@ -1,67 +1,62 @@
-{ pname
-, version
-, homepage
-, lib
-, gitUpdater
+{ gitUpdater
 , writers
 , jq
 , yq
 , gnused
+, _experimental-update-script-combinators
 }:
 
 let
-  updater = gitUpdater {
-    inherit pname version;
-    attrPath = lib.toLower pname;
+  updateSource = gitUpdater {
     rev-prefix = "v";
   };
-  updateScript = builtins.elemAt updater.command 0;
-  updateArgs = map (lib.escapeShellArg) (builtins.tail updater.command);
-in writers.writeBash "update-epgstation" ''
-  set -euxo pipefail
+  updateLocks = writers.writeBash "update-epgstation" ''
+    set -euxo pipefail
 
-  # bump the version
-  ${updateScript} ${lib.concatStringsSep " " updateArgs}
+    cd "$1"
 
-  cd "${toString ./.}"
+    # Get the path to the latest source. Note that we can't just pass the value
+    # of epgstation.src directly because it'd be evaluated before we can run
+    # updateScript.
+    SRC="$(nix-build ../../../.. --no-out-link -A epgstation.src)"
+    if [[ "$UPDATE_NIX_OLD_VERSION" == "$(${jq}/bin/jq -r .version "$SRC/package.json")" ]]; then
+      echo "[INFO] Already using the latest version of $UPDATE_NIX_PNAME" >&2
+      exit
+    fi
 
-  # Get the path to the latest source. Note that we can't just pass the value
-  # of epgstation.src directly because it'd be evaluated before we can run
-  # updateScript.
-  SRC="$(nix-build ../../../.. --no-out-link -A epgstation.src)"
-  if [[ "${version}" == "$(${jq}/bin/jq -r .version "$SRC/package.json")" ]]; then
-    echo "[INFO] Already using the latest version of ${pname}" >&2
-    exit
-  fi
+    # Regenerate package.json from the latest source.
+    ${jq}/bin/jq '. + {
+        dependencies: (.dependencies + .devDependencies),
+      } | del(.devDependencies, .main, .scripts)' \
+      "$SRC/package.json" \
+      > package.json
+    ${jq}/bin/jq '. + {
+        dependencies: (.dependencies + .devDependencies),
+      } | del(.devDependencies, .main, .scripts)' \
+      "$SRC/client/package.json" \
+      > client/package.json
 
-  # Regenerate package.json from the latest source.
-  ${jq}/bin/jq '. + {
-      dependencies: (.dependencies + .devDependencies),
-    } | del(.devDependencies, .main, .scripts)' \
-    "$SRC/package.json" \
-    > package.json
-  ${jq}/bin/jq '. + {
-      dependencies: (.dependencies + .devDependencies),
-    } | del(.devDependencies, .main, .scripts)' \
-    "$SRC/client/package.json" \
-    > client/package.json
+    # Fix issue with old sqlite3 version pinned that depends on very old node-gyp 3.x
+    ${gnused}/bin/sed -i -e 's/"sqlite3":\s*"5.0.[0-9]\+"/"sqlite3": "5.0.11"/' package.json
 
-  # Fix issue with old sqlite3 version pinned that depends on very old node-gyp 3.x
-  ${gnused}/bin/sed -i -e 's/"sqlite3":\s*"5.0.[0-9]\+"/"sqlite3": "5.0.11"/' package.json
+    # Regenerate node packages to update the pre-overriden epgstation derivation.
+    # This must come *after* package.json has been regenerated.
+    pushd ../../../development/node-packages
+    ./generate.sh
+    popd
 
-  # Regenerate node packages to update the pre-overriden epgstation derivation.
-  # This must come *after* package.json has been regenerated.
-  pushd ../../../development/node-packages
-  ./generate.sh
-  popd
+    # Generate default streaming settings for the nixos module.
+    pushd ../../../../nixos/modules/services/video/epgstation
+    ${yq}/bin/yq -j '{ urlscheme , stream }' \
+      "$SRC/config/config.yml.template" \
+      > streaming.json
 
-  # Generate default streaming settings for the nixos module.
-  pushd ../../../../nixos/modules/services/video/epgstation
-  ${yq}/bin/yq -j '{ urlscheme , stream }' \
-    "$SRC/config/config.yml.template" \
-    > streaming.json
-
-  # Fix generated output for EditorConfig compliance
-  printf '\n' >> streaming.json  # rule: insert_final_newline
-  popd
-''
+    # Fix generated output for EditorConfig compliance
+    printf '\n' >> streaming.json  # rule: insert_final_newline
+    popd
+  '';
+in
+_experimental-update-script-combinators.sequence [
+  updateSource
+  [updateLocks ./.]
+]


### PR DESCRIPTION
###### Description of changes

- `gnused` was not passed, use `callPackage` to prevent such issues in the future.
- Do not pass redundant attributes like `pname` or `version` to the script,
  `update.nix` already passes them as environment variables.
- Do not combine the scripts manually, we have combinators for that, suggested in https://github.com/NixOS/nixpkgs/pull/193248#discussion_r981784640
- Pass the path to update as an argument so that `update.nix`
  can ensure it is a writeable path instead a one in the Nix store.

Broken by e51b313775b7473a66926d28b1e2c07b8dcfdf74:

```
error: anonymous function at /home/jtojnar/Projects/nixpkgs/pkgs/applications/video/epgstation/update.nix:1:1 called without required argument 'gnused'

       at /home/jtojnar/Projects/nixpkgs/pkgs/applications/video/epgstation/default.nix:111:29:

          110|     # nixpkgs.nodePackages
          111|     passthru.updateScript = import ./update.nix {
             |                             ^
          112|       inherit lib;
(use '--show-trace' to show detailed location information)
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
