### PR TITLE
factplusplus: init at 1.6.5

### DIFF
--- a/pkgs/by-name/fa/factplusplus/package.nix
+++ b/pkgs/by-name/fa/factplusplus/package.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  lib,
+  fetchFromBitbucket,
+  jdk,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "factplusplus";
+  version = "1.6.5";
+
+  src = fetchFromBitbucket {
+    owner = "dtsarkov";
+    repo = "factplusplus";
+    rev = "Release-${version}";
+    sha256 = "wzK1QJsNN0Q73NM+vjaE/vLuGf8J1Zu5ZPAkZNiKnME=";
+  };
+
+  buildInputs = [ jdk ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    sed -i 's/OS = MACOSX/OS = LINUX/g' Makefile.include
+    printf '%s\n%s\n' '#include <iostream>' "$(cat Kernel/AtomicDecomposer.cpp)" > Kernel/AtomicDecomposer.cpp
+
+    runHook postConfigure
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 FaCT++.{C,JNI,KE,Kernel}/obj/*.{so,o} -t $out/lib/
+    install -Dm755 FaCT++/obj/FaCT++ -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tableaux-based reasoner for expressive Description Logics (DL)";
+    homepage = "http://owl.cs.manchester.ac.uk/tools/fact/";
+    maintainers = [ maintainers.mgttlinger ];
+    license = licenses.gpl2Plus;
+    platforms = with platforms; linux ++ darwin ++ windows;
+    broken = !stdenv.hostPlatform.isLinux;
+    mainProgram = "FaCT++";
+  };
+}


### PR DESCRIPTION
###### Things done

Packaged the FaCT++ reasoner as a widespread OWL reasoner.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
