### PR TITLE
nixos/tests/common/bind-dns.nix: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -88,6 +88,7 @@ in {
   beanstalkd = handleTest ./beanstalkd.nix {};
   bees = handleTest ./bees.nix {};
   bind = handleTest ./bind.nix {};
+  bind-test-module-test = runTest ./common/bind-dns-test.nix;
   bird = handleTest ./bird.nix {};
   bitcoind = handleTest ./bitcoind.nix {};
   bittorrent = handleTest ./bittorrent.nix {};

--- a/nixos/tests/common/bind-dns-test.nix
+++ b/nixos/tests/common/bind-dns-test.nix
@@ -1,0 +1,110 @@
+/*
+  This tests ./bind-dns.nix, so it is a test for test-support code.
+
+  Bind itself is tested in ../bind.nix.
+*/
+{ lib, ... }: {
+  name = "testsupport-bind-dns-test";
+  meta.maintainers = with lib.maintainers; [ roberth ];
+
+  imports = [ ./bind-dns.nix ];
+
+  defaults = { pkgs, ... }: {
+    environment.systemPackages = [ ];
+    virtualisation.memorySize = 256; # no demanding programs, so this can be low
+
+    # Make sure we don't accidentally test the hosts file
+    networking.hostFiles = lib.mkForce [
+      (pkgs.writeText "dead-simple-etc-hosts" ''
+        127.0.0.1 localhost
+      '')
+    ];
+  };
+
+  nodes.simple = { };
+  nodes.hostname = {
+    networking.hostName = "custom-hostname";
+    system.name = "hostname";
+  };
+  nodes.overridedns = { config, ... }: {
+    networking.bindZoneRules = lib.mkForce ''
+      overriddendns. IN A ${config.networking.primaryIPAddress}
+    '';
+  };
+  nodes.extradns = { config, ... }: {
+    networking.bindZoneRules = ''
+      an-extra-name. IN A ${config.networking.primaryIPAddress}
+    '';
+  };
+  nodes.indomain = {
+    networking.domain = "thedomain";
+  };
+
+  testScript = { nodes, ... }: ''
+    start_all()
+
+    dns.wait_for_unit("network-online.target")
+    dns.wait_for_unit("bind.service")
+    dns.wait_for_open_port(53)
+    simple.wait_for_unit("network-online.target")
+
+    # Make sure that a helpful test framework + helpful host command can not
+    # ruin the test, and our override works (dead-simple-etc-hosts).
+    simple.succeed("""
+      ! grep custom-hostname /etc/hosts
+      """)
+
+    # record is present on server
+    simple.succeed("""
+      host simple ${nodes.dns.networking.primaryIPAddress} \
+        | tee /dev/stderr \
+        | grep 'simple has address ${nodes.simple.networking.primaryIPAddress}'
+      """)
+
+    # simple can resolve itself without specifying server
+    simple.succeed("""
+      host simple \
+        | tee /dev/stderr \
+        | grep 'simple has address ${nodes.simple.networking.primaryIPAddress}'
+      """)
+
+    # simple can be resolved on a different host (without specifying server)
+    hostname.succeed("""
+      host simple \
+        | tee /dev/stderr \
+        | grep 'simple has address ${nodes.simple.networking.primaryIPAddress}'
+      """)
+
+    # custom-hostname can be resolved on a different host (without specifying server)
+    simple.succeed("""
+      host custom-hostname \
+        | tee /dev/stderr \
+        | grep 'custom-hostname has address ${nodes.hostname.networking.primaryIPAddress}'
+      """)
+
+    simple.succeed("""
+      ! host overridedns
+      """)
+    simple.succeed("""
+      host overriddendns
+      """)
+
+    simple.succeed("""
+      host extradns \
+        | tee /dev/stderr \
+        | grep 'extradns has address ${nodes.extradns.networking.primaryIPAddress}'
+      """)
+    simple.succeed("""
+      host an-extra-name \
+        | tee /dev/stderr \
+        | grep 'an-extra-name has address ${nodes.extradns.networking.primaryIPAddress}'
+      """)
+
+    simple.succeed("""
+      host indomain.thedomain \
+        | tee /dev/stderr \
+        | grep 'indomain.thedomain has address ${nodes.indomain.networking.primaryIPAddress}'
+      """)
+
+  '';
+}

--- a/nixos/tests/common/bind-dns.nix
+++ b/nixos/tests/common/bind-dns.nix
@@ -1,0 +1,83 @@
+/*
+  A NixOS test module that provides a DNS server and configures it on all nodes.
+*/
+{ config, lib, ... }:
+let
+
+  inherit (lib)
+    concatMapStringsSep
+    mkOption types
+    ;
+
+  cfg = config.dns;
+
+in
+{
+
+  options = {
+    dns.nodeName = mkOption {
+      description = ''
+        The `<name>` in `nodes.<name>` for the DNS server.
+      '';
+      type = types.str;
+      default = "dns";
+    };
+  };
+
+  config = {
+
+    nodes.${cfg.nodeName} = { nodes, pkgs, ... }: {
+      networking.firewall.allowedUDPPorts = [ 53 ];
+      services.bind.enable = true;
+      services.bind.extraOptions = "empty-zones-enable no;";
+      services.bind.zones = [{
+        name = ".";
+        master = true;
+        file = pkgs.writeText "root.zone" ''
+          $TTL 3600
+          . IN SOA ${cfg.nodeName}. ${cfg.nodeName}. ( 1 8 2 4 1 )
+          . IN NS ${cfg.nodeName}.
+          ${concatMapStringsSep
+            "\n"
+            (node: "${node.networking.bindZoneRules}")
+            (builtins.attrValues nodes)
+          }
+        '';
+      }];
+    };
+
+    defaults = { nodes, config, options, ... }: {
+      options = {
+        networking.bindZoneRules = mkOption {
+          type = types.lines;
+          description = ''
+            This node's contribution to the bind DNS server config that's in the test network.
+
+            NixOS specialisations are ignored.
+
+            The default is defined with regular priority, so that it is merged with normal definitions. Use `lib.mkForce` to replace the default.
+          '';
+          defaultText = "\"\${if domain == null then hostName else fqdn}. IN A \${config.networking.primaryIPAddress}\"";
+        };
+      };
+      config =
+        let
+          # TODO apply https://github.com/NixOS/nixpkgs/pull/194759
+          fqdn =
+            if config.networking.domain == null
+            then config.networking.hostName
+            else config.networking.fqdn;
+        in
+        {
+          networking.dhcpcd.enable = false;
+          environment.etc."resolv.conf".text = ''
+            nameserver ${nodes.${cfg.nodeName}.networking.primaryIPAddress}
+          '';
+          networking.bindZoneRules =
+            "${fqdn}. IN A ${config.networking.primaryIPAddress}";
+        };
+    };
+
+  };
+
+}


### PR DESCRIPTION
###### Description of changes

A generic auto configuring `bind` DNS node for other NixOS tests to use (in-tree or otherwise).
I'm not changing any of the current tests for now; that's up to those test authors, because the indirection may not be productive for them.

TODO
 - [ ] documentation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
