### PR TITLE
jetbrains.gateway: init at 223.6160.27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7330,6 +7330,12 @@
     githubId = 2037002;
     name = "Konstantinos";
   };
+  kouyk = {
+    email = "skykinetic@stevenkou.xyz";
+    github = "kouyk";
+    githubId = 1729497;
+    name = "Steven Kou";
+  };
   kovirobi = {
     email = "kovirobi@gmail.com";
     github = "KoviRobi";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -86,6 +86,22 @@ let
       };
     });
 
+  buildGateway = { pname, version, src, license, description, wmClass, ... }:
+    (mkJetBrainsProduct {
+      inherit pname version src wmClass jdk;
+      product = "Gateway";
+      meta = with lib; {
+        homepage = "https://www.jetbrains.com/remote-development/gateway/";
+        inherit description license platforms;
+        longDescription = ''
+          JetBrains Gateway is a lightweight launcher that connects a remote
+          server with your local machine, downloads necessary components on the
+          backend, and opens your project in JetBrains Client.
+        '';
+        maintainers = with maintainers; [ kouyk ];
+      };
+    });
+
   buildGoland = { pname, version, src, license, description, wmClass, ... }:
     (mkJetBrainsProduct {
       inherit pname version src wmClass jdk;
@@ -299,6 +315,19 @@ in
     };
     wmClass = "jetbrains-datagrip";
     update-channel = products.datagrip.update-channel;
+  };
+
+  gateway = buildGateway rec {
+    pname = "gateway";
+    version = products.gateway.version;
+    description = "Your single entry point to all remote development environments";
+    license = lib.licenses.unfree;
+    src = fetchurl {
+      url = products.gateway.url;
+      sha256 = products.gateway.sha256;
+    };
+    wmClass = "jetbrains-gateway";
+    update-channel = products.gateway.update-channel;
   };
 
   goland = buildGoland rec {

--- a/pkgs/applications/editors/jetbrains/linux.nix
+++ b/pkgs/applications/editors/jetbrains/linux.nix
@@ -80,6 +80,7 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
       --set-default JDK_HOME "$jdk" \
       --set-default ANDROID_JAVA_HOME "$jdk" \
       --set-default JAVA_HOME "$jdk" \
+      --set-default JETBRAINSCLIENT_JDK "$jdk" \
       --set ${hiName}_JDK "$jdk" \
       --set ${hiName}_VM_OPTIONS ${vmoptsFile}
 

--- a/pkgs/applications/editors/jetbrains/versions.json
+++ b/pkgs/applications/editors/jetbrains/versions.json
@@ -18,6 +18,15 @@
       "version-major-minor": "2022.1.1",
       "build_number": "222.4345.5"
     },
+    "gateway": {
+      "update-channel": "Gateway EAP",
+      "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
+      "version": "2022.3 EAP",
+      "sha256": "4868baed9350065c1db760f07a09badd1473132af640cc19330e20c8a0940d7d",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-223.6646.21.tar.gz",
+      "version-major-minor": "2022.3",
+      "build_number": "223.6646.21"
+    },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
@@ -128,6 +137,15 @@
       "version-major-minor": "2022.1.1",
       "build_number": "222.4345.5"
     },
+    "gateway": {
+      "update-channel": "Gateway EAP",
+      "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
+      "version": "2022.3 EAP",
+      "sha256": "2db71a052501db41d5cfe142f1a6e3178fe02830f0da127d00fbf93a4629c61b",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-223.6646.21.dmg",
+      "version-major-minor": "2022.3",
+      "build_number": "223.6646.21"
+    },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
@@ -237,6 +255,15 @@
       "url": "https://download.jetbrains.com/datagrip/datagrip-2022.2.5-aarch64.dmg",
       "version-major-minor": "2022.1.1",
       "build_number": "222.4345.5"
+    },
+    "gateway": {
+      "update-channel": "Gateway EAP",
+      "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
+      "version": "2022.3 EAP",
+      "sha256": "513d3a271c5ff20fdc5c22f6e28eb21cfbb283d01ade2d11f33bb7eb79317410",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-223.6646.21-aarch64.dmg",
+      "version-major-minor": "2022.3",
+      "build_number": "223.6646.21"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",


### PR DESCRIPTION
###### Description of changes

Add JetBrains Gateway. This has been tested against JetBrains JDK 17 to be working on NixOS unstable. There is also a minor fix in environment variables for the JetBrains Client to launch correctly from any of the JetBrains IDEs including this as well.

I don't have a darwin device to test this, would appreciate if darwin users can try it out as well.

Credits to https://discourse.nixos.org/t/jetbrains-gateway-client-support-on-nixos/18108 on identifying the additional environment variable to be set.

This should supersede the previous PR #148035.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
