### PR TITLE
chromedriver: fix darwin aarch64

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -70,9 +70,7 @@ def get_matching_chromedriver(version):
             'version': chromedriver_version,
             'sha256_linux': nix_prefetch_url(get_chromedriver_url('linux64')),
             'sha256_darwin': nix_prefetch_url(get_chromedriver_url('mac64')),
-            # TODO: No such object: chromedriver/106.0.5249.61/chromedriver_mac64_m1.zip:
-            # 'sha256_darwin_aarch64': nix_prefetch_url(get_chromedriver_url('mac64_m1'))
-            'sha256_darwin_aarch64': "0000000000000000000000000000000000000000000000000000000000000000"
+            'sha256_darwin_aarch64': nix_prefetch_url(get_chromedriver_url('mac_arm64'))
         }
 
 

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -15,7 +15,7 @@
       "version": "106.0.5249.61",
       "sha256_linux": "0l2270d5az46pc6icpn3zx7yr8ilkszsrfy3qmwrx3cyc4xnmznj",
       "sha256_darwin": "07k76i9m3j34h6ybn1wafy39d2ngf06bhp24qzwvv45rks714hqa",
-      "sha256_darwin_aarch64": "0000000000000000000000000000000000000000000000000000000000000000"
+      "sha256_darwin_aarch64": "1nvid0s44nlzy46cgxzsyyb3jfpyl3xy7aqafwskmbxdczx7bdap"
     }
   },
   "beta": {

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -18,10 +18,10 @@ let
       sha256 = upstream-info.sha256_darwin;
     };
 
-    # aarch64-darwin = {
-    #   system = "mac64_m1";
-    #   sha256 = upstream-info.sha256_darwin_aarch64;
-    # };
+    aarch64-darwin = {
+      system = "mac_arm64";
+      sha256 = upstream-info.sha256_darwin_aarch64;
+    };
   };
 
   spec = allSpecs.${stdenv.hostPlatform.system}


### PR DESCRIPTION
###### Description of changes

Restore darwin aarch64 support, ref https://github.com/NixOS/nixpkgs/pull/194632 cc @primeos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
