### PR TITLE
python3Packages.sphinx-automodapi: enable tests

### DIFF
--- a/pkgs/development/python-modules/sphinx-automodapi/default.nix
+++ b/pkgs/development/python-modules/sphinx-automodapi/default.nix
@@ -1,11 +1,13 @@
 { lib
 , buildPythonPackage
+, cython
 , fetchFromGitHub
+, fetchurl
+, gcc
+, graphviz
 , pytestCheckHook
 , pythonOlder
 , sphinx
-, gcc
-, cython
 }:
 
 buildPythonPackage rec {
@@ -25,12 +27,22 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ sphinx ];
 
   # https://github.com/astropy/sphinx-automodapi/issues/155
-  doCheck = false;
+  testInventory = fetchurl {
+    # Originally: https://docs.python.org/3/objects.inv
+    url = "https://web.archive.org/web/20221007193144/https://docs.python.org/3/objects.inv";
+    hash = "sha256-1cbUmdJJSoifkiIYa70SxnLsaK3F2gvnTEWo9vo/6rY=";
+  };
+
+  postPatch = ''
+    substituteInPlace "sphinx_automodapi/tests/helpers.py" \
+      --replace '[0]), None)' "[0]), (None, '${testInventory}'))"
+  '';
 
   checkInputs = [
     pytestCheckHook
-    gcc
     cython
+    gcc
+    graphviz
   ];
 
   pythonImportsCheck = [ "sphinx_automodapi" ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
