### PR TITLE
vsmartcard-vpcd, vsmartcard-pcsc-relay: init at 0.9-unstable-2025-01-25, nixos/vsmartcard-vpcd: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -127,6 +127,8 @@
 
 - [Stash](https://github.com/stashapp/stash), An organizer for your adult videos/images, written in Go. Available as [services.stash](#opt-services.stash.enable).
 
+- [vsmartcard-vpcd](https://frankmorgner.github.io/vsmartcard/virtualsmartcard/README.html), a virtual smart card driver. Available as [services.vsmartcard-vpcd](#opt-services.vsmartcard-vpcd.enable).
+
 - [Fider](https://fider.io/), an open platform to collect and prioritize feedback. Available as [services.fider](#opt-services.fider.enable).
 
 - [PDS](https://github.com/bluesky-social/pds), Personal Data Server for [bsky](https://bsky.social/). Available as [services.pds](option.html#opt-services.pds).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -567,6 +567,7 @@
   ./services/development/lorri.nix
   ./services/development/nixseparatedebuginfod.nix
   ./services/development/rstudio-server/default.nix
+  ./services/development/vsmartcard-vpcd.nix
   ./services/development/zammad.nix
   ./services/display-managers/default.nix
   ./services/display-managers/greetd.nix

--- a/nixos/modules/services/development/vsmartcard-vpcd.nix
+++ b/nixos/modules/services/development/vsmartcard-vpcd.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+
+  cfg = config.services.vsmartcard-vpcd;
+
+in
+{
+
+  options.services.vsmartcard-vpcd = {
+    enable = lib.mkEnableOption "Virtual smart card driver.";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 35963;
+      description = ''
+        Port number vpcd will be listening on.
+      '';
+    };
+
+    hostname = lib.mkOption {
+      type = lib.types.str;
+      default = "/dev/null";
+      description = ''
+        Hostname of a waiting vpicc server vpcd will be connecting to. Use /dev/null for listening mode.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.pcscd.readerConfigs = [
+      ''
+        FRIENDLYNAME "Virtual PCD"
+        DEVICENAME   ${cfg.hostname}:0x${lib.toHexString cfg.port}
+        LIBPATH      ${pkgs.vsmartcard-vpcd}/var/lib/pcsc/drivers/serial/libifdvpcd.so
+        CHANNELID    0x${lib.toHexString cfg.port}
+      ''
+    ];
+
+    environment.systemPackages = [ pkgs.vsmartcard-vpcd ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ stargate01 ];
+}

--- a/pkgs/by-name/vs/vsmartcard-pcsc-relay/package.nix
+++ b/pkgs/by-name/vs/vsmartcard-pcsc-relay/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libtool,
+  autoreconfHook,
+  pcsclite,
+  libnfc,
+  python3,
+  help2man,
+  gengetopt,
+  vsmartcard-vpcd,
+  darwin,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vsmartcard-pcsc-relay";
+
+  inherit (vsmartcard-vpcd) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/pcsc-relay";
+
+  nativeBuildInputs = [
+    autoreconfHook
+    libtool
+    pkg-config
+    help2man
+  ];
+
+  buildInputs =
+    [
+      pcsclite
+      libnfc
+      gengetopt
+      (python3.withPackages (
+        pp: with pp; [
+          pyscard
+          pycrypto
+          pbkdf2
+          pillow
+          gnureadline
+        ]
+      ))
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.PCSC
+    ];
+
+  meta = {
+    description = "Relays a smart card using an contact-less interface";
+    homepage = "https://frankmorgner.github.io/vsmartcard/pcsc-relay/README.html";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
+    broken = stdenv.isDarwin;
+    maintainers = with lib.maintainers; [ stargate01 ];
+  };
+})

--- a/pkgs/by-name/vs/vsmartcard-vpcd/package.nix
+++ b/pkgs/by-name/vs/vsmartcard-vpcd/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libtool,
+  autoreconfHook,
+  pcsclite,
+  qrencode,
+  python3,
+  help2man,
+  darwin,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vsmartcard-vpcd";
+  version = "0.9-unstable-2025-01-25";
+
+  src = fetchFromGitHub {
+    owner = "frankmorgner";
+    repo = "vsmartcard";
+    rev = "7369dae26bcb709845003ae2128b8db9df7031ae";
+    hash = "sha256-mfw/Yv12ceBVZIyAKJqBh+w4otj3rYYZbJUjKRLcsr4=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/virtualsmartcard";
+
+  nativeBuildInputs = [
+    autoreconfHook
+    libtool
+    pkg-config
+    help2man
+  ];
+
+  buildInputs =
+    [
+      pcsclite
+      qrencode
+      (python3.withPackages (
+        pp: with pp; [
+          pyscard
+          pycrypto
+          pbkdf2
+          pillow
+          gnureadline
+        ]
+      ))
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.PCSC
+    ];
+
+  configureFlags = lib.optional stdenv.isDarwin "--enable-infoplist";
+
+  meta = {
+    description = "Emulates a smart card and makes it accessible through PC/SC";
+    homepage = "http://frankmorgner.github.io/vsmartcard/virtualsmartcard/README.html";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
+    broken = stdenv.isDarwin;
+    maintainers = with lib.maintainers; [ stargate01 ];
+  };
+})


### PR DESCRIPTION
###### Description of changes

This PR adds the virtual smart card reader and relay: https://frankmorgner.github.io/vsmartcard/ . It can be used to e.g. emulate a smartcard when combined with e.g. https://jcardsim.org/ , or to debug smartcard communications via an Android phone bridge.

The service module `service.services.vsmartcard-vpcd` is used to enable and configure the virtual smart card driver. It appends a configuration to the `pcscd` `readers.conf`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
