### PR TITLE
vector: patch to compile with rust 1.64.

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , rustPlatform
 , pkg-config
 , llvmPackages
@@ -40,10 +41,28 @@ rustPlatform.buildRustPackage {
     owner = "vectordotdev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-RfKg14r3B5Jx2vIa4gpJs5vXRqSXKOXKRFmmQmzQorQ=";
+    hash = "sha256-RfKg14r3B5Jx2vIa4gpJs5vXRqSXKOXKRFmmQmzQorQ=";
   };
 
-  cargoSha256 = "sha256-l2rrT2SeeH4bYYlzSiFASNBxtg4TBm1dRA4cFRfvpkk=";
+  patches = [
+    (fetchpatch {
+      name = "rust-1.64-part1.patch";
+      url = "https://github.com/vectordotdev/vector/commit/e7437df97711b6a660a3532fe5026244472a900f.patch";
+      hash = "sha256-EyheI3nngt72+ZZNNsjp3KV1CuRb9CZ7wUCHt0twFVs=";
+    })
+    (fetchpatch {
+      name = "rust-1.64-part2.patch";
+      url = "https://github.com/vectordotdev/vector/commit/e80c7afaf7601cf936c7c3468bd7b4b230ef6149.patch";
+      hash = "sha256-pHcq7XLn+9PKs0DnBTK5FawN5KSF8BuJf7sBO9u5Gb8=";
+      excludes = [
+        # There are too many conflicts to easily resolve patching this file, but
+        # the changes here do not block compilation.
+        "lib/lookup/src/lookup_v2/owned.rs"
+      ];
+    })
+  ];
+
+  cargoHash = "sha256-l2rrT2SeeH4bYYlzSiFASNBxtg4TBm1dRA4cFRfvpkk=";
   nativeBuildInputs = [ pkg-config cmake perl ];
   buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]
     ++ lib.optionals stdenv.isDarwin [ Security libiconv coreutils CoreServices ];
@@ -111,3 +130,4 @@ rustPlatform.buildRustPackage {
     platforms = with platforms; all;
   };
 }
+


### PR DESCRIPTION
###### Description of changes

Related to https://github.com/NixOS/nixpkgs/pull/193494.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
