### PR TITLE
netbsd: Adapt to BSD-common infra changes for FreeBSD

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/compat-cxx-safe-header.patch
+++ b/pkgs/os-specific/bsd/netbsd/compat-cxx-safe-header.patch
@@ -1,6 +1,6 @@
 diff -u -r1.35.2.1 nbtool_config.h.in
---- a/nbtool_config.h.in	22 Apr 2015 07:18:58 -0000	1.35.2.1
-+++ b/nbtool_config.h.in	31 May 2018 01:46:53 -0000
+--- a/tools/compat/nbtool_config.h.in	22 Apr 2015 07:18:58 -0000	1.35.2.1
++++ b/tools/compat/nbtool_config.h.in	31 May 2018 01:46:53 -0000
 @@ -680,5 +680,14 @@
  /* Define if you have u_int8_t, but not uint8_t. */
  #undef uint8_t

--- a/pkgs/os-specific/bsd/netbsd/compat-dont-configure-twice.patch
+++ b/pkgs/os-specific/bsd/netbsd/compat-dont-configure-twice.patch
@@ -6,8 +6,8 @@ Date:   Wed Sep 1 15:38:56 2021 +0000
 
 diff --git a/Makefile b/Makefile
 index b5adb8a5f2e9..1a914ef16739 100644
---- a/Makefile
-+++ b/Makefile
+--- a/tools/compat/Makefile
++++ b/tools/compat/Makefile
 @@ -76,11 +76,6 @@ _CURDIR:=	${.CURDIR}
  
  SRCS:=		${SRCS:M*.c}

--- a/pkgs/os-specific/bsd/netbsd/compat-no-force-native.patch
+++ b/pkgs/os-specific/bsd/netbsd/compat-no-force-native.patch
@@ -8,8 +8,8 @@ Date:   Wed Sep 1 15:38:56 2021 +0000
 
 diff --git a/Makefile b/Makefile
 index 4bcf227f0e75..9ed1d6eea6ff 100644
---- a/Makefile
-+++ b/Makefile
+--- a/tools/compat/Makefile
++++ b/tools/compat/Makefile
 @@ -1,6 +1,6 @@
  #	$NetBSD: Makefile,v 1.87 2019/05/08 02:25:50 thorpej Exp $
  

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -3,7 +3,7 @@
 , buildPackages, splicePackages, newScope
 , bsdSetupHook, makeSetupHook, fetchcvs, groff, mandoc, byacc, flex
 , zlib
-, writeScript, writeText, runtimeShell, symlinkJoin
+, writeShellScript, writeText, runtimeShell, symlinkJoin
 }:
 
 let
@@ -281,8 +281,7 @@ in lib.makeScopeWithSplicing
 
   # HACK: to ensure parent directories exist. This emulates GNU
   # install’s -D option. No alternative seems to exist in BSD install.
