### PR TITLE
profile-sync-daemon: improve launch and add overlayfs option.

### DIFF
--- a/nixos/modules/services/desktops/profile-sync-daemon.nix
+++ b/nixos/modules/services/desktops/profile-sync-daemon.nix
@@ -28,6 +28,15 @@ in
         omitted.
       '';
     };
+    overlayfsUsers = lib.mkOption {
+      type = listOf str;
+      default = [ ];
+      example = "[ \"somebody\" ]";
+      description = ''
+        The users to add to sudoers that can run psd-overlay-helper without
+        a password. See the manpage FAQ for an explanation.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -53,7 +62,7 @@ in
             serviceConfig = {
               Type = "oneshot";
               RemainAfterExit = "yes";
-              ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon sync";
+              ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon startup";
               ExecStop = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon unsync";
             };
           };
@@ -93,5 +102,17 @@ in
         };
       };
     };
+    security.sudo.extraRules = lib.mkAfter (
+      lib.lists.optional (cfg.overlayfsUsers != [ ]) {
+        users = cfg.overlayfsUsers;
+        runAs = "ALL";
+        commands = [
+          {
+            command = "${pkgs.profile-sync-daemon}/bin/psd-overlay-helper";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+      }
+    );
   };
 }

--- a/pkgs/by-name/pr/profile-sync-daemon/package.nix
+++ b/pkgs/by-name/pr/profile-sync-daemon/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   util-linux,
   coreutils,
+  glib,
+  procps,
 }:
 
 stdenv.mkDerivation rec {
@@ -21,12 +23,19 @@ stdenv.mkDerivation rec {
     PREFIX=\"\" DESTDIR=$out make install
     substituteInPlace $out/bin/profile-sync-daemon \
       --replace "/usr/" "$out/" \
-      --replace "sudo " "/run/wrappers/bin/sudo "
+      --replace "sudo " "/run/wrappers/bin/sudo " \
+      --replace "gdbus" "${glib}/bin/gdbus" \
+      --replace " psd-overlay-helper" " $out/bin/psd-overlay-helper" \
+      --replace "pkill" "${procps}/bin/pkill" \
+      --replace "pgrep" "${procps}/bin/pgrep"
     # $HOME detection fails (and is unnecessary)
     sed -i '/^HOME/d' $out/bin/profile-sync-daemon
     substituteInPlace $out/bin/psd-overlay-helper \
       --replace "PATH=/usr/bin:/bin" "PATH=${util-linux.bin}/bin:${coreutils}/bin" \
       --replace "sudo " "/run/wrappers/bin/sudo "
+    substituteInPlace $out/bin/psd-suspend-sync \
+      --replace "/usr" "$out" \
+      --replace "gdbus" "${glib}/bin/gdbus"
   '';
 
   meta = {


### PR DESCRIPTION
###### Description of changes

This fixes the systemd launch command (which in particular allows psd-suspend-sync to work), fixes paths for some dependent binaries, and adds a module option for adding psd-overlay-helper to sudoers for selected users.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
