### PR TITLE
libreswan: 4.7 -> 4.8

### DIFF
--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -30,6 +30,7 @@
 , docbook_xml_dtd_412
 , docbook_xsl
 , findXMLCatalogs
+, dns-root-data
 }:
 
 let
@@ -43,11 +44,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libreswan";
-  version = "4.7";
+  version = "4.8";
 
   src = fetchurl {
     url = "https://download.libreswan.org/${pname}-${version}.tar.gz";
-    sha256 = "0i7wyfgkaq6kcfhh1yshb1v7q42n3zvdkhq10f3ks1h075xk7mnx";
+    sha256 = "sha256-gEy5EX1/tBGYE7FVrJF+NFZY41ehOBim9t/Oikch4gs=";
   };
 
   strictDeps = true;
@@ -77,9 +78,9 @@ stdenv.mkDerivation rec {
         -e 's|/bin/bash|${runtimeShell}|g' \
         -i initsystems/systemd/ipsec.service.in \
            programs/barf/barf.in \
-           programs/verify/verify.in
+           programs/verify.linux/verify.in
     sed -e 's|\([[:blank:]]\)\(ip6\?tables\(-save\)\? -\)|\1${iptables}/bin/\2|' \
-        -i programs/verify/verify.in
+        -i programs/verify.linux/verify.in
 
     # Prevent the makefile from trying to
     # reload the systemd daemon or create tmpfiles
@@ -92,7 +93,7 @@ stdenv.mkDerivation rec {
 
     # Fix python script to use the correct python
     sed -e 's/^\(\W*\)installstartcheck()/\1sscmd = "ss"\n\0/' \
-        -i programs/verify/verify.in
+        -i programs/verify.linux/verify.in
 
     # Replace wget with curl to save a dependency
     curlArgs='-s --remote-name-all --output-dir'
@@ -113,6 +114,7 @@ stdenv.mkDerivation rec {
     "UNITDIR=$(out)/etc/systemd/system/"
     "TMPFILESDIR=$(out)/lib/tmpfiles.d/"
     "LINUX_VARIANT=nixos"
+    "DEFAULT_DNSSEC_ROOTKEY_FILE=${dns-root-data}/root.key"
   ];
 
   # Hack to make install work


### PR DESCRIPTION
###### Description of changes

Version bump

Note: this also fixes DNSSEC support, which was enabled but not working due to the (most likely) missing DNS root file.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested `libreswan.tests`
- [x] Tested compilation of all packages that depend on this change (`hash-slinger`)
- [x] Tested basic functionality of all binary files (`ipsec` works as expected)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
