### PR TITLE
adguardhome: 0.107.14 -> 0.107.16

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,23 +1,23 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-llVKoUAB5cIeRE79Lw5oAvR9rwXdtmALYEwiIg1vN9Q=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.14/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-rVc1ad8qwXfEuqZUrTsdzSQHUit3j8PQp3B0dD6FrcQ=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-v6Dvs0Ny39tOO+f9JWadBa07QwKCC9gHU69+OMmPxXM=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.14/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-GaeTdv467dVfSk2YuILmi2KphMfFYfLdpNI+dVx/UoU=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-ofx16H6+tSTOEz+UuTXKzzVx3hREwW8EjEqAgXdnqQg=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.14/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-6fXU2vU3MgveWZhgrphOeczDc1GUBv7ZUehPF8+GUdY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-kftAZ2snv3xsrVPq3y5uJKwZhHtNO/VQL1LBh5yk/DA=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.14/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-6rUC0R0bGS4omX9bybShk78mFaNRjUUkQqczZE2Wz5M=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-JVy2dDZGfH+vZhNJ94wvoYY3I0tQA6CSZ/c1rBikZWw=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.14/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-3cowMi081TIx65dgzBP+YkIj4IBwyK1Yd/gn2zL9kOI=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.14";
+  version = "0.107.16";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
