### PR TITLE
cargo-audit: 0.17.0 -> 0.17.2, add figsoda as a maintainer

### DIFF
--- a/pkgs/development/tools/rust/cargo-audit/default.nix
+++ b/pkgs/development/tools/rust/cargo-audit/default.nix
@@ -1,25 +1,22 @@
 { lib
-, stdenv
 , rustPlatform
-, fetchFromGitHub
-, openssl
+, fetchCrate
 , pkg-config
+, openssl
+, stdenv
 , Security
-, libiconv
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-audit";
-  version = "0.17.0";
+  version = "0.17.2";
 
-  src = fetchFromGitHub {
-    owner = "RustSec";
-    repo = "rustsec";
-    rev = "cargo-audit%2Fv${version}";
-    sha256 = "sha256-x91x5XjIRXLhs96r06ITbpHCkHoaCaMXH+VCp6f57Gg=";
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-fSdh8yCV+2AdAtF4eO2z8+uxOAf2N0IxqIFLw4B8dKE=";
   };
 
-  cargoSha256 = "sha256-/CzRkdo4kfvRwOZsfyu0zL3UnjEKCBj7wj40jlydSDI=";
+  cargoSha256 = "sha256-YCEQaUcTmZ9zTdGcDQkaVI0Dc8oIBvt840s3x9PUlrg=";
 
   nativeBuildInputs = [
     pkg-config
@@ -27,12 +24,11 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     openssl
-    libiconv
   ] ++ lib.optionals stdenv.isDarwin [
     Security
   ];
 
-  buildFeatures = [ "fix" ];
+  buildFeatures = [ "binary-scanning" "fix" ];
 
   # The tests require network access which is not available in sandboxed Nix builds.
   doCheck = false;
@@ -40,7 +36,8 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Audit Cargo.lock files for crates with security vulnerabilities";
     homepage = "https://rustsec.org";
+    changelog = "https://github.com/rustsec/rustsec/blob/cargo-audit/v${version}/cargo-audit/CHANGELOG.md";
     license = with licenses; [ mit /* or */ asl20 ];
-    maintainers = with maintainers; [ basvandijk jk ];
+    maintainers = with maintainers; [ basvandijk figsoda jk ];
   };
 }


### PR DESCRIPTION
###### Description of changes

switched to `fetchCrate` since `Cargo.lock` is no longer available in the repository
also adds the new `binary-scanning` feature which adds a `bin` subcommand

https://github.com/rustsec/rustsec/compare/cargo-audit/v0.17.0...cargo-audit/v0.17.2
[changelog](https://github.com/rustsec/rustsec/blob/cargo-audit/v0.17.2/cargo-audit/CHANGELOG.md)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
