### PR TITLE
lib/debug: throw functions that have been deprecated since 2018 

### DIFF
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -206,86 +206,63 @@ rec {
 
   # -- DEPRECATED --
 
-  traceShowVal = x: trace (showVal x) x;
-  traceShowValMarked = str: x: trace (str + showVal x) x;
+  traceShowVal = _:
+    throw ( "`traceShowVal` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `FILL IN`." );
+  traceShowValMarked = _:
+    throw ( "`traceShowValMarked` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `FILL IN`." );
 
-  attrNamesToStr = a:
-    trace ( "Warning: `attrNamesToStr` is deprecated "
-          + "and will be removed in the next release. "
+  attrNamesToStr =  _:
+    throw ( "`attrNamesToStr` is deprecated "
+          + "and will be removed in release 23.05. "
           + "Please use more specific concatenation "
-          + "for your uses (`lib.concat(Map)StringsSep`)." )
-    (concatStringsSep "; " (map (x: "${x}=") (attrNames a)));
+          + "for your uses (`lib.concat(Map)StringsSep`)." );
 
-  showVal =
-    trace ( "Warning: `showVal` is deprecated "
-          + "and will be removed in the next release, "
-          + "please use `traceSeqN`" )
-    (let
-      modify = v:
-        let pr = f: { __pretty = f; val = v; };
-        in   if isDerivation v then pr
-          (drv: "<δ:${drv.name}:${concatStringsSep ","
-                                 (attrNames drv)}>")
-        else if [] ==   v then pr (const "[]")
-        else if isList  v then pr (l: "[ ${go (head l)}, … ]")
-        else if isAttrs v then pr
-          (a: "{ ${ concatStringsSep ", " (attrNames a)} }")
-        else v;
-      go = x: generators.toPretty
-        { allowPrettyValues = true; }
-        (modify x);
-    in go);
+  showVal = _:
+    throw ( "`showVal` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "please use `traceSeqN`" );
 
-  traceXMLVal = x:
-    trace ( "Warning: `traceXMLVal` is deprecated "
-          + "and will be removed in the next release. "
-          + "Please use `traceValFn builtins.toXML`." )
-    (trace (builtins.toXML x) x);
-  traceXMLValMarked = str: x:
-    trace ( "Warning: `traceXMLValMarked` is deprecated "
-          + "and will be removed in the next release. "
-          + "Please use `traceValFn (x: str + builtins.toXML x)`." )
-    (trace (str + builtins.toXML x) x);
+  traceXMLVal = _:
+    throw ( "`traceXMLVal` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `traceValFn builtins.toXML`." );
+  traceXMLValMarked = _:
+    throw ( "`traceXMLValMarked` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `traceValFn (x: str + builtins.toXML x)`." );
 
-  # trace the arguments passed to function and its result
-  # maybe rewrite these functions in a traceCallXml like style. Then one function is enough
-  traceCall  = n: f: a: let t = n2: x: traceShowValMarked "${n} ${n2}:" x; in t "result" (f (t "arg 1" a));
-  traceCall2 = n: f: a: b: let t = n2: x: traceShowValMarked "${n} ${n2}:" x; in t "result" (f (t "arg 1" a) (t "arg 2" b));
-  traceCall3 = n: f: a: b: c: let t = n2: x: traceShowValMarked "${n} ${n2}:" x; in t "result" (f (t "arg 1" a) (t "arg 2" b) (t "arg 3" c));
+  traceCall  = _:
+    throw ( "`traceCall` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `FILL IN`." );
 
-  traceValIfNot = c: x:
-    trace ( "Warning: `traceValIfNot` is deprecated "
-          + "and will be removed in the next release. "
-          + "Please use `if/then/else` and `traceValSeq 1`.")
-    (if c x then true else traceSeq (showVal x) false);
+  traceCall2 = _:
+    throw ( "`traceCall2` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `FILL IN`." );
+
+  traceCall3 = _:
+    throw ( "`traceCall3` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `FILL IN`." );
+
+  traceValIfNot = _:
+    throw ( "`traceValIfNot` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `if/then/else` and `traceValSeq 1`.");
 
 
-  addErrorContextToAttrs = attrs:
-    trace ( "Warning: `addErrorContextToAttrs` is deprecated "
-          + "and will be removed in the next release. "
-          + "Please use `builtins.addErrorContext` directly." )
-    (mapAttrs (a: v: addErrorContext "while evaluating ${a}" v) attrs);
+  addErrorContextToAttrs = _:
+    throw ( "`addErrorContextToAttrs` is deprecated "
+          + "and will be removed in release 23.05. "
+          + "Please use `builtins.addErrorContext` directly." );
 
-  # example: (traceCallXml "myfun" id 3) will output something like
-  # calling myfun arg 1: 3 result: 3
-  # this forces deep evaluation of all arguments and the result!
-  # note: if result doesn't evaluate you'll get no trace at all (FIXME)
-  #       args should be printed in any case
-  traceCallXml = a:
-    trace ( "Warning: `traceCallXml` is deprecated "
-          + "and will be removed in the next release. "
-          + "Please complain if you use the function regularly." )
-    (if !isInt a then
-      traceCallXml 1 "calling ${a}\n"
-    else
-      let nr = a;
-      in (str: expr:
-          if isFunction expr then
-            (arg:
-              traceCallXml (builtins.add 1 nr) "${str}\n arg ${builtins.toString nr} is \n ${builtins.toXML (builtins.seq arg arg)}" (expr arg)
-            )
-          else
-            let r = builtins.seq expr expr;
-            in trace "${str}\n result:\n${builtins.toXML r}" r
-      ));
+  traceCallXml = _:
+    throw ( "`traceCallXml` is deprecated "
+          + "and will be removed in release 23.05. "
+          );
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -140,11 +140,14 @@ let
       isOptionType mkOptionType;
     inherit (self.asserts)
       assertMsg assertOneOf;
-    inherit (self.debug) addErrorContextToAttrs traceIf traceVal traceValFn
-      traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
-      traceValSeqFn traceValSeqN traceValSeqNFn traceFnSeqN traceShowVal
-      traceShowValMarked showVal traceCall traceCall2 traceCall3
-      traceValIfNot runTests testAllTrue traceCallXml attrNamesToStr;
+    inherit (self.debug) traceIf traceVal traceValFn
+      traceSeq traceSeqN traceValSeq
+      traceValSeqFn traceValSeqN traceValSeqNFn traceFnSeqN
+      runTests testAllTrue
+      # Deprecated
+      traceShowVal traceShowValMarked attrNamesToStr showVal traceXMLVal traceXMLValMarked
+      traceCall traceCall2 traceCall3 traceValIfNot addErrorContextToAttrs traceCallXml
+      ;
     inherit (self.misc) maybeEnv defaultMergeArg defaultMerge foldArgs
       maybeAttrNullable maybeAttr ifEnable checkFlag getValue
       checkReqs uniqList uniqListExt condConcat lazyGenericClosure

--- a/maintainers/scripts/find-tarballs.nix
+++ b/maintainers/scripts/find-tarballs.nix
@@ -31,7 +31,7 @@ let
     if !canEval x then []
     else if isDerivation x then optional (canEval x.drvPath) x
     else if isList x then concatLists (map derivationsIn' x)
-    else if isAttrs x then concatLists (mapAttrsToList (n: v: addErrorContext "while finding tarballs in '${n}':" (derivationsIn' v)) x)
+    else if isAttrs x then concatLists (mapAttrsToList (n: v: builtins.addErrorContext "while finding tarballs in '${n}':" (derivationsIn' v)) x)
     else [ ];
 
   keyDrv = drv: if canEval drv.drvPath then { key = drv.drvPath; value = drv; } else { };


### PR DESCRIPTION
traceShowVal
traceShowValMarked
attrNamesToStr
showVal
traceXMLVal
traceXMLValMarked
traceCall
traceCall2
traceCall3
traceValIfNot
addErrorContextToAttrs
traceCallXml

they were deprecated in https://github.com/NixOS/nixpkgs/pull/38368

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
