### PR TITLE
libdwarf: use latest version by default

### DIFF
--- a/pkgs/development/libraries/libdwarf/0.4.nix
+++ b/pkgs/development/libraries/libdwarf/0.4.nix
@@ -1,8 +1,0 @@
-{ callPackage, zlib }:
-callPackage ./common.nix rec {
-  version = "0.4.2";
-  url = "https://www.prevanders.net/libdwarf-${version}.tar.xz";
-  sha512 = "6d2a3ebf0104362dd9cecec272935684f977db119810eea0eec88c9f56a042f260a4f6ed3bbabde8592fe16f98cbd81b4ab2878005140e05c8f475df6380d1c2";
-  buildInputs = [ zlib ];
-  knownVulnerabilities = [];
-}

--- a/pkgs/development/libraries/libdwarf/20210528.nix
+++ b/pkgs/development/libraries/libdwarf/20210528.nix
@@ -1,0 +1,8 @@
+{ callPackage, zlib, libelf }:
+callPackage ./common.nix rec {
+  version = "20210528";
+  url = "https://www.prevanders.net/libdwarf-${version}.tar.gz";
+  sha512 = "e0f9c88554053ee6c1b1333960891189e7820c4a4ddc302b7e63754a4cdcfc2acb1b4b6083a722d1204a75e994fff3401ecc251b8c3b24090f8cb4046d90f870";
+  buildInputs = [ zlib libelf ];
+  knownVulnerabilities = [ "CVE-2022-32200" "CVE-2022-39170" ];
+}

--- a/pkgs/development/libraries/libdwarf/default.nix
+++ b/pkgs/development/libraries/libdwarf/default.nix
@@ -1,8 +1,8 @@
-{ callPackage, zlib, libelf }:
+{ callPackage, zlib }:
 callPackage ./common.nix rec {
-  version = "20210528";
-  url = "https://www.prevanders.net/libdwarf-${version}.tar.gz";
-  sha512 = "e0f9c88554053ee6c1b1333960891189e7820c4a4ddc302b7e63754a4cdcfc2acb1b4b6083a722d1204a75e994fff3401ecc251b8c3b24090f8cb4046d90f870";
-  buildInputs = [ zlib libelf ];
-  knownVulnerabilities = [ "CVE-2022-32200" "CVE-2022-39170" ];
+  version = "0.4.2";
+  url = "https://www.prevanders.net/libdwarf-${version}.tar.xz";
+  sha512 = "6d2a3ebf0104362dd9cecec272935684f977db119810eea0eec88c9f56a042f260a4f6ed3bbabde8592fe16f98cbd81b4ab2878005140e05c8f475df6380d1c2";
+  buildInputs = [ zlib ];
+  knownVulnerabilities = [];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19690,7 +19690,7 @@ with pkgs;
 
   libdwarf = callPackage ../development/libraries/libdwarf { };
   dwarfdump = libdwarf.bin;
-  libdwarf_0_4 = callPackage ../development/libraries/libdwarf/0.4.nix { };
+  libdwarf_20210528 = callPackage ../development/libraries/libdwarf/20210528.nix { };
 
   libe57format = callPackage ../development/libraries/libe57format { };
 
@@ -27622,7 +27622,9 @@ with pkgs;
 
   elementary-planner = callPackage ../applications/office/elementary-planner { };
 
-  elf-dissector = libsForQt5.callPackage ../applications/misc/elf-dissector { };
+  elf-dissector = libsForQt5.callPackage ../applications/misc/elf-dissector {
+    libdwarf = libdwarf_20210528;
+  };
 
   elfx86exts = callPackage ../applications/misc/elfx86exts { };
 


### PR DESCRIPTION
###### Description of changes

The legacy version has been kept for `elf-dissector` but the package is broken anyway.

Follow up to #194909
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>anbox</li>
    <li>apitrace</li>
    <li>ctypes_sh</li>
    <li>libdwarf (dwarfdump)</li>
  </ul>
</details>
