### PR TITLE
ante: unstable-08-22 -> unstable-10-06

### DIFF
--- a/pkgs/development/compilers/ante/default.nix
+++ b/pkgs/development/compilers/ante/default.nix
@@ -1,48 +1,57 @@
 { fetchFromGitHub
+, installShellFiles
 , lib
 , libffi
 , libxml2
-, llvmPackages_13
+, llvmPackages # By default this is llvmPackages_13 from the callPackage call
 , ncurses
 , rustPlatform
 }:
 
 rustPlatform.buildRustPackage {
   pname = "ante";
-  version = "unstable-2022-08-22";
+  version = "unstable-2022-10-06";
   src = fetchFromGitHub {
     owner = "jfecher";
     repo = "ante";
-    rev = "8b708d549c213c34e4ca62d31cf0dd25bfa7b548";
-    sha256 = "sha256-s8nDuG32lI4pBLsOzgfyUGpc7/r0j4EhzH54ErBK7A0=";
+    rev = "867cfea7334a241908207dc665f6614e07b77b77";
+    sha256 = "plXwewVYF/E7SO1qHFA/MhvCP0iWB1V/i1RbmuzNFlk=";
   };
-  cargoSha256 = "sha256-29D7kPG7vop9lIxWQnaHkCTRY8YsCjERRCOvbU7oemQ=";
+  cargoSha256 = "NwK8BbXFneemfFFa9oxGzmxZ3QCzon3TKNCilhK3yR8=";
 
   /*
      https://crates.io/crates/llvm-sys#llvm-compatibility
      llvm-sys requires a specific version of llvmPackages,
      that is not the same as the one included by default with rustPlatform.
   */
-  nativeBuildInputs = [ llvmPackages_13.llvm ];
+  nativeBuildInputs = [ llvmPackages.llvm installShellFiles ];
   buildInputs = [ libffi libxml2 ncurses ];
 
   postPatch = ''
     substituteInPlace tests/golden_tests.rs --replace \
       'target/debug' "target/$(rustc -vV | sed -n 's|host: ||p')/release"
   '';
+
   preBuild =
     let
-      major = lib.versions.major llvmPackages_13.llvm.version;
-      minor = lib.versions.minor llvmPackages_13.llvm.version;
+      major = lib.versions.major llvmPackages.llvm.version;
+      minor = lib.versions.minor llvmPackages.llvm.version;
       llvm-sys-ver = "${major}${builtins.substring 0 1 minor}";
     in
     ''
       # On some architectures llvm-sys is not using the package listed inside nativeBuildInputs
-      export LLVM_SYS_${llvm-sys-ver}_PREFIX=${llvmPackages_13.llvm.dev}
+      export LLVM_SYS_${llvm-sys-ver}_PREFIX=${llvmPackages.llvm.dev}
       export ANTE_STDLIB_DIR=$out/lib
       mkdir -p $ANTE_STDLIB_DIR
       cp -r $src/stdlib/* $ANTE_STDLIB_DIR
     '';
+
+  postInstall = ''
+    installShellCompletion --cmd ante \
+      --bash <($out/bin/ante --shell-completion bash) \
+      --fish <($out/bin/ante --shell-completion fish) \
+      --zsh <($out/bin/ante --shell-completion zsh)
+  '';
 
   meta = with lib; {
     homepage = "https://antelang.org/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13176,7 +13176,7 @@ with pkgs;
 
   algol68g = callPackage ../development/compilers/algol68g { };
 
-  ante = callPackage ../development/compilers/ante { };
+  ante = callPackage ../development/compilers/ante { llvmPackages = llvmPackages_13; };
 
   armips = callPackage ../development/compilers/armips {
     stdenv = gcc10Stdenv;


### PR DESCRIPTION
###### Description of changes
New compiler features:
- String interpolation
- Command line syntax completion
- Various bug fixes

###### Things done
- Updated the source commit.
- Configured shell completion install script.
- Set the `llvmPackages` override to `llvmPackages_13` with `callPackage`rather than explicitly listing `llvmPackages_13` in package derivation arguments, in case that dependency changes down the line.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
