### PR TITLE
python310Packages.pyquil: 3.3.2 -> 3.3.2

### DIFF
--- a/pkgs/development/python-modules/pyquil/default.nix
+++ b/pkgs/development/python-modules/pyquil/default.nix
@@ -14,15 +14,17 @@
 , pytestCheckHook
 , pythonOlder
 , qcs-api-client
-, retry
 , respx
+, retry
 , rpcq
 , scipy
+, types-python-dateutil
+, types-retry
 }:
 
 buildPythonPackage rec {
   pname = "pyquil";
-  version = "3.3.1";
+  version = "3.3.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -31,7 +33,7 @@ buildPythonPackage rec {
     owner = "rigetti";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-eBEv0rpM0IOaMHWjXDgF0yFK+NNr49cI8fxVi0sfbXs=";
+    hash = "sha256-Ur7dRxmnaAWXHk7c6NC3lBw59RRgh9vwAHFW00fViD4=";
   };
 
   nativeBuildInputs = [
@@ -46,6 +48,8 @@ buildPythonPackage rec {
     retry
     rpcq
     scipy
+    types-python-dateutil
+    types-retry
   ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
   ];

--- a/pkgs/development/python-modules/types-python-dateutil/default.nix
+++ b/pkgs/development/python-modules/types-python-dateutil/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-python-dateutil";
+  version = "2.8.19";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-v9PrOcclOupLojsQ9psBfTCwE2YrtL5KtIsgu9dj8wk=";
+  };
+
+  # Modules doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "dateutil-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Typing stubs for python-dateutil";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/types-retry/default.nix
+++ b/pkgs/development/python-modules/types-retry/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-retry";
+  version = "0.9.9";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-sQh7J0aAtULHllSehIiJjQsizYmYjvEBbvVtQ2f/T0E=";
+  };
+
+  # Modules doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "retry-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Typing stubs for retry";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11374,6 +11374,8 @@ in {
 
   types-protobuf = callPackage ../development/python-modules/types-protobuf { };
 
+  types-python-dateutil = callPackage ../development/python-modules/types-python-dateutil { };
+
   types-pytz = callPackage ../development/python-modules/types-pytz { };
 
   types-pyyaml = callPackage ../development/python-modules/types-pyyaml { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11380,6 +11380,8 @@ in {
 
   types-redis = callPackage ../development/python-modules/types-redis { };
 
+  types-retry = callPackage ../development/python-modules/types-retry { };
+
   types-requests = callPackage ../development/python-modules/types-requests { };
 
   types-setuptools = callPackage ../development/python-modules/types-setuptools { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
