### PR TITLE
llvmPackages_{13,14}.lldb: fix build on x86 macOS

### DIFF
--- a/pkgs/development/compilers/llvm/13/lldb/cpu_subtype_arm64e_replacement.patch
+++ b/pkgs/development/compilers/llvm/13/lldb/cpu_subtype_arm64e_replacement.patch
@@ -1,0 +1,12 @@
+diff --git a/source/Host/macosx/objcxx/HostInfoMacOSX.mm b/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+--- a/source/Host/macosx/objcxx/HostInfoMacOSX.mm
++++ b/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+@@ -233,7 +233,7 @@ void HostInfoMacOSX::ComputeHostArchitectureSupport(ArchSpec &arch_32,
+     len = sizeof(is_64_bit_capable);
+     ::sysctlbyname("hw.cpu64bit_capable", &is_64_bit_capable, &len, NULL, 0);
+ 
+-    if (cputype == CPU_TYPE_ARM64 && cpusubtype == CPU_SUBTYPE_ARM64E) {
++    if (cputype == CPU_TYPE_ARM64 && cpusubtype == ((cpu_subtype_t) 2)) { // CPU_SUBTYPE_ARM64E is not available in the macOS 10.12 headers
+       // The arm64e architecture is a preview. Pretend the host architecture
+       // is arm64.
+       cpusubtype = CPU_SUBTYPE_ARM64_ALL;

--- a/pkgs/development/compilers/llvm/13/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/13/lldb/default.nix
@@ -20,6 +20,7 @@
 , Cocoa
 , lit
 , makeWrapper
+, darwin
 , enableManpages ? false
 }:
 
@@ -38,7 +39,22 @@ stdenv.mkDerivation (rec {
       substitute '${./resource-dir.patch}' "$out" --subst-var clangLibDir
     '')
     ./gnu-install-dirs.patch
-  ];
+  ]
+  # This is a stopgap solution if/until the macOS SDK used for x86_64 is
+  # updated.
+  #
+  # The older 10.12 SDK used on x86_64 as of this writing has a `mach/machine.h`
+  # header that does not define `CPU_SUBTYPE_ARM64E` so we replace the one use
+  # of this preprocessor symbol in `lldb` with its expansion.
+  #
+  # See here for some context:
+  # https://github.com/NixOS/nixpkgs/pull/194634#issuecomment-1272129132
+  ++ lib.optional (
+    stdenv.targetPlatform.isDarwin
+      && !stdenv.targetPlatform.isAarch64
+      && (lib.versionOlder darwin.apple_sdk.sdk.version "11.0")
+  ) ./cpu_subtype_arm64e_replacement.patch;
+
 
   outputs = [ "out" "lib" "dev" ];
 
@@ -102,7 +118,6 @@ stdenv.mkDerivation (rec {
   '';
 
   meta = llvm_meta // {
-    broken = stdenv.isDarwin;
     homepage = "https://lldb.llvm.org/";
     description = "A next-generation high-performance debugger";
     longDescription = ''

--- a/pkgs/development/compilers/llvm/14/lldb/cpu_subtype_arm64e_replacement.patch
+++ b/pkgs/development/compilers/llvm/14/lldb/cpu_subtype_arm64e_replacement.patch
@@ -1,0 +1,12 @@
+diff --git a/source/Host/macosx/objcxx/HostInfoMacOSX.mm b/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+--- a/source/Host/macosx/objcxx/HostInfoMacOSX.mm
++++ b/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+@@ -233,7 +233,7 @@ void HostInfoMacOSX::ComputeHostArchitectureSupport(ArchSpec &arch_32,
+     len = sizeof(is_64_bit_capable);
+     ::sysctlbyname("hw.cpu64bit_capable", &is_64_bit_capable, &len, NULL, 0);
+ 
+-    if (cputype == CPU_TYPE_ARM64 && cpusubtype == CPU_SUBTYPE_ARM64E) {
++    if (cputype == CPU_TYPE_ARM64 && cpusubtype == ((cpu_subtype_t) 2)) { // CPU_SUBTYPE_ARM64E is not available in the macOS 10.12 headers
+       // The arm64e architecture is a preview. Pretend the host architecture
+       // is arm64.
+       cpusubtype = CPU_SUBTYPE_ARM64_ALL;


### PR DESCRIPTION
###### Description of changes

This is a backport of the fixes applied to `llvmPackages_15.lldb`; see: https://github.com/NixOS/nixpkgs/pull/194634#issuecomment-1272129132.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
