### PR TITLE
python310Packages.protobuf: remove old and no longer required code

### DIFF
--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -1,41 +1,14 @@
 { buildPackages
 , lib
-, fetchpatch
-, python
 , buildPythonPackage
-, isPy37
 , protobuf
-, google-apputils ? null
-, six
 , pyext
-, isPy27
-, disabled
-, doCheck ? true
+, isPyPy
 }:
 
 buildPythonPackage {
   inherit (protobuf) pname src version;
-  inherit disabled;
-  doCheck = doCheck && !isPy27; # setuptools>=41.4 no longer collects correctly on python2
-
-  propagatedBuildInputs = [ six ] ++ lib.optionals isPy27 [ google-apputils ];
-  propagatedNativeBuildInputs = let
-    protobufVersion = "${lib.versions.major protobuf.version}_${lib.versions.minor protobuf.version}";
-  in [
-    buildPackages."protobuf${protobufVersion}" # For protoc of the same version.
-  ];
-
-  nativeBuildInputs = [ pyext ] ++ lib.optionals isPy27 [ google-apputils ];
-  buildInputs = [ protobuf ];
-
-  patches = lib.optional (isPy37 && (lib.versionOlder protobuf.version "3.6.1.2"))
-    # Python 3.7 compatibility (not needed for protobuf >= 3.6.1.2)
-    (fetchpatch {
-      url = "https://github.com/protocolbuffers/protobuf/commit/0a59054c30e4f0ba10f10acfc1d7f3814c63e1a7.patch";
-      sha256 = "09hw22y3423v8bbmc9xm07znwdxfbya6rp78d4zqw6fisdvjkqf1";
-      stripLen = 1;
-    })
-  ;
+  disabled = isPyPy;
 
   prePatch = ''
     while [ ! -d python ]; do
@@ -44,14 +17,25 @@ buildPythonPackage {
     cd python
   '';
 
-  setupPyGlobalFlags = lib.optional (lib.versionAtLeast protobuf.version "2.6.0")
-    "--cpp_implementation";
+  nativeBuildInputs = [ pyext ];
+
+  buildInputs = [ protobuf ];
+
+  propagatedNativeBuildInputs = [
+    # For protoc of the same version.
+    buildPackages."protobuf${lib.versions.major protobuf.version}_${lib.versions.minor protobuf.version}"
+  ];
+
+  setupPyGlobalFlags = "--cpp_implementation";
 
   pythonImportsCheck = [
     "google.protobuf"
-  ] ++ lib.optionals (lib.versionAtLeast protobuf.version "2.6.0") [
     "google.protobuf.internal._api_implementation" # Verify that --cpp_implementation worked
   ];
+
+  passthru = {
+    inherit protobuf;
+  };
 
   meta = with lib; {
     description = "Protocol Buffers are Google's data interchange format";
@@ -59,6 +43,4 @@ buildPythonPackage {
     license = licenses.bsd3;
     maintainers = with maintainers; [ knedlsepp ];
   };
-
-  passthru.protobuf = protobuf;
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7330,9 +7330,7 @@ in {
   proto-plus = callPackage ../development/python-modules/proto-plus { };
 
   protobuf = callPackage ../development/python-modules/protobuf {
-    disabled = isPyPy;
     # If a protobuf upgrade causes many Python packages to fail, please pin it here to the previous version.
-    doCheck = !isPy3k;
     inherit (pkgs) protobuf;
   };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
