### PR TITLE
limine: init at 4.20230120.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3079,6 +3079,12 @@
     githubId = 217899;
     name = "Cyryl Płotnicki";
   };
+  czapek = {
+    name = "Gabriel Waksmundzki";
+    email = "czapek1337@gmail.com";
+    github = "czapek1337";
+    githubId = 32851089;
+  };
   d-goldin = {
     email = "dgoldin+github@protonmail.ch";
     github = "d-goldin";

--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -474,6 +474,13 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>limine</literal> bootloader module was
+          introduced. It can be used as an alternative to systemd-boot
+          or GRUB.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>dokuwiki</literal> service now takes
           configuration via the
           <literal>services.dokuwiki.sites.&lt;name&gt;.settings</literal>

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -118,6 +118,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   `services.dnsmasq.extraConfig` will be deprecated when NixOS 22.11 reaches
   end of life.
 
+- The `limine` bootloader module was introduced. It can be used as an alternative to systemd-boot or GRUB.
+
 - The `dokuwiki` service now takes configuration via the `services.dokuwiki.sites.<name>.settings` attribute set, `extraConfig` is deprecated and will be removed.
   The `{aclUse,superUser,disableActions}` attributes have been renamed, `pluginsConfig` now also accepts an attribute set of booleans, passing plain PHP is deprecated.
   Same applies to `acl` which now also accepts structured settings.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1285,6 +1285,7 @@
   ./system/boot/loader/grub/memtest.nix
   ./system/boot/loader/external/external.nix
   ./system/boot/loader/init-script/init-script.nix
+  ./system/boot/loader/limine/limine.nix
   ./system/boot/loader/loader.nix
   ./system/boot/loader/raspberrypi/raspberrypi.nix
   ./system/boot/loader/systemd-boot/systemd-boot.nix

--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -1,0 +1,316 @@
+#!@python3@/bin/python3 -B
+
+from typing import Any, List, Optional, Tuple
+
+import hashlib
+import json
+import os
+import psutil
+import re
+import shutil
+import subprocess
+import textwrap
+
+
+limine_dir = None
+root_fs_uuid = None
+can_use_direct_paths = False
+install_config = json.load(open('@configPath@', 'r'))
+
+
+def config(*path: List[str]) -> Optional[Any]:
+  result = install_config
+  for component in path:
+    result = result[component]
+  return result
+
+
+def get_system_path(profile: str = 'system', gen: Optional[str] = None, spec: Optional[str] = None) -> str:
+  if profile == 'system':
+    result = '/nix/var/nix/profiles/system'
+  else:
+    result = f'/nix/var/nix/profiles/system-profiles/{profile}'
+
+  if gen is not None:
+    result += f'-{gen}-link'
+
+  if spec is not None:
+    result = os.path.join(result, 'specialisation', spec)
+
+  return result
+
+
+def get_profiles() -> List[str]:
+  profiles_dir = '/nix/var/nix/profiles/system-profiles/'
+  dirs = os.listdir(profiles_dir) if os.path.isdir(profiles_dir) else []
+
+  return [path for path in dirs if not path.endswith('-link')]
+
+
+def get_specs(profile: str, gen: Optional[str]) -> List[str]:
+  gen_dir = get_system_path(profile, gen)
+  spec_dir = os.path.join(gen_dir, 'specialisation')
+
+  return os.listdir(spec_dir) if os.path.exists(spec_dir) else []
+
+
+def get_gens(profile: str = 'system') -> List[Tuple[int, List[str]]]:
+  nix_env = os.path.join(config('nixPath'), 'bin', 'nix-env')
+  output = subprocess.check_output([
+    nix_env, '--list-generations',
+    '-p', get_system_path(profile),
+    '--option', 'build-users-group', '',
+  ], universal_newlines=True)
+
+  gen_lines = output.splitlines()
+  gen_nums = [int(line.split()[0]) for line in gen_lines]
+
+  return [(gen, get_specs(profile, gen)) for gen in gen_nums][-config('maxGenerations'):]
+
+
+def is_encrypted(device: str) -> bool:
+  for name, _ in config('luksDevices').items():
+    if os.readlink(f'/dev/mapper/{name}') == os.readlink(device):
+      return True
+
+  return False
+
+
+def is_fs_type_supported(fs_type: str) -> bool:
+  return fs_type.startswith('ext') or fs_type.startswith('vfat')
+
+
+def get_file_uri(profile: str, gen: Optional[str], spec: Optional[str], name: str) -> str:
+  gen_path = get_system_path(profile, gen, spec)
+  path_in_store = os.path.realpath(os.path.join(gen_path, name))
+  result = ''
+
+  if can_use_direct_paths:
+    result = f'uuid://{root_fs_uuid}{path_in_store}'
+  else:
+    package_id = os.path.basename(os.path.dirname(path_in_store))
+    suffix = os.path.basename(path_in_store)
+    dest_file = f'{package_id}-{suffix}'
+    dest_path = os.path.join(limine_dir, dest_file)
+
+    if not os.path.exists(dest_path):
+      copy_file(path_in_store, dest_path)
+
+    path_with_prefix = os.path.join('/limine', dest_file)
+    result = f'boot://{path_with_prefix}'
+
+  if config('validateChecksums'):
+    with open(path_in_store, 'rb') as file:
+      b2sum = hashlib.blake2b()
+      b2sum.update(file.read())
+
+      result += f'#{b2sum.hexdigest()}'
+
+  return result
+
+
+def generate_config_entry(profile: str, gen: Optional[str], spec: Optional[str]) -> str:
+  entry_name = f'Generation {gen}'
+
+  if spec:
+    entry_name += f' (specialisation {spec})'
+
+  gen_path = os.readlink(get_system_path(profile, gen, spec))
+  kernel_path = get_file_uri(profile, gen, spec, 'kernel')
+  initrd_path = get_file_uri(profile, gen, spec, 'initrd')
+  cmdline = f'init={gen_path}/init '
+
+  with open(f'{gen_path}/kernel-params') as file:
+    cmdline += file.read()
+
+  return textwrap.dedent(f'''
+    ::{entry_name}
+    PROTOCOL=linux
+    CMDLINE={cmdline.strip()}
+    KERNEL_PATH={kernel_path}
+    MODULE_PATH={initrd_path}
+  ''')
+
+
+def find_disk_device(part: str) -> str:
+  part = os.path.realpath(part)
+  part = part.removeprefix('/dev/')
+  disk = os.path.realpath(f'/sys/class/block/{part}')
+  disk = os.path.dirname(disk)
+
+  return f'/dev/{os.path.basename(disk)}'
+
+
+def find_mounted_device(path: str) -> str:
+  path = os.path.abspath(path)
+
+  while not os.path.ismount(path):
+    path = os.path.dirname(path)
+
+  devices = [x for x in psutil.disk_partitions(all=True) if x.mountpoint == path]
+
+  assert len(devices) == 1
+  return devices[0].device
+
+
+def copy_file(from_path: str, to_path: str):
+  dirname = os.path.dirname(to_path)
+
+  if not os.path.exists(dirname):
+    os.makedirs(dirname)
+
+  shutil.copyfile(from_path, to_path)
+
+
+def main():
+  global root_fs_uuid
+  global can_use_direct_paths
+  global limine_dir
+
+  root_fs = None
+  boot_fs = None
+
+  for mount_point, fs in config('fileSystems').items():
+    if mount_point == '/':
+      root_fs = fs
+      root_fs_uuid = fs['device'].split('/')[-1]
+    elif mount_point == '/boot':
+      boot_fs = fs
+
+  is_root_fs_type_ok = is_fs_type_supported(root_fs['fsType'])
+  is_root_fs_encrypted = is_encrypted(root_fs['device'])
+  can_use_direct_paths = config('useStorePaths') and is_root_fs_type_ok and not is_root_fs_encrypted
+
+  if config('canTouchEfiVariables'):
+    limine_dir = os.path.join(config('efiMountPoint'), 'limine')
+  elif can_use_direct_paths:
+    limine_dir = '/limine'
+  else:
+    if boot_fs and is_fs_type_supported(boot_fs['fsType']) and not is_encrypted(boot_fs['device']):
+      limine_dir = '/boot/limine'
+    else:
+      possible_causes = [
+        f'/limine on the root partition ({is_root_fs_type_ok=} {is_root_fs_encrypted=})'
+      ]
+
+      if not boot_fs:
+        possible_causes.append(f'/limine on the boot partition (not present)')
+      else:
+        is_boot_fs_type_ok = is_fs_type_supported(boot_fs['fsType'])
+        is_boot_fs_encrypted = is_encrypted(boot_fs['device'])
+        possible_causes.append(f'/limine on the boot partition ({is_boot_fs_type_ok=} {is_boot_fs_encrypted=})')
+
+      causes_str = textwrap.indent(possible_causes.join('\n'), '  - ')
+
+      raise Exception(textwrap.dedent('''
+        Could not find a valid place for Limine configuration files!'
+
+        Possible candidates that were ruled out:
+      ''') + causes_str + textwrap.dedent('''
+        Limine cannot be installed on a system without an unencrypted
+        partition formatted as EXT2/3/4 or FAT.
+      '''))
+
+  if not os.path.exists(limine_dir):
+    os.makedirs(limine_dir)
+
+  profiles = [('system', get_gens())]
+
+  for profile in get_profiles():
+    profiles += (profile, get_gens(profile))
+
+  timeout = config('timeout')
+  editor_enabled = 'yes' if config('enableEditor') else 'no'
+  hash_mismatch_panic = 'yes' if config('panicOnChecksumMismatch') else 'no'
+  config_file = textwrap.dedent(f'''
+    TIMEOUT={timeout}
+    EDITOR_ENABLED={editor_enabled}
+    HASH_MISMATCH_PANIC={hash_mismatch_panic}
+    GRAPHICS=yes
+    DEFAULT_ENTRY=2
+
+    # NixOS boot entries start here
+  ''')
+
+  for (profile, gens) in profiles:
+    group_name = 'default profile' if profile == 'system' else f"profile '{profile}'"
+    config_file += f':+NixOS {group_name}\n'
+
+    for (gen, specs) in sorted(gens, key=lambda x: x[0], reverse=True):
+      config_file += generate_config_entry(profile, gen, None)
+
+      for spec in specs:
+        config_file += generate_config_entry(profile, gen, spec)
+
+  config_file_path = os.path.join(limine_dir, 'limine.cfg')
+  config_file += '\n# NixOS boot entries end here\n\n'
+
+  for name, entry in config('additionalEntries').items():
+    indented_entry = textwrap.indent(entry, '  ')
+    config_file += f':{name}\n{indented_entry}\n'
+
+  with open(config_file_path, 'w') as file:
+    file.write(config_file.strip())
+
+  for dest_path, source_path in config('additionalFiles').items():
+    dest_path = os.path.join(limine_dir, dest_path)
+
+    copy_file(source_path, dest_path)
+
+  if config('canTouchEfiVariables'):
+    cpu_family = config('hostArchitecture', 'family')
+
+    if cpu_family == 'x86':
+      if config('hostArchitecture', 'bits') == 32:
+        boot_file = 'BOOTIA32.EFI'
+      elif config('hostArchitecture', 'bits') == 64:
+        boot_file = 'BOOTX64.EFI'
+    else:
+      raise Exception(f'Unsupported CPU family: {cpu_family}')
+
+    efi_path = os.path.join(config('liminePath'), 'share', 'limine', boot_file)
+    dest_path = os.path.join(config('efiMountPoint'), 'efi', 'boot', boot_file)
+
+    copy_file(efi_path, dest_path)
+
+    efibootmgr = os.path.join(config('efiBootMgrPath'), 'bin', 'efibootmgr')
+    efi_partition = find_mounted_device(config('efiMountPoint'))
+    efi_disk = find_disk_device(efi_partition)
+    efibootmgr_output = subprocess.check_output([
+      efibootmgr,
+      '-c',
+      '-d', efi_disk,
+      '-p', efi_partition.removeprefix(efi_disk).removeprefix('p'),
+      '-l', f'\\efi\\boot\\{boot_file}',
+      '-L', 'Limine',
+    ], stderr=subprocess.STDOUT, universal_newlines=True)
+
+    for line in efibootmgr_output.split('\n'):
+      if matches := re.findall(r'Boot([0-9a-fA-F]{4}) has same label Limine', line):
+        subprocess.run(
+          [efibootmgr, '-b', matches[0], '-B'],
+          stdout=subprocess.DEVNULL,
+          stderr=subprocess.DEVNULL,
+        )
+  else:
+    disk_device = find_disk_device(root_fs['device'])
+    limine_deploy = os.path.join(config('liminePath'), 'bin', 'limine-deploy')
+    limine_sys = os.path.join(config('liminePath'), 'share', 'limine', 'limine.sys')
+    limine_sys_dest = os.path.join(limine_dir, 'limine.sys')
+    limine_deploy_args = [limine_deploy, disk_device]
+
+    if config('forceMbr'):
+      limine_deploy_args += '--force-mbr'
+
+    copy_file(limine_sys, limine_sys_dest)
+
+    try:
+      subprocess.run(limine_deploy_args)
+    except:
+      raise Exception(
+        'Failed to deploy stage 1 Limine bootloader!\n' +
+        'You might want to try enabling the `boot.loader.limine.forceMbr` option.'
+      )
+
+
+main()

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -1,0 +1,157 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.boot.loader.limine;
+  efi = config.boot.loader.efi;
+  limineInstallConfig = pkgs.writeText "limine-install.json" (builtins.toJSON {
+    nixPath = config.nix.package;
+    efiBootMgrPath = pkgs.efibootmgr;
+    liminePath = cfg.package;
+    efiMountPoint = efi.efiSysMountPoint;
+    fileSystems = config.fileSystems;
+    luksDevices = config.boot.initrd.luks.devices;
+    canTouchEfiVariables = efi.canTouchEfiVariables;
+    maxGenerations = if cfg.maxGenerations == null then 0 else cfg.maxGenerations;
+    hostArchitecture = pkgs.stdenv.hostPlatform.parsed.cpu;
+    timeout = if config.boot.loader.timeout != null then config.boot.loader.timeout else 10;
+    enableEditor = cfg.enableEditor;
+    additionalEntries = cfg.additionalEntries;
+    additionalFiles = cfg.additionalFiles;
+    forceMbr = cfg.forceMbr;
+    useStorePaths = cfg.useStorePaths;
+    validateChecksums = cfg.validateChecksums;
+    panicOnChecksumMismatch = cfg.panicOnChecksumMismatch;
+  });
+
+in
+{
+  options.boot.loader.limine = {
+    enable = mkOption {
+      default = false;
+      type = types.bool;
+      description = mdDoc ''
+        Whether to enable the Limine bootloader.
+      '';
+    };
+
+    enableEditor = mkOption {
+      default = true;
+      type = types.bool;
+      description = mdDoc ''
+        Whether to allow editing the boot entries before booting them.
+        It is recommended to set this to false, as it allows gaining root
+        access by passing `init=/bin/sh` as a kernel parameter.
+      '';
+    };
+
+    maxGenerations = mkOption {
+      default = 10;
+      example = 50;
+      type = types.nullOr types.int;
+      description = mdDoc ''
+        Maximum number of latest generations in the boot menu.
+        Useful to prevent boot partition of running out of disk space.
+
+        `null` means no limit i.e. all generations that were not
+        garbage collected yet.
+      '';
+    };
+
+    additionalEntries = mkOption {
+      default = { };
+      type = types.attrsOf types.str;
+      example = literalExpression ''
+        {
+          "memtest86" = '''
+            PROTOCOL=chainload
+            IMAGE_PATH=boot:///efi/memtest86/memtest86.efi
+          ''';
+        }
+      '';
+      description = mdDoc ''
+        Any additional entries you want added to the Limine boot menu. Each attribute denotes
+        the display name of the boot entry, which need be formatted according to the Limine
+        documentation which you can find [here](https://github.com/limine-bootloader/limine/blob/trunk/CONFIG.md).
+      '';
+    };
+
+    additionalFiles = mkOption {
+      default = { };
+      type = types.attrsOf types.path;
+      example = literalExpression ''
+        { "efi/memtest86/memtest86.efi" = "''${pkgs.memtest86-efi}/BOOTX64.efi"; }
+      '';
+      description = mdDoc ''
+        A set of files to be copied to {file}`/boot`. Each attribute name denotes the
+        destination file name in {file}`/boot`, while the corresponding attribute value
+        specifies the source file.
+      '';
+    };
+
+    forceMbr = mkOption {
+      default = false;
+      type = types.bool;
+      description = mdDoc ''
+        Force MBR detection to work even if the safety checks fail, use absolutely only if necessary!
+      '';
+    };
+
+    useStorePaths = mkOption {
+      default = false;
+      type = types.bool;
+      description = mdDoc ''
+        Use direct Nix store paths instead of copying boot files onto the boot partition. This is
+        noticeably slower but can greatly reduce the space usage on the boot partition.
+      '';
+    };
+
+    validateChecksums = mkOption {
+      default = true;
+      type = types.bool;
+      description = mdDoc ''
+        Whether to validate file checksums before booting.
+      '';
+    };
+
+    panicOnChecksumMismatch = mkOption {
+      default = false;
+      type = types.bool;
+      description = mdDoc ''
+        Whether or not checksum validation failure should be a fatal
+        error at boot time.
+      '';
+    };
+
+    package = mkOption {
+      default = pkgs.limine;
+      defaultText = literalExpression "pkgs.limine";
+      type = types.package;
+      description = mdDoc ''
+        Which Limine package to use for installation.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = pkgs.stdenv.hostPlatform.isx86;
+        message = "Limine can only be installed on x86 platforms";
+      }
+    ];
+
+    boot.loader.grub.enable = mkDefault false;
+    system = {
+      boot.loader.id = "limine";
+      build.installBootLoader = pkgs.substituteAll {
+        src = ./limine-install.py;
+        isExecutable = true;
+
+        python3 = (pkgs.python3.withPackages (python-packages: [ python-packages.psutil ]));
+        configPath = limineInstallConfig;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -357,6 +357,7 @@ in {
   lightdm = handleTest ./lightdm.nix {};
   lighttpd = handleTest ./lighttpd.nix {};
   limesurvey = handleTest ./limesurvey.nix {};
+  limine = handleTest ./limine.nix {};
   listmonk = handleTest ./listmonk.nix {};
   litestream = handleTest ./litestream.nix {};
   locate = handleTest ./locate.nix {};

--- a/nixos/tests/limine.nix
+++ b/nixos/tests/limine.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "limine";
+  meta = with lib.maintainers; {
+    maintainers = [ czapek ];
+  };
+
+  nodes.machine = { ... }: {
+    virtualisation.useBootLoader = true;
+    virtualisation.useEFIBoot = true;
+
+    boot.loader.efi.canTouchEfiVariables = true;
+    boot.loader.limine.enable = true;
+    boot.loader.timeout = 0;
+  };
+
+  testScript = ''
+    machine.start()
+
+    with subtest('Machine boots correctly'):
+      machine.wait_for_unit('multi-user.target')
+  '';
+})

--- a/pkgs/tools/bootloaders/limine/default.nix
+++ b/pkgs/tools/bootloaders/limine/default.nix
@@ -1,0 +1,23 @@
+{ lib, clangStdenv, fetchurl, nasm }:
+
+clangStdenv.mkDerivation rec {
+  pname = "limine";
+  version = "4.20230120.0";
+  src = fetchurl {
+    url = "https://github.com/limine-bootloader/limine/releases/download/v${version}/limine-${version}.tar.xz";
+    sha256 = "sha256-ZI6qDSrpjd8og5vqkACswHjPe2453jazwG0wIVN9yug=";
+  };
+  nativeBuildInputs = [ nasm ];
+  configureFlags = [
+    "--enable-uefi-x86_64"
+    "--enable-uefi-ia32"
+    "--enable-bios"
+  ];
+  meta = with lib; {
+    homepage = "https://limine-bootloader.org/";
+    description = "Limine Bootloader";
+    license = licenses.bsd2;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = [ maintainers.czapek ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37790,6 +37790,8 @@ with pkgs;
 
   refind = callPackage ../tools/bootloaders/refind { };
 
+  limine = callPackage ../tools/bootloaders/limine { };
+
   spectra = callPackage ../development/libraries/spectra { };
 
   spectrojack = callPackage ../applications/audio/spectrojack { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This patch introduces support for the [Limine bootloader](https://github.com/limine-bootloader/limine/). Limine is a modern, advanced, portable, multiprotocol bootloader. It supports the following architectures (currently only the first two are supported by this PR due to lack of testing):

- IA-32 (32-bit x86)
- x86_64
- aarch64 (arm64)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
