### PR TITLE
kernelPackages.nvidia_x11_vulkan_beta: 515.49.15 → 515.49.24

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -54,11 +54,11 @@ rec {
   # Vulkan developer beta driver
   # See here for more information: https://developer.nvidia.com/vulkan-driver
   vulkan_beta = generic rec {
-    version = "515.49.19";
+    version = "515.49.24";
     persistencedVersion = "515.48.07";
     settingsVersion = "515.48.07";
-    sha256_64bit = "sha256-J5+rI2zfQKwV40kG6IY8zGo91PcCnKOKoyVu6zb5L3E=";
-    openSha256 = "sha256-5NXsr7/aYOLAYP9TY5uKj6R5rUSmv1sj90EprEvAZsA=";
+    sha256_64bit = "sha256-hiTG1gZr02hyetOGvHzY8Be9jaWklhteqe24BRvpw+c=";
+    openSha256 = "sha256-4NFR4oY728E/yE3FoD3vph8NvSHGD0f0iK2FHqlgK94=";
     settingsSha256 = "sha256-XwdMsAAu5132x2ZHqjtFvcBJk6Dao7I86UksxrOkknU=";
     persistencedSha256 = "sha256-BTfYNDJKe4tOvV71/1JJSPltJua0Mx/RvDcWT5ccRRY=";
     url = "https://developer.nvidia.com/vulkan-beta-${lib.concatStrings (lib.splitString "." version)}-linux";

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -54,11 +54,11 @@ rec {
   # Vulkan developer beta driver
   # See here for more information: https://developer.nvidia.com/vulkan-driver
   vulkan_beta = generic rec {
-    version = "515.49.15";
+    version = "515.49.19";
     persistencedVersion = "515.48.07";
     settingsVersion = "515.48.07";
-    sha256_64bit = "sha256-yQbNE+YsbHUc4scXvMZFGuuBRrFTa42g1XoMVZEO/zo=";
-    openSha256 = "sha256-2RvogIdTA7Rg4oq14TG7Kh31HWuj860xsK7/MYFitpQ=";
+    sha256_64bit = "sha256-J5+rI2zfQKwV40kG6IY8zGo91PcCnKOKoyVu6zb5L3E=";
+    openSha256 = "sha256-5NXsr7/aYOLAYP9TY5uKj6R5rUSmv1sj90EprEvAZsA=";
     settingsSha256 = "sha256-XwdMsAAu5132x2ZHqjtFvcBJk6Dao7I86UksxrOkknU=";
     persistencedSha256 = "sha256-BTfYNDJKe4tOvV71/1JJSPltJua0Mx/RvDcWT5ccRRY=";
     url = "https://developer.nvidia.com/vulkan-beta-${lib.concatStrings (lib.splitString "." version)}-linux";


### PR DESCRIPTION
###### Description of changes

- September 30th, 2022 - Windows 517.57, Linux 515.49.19
  - New:
    - VK_EXT_extended_dynamic_state3 support for the following dynamic states:
      - VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT
      - VK_DYNAMIC_STATE_POLYGON_MODE_EXT
      - VK_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT
      - VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT
      - VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT
      - VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT
      - VK_DYNAMIC_STATE_DEPTH_CLIP_ENABLE_EXT
      - VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT
      - VK_DYNAMIC_STATE_PROVOKING_VERTEX_MODE_EXT
      - VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT
      - VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT
    - Provisional Vulkan video extension updates:
      - VK_KHR_video_queue: 6 -> 7
      - Note: these changes are not backwards compatible with the old revisions so applications using the old revisions will need to be updated to continue working
  - Fixes:
    - Fixed regression with mesh shader queries
    - Updated OpEmitMeshTasksEXT to be interpreted as a terminator instruction

- September 27th, 2022 - Windows 517.55, Linux 515.49.18
  - New:
    - VK_EXT_mutable_descriptor_type
    - VK_EXT_depth_clamp_zero_one
    - Provisional Vulkan video extension updates:
      - VK_KHR_video_queue: 4 -> 6
      - VK_KHR_video_decode_queue: 4 -> 6
      - VK_KHR_video_encode_queue: 5 -> 7
      - VK_EXT_video_decode_h264: 5 -> 7
      - VK_EXT_video_decode_h265: 3 -> 5
      - VK_EXT_video_encode_h264: 7 -> 9
      - Note: these changes are not backwards compatible with the old revisions so applications using the old revisions will need to be updated to continue working
  - Fixes:
    - Fixed possible multi-threaded pipeline creation stall when VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT is used
    - Fixed support for image load/store/atomics with linear images

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
