### PR TITLE
x264: pull upstream parallel build fix

### DIFF
--- a/pkgs/development/libraries/x264/default.nix
+++ b/pkgs/development/libraries/x264/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitLab, nasm
+{ stdenv, lib, fetchFromGitLab, fetchpatch, nasm
 , enableShared ? !stdenv.hostPlatform.isStatic
  }:
 
@@ -16,7 +16,15 @@ stdenv.mkDerivation rec {
 
   # Upstream ./configure greps for (-mcpu|-march|-mfpu) in CFLAGS, which in nix
   # is put in the cc wrapper anyway.
-  patches = [ ./disable-arm-neon-default.patch ];
+  patches = [
+    ./disable-arm-neon-default.patch
+    (fetchpatch {
+      # https://code.videolan.org/videolan/x264/-/merge_requests/114
+      name = "fix-parallelism.patch";
+      url = "https://code.videolan.org/videolan/x264/-/commit/e067ab0b530395f90b578f6d05ab0a225e2efdf9.patch";
+      hash = "sha256-16h2IUCRjYlKI2RXYq8QyXukAdfoQxyBKsK/nI6vhRI=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs .


### PR DESCRIPTION
Without the change parallel builds occasionally fail as:

    $ make --shuffle
    ...
    gcc ... -c common/opencl.c -o common/opencl-8.o ...
    common/opencl.c:116:10: fatal error: common/oclobj.h: No such file or directory
      116 | #include "common/oclobj.h"
          |          ^~~~~~~~~~~~~~~~~

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
