### PR TITLE
pre-commit: use absolute path for binary in hook

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -142,6 +142,10 @@ buildPythonPackage rec {
     "test_install_existing_hooks_no_overwrite"
     "test_installed_from_venv"
     "test_uninstall_restores_legacy_hooks"
+
+    # Expects `git commit` to fail when `pre-commit` is not in the `$PATH`,
+    # but we use an absolute path so it's not an issue.
+    "test_environment_not_sourced"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/tools/misc/pre-commit/hook-tmpl.patch
+++ b/pkgs/tools/misc/pre-commit/hook-tmpl.patch
@@ -1,15 +1,17 @@
 diff --git a/pre_commit/resources/hook-tmpl b/pre_commit/resources/hook-tmpl
-index 53d29f9..66a8ad3 100755
+index 53d29f9..9b5dc2c 100755
 --- a/pre_commit/resources/hook-tmpl
 +++ b/pre_commit/resources/hook-tmpl
-@@ -10,9 +10,7 @@ ARGS=(hook-impl)
+@@ -10,11 +10,4 @@ ARGS=(hook-impl)
  HERE="$(cd "$(dirname "$0")" && pwd)"
  ARGS+=(--hook-dir "$HERE" -- "$@")
  
 -if [ -x "$INSTALL_PYTHON" ]; then
 -    exec "$INSTALL_PYTHON" -mpre_commit "${ARGS[@]}"
 -elif command -v pre-commit > /dev/null; then
-+if command -v pre-commit > /dev/null; then
-     exec pre-commit "${ARGS[@]}"
- else
-     echo '`pre-commit` not found.  Did you forget to activate your virtualenv?' 1>&2
+-    exec pre-commit "${ARGS[@]}"
+-else
+-    echo '`pre-commit` not found.  Did you forget to activate your virtualenv?' 1>&2
+-    exit 1
+-fi
++exec @pre-commit@/bin/pre-commit "${ARGS[@]}"


### PR DESCRIPTION
This changes the generated Git hook to refer to the `pre-commit` binary by its absolute path. This means that Git hooks created with `nix-shell --run 'pre-commit install'` or similar will be usable outside of the Nix shell they were created in.

I think this is the intended behavior for this package, considering that the `postPatch` phase already includes a substitution for this variable, otherwise unused:

    substituteInPlace pre_commit/resources/hook-tmpl \
      --subst-var-by pre-commit $out

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
