### PR TITLE
ocamlPackages.ff: 0.4.0 → 0.6.2

### DIFF
--- a/pkgs/development/ocaml-modules/ff/default.nix
+++ b/pkgs/development/ocaml-modules/ff/default.nix
@@ -1,32 +1,22 @@
-{ lib, fetchFromGitLab, buildDunePackage, ocaml, zarith, alcotest }:
+{ lib, buildDunePackage, ff-pbt, ff-sig, zarith, alcotest }:
 
 buildDunePackage rec {
   pname = "ff";
-  version = "0.4.0";
-
-  src = fetchFromGitLab {
-    owner = "dannywillems";
-    repo = "ocaml-ff";
-    rev = version;
-    sha256 = "1ik29srzkd0pl48p1si9p1c4f8vmx5rgm02yv2arj3vg0a1nfhdv";
-  };
-
-  useDune2 = true;
+  inherit (ff-sig) version src;
 
   propagatedBuildInputs = [
+    ff-sig
     zarith
   ];
 
   checkInputs = [
     alcotest
+    ff-pbt
   ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
-  meta = {
-    homepage = "https://gitlab.com/dannywillems/ocaml-ff";
+  meta = ff-sig.meta // {
     description = "OCaml implementation of Finite Field operations";
-    license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.ulrikstrid ];
   };
 }

--- a/pkgs/development/ocaml-modules/ff/pbt.nix
+++ b/pkgs/development/ocaml-modules/ff/pbt.nix
@@ -1,14 +1,16 @@
-{ lib, fetchFromGitLab, buildDunePackage, zarith, ff-sig, alcotest }:
+{ lib, buildDunePackage, zarith, ff-sig, alcotest }:
 
 buildDunePackage {
   pname = "ff-pbt";
-  inherit (ff-sig) version src doCheck useDune2;
+  inherit (ff-sig) version src;
 
   minimalOCamlVersion = "4.08";
 
   checkInputs = [
     alcotest
   ];
+
+  doCheck = true;
 
   propagatedBuildInputs = [
     zarith

--- a/pkgs/development/ocaml-modules/ff/sig.nix
+++ b/pkgs/development/ocaml-modules/ff/sig.nix
@@ -2,15 +2,13 @@
 
 buildDunePackage rec {
   pname = "ff-sig";
-  version = "0.6.1";
+  version = "0.6.2";
   src = fetchFromGitLab {
-    owner = "dannywillems";
-    repo = "ocaml-ff";
+    owner = "nomadic-labs";
+    repo = "cryptography/ocaml-ff";
     rev = version;
-    sha256 = "0p42ivyfbn1pwm18773y4ga9cm64ysha0rplzvrnhszg01anarc0";
+    sha256 = "sha256-IoUH4awMOa1pm/t8E5io87R0TZsAxJjGWaXhXjn/w+Y=";
   };
-
-  useDune2 = true;
 
   propagatedBuildInputs = [
     zarith
@@ -19,7 +17,7 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = {
-    homepage = "https://gitlab.com/dannywillems/ocaml-ff";
+    inherit (src.meta) homepage;
     description = "Minimal finite field signatures";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];


### PR DESCRIPTION
ocamlPackages.ff-pbt: 0.6.1 → 0.6.2
ocamlPackages.ff-sig: 0.6.1 → 0.6.2

###### Description of changes

Fix `src` attribute.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
