### PR TITLE
duckstation: unstable-2022-08-22 -> unstable-2022-07-08

### DIFF
--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -7,28 +7,28 @@
 , makeDesktopItem
 , curl
 , extra-cmake-modules
+, libevdev
 , libpulseaudio
 , libXrandr
 , mesa # for libgbm
 , ninja
 , pkg-config
 , qtbase
-, qtsvg
 , qttools
 , vulkan-loader
-, wayland
+#, wayland # Wayland doesn't work correctly this version
 , wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "duckstation";
-  version = "unstable-2022-08-22";
+  version = "unstable-2022-07-08";
 
   src = fetchFromGitHub {
     owner = "stenzek";
     repo = pname;
-    rev = "4f2da4213d1d2c69417392d15b27bb123ee9d297";
-    sha256 = "sha256-VJeKbJ40ZErlu/6RETvk0KDSc9T7ssBrLDecNczQlXU=";
+    rev = "82965f741e81e4d2f7e1b2abdc011e1f266bfe7f";
+    sha256 = "sha256-D8Ps/EQRcHLsps/KEUs56koeioOdE/GPA0QJSrbSdYs=";
   };
 
   nativeBuildInputs = [
@@ -44,30 +44,31 @@ stdenv.mkDerivation rec {
   buildInputs = [
     SDL2
     curl
+    libevdev
     libpulseaudio
     libXrandr
     mesa
     qtbase
-    qtsvg
     vulkan-loader
-    wayland
+    #wayland
   ];
 
   cmakeFlags = [
     "-DUSE_DRMKMS=ON"
-    "-DUSE_WAYLAND=ON"
+    #"-DUSE_WAYLAND=ON"
   ];
 
   desktopItems = [
     (makeDesktopItem {
-      name = "DuckStation";
-      desktopName = "JamesDSP";
+      name = "duckstation-qt";
+      desktopName = "DuckStation";
       genericName = "PlayStation 1 Emulator";
       icon = "duckstation";
       tryExec = "duckstation-qt";
       exec = "duckstation-qt %f";
       comment = "Fast PlayStation 1 emulator";
       categories = [ "Game" "Emulator" "Qt" ];
+      type = "Application";
     })
   ];
 
@@ -79,7 +80,7 @@ stdenv.mkDerivation rec {
     cp -r bin $out/share/duckstation
     ln -s $out/share/duckstation/duckstation-qt $out/bin/
 
-    install -Dm644 bin/resources/images/duck.png $out/share/pixmaps/duckstation.png
+    install -Dm644 ../extras/icons/icon-256px.png $out/share/pixmaps/duckstation.png
 
     runHook postInstall
   '';
@@ -93,6 +94,7 @@ stdenv.mkDerivation rec {
 
   # Libpulseaudio fixes https://github.com/NixOS/nixpkgs/issues/171173
   qtWrapperArgs = [
+    "--set QT_QPA_PLATFORM xcb"
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio vulkan-loader ]}"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1494,7 +1494,7 @@ with pkgs;
 
   dosbox-staging = callPackage ../applications/emulators/dosbox-staging { };
 
-  duckstation = qt6Packages.callPackage ../applications/emulators/duckstation {};
+  duckstation = libsForQt5.callPackage ../applications/emulators/duckstation {};
 
   dynamips = callPackage ../applications/emulators/dynamips { };
 


### PR DESCRIPTION
###### Description of changes
Reverts #188024 (it wasn't meant to be merged, it was a preview version), but still moves Duckstation to a more recent version than before (the current latest stable).
Wayland is disabled because it's problematic in this version.
For those who used the preview version temporarily, there should be any problem downgrading (unstable-2022-08-22 saves data in a completely different folder, so it didn't touch any older data).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
