### PR TITLE
rust-motd: 0.2.1 -> 1.0.0

### DIFF
--- a/pkgs/tools/misc/rust-motd/default.nix
+++ b/pkgs/tools/misc/rust-motd/default.nix
@@ -15,20 +15,27 @@ rustPlatform.buildRustPackage rec {
     owner = "rust-motd";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-w984vvjjieSv4eM3jT8zJIIR7/7pmADhR3Esj+2dCTs=";
+    hash = "sha256-w984vvjjieSv4eM3jT8zJIIR7/7pmADhR3Esj+2dCTs=";
   };
 
-  cargoSha256 = "sha256-L/QdFjSYm3PekKS3tdsUl8XBVyIBE044EHOIB+aEltI=";
+  cargoHash = "sha256-L/QdFjSYm3PekKS3tdsUl8XBVyIBE044EHOIB+aEltI=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
 
-  buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
+  buildInputs = [
+    openssl
+  ] ++ lib.optional stdenv.isDarwin [
+    Security
+  ];
 
   OPENSSL_NO_VENDOR = 1;
 
   meta = with lib; {
     description = "Beautiful, useful MOTD generation with zero runtime dependencies";
     homepage = "https://github.com/rust-motd/rust-motd";
+    changelog = "https://github.com/rust-motd/rust-motd/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
   };

--- a/pkgs/tools/misc/rust-motd/default.nix
+++ b/pkgs/tools/misc/rust-motd/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-motd";
-  version = "0.2.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "rust-motd";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-iuADR7m+wdmsQ897o4CQHqDv9PmYu/vJgO5C6Dluao4=";
+    sha256 = "sha256-w984vvjjieSv4eM3jT8zJIIR7/7pmADhR3Esj+2dCTs=";
   };
 
-  cargoSha256 = "sha256-kdSMcADoTpMU4w2XSv0pPQZC155rrQACQ4XTVyj7eeA=";
+  cargoSha256 = "sha256-L/QdFjSYm3PekKS3tdsUl8XBVyIBE044EHOIB+aEltI=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
###### Description of changes

https://github.com/rust-motd/rust-motd/compare/v0.2.1...v1.0.0
https://github.com/rust-motd/rust-motd/releases/tag/v1.0.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
