### PR TITLE
libretro.beetle-supafaust: init at unstable-2022-10-01

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -204,6 +204,14 @@ in
     makefile = "Makefile";
   };
 
+  beetle-supafaust = mkLibRetroCore {
+    core = "mednafen-supafaust";
+    src = getCoreSrc "beetle-supafaust";
+    description = "Port of Mednafen's experimental snes_faust core to libretro";
+    license = lib.licenses.gpl2Plus;
+    makefile = "Makefile";
+  };
+
   beetle-supergrafx = mkLibRetroCore {
     core = "mednafen-supergrafx";
     src = getCoreSrc "beetle-supergrafx";

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -53,6 +53,12 @@
         "rev": "d770563fc3c4bd9abb522952cefb4aa923ba0b91",
         "sha256": "zHPtfgp9hc8Q4gXJ5VgfJLWLeYjCsQhkfU1T5RM7AL0="
     },
+    "beetle-supafaust": {
+        "owner": "libretro",
+        "repo": "supafaust",
+        "rev": "85b5527231a6ad6f9475c15c8ff1b9d16884cd30",
+        "sha256": "6ynxRfGYlp7Fuq3XT2uHsR9Uwu7WMIYjclLc0Pf/qNM="
+    },
     "beetle-supergrafx": {
         "owner": "libretro",
         "repo": "beetle-supergrafx-libretro",

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -18,6 +18,7 @@ CORES = {
     "beetle-psx": {"repo": "beetle-psx-libretro"},
     "beetle-saturn": {"repo": "beetle-saturn-libretro"},
     "beetle-snes": {"repo": "beetle-bsnes-libretro"},
+    "beetle-supafaust": {"repo": "supafaust"},
     "beetle-supergrafx": {"repo": "beetle-supergrafx-libretro"},
     "beetle-vb": {"repo": "beetle-vb-libretro"},
     "beetle-wswan": {"repo": "beetle-wswan-libretro"},


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Like we don't already have SNES cores enough :sweat_smile:.

This one is particularly interesting because it is the only emulator that I know that is not based on either Snes9x nor bsnes/higan. It seems to focus in speed while being reasonable accurate, and it seems to be the only SNES emulator out there that is actually optimized for multi-core rendering (from what I saw, it seems the PPU has its own dedicated thread).

Does it make any sense for any `x86_64` system? No. But maybe if someone is trying to run this in a Raspberry Pi 2/3/4, they're going to be happy.

https://github.com/libretro/supafaust

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
