### PR TITLE
ghdl: 1.0.0 -> 2.0.0

### DIFF
--- a/pkgs/development/compilers/ghdl/default.nix
+++ b/pkgs/development/compilers/ghdl/default.nix
@@ -1,40 +1,63 @@
-{ stdenv, fetchFromGitHub, fetchpatch, callPackage, gnat11, zlib, llvm, lib
-, backend ? "mcode" }:
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, callPackage
+, gnat
+, zlib
+, llvm
+, lib
+, backend ? "mcode"
+}:
 
 assert backend == "mcode" || backend == "llvm";
 
 stdenv.mkDerivation rec {
   pname = "ghdl-${backend}";
-  version = "1.0.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner  = "ghdl";
     repo   = "ghdl";
     rev    = "v${version}";
-    sha256 = "1gyh0xckwbzgslbpw9yrpj4gqs9fm1a2qpbzl0sh143fk1kwjlly";
+    sha256 = "sha256-B/G3FGRzYy4Y9VNNB8yM3FohiIjPJhYSVbqsTN3cL5k=";
   };
 
   patches = [
-    # Allow compilation with GNAT 11, picked from master
+    # https://github.com/ghdl/ghdl/issues/2056
     (fetchpatch {
-      name = "fix-gnat-11-compilation.patch";
-      url = "https://github.com/ghdl/ghdl/commit/8356ea3bb4e8d0e5ad8638c3d50914b64fc360ec.patch";
-      sha256 = "04pzn8g7xha8000wbjjmry6h1grfqyn3bjvj47hi4qwgl21wfjra";
+      name = "fix-build-gcc-12.patch";
+      url = "https://github.com/ghdl/ghdl/commit/f8b87697e8b893b6293ebbfc34670c32bfb49397.patch";
+      hash = "sha256-tVbMm8veFkNPs6WFBHvaic5Jkp1niyg0LfFufa+hT/E=";
     })
   ];
 
   LIBRARY_PATH = "${stdenv.cc.libc}/lib";
 
-  buildInputs = [ gnat11 zlib ] ++ lib.optional (backend == "llvm") [ llvm ];
-  propagatedBuildInputs = lib.optionals (backend == "llvm") [ zlib ];
+  nativeBuildInputs = [
+    gnat
+  ];
+  buildInputs = [
+    zlib
+  ] ++ lib.optional (backend == "llvm") [
+    llvm
+  ];
+  propagatedBuildInputs = [
+  ] ++ lib.optionals (backend == "llvm") [
+    zlib
+  ];
 
   preConfigure = ''
     # If llvm 7.0 works, 7.x releases should work too.
     sed -i 's/check_version  7.0/check_version  7/g' configure
   '';
 
-  configureFlags = [ "--enable-synth" ] ++ lib.optional (backend == "llvm")
-    "--with-llvm-config=${llvm.dev}/bin/llvm-config";
+  configureFlags = [
+    # See https://github.com/ghdl/ghdl/pull/2058
+    "--disable-werror"
+    "--enable-synth"
+  ] ++ lib.optionals (backend == "llvm") [
+    "--with-llvm-config=${llvm.dev}/bin/llvm-config"
+  ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/compilers/yosys/plugins/ghdl.nix
+++ b/pkgs/development/compilers/yosys/plugins/ghdl.nix
@@ -1,5 +1,11 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config
-, yosys, readline, zlib, ghdl
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, yosys
+, readline
+, zlib
+, ghdl
 }:
 
 stdenv.mkDerivation {
@@ -14,8 +20,15 @@ stdenv.mkDerivation {
     sha256 = "01d9wb7sqkmkf2y9bnn3pmhy08khzs5m1d06whxsiwgwnjzfk9mx";
   };
 
-  buildInputs = [ yosys readline zlib ghdl ];
-  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    yosys
+    readline
+    zlib
+    ghdl
+  ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
 
   doCheck = true;
   installPhase = ''
@@ -25,6 +38,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "GHDL plugin for Yosys";
+    homepage    = "https://github.com/ghdl/ghdl-yosys-plugin";
     license     = licenses.isc;
     platforms   = platforms.all;
     maintainers = with maintainers; [ thoughtpolice ];

--- a/pkgs/development/compilers/yosys/plugins/ghdl.nix
+++ b/pkgs/development/compilers/yosys/plugins/ghdl.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation {
   pname = "yosys-ghdl";
-  version = "2021.01.25";
-  plugin = "ghdl";
+  # This is not the latest commit, but it's the latest that builds with current stable ghdl 2.0.0
+  version = "2022.01.11";
 
   src = fetchFromGitHub {
     owner  = "ghdl";
     repo   = "ghdl-yosys-plugin";
-    rev    = "cba859cacf8c6631146dbdaa0f297c060b5a68cd";
-    sha256 = "01d9wb7sqkmkf2y9bnn3pmhy08khzs5m1d06whxsiwgwnjzfk9mx";
+    rev    = "c9b05e481423c55ffcbb856fd5296701f670808c";
+    sha256 = "sha256-tT2+DXUtbJIBzBUBcyG2sz+3G+dTkciLVIczcRPr0Jw=";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

ghdl was broken ever since https://github.com/NixOS/nixpkgs/issues/186482 .

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
