### PR TITLE
python310Packages.pyipp: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/pyipp/default.nix
+++ b/pkgs/development/python-modules/pyipp/default.nix
@@ -1,28 +1,40 @@
 { lib
 , aiohttp
 , aresponses
+, awesomeversion
+, backoff
 , buildPythonPackage
 , deepmerge
 , fetchFromGitHub
+, poetry-core
 , pytest-asyncio
 , pytestCheckHook
-, pytest-cov
+, pythonOlder
 , yarl
 }:
 
 buildPythonPackage rec {
   pname = "pyipp";
-  version = "0.11.0";
+  version = "0.12.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
    owner = "ctalkington";
    repo = "python-ipp";
    rev = version;
-   sha256 = "0ar3mkyfa9qi3av3885bvacpwlxh420if9ymdj8i4x06ymzc213d";
+   hash = "sha256-umlFGI0Y9cWF3N46yFztv0OlhLIzqhQF8e4quCmqn78=";
   };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   propagatedBuildInputs = [
     aiohttp
+    awesomeversion
+    backoff
     deepmerge
     yarl
   ];
@@ -30,11 +42,18 @@ buildPythonPackage rec {
   checkInputs = [
     aresponses
     pytest-asyncio
-    pytest-cov
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "pyipp" ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'version = "0.0.0"' 'version = "${version}"' \
+      --replace " --cov" ""
+  '';
+
+  pythonImportsCheck = [
+    "pyipp"
+  ];
 
   meta = with lib; {
     description = "Asynchronous Python client for Internet Printing Protocol (IPP)";


### PR DESCRIPTION
###### Description of changes
https://github.com/ctalkington/python-ipp/releases/tag/0.12.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
