### PR TITLE
material-design-icons: 6.6.96 -> 7.0.96

### DIFF
--- a/pkgs/data/fonts/material-design-icons/default.nix
+++ b/pkgs/data/fonts/material-design-icons/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchFromGitHub }:
 
 let
-  version = "6.6.96";
+  version = "7.0.96";
 in fetchFromGitHub {
   name = "material-design-icons-${version}";
   owner  = "Templarian";
@@ -9,17 +9,19 @@ in fetchFromGitHub {
   rev    = "v${version}";
 
   postFetch = ''
-    tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/{eot,truetype,woff,woff2}
-    cp fonts/*.eot $out/share/fonts/eot/
-    cp fonts/*.ttf $out/share/fonts/truetype/
-    cp fonts/*.woff $out/share/fonts/woff/
-    cp fonts/*.woff2 $out/share/fonts/woff2/
+    mv $out/fonts/*.eot $out/share/fonts/eot/
+    mv $out/fonts/*.ttf $out/share/fonts/truetype/
+    mv $out/fonts/*.woff $out/share/fonts/woff/
+    mv $out/fonts/*.woff2 $out/share/fonts/woff2/
+    shopt -s extglob dotglob
+    rm -rf $out/!(share)
+    shopt -u extglob dotglob
   '';
-  sha256 = "sha256-rfDb9meTF0Y0kiCQd11SgnntQnw34Ti/IXn35xaPO1M=";
+  sha256 = "sha256-l60LRXLwLh+7Ls3kMTJ5eDTVpVMcqtshMv/ehIk8fCk=";
 
   meta = with lib; {
-    description = "4600+ Material Design Icons from the Community";
+    description = "7000+ Material Design Icons from the Community";
     longDescription = ''
       Material Design Icons' growing icon collection allows designers and
       developers targeting various platforms to download icons in the format,


### PR DESCRIPTION
###### Description of changes
Bump version of material-design-icons.
https://github.com/Templarian/MaterialDesign-Webfont
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
