### PR TITLE
buildPythonPackage: fix regression if no setuptools is used

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-output-dist-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-output-dist-hook.sh
@@ -3,7 +3,21 @@ echo "Sourcing python-catch-conflicts-hook.sh"
 
 pythonOutputDistPhase() {
     echo "Executing pythonOutputDistPhase"
-    mv "dist" "$dist"
+    if [[ -d dist ]]; then
+        mv "dist" "$dist"
+    else
+        cat >&2 <<EOF
+The build contains no ./dist directory.
+If this project is not setuptools-based, pass
+
+  format = "other";
+
+to buildPythonApplication/buildPythonPackage or another appropriate value as described here:
+
+  https://nixos.org/manual/nixpkgs/stable/#buildpythonpackage-function
+EOF
+        false
+    fi
     echo "Finished executing pythonOutputDistPhase"
 }
 


### PR DESCRIPTION
Before packages did not had to set `format = "other";` if it had a custom installPhase and would not produce a dist folder.
While it maybe desirable for all packages to have the correct format set, it is easier this builder if it just works(tm) by gracefully degrading. The current error message is hard to understand by new users:

> Executing pythonOutputDistPhase
> mv: cannot stat 'dist': No such file or directory

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
