### PR TITLE
obs-studio-plugins.wlrobs: unstable (6f51 -> f71f)

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/wlrobs.nix
+++ b/pkgs/applications/video/obs-studio/plugins/wlrobs.nix
@@ -1,16 +1,18 @@
-{ lib, stdenv, fetchhg
+{ lib, stdenv, fetchFromSourcehut
 , meson, pkg-config, ninja
 , wayland, obs-studio, libX11
 }:
 
 stdenv.mkDerivation {
   pname = "wlrobs";
-  version = "unstable-2021-05-13";
+  version = "unstable-2022-10-06";
 
-  src = fetchhg {
-    url = "https://hg.sr.ht/~scoopta/wlrobs";
-    rev = "4184a4a8ea7dc054c993efa16007f3a75b2c6f51";
-    sha256 = "146xirzd3nw1sd216y406v1riky9k08b6a0j4kwxrif5zyqa3adc";
+  src = fetchFromSourcehut {
+    vc = "hg";
+    owner = "~scoopta";
+    repo = "wlrobs";
+    rev = "78be323b25e1365f5c8f9dcba6938063ca10f71f";
+    sha256 = "sha256-/VemJkk695BdSDsODmYIPdhPwggzIhBi/0m6P+AYfx0=";
   };
 
   nativeBuildInputs = [ meson pkg-config ninja ];


### PR DESCRIPTION
###### Description of changes

4184a4a8ea7dc054c993efa16007f3a75b2c6f51 -> 78be323b25e1365f5c8f9dcba6938063ca10f71f
Tested with #194578 but not depending

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
