### PR TITLE
libbpf: disable auto updates for 0.8 branch

### DIFF
--- a/pkgs/os-specific/linux/libbpf/0.x.nix
+++ b/pkgs/os-specific/linux/libbpf/0.x.nix
@@ -7,6 +7,11 @@
 , nixosTests
 }:
 
+# update bot does not seem to limit updates here to 0.8.x despite
+# the all-packages derivation being libbpf_0 as the libbpf base alias
+# is still present: just disable it for 0.x:
+# nixpkgs-update: no auto update
+
 stdenv.mkDerivation rec {
   pname = "libbpf";
   version = "0.8.1";


### PR DESCRIPTION
###### Description of changes

update bot keeps opening update to 1.0.1 PRs despite libbpf_1 being available, disable autoupdates for the old branch instead as per this comment:
https://github.com/NixOS/nixpkgs/pull/193996#issuecomment-1264508493

it might be possible to restrict the version in a pattern instead so we'd get later 0.8.x? But upstream release rate for it should be near nil, so not bothering to look.