-  install = let binstall = writeScript "binstall" ''
-    #!${runtimeShell}
+  install = let binstall = writeShellScript "binstall" ''
     set -eu
     for last in "$@"; do true; done
     mkdir -p $(dirname $last)

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -94,7 +94,7 @@ in lib.makeScopeWithSplicing
     }.${stdenv'.hostPlatform.parsed.cpu.name}
       or stdenv'.hostPlatform.parsed.cpu.name;
 
-    BSD_PATH = attrs.path;
+    COMPONENT_PATH = attrs.path;
 
     makeFlags = defaultMakeFlags;
 
@@ -126,7 +126,7 @@ in lib.makeScopeWithSplicing
     postPatch = lib.optionalString (!stdenv'.hostPlatform.isNetBSD) ''
       set +e
       grep -Zlr "^__RCSID
-      ^__BEGIN_DECLS" $BSD_PATH | xargs -0r grep -FLZ nbtool_config.h |
+      ^__BEGIN_DECLS" $COMPONENT_PATH | xargs -0r grep -FLZ nbtool_config.h |
           xargs -0tr sed -i '0,/^#/s//#include <nbtool_config.h>\n\0/'
       set -e
     '' + attrs.postPatch or "";
@@ -146,7 +146,7 @@ in lib.makeScopeWithSplicing
     skipIncludesPhase = true;
 
     postPatch = ''
-      patchShebangs $BSD_PATH/configure
+      patchShebangs $COMPONENT_PATH/configure
       ${self.make.postPatch}
     '';
 
@@ -707,10 +707,10 @@ in lib.makeScopeWithSplicing
     SHLIBINSTALLDIR = "$(out)/lib";
     makeFlags = defaultMakeFlags ++ [ "LIBDO.terminfo=${self.libterminfo}/lib" ];
     postPatch = ''
-      sed -i '1i #undef bool_t' $BSD_PATH/el.h
-      substituteInPlace $BSD_PATH/config.h \
+      sed -i '1i #undef bool_t' $COMPONENT_PATH/el.h
+      substituteInPlace $COMPONENT_PATH/config.h \
         --replace "#define HAVE_STRUCT_DIRENT_D_NAMLEN 1" ""
-      substituteInPlace $BSD_PATH/readline/Makefile --replace /usr/include "$out/include"
+      substituteInPlace $COMPONENT_PATH/readline/Makefile --replace /usr/include "$out/include"
     '';
     NIX_CFLAGS_COMPILE = [
       "-D__noinline="
@@ -730,8 +730,8 @@ in lib.makeScopeWithSplicing
     buildInputs = with self; compatIfNeeded;
     SHLIBINSTALLDIR = "$(out)/lib";
     postPatch = ''
-      substituteInPlace $BSD_PATH/term.c --replace /usr/share $out/share
-      substituteInPlace $BSD_PATH/setupterm.c \
+      substituteInPlace $COMPONENT_PATH/term.c --replace /usr/share $out/share
+      substituteInPlace $COMPONENT_PATH/setupterm.c \
         --replace '#include <curses.h>' 'void use_env(bool);'
     '';
     postBuild = ''
@@ -759,10 +759,10 @@ in lib.makeScopeWithSplicing
     MKDOC = "no"; # missing vfontedpr
     makeFlags = defaultMakeFlags ++ [ "LIBDO.terminfo=${self.libterminfo}/lib" ];
     postPatch = lib.optionalString (!stdenv.isDarwin) ''
-      substituteInPlace $BSD_PATH/printw.c \
+      substituteInPlace $COMPONENT_PATH/printw.c \
         --replace "funopen(win, NULL, __winwrite, NULL, NULL)" NULL \
         --replace "__strong_alias(vwprintw, vw_printw)" 'extern int vwprintw(WINDOW*, const char*, va_list) __attribute__ ((alias ("vw_printw")));'
-      substituteInPlace $BSD_PATH/scanw.c \
+      substituteInPlace $COMPONENT_PATH/scanw.c \
         --replace "__strong_alias(vwscanw, vw_scanw)" 'extern int vwscanw(WINDOW*, const char*, va_list) __attribute__ ((alias ("vw_scanw")));'
     '';
   };
@@ -987,7 +987,7 @@ in lib.makeScopeWithSplicing
     # man0 generates a man.pdf using ps2pdf, but doesn't install it later,
     # so we can avoid the dependency on ghostscript
     postPatch = ''
-      substituteInPlace $BSD_PATH/man0/Makefile --replace "ps2pdf" "echo noop "
+      substituteInPlace $COMPONENT_PATH/man0/Makefile --replace "ps2pdf" "echo noop "
     '';
     makeFlags = defaultMakeFlags ++ [
       "FILESDIR=$(out)/share"

--- a/pkgs/os-specific/bsd/netbsd/getent.patch
+++ b/pkgs/os-specific/bsd/netbsd/getent.patch
@@ -1,8 +1,8 @@
 Author: Matthew Bauer
 Description: Remove unavailable getent databases
 Version: 7.1.2
---- a/getent.c	2018-04-16 13:33:49.000000000 -0500
-+++ b/getent.c	2018-04-16 13:29:30.000000000 -0500
+--- a/usr.bin/getent/getent.c	2018-04-16 13:33:49.000000000 -0500
++++ b/usr.bin/getent/getent.c	2018-04-16 13:29:30.000000000 -0500
 @@ -42,7 +42,6 @@
  #include <grp.h>
  #include <limits.h>

--- a/pkgs/os-specific/bsd/netbsd/locale.patch
+++ b/pkgs/os-specific/bsd/netbsd/locale.patch
@@ -1,5 +1,5 @@
---- a/locale.c	2018-06-11 14:39:06.449762000 -0400
-+++ b/locale.c	2018-06-11 14:42:28.461122899 -0400
+--- a/usr.bin/locale/locale.c	2018-06-11 14:39:06.449762000 -0400
++++ b/usr.bin/locale/locale.c	2018-06-11 14:42:28.461122899 -0400
 @@ -56,14 +56,8 @@
  #include <stringlist.h>
  #include <unistd.h>

--- a/pkgs/os-specific/bsd/netbsd/no-dynamic-linker.patch
+++ b/pkgs/os-specific/bsd/netbsd/no-dynamic-linker.patch
@@ -4,8 +4,8 @@ rcsdiff: /ftp/cvs/cvsroot/src/sys/arch/i386/stand/efiboot/Makefile.efiboot,v: wa
 retrieving revision 1.16
 retrieving revision 1.17
 diff -u -p -r1.16 -r1.17
---- sys/arch/i386/stand/efiboot/Makefile.efiboot	2019/09/13 02:19:45	1.16
-+++ sys/arch/i386/stand/efiboot/Makefile.efiboot	2020/04/04 15:30:46	1.17
+--- a/sys/arch/i386/stand/efiboot/Makefile.efiboot	2019/09/13 02:19:45	1.16
++++ b/sys/arch/i386/stand/efiboot/Makefile.efiboot	2020/04/04 15:30:46	1.17
 @@ -41,6 +41,7 @@ BINMODE=444
  .PATH:	${.CURDIR}/../../libsa
  

--- a/pkgs/os-specific/bsd/netbsd/sys-headers-incsdir.patch
+++ b/pkgs/os-specific/bsd/netbsd/sys-headers-incsdir.patch
@@ -1,7 +1,7 @@
 diff --git a/Makefile b/Makefile
 index 3f1e18dc659d..163362b82f94 100644
---- a/Makefile
-+++ b/Makefile
+--- a/sys/Makefile
++++ b/sys/Makefile
 @@ -2,6 +2,8 @@
  
  .include <bsd.own.mk>

--- a/pkgs/os-specific/bsd/setup-hook.sh
+++ b/pkgs/os-specific/bsd/setup-hook.sh
@@ -66,9 +66,9 @@ setBSDSourceDir() {
 }
 
 cdBSDPath() {
-  if [ -d "$BSD_PATH" ]
-    then sourceRoot=$sourceRoot/$BSD_PATH
-    cd $BSD_PATH
+  if [ -d "$COMPONENT_PATH" ]
+    then sourceRoot=$sourceRoot/$COMPONENT_PATH
+    cd $COMPONENT_PATH
   fi
 }
 

--- a/pkgs/os-specific/bsd/setup-hook.sh
+++ b/pkgs/os-specific/bsd/setup-hook.sh
@@ -48,6 +48,7 @@ addMakeFlags() {
   makeFlags="BINDIR=${!outputBin}/bin $makeFlags"
   makeFlags="LIBDIR=${!outputLib}/lib $makeFlags"
   makeFlags="SHLIBDIR=${!outputLib}/lib $makeFlags"
+  makeFlags="SHAREDIR=${!outputLib}/share $makeFlags"
   makeFlags="MANDIR=${!outputMan}/share/man $makeFlags"
   makeFlags="INFODIR=${!outputInfo}/share/info $makeFlags"
   makeFlags="DOCDIR=${!outputDoc}/share/doc $makeFlags"
@@ -61,10 +62,13 @@ setBSDSourceDir() {
   sourceRoot=$PWD/$sourceRoot
   export BSDSRCDIR=$sourceRoot
   export _SRC_TOP_=$BSDSRCDIR
-
   cd $sourceRoot
+}
+
+cdBSDPath() {
   if [ -d "$BSD_PATH" ]
     then sourceRoot=$sourceRoot/$BSD_PATH
+    cd $BSD_PATH
   fi
 }
 
@@ -104,6 +108,7 @@ moveUsrDir() {
 }
 
 postUnpackHooks+=(setBSDSourceDir)
+postPatchHooks+=(cdBSDPath)
 preConfigureHooks+=(addMakeFlags)
 preInstallHooks+=(includesPhase)
 fixupOutputHooks+=(moveUsrDir)


### PR DESCRIPTION
###### Description of changes

See https://github.com/NixOS/nixpkgs/pull/82131 for the rest of the changes for FreeBSD. This is PRed separately because it is a macOS moderate rebuild so we target staging.

The main change is that we CD to the path we're building *after* applying patches, so we can patch other parts of the tree (from `extraPaths`) as needed.

Another change is that `netbsd.install` no longer depends on `fts`, which it evidently no longer needs.

Also, rename `BSD_PATH` to `COMPONENT_PATH `.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
