### PR TITLE
balena-cli: init at 15.1.1

### DIFF
--- a/pkgs/tools/admin/balena-cli/default.nix
+++ b/pkgs/tools/admin/balena-cli/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchzip
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  plat = {
+    x86_64-linux = "linux-x64";
+    x86_64-darwin = "macOS-x64";
+    # Balena only packages for x86 so we rely on Rosetta for Apple Silicon
+    aarch64-darwin = "macOS-x64";
+    x86_64-windows = "windows-x64";
+  }.${system} or throwSystem;
+
+  sha256 = {
+    x86_64-linux = "0gxki6w8p7ihv0zy02978hg8i242algiw0wpcajrvbx1ncbcb7yn";
+    x86_64-darwin = "1ihxyf35px3s6q2yk4p3dy03rcj93hy96bj3pxqlv0rp05gnsf02";
+    aarch64-darwin = "1ihxyf35px3s6q2yk4p3dy03rcj93hy96bj3pxqlv0rp05gnsf02";
+    x86_64-windows = "104hc3qvs04l2hmjmp0bcjr5g5scp4frhprk1fpszziqhdmhwa40";
+  }.${system} or throwSystem;
+in
+stdenv.mkDerivation rec {
+  pname = "balena-cli";
+  version = "15.1.1";
+
+  src = fetchzip {
+    url = "https://github.com/balena-io/balena-cli/releases/download/v${version}/balena-cli-v${version}-${plat}-standalone.zip";
+    inherit sha256;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r ./* $out/
+
+    ln -s $out/balena $out/bin/balena
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A command line interface for balenaCloud or openBalena";
+    longDescription = ''
+      The balena CLI is a Command Line Interface for balenaCloud or openBalena. It is a software
+      tool available for Windows, macOS and Linux, used through a command prompt / terminal window.
+      It can be used interactively or invoked in scripts. The balena CLI builds on the balena API
+      and the balena SDK, and can also be directly imported in Node.js applications.
+    '';
+    homepage = "https://github.com/balena-io/balena-cli";
+    changelog = "https://github.com/balena-io/balena-cli/blob/v${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = [ maintainers.kalebpace ];
+    platforms = platforms.linux ++ platforms.darwin ++ platforms.cygwin ++ platforms.windows;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    mainProgram = "balena";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1429,6 +1429,8 @@ with pkgs;
 
   asleap = callPackage ../tools/networking/asleap { };
 
+  balena-cli = callPackage ../tools/admin/balena-cli { };
+
   butler = callPackage ../games/itch/butler.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };


### PR DESCRIPTION
###### Description of changes

This PR includes the [balena-cli](https://github.com/balena-io/balena-cli) tool.
"...It is a software tool available for Windows, macOS and Linux, used through a command prompt / terminal window. It can be used interactively or invoked in scripts. The balena CLI builds on the [balena API](https://www.balena.io/docs/reference/api/overview/) and the [balena SDK](https://www.balena.io/docs/reference/sdk/node-sdk/), and can also be directly imported in Node.js applications..."

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-darwin (rosetta)
  - [ ] x86_64-windows
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
