### PR TITLE
geomyidae: fix on darwin

### DIFF
--- a/pkgs/applications/networking/gopher/geomyidae/default.nix
+++ b/pkgs/applications/networking/gopher/geomyidae/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libressl ];
 
+  patches = lib.optionals stdenv.isDarwin [ ./modification-time.patch ];
+
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   meta = with lib; {

--- a/pkgs/applications/networking/gopher/geomyidae/modification-time.patch
+++ b/pkgs/applications/networking/gopher/geomyidae/modification-time.patch
@@ -1,0 +1,13 @@
+diff --git a/geomyidae-v0.51/handlr.c b/geomyidae-v0.51/handlr.c
+index 0c230d32519..9fc043fa3c9 100644
+--- a/handlr.c
++++ b/handlr.c
+@@ -71,7 +71,7 @@ handledir(int sock, char *path, char *port, char *base, char *args,
+ 					*type->type,
+ 					dirent[i]->d_name,
+ 					humansize(st.st_size),
+-					humantime(&(st.st_mtim.tv_sec)),
++					humantime(&(st.st_mtimespec.tv_sec)),
+ 					e, ohost, port);
+ 			free(file);
+ 			free(dirent[i]);


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

@athas I caught the build failure in #194800. I don't know ho to interact with the forge but what I have to say is that is use a non-portable field:

```
               /* Since Linux 2.6, the kernel supports nanosecond
                  precision for the following timestamp fields.
                  For the details before Linux 2.6, see NOTES. */

               struct timespec st_atim;  /* Time of last access */
               struct timespec st_mtim;  /* Time of last modification */
               struct timespec st_ctim;  /* Time of last status change */

           #define st_atime st_atim.tv_sec      /* Backward compatibility */
           #define st_mtime st_mtim.tv_sec
           #define st_ctime st_ctim.tv_sec
```
https://man7.org/linux/man-pages/man2/lstat.2.html on linux but
```
         struct timespec st_atimespec;     /* time of last access */
         struct timespec st_mtimespec;     /* time of last data modification */
         struct timespec st_ctimespec;     /* time of last status change */
         struct timespec st_birthtimespec; /* time of file creation(birth) */
```
on Darwin


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
