### PR TITLE
guestfs-tools: init at 1.48.2

### DIFF
--- a/pkgs/development/tools/guestfs-tools/default.nix
+++ b/pkgs/development/tools/guestfs-tools/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, libguestfs-with-appliance
+, ncurses
+, cpio
+, cdrkit
+, flex
+, bison
+, qemu
+, hivex
+, bash-completion
+, pcre2
+, libxml2
+, libvirt
+, jansson
+, getopt
+, perlPackages
+, ocamlPackages
+, xz
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "guestfs-tools";
+  version = "1.48.2";
+
+  src = fetchurl {
+    url = "https://download.libguestfs.org/guestfs-tools/${lib.versions.majorMinor version}-stable/${pname}-${version}.tar.gz";
+    sha256 = "sha256-G9l5sG5g5kMlSXzg0GX8+Et7M9/k2dRLMBgsMI4MaxA=";
+  };
+
+  nativeBuildInputs = [
+    bison
+    cdrkit
+    cpio
+    flex
+    getopt
+    pkg-config
+    qemu
+  ] ++ (with perlPackages; [ perl libintl-perl GetoptLong ModuleBuild ])
+    ++ (with ocamlPackages; [ ocaml findlib ]);
+  buildInputs = [
+    libguestfs-with-appliance
+    ncurses
+    jansson
+    pcre2
+    hivex
+    libxml2
+    libvirt
+    bash-completion
+    xz
+    openssl
+  ] ++ (with ocamlPackages; [ ocamlbuild ocaml_libvirt gettext-stub ounit2 ]);
+
+  postPatch = ''
+    patchShebangs ocaml-dep.sh.in ocaml-link.sh.in run.in
+  '';
+
+  makeFlags = [ "LIBGUESTFS_PATH=${libguestfs-with-appliance}/lib/guestfs" ];
+
+  installFlags = [
+    "BASH_COMPLETIONS_DIR=${placeholder "out"}/share/bash-completion/completions"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Tools for accessing and modifying virtual machine disk images";
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    homepage = "https://libguestfs.org/";
+    maintainers = with maintainers; [ offline astro ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18995,6 +18995,8 @@ with pkgs;
 
   gts = callPackage ../development/libraries/gts { };
 
+  guestfs-tools = callPackage ../development/tools/guestfs-tools { };
+
   gumbo = callPackage ../development/libraries/gumbo { };
 
   gvfs = callPackage ../development/libraries/gvfs { };


### PR DESCRIPTION
###### Description of changes

This restores a set of tools that were split off libguestfs in 1.46.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
