### PR TITLE
adcli: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/os-specific/linux/adcli/default.nix
+++ b/pkgs/os-specific/linux/adcli/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitLab
-, fetchpatch
 , openldap
 , libkrb5
 , libxslt
@@ -16,24 +15,15 @@
 
 stdenv.mkDerivation rec {
   pname = "adcli";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "realmd";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Zzt4qgLiJNuSrbtDWuxJEfGL7sWSbqN301q3qXZpn9c=";
+    sha256 = "sha256-dipNKlIdc1DpXLg/YJjUxZlNoMFy+rt8Y/+AfWFA4dE=";
   };
-
-  # https://bugs.gentoo.org/820224
-  # Without this it produces some weird missing symbol error in glibc
-  patches = [
-    (fetchpatch {
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-crypt/adcli/files/adcli-0.9.1-glibc-2.34-resolv.patch?id=01db544de893262e857685e11b33c2a74210181f";
-      sha256 = "sha256-dZ6dkzxd+0XjY/X9/2IWMan3syvCDGFHiMbxFxMHGFA=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace tools/Makefile.am \
@@ -52,6 +42,7 @@ stdenv.mkDerivation rec {
     patch_docbook doc/adcli-devel.xml
     patch_docbook doc/adcli-docs.xml
   '';
+
   nativeBuildInputs = [ autoreconfHook pkg-config docbook_xsl ];
 
   buildInputs = [ openldap libkrb5 libxslt cyrus_sasl util-linux xmlto docbook_xsl ];

--- a/pkgs/os-specific/linux/adcli/default.nix
+++ b/pkgs/os-specific/linux/adcli/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.freedesktop.org/software/realmd/adcli/adcli.html";
     description = "A helper library and tools for Active Directory client operations.";
     license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ SohamG ];
+    maintainers = with maintainers; [ SohamG anthonyroussel ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/adcli/default.nix
+++ b/pkgs/os-specific/linux/adcli/default.nix
@@ -25,6 +25,23 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dipNKlIdc1DpXLg/YJjUxZlNoMFy+rt8Y/+AfWFA4dE=";
   };
 
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    docbook_xsl
+    util-linux
+    xmlto
+  ];
+
+  buildInputs = [
+    openldap
+    libkrb5
+    libxslt
+    cyrus_sasl
+  ];
+
+  configureFlags = [ "--disable-debug" ];
+
   postPatch = ''
     substituteInPlace tools/Makefile.am \
       --replace 'sbin_PROGRAMS' 'bin_PROGRAMS'
@@ -33,7 +50,7 @@ stdenv.mkDerivation rec {
         --replace 'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl' \
                   '${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl'
 
-    function patch_docbook(){
+    function patch_docbook() {
       substituteInPlace $1 \
         --replace "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" \
                   "${docbook_xml_dtd_43}/xml/dtd/docbook/docbookx.dtd"
@@ -42,12 +59,6 @@ stdenv.mkDerivation rec {
     patch_docbook doc/adcli-devel.xml
     patch_docbook doc/adcli-docs.xml
   '';
-
-  nativeBuildInputs = [ autoreconfHook pkg-config docbook_xsl ];
-
-  buildInputs = [ openldap libkrb5 libxslt cyrus_sasl util-linux xmlto docbook_xsl ];
-
-  configureFlags = [ "--disable-debug" ];
 
   meta = with lib; {
     homepage = "https://www.freedesktop.org/software/realmd/adcli/adcli.html";


### PR DESCRIPTION
###### Description of changes

* Upgrade adcli from 0.9.1 to 0.9.2
  * See https://gitlab.freedesktop.org/realmd/adcli/-/compare/0.9.1...0.9.2

* Add myself to maintainers
* Cleanup: attribute ordering, native build inputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
