### PR TITLE
rectangle: init at 0.59

### DIFF
--- a/pkgs/os-specific/darwin/rectangle/default.nix
+++ b/pkgs/os-specific/darwin/rectangle/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchurl, cpio, xar, undmg, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "rectangle";
+  version = "0.59";
+
+  src = fetchurl {
+    url = "https://github.com/rxhanson/Rectangle/releases/download/v${version}/Rectangle${version}.dmg";
+    sha256 = "sha256-6K4HJ4qWjf/BsoxmSWyO/Km3BZujCnMJ2/xCMkH3TaI=";
+  };
+
+  sourceRoot = "Rectangle.app";
+
+  nativeBuildInputs = [ undmg ];
+
+  installPhase = ''
+    mkdir -p $out/Applications/Rectangle.app
+    cp -R . $out/Applications/Rectangle.app
+  '';
+
+  meta = with lib; {
+    description = "Move and resize windows in macOS using keyboard shortcuts or snap areas";
+    homepage = "https://rectangleapp.com/";
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ Enzime ];
+    license = licenses.mit;
+  };
+}
+

--- a/pkgs/os-specific/darwin/rectangle/default.nix
+++ b/pkgs/os-specific/darwin/rectangle/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Move and resize windows in macOS using keyboard shortcuts or snap areas";
     homepage = "https://rectangleapp.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     platforms = platforms.darwin;
     maintainers = with maintainers; [ Enzime ];
     license = licenses.mit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25187,6 +25187,8 @@ with pkgs;
 
   reap = callPackage ../os-specific/linux/reap { };
 
+  rectangle = callPackage ../os-specific/darwin/rectangle { };
+
   regionset = callPackage ../os-specific/linux/regionset { };
 
   rfkill_udev = callPackage ../os-specific/linux/rfkill/udev.nix { };


### PR DESCRIPTION
###### Description of changes

> Move and resize windows in macOS using keyboard shortcuts or snap areas

https://rectangleapp.com/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).