### PR TITLE
ocamlPackages.mirage-block-unix: 2.14.1 → 2.14.2

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-block-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block-unix/default.nix
@@ -1,19 +1,19 @@
-{ lib, fetchurl, buildDunePackage, cstruct-lwt, diet, io-page, logs
+{ lib, fetchurl, buildDunePackage, cstruct-lwt, diet, logs
 , mirage-block, ounit2, rresult, uri }:
 
 buildDunePackage rec {
   pname = "mirage-block-unix";
-  version = "2.14.1";
+  version = "2.14.2";
 
   src = fetchurl {
     url =
       "https://github.com/mirage/mirage-block-unix/releases/download/v${version}/mirage-block-unix-${version}.tbz";
-    sha256 = "sha256-FcUhbjHKT11ePDXaAVzUdV/WOHoxMoXyZKG5ikKpBNU=";
+    sha256 = "sha256-6ReAzd+pCd5ccmXOh6GlSxHo4GuEgptxLha62n+dBsE=";
   };
 
-  minimalOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.08";
 
-  propagatedBuildInputs = [ cstruct-lwt io-page logs mirage-block rresult uri ];
+  propagatedBuildInputs = [ cstruct-lwt logs mirage-block rresult uri ];
 
   doCheck = true;
   checkInputs = [ diet ounit2 ];


### PR DESCRIPTION
###### Description of changes

Improvements: https://github.com/mirage/mirage-block-unix/blob/v2.14.2/CHANGES.md#v2142-2022-09-15

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
