### PR TITLE
nixos/networkd: reload instead of restarting

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1950,7 +1950,7 @@ in
       systemd.services.systemd-networkd = {
         wantedBy = [ "multi-user.target" ];
         aliases = [ "dbus-org.freedesktop.network1.service" ];
-        restartTriggers = map (x: x.source) (attrValues unitFiles) ++ [
+        reloadTriggers = map (x: x.source) (attrValues unitFiles) ++ [
           config.environment.etc."systemd/networkd.conf".source
         ];
       };


### PR DESCRIPTION
When its configuration files change, reload systemd-networkd (`networkctl reload`) instead of restarting it.

This fixes the following race condition during activation:
- systemd-networkd.service is stopped
- ⚠ someone calls `networkctl`, which immediately restarts networkd, which reconfigures itself using the *old* /etc
- the new /etc is set up
- systemd-networkd.service is started (doing nothing)