### PR TITLE
python3Packages.invisible-watermark: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/invisible-watermark/default.nix
+++ b/pkgs/development/python-modules/invisible-watermark/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, opencv4
+, pytorch
+, onnx
+, onnxruntime
+, pillow
+, pywavelets
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "invisible-watermark";
+  version = "0.1.5";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "ShieldMnt";
+    repo = "invisible-watermark";
+    rev = version;
+    sha256 = "sha256-NGDPEETuM7rYbo8kXYoRWLJWpa/lWLKEvaaiDzSWYZ4=";
+  };
+
+  propagatedBuildInputs = [
+    opencv4
+    pytorch
+    onnx
+    onnxruntime
+    pillow
+    pywavelets
+    numpy
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'opencv-python>=4.1.0.25' 'opencv'
+  '';
+
+  pythonImportsCheck = [ "imwatermark" ];
+
+  meta = with lib; {
+    description = "A library for creating and decoding invisible image watermarks";
+    homepage = "https://github.com/ShieldMnt/invisible-watermark";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4551,6 +4551,8 @@ self: super: with self; {
 
   intreehooks = callPackage ../development/python-modules/intreehooks { };
 
+  invisible-watermark = callPackage ../development/python-modules/invisible-watermark { };
+
   invocations = callPackage ../development/python-modules/invocations { };
 
   invoke = callPackage ../development/python-modules/invoke { };


### PR DESCRIPTION
###### Description of changes
Add invisible-watermark, a program to create and decode invisible image watermarks.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).