### PR TITLE
sml: init at 24d762d

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10863,6 +10863,12 @@
       }
     ];
   };
+  prtzl = {
+    email = "matej.blagsic@protonmail.com";
+    github = "prtzl";
+    githubId = 32430344;
+    name = "Matej Blagsic";
+  };
   ProducerMatt = {
     name = "Matthew Pherigo";
     email = "ProducerMatt42@gmail.com";

--- a/pkgs/development/libraries/boost-ext/boost-sml/default.nix
+++ b/pkgs/development/libraries/boost-ext/boost-sml/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, cmake
+, fetchFromGitHub
+, boost
+}:
+
+stdenv.mkDerivation rec {
+  pname = "boost-sml";
+  # This is first commit since 1.1.6 that passes all tests (test_policies_logging is commented out)
+  version = "1.1.6";
+  working_tests = "24d762d1901f4f6afaa5c5e0d1b7b77537964694";
+
+  src = fetchFromGitHub {
+    owner = "boost-ext";
+    repo = "sml";
+    rev = "${working_tests}";
+    hash = "sha256-ZhIfyYdzrzPTAYevOz5I6tAcUiLRMV8HENKX9jychEY=";
+  };
+
+  buildInputs = [ boost ];
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DSML_BUILD_BENCHMARKS=OFF"
+    "-DSML_BUILD_EXAMPLES=OFF"
+    "-DSML_BUILD_TESTS=ON"
+    "-DSML_USE_EXCEPTIONS=ON"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Header only state machine library with no dependencies";
+    homepage = "https://github.com/boost-ext/sml";
+    license = licenses.boost;
+    maintainers = with maintainers; [ prtzl ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11216,6 +11216,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  boost-sml = callPackage ../development/libraries/boost-ext/boost-sml {};
+
   smu = callPackage ../tools/text/smu { };
 
   smug = callPackage ../tools/misc/smug { };


### PR DESCRIPTION
SML is a single header state machine library that does not rely on either boost or stl. It can be compiled with `-fno-exceptions`, `-fno-rtti` and uses no dynamic memory allocation. This makes it ideal for embedded projects.
Homepage: https://github.com/boost-ext/sml

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).