### PR TITLE
calibre-web: 0.6.18 -> 0.6.19

### DIFF
--- a/pkgs/servers/calibre-web/db-migrations.patch
+++ b/pkgs/servers/calibre-web/db-migrations.patch
@@ -1,14 +1,14 @@
 diff --git a/cps/__init__.py b/cps/__init__.py
-index 627cca0b..233bb2dd 100644
+index 1ba1f778..fd5dc2f1 100644
 --- a/cps/__init__.py
 +++ b/cps/__init__.py
-@@ -87,6 +87,9 @@ db.CalibreDB.setup_db(config, cli.settingspath)
- 
- calibre_db = db.CalibreDB()
- 
-+if os.environ.get('__RUN_MIGRATIONS_AND_EXIT'):
-+    sys.exit(0)
+@@ -116,6 +116,9 @@ def create_app():
+     db.CalibreDB.setup_db(config.config_calibre_dir, cli_param.settings_path)
+     calibre_db.init_db()
+
++    if os.environ.get('__RUN_MIGRATIONS_AND_EXIT'):
++        sys.exit(0)
 +
- def create_app():
-     app.wsgi_app = ReverseProxied(app.wsgi_app)
-     # For python2 convert path to unicode
+     updater_thread.init_updater(config, web_server)
+     # Perform dry run of updater and exit afterwards
+     if cli_param.dry_run:

--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -6,16 +6,17 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "calibre-web";
-  version = "0.6.18";
+  version = "0.6.19";
 
   src = fetchFromGitHub {
     owner = "janeczku";
     repo = "calibre-web";
     rev = version;
-    sha256 = "sha256-KjmpFetNhNM5tL34e/Pn1i3hc86JZglubSMsHZWu198=";
+    hash = "sha256-mNYLQ+3u6xRaoZ5oH6HdylFfgz1fq1ZB86AWk9vULWQ=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
+    APScheduler
     advocate
     backports_abc
     chardet
@@ -57,7 +58,7 @@ python3.pkgs.buildPythonApplication rec {
       --replace "cps = calibreweb:main" "calibre-web = calibreweb:main" \
       --replace "chardet>=3.0.0,<4.1.0" "chardet>=3.0.0,<6" \
       --replace "Flask>=1.0.2,<2.1.0" "Flask>=1.0.2" \
-      --replace "Flask-Login>=0.3.2,<0.5.1" "Flask-Login>=0.3.2" \
+      --replace "Flask-Login>=0.3.2,<0.6.2" "Flask-Login>=0.3.2" \
       --replace "flask-wtf>=0.14.2,<1.1.0" "flask-wtf>=0.14.2" \
       --replace "lxml>=3.8.0,<4.9.0" "lxml>=3.8.0" \
       --replace "tornado>=4.1,<6.2" "tornado>=4.1,<7" \


### PR DESCRIPTION
###### Description of changes

* calibre-web: 0.6.18 -> 0.6.19
  * https://github.com/janeczku/calibre-web/releases/tag/0.6.19
  * https://github.com/janeczku/calibre-web/compare/0.6.18...0.6.19

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
