### PR TITLE
python3.pkgs.linien: init at 0.5.3

### DIFF
--- a/pkgs/development/python-modules/asyncserial/default.nix
+++ b/pkgs/development/python-modules/asyncserial/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+}:
+
+buildPythonPackage rec {
+  pname = "asyncserial";
+  version = "unstable-2022-06-10";
+
+  src = fetchFromGitHub {
+    owner = "m-labs";
+    repo = "asyncserial";
+    rev = "446559fec892a556876b17d17f182ae9647d5952";
+    hash = "sha256-WExmgh55sTH2w7wV3i96J1F1FN7L5rX3L/Ayvt2Kw/g=";
+  };
+
+  propagatedBuildInputs = [
+    pyserial
+  ];
+
+  pythonImportsCheck = [ "asyncserial" ];
+
+  meta = with lib; {
+    description = "asyncio support for pyserial";
+    homepage = "https://github.com/m-labs/asyncserial";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/linien/add-client-python-package-to-gui.patch
+++ b/pkgs/development/python-modules/linien/add-client-python-package-to-gui.patch
@@ -1,0 +1,13 @@
+diff --git i/setup_gui.py w/setup_gui.py
+index b47f0fb..2b95efb 100644
+--- i/setup_gui.py
++++ w/setup_gui.py
+@@ -38,7 +38,7 @@ setuptools.setup(
+     url="https://github.com/linien-org/linien",
+     # IMPORTANT: any changes have to be made in setup_client_and_gui.py
+     # of flathub repo as well
+-    packages=["linien", "linien.gui", "linien.gui.ui"],
++    packages=["linien", "linien.client", "linien.gui", "linien.gui.ui"],
+     classifiers=[
+         "Programming Language :: Python :: 3",
+         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/pkgs/development/python-modules/linien/client.nix
+++ b/pkgs/development/python-modules/linien/client.nix
@@ -1,0 +1,11 @@
+{ callPackage
+, paramiko
+, cma
+}:
+
+callPackage ./common.nix {
+  propagatedBuildInputs = [
+    paramiko
+    cma
+  ];
+} "client"

--- a/pkgs/development/python-modules/linien/common.nix
+++ b/pkgs/development/python-modules/linien/common.nix
@@ -1,0 +1,89 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, buildPythonPackage
+, propagatedBuildInputs ? []
+, nativeBuildInputs ? []
+, preFixup ? ""
+, numpy
+, plumbum
+, rpyc
+, scipy
+, pytestCheckHook
+, pytest-plt
+, matplotlib
+, migen
+, misoc
+}:
+
+# subprj is either "GUI" / "Client" / "Server" - they are turned into lower
+# case in most usages
+subproject: let
+  subprj = lib.toLower subproject;
+  version = "0.5.3";
+# Not using rec to differentiate inputs from callPackage arguments to inputs
+# from buildPythonPackage arguments
+in buildPythonPackage {
+  pname = "linien-${subprj}";
+  inherit version;
+  # The pypi package named `linien` contains only the gui python package, and
+  # it doesn't contain the tests. Using this src, we get the tests and we can
+  # build all linien-* packages with the same src.
+  src = fetchFromGitHub {
+    owner = "linien-org";
+    repo = "linien";
+    rev = "v${version}";
+    hash = "sha256-VOT/mw4o9dbkrtMxL0Ar5UcnxsZ7CYcoTj+VVrWADR4=";
+  };
+  patches = [
+    # Removes unrequired uuid dependency, see:
+    # https://github.com/linien-org/linien/pull/289
+    (fetchpatch {
+      url = "https://github.com/doronbehar/linien/commit/58fd44aee33858b5550e239039a96e6df5a31b2a.patch";
+      hash = "sha256-hg6bNSLcYruD3f3owo4aKeuRfhABTPZej3gPOJKrQ54=";
+    })
+  ] ++ lib.optionals (subprj == "gui") [
+    # From some reason upstream didn't add the linien.client package which is
+    # needed when running the gui - it's also unavailable in the pypi package
+    # named `linien`. See https://github.com/linien-org/linien/issues/290
+    ./add-client-python-package-to-gui.patch
+  ];
+  postPatch = ''
+    # Fool the python builder
+    ln -s setup_${subprj}.py setup.py
+    # Add a missing VERSION file to fix build not from pypi
+    echo ${version} > linien/VERSION
+    # Remove dependencies pinning, doesn't remove pinning of linien-client
+    sed -i -E 's/([a-zA-Z0-9])[><=]{2}.*",/\1",/g' setup_${subprj}.py
+  '';
+
+  propagatedBuildInputs = propagatedBuildInputs ++ [
+    numpy
+    plumbum
+    rpyc
+    scipy
+  ];
+
+  # The tests are identical to all subprojects and they take a long time, so
+  # run them only for one of the subprojects.
+  doCheck = (subprj == "server");
+  checkInputs = [
+    pytestCheckHook
+    pytest-plt
+    matplotlib
+    migen
+    misoc
+  ];
+
+  inherit
+    nativeBuildInputs
+    preFixup
+  ;
+
+  meta = with lib; {
+    description = "Spectroscopy lock application using RedPitaya: ${subproject}";
+    homepage = "https://github.com/linien-org/linien";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/linien/gui.nix
+++ b/pkgs/development/python-modules/linien/gui.nix
@@ -1,0 +1,28 @@
+{ callPackage
+, click
+, paramiko
+, pyqtgraph
+, pyqt5
+, qt5
+, superqt
+, linien-client
+, appdirs
+}:
+
+callPackage ./common.nix {
+  propagatedBuildInputs = [
+    click
+    paramiko
+    pyqtgraph
+    pyqt5
+    superqt
+    linien-client
+    appdirs
+  ];
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+  ];
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+} "GUI"

--- a/pkgs/development/python-modules/linien/server.nix
+++ b/pkgs/development/python-modules/linien/server.nix
@@ -1,0 +1,24 @@
+{ callPackage
+, click
+, cma
+, myhdl
+, pylpsd
+, pyrp3
+}:
+
+callPackage ./common.nix {
+  # The server is usually installed by the GUI on a Redpitaya machine where
+  # there's no Nix available by default. The server also includes bash scripts
+  # to start and stop it, along with authentication environment variables
+  # passed from the client to the server when it connects via ssh to it.
+  # Ideally upstream would have changed the design of the server so it'd work
+  # with systemd and make the authentication work with a better technology then
+  # environment variables.
+  propagatedBuildInputs = [
+    click
+    cma
+    myhdl
+    pylpsd
+    pyrp3
+  ];
+} "server"

--- a/pkgs/development/python-modules/migen/default.nix
+++ b/pkgs/development/python-modules/migen/default.nix
@@ -7,14 +7,13 @@
 
 buildPythonPackage rec {
   pname = "migen";
-  version = "unstable-2021-09-14";
-  disabled = pythonOlder "3.3";
+  version = "unstable-2022-09-02";
 
   src = fetchFromGitHub {
     owner = "m-labs";
     repo = "migen";
-    rev = "a5bc262560238f93ceaad423820eb06843326274";
-    sha256 = "32UjaIam/B7Gx6XbPcR067LcXfokJH2mATG9mU38a6o=";
+    rev = "639e66f4f453438e83d86dc13491b9403bbd8ec6";
+    hash = "sha256-IPyhoFZLhY8d3jHB8jyvGdbey7V+X5eCzBZYSrJ18ec=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/misoc/default.nix
+++ b/pkgs/development/python-modules/misoc/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, asyncserial
+, jinja2
+, migen
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "misoc";
+  version = "unstable-2022-10-08";
+
+  src = fetchFromGitHub {
+    owner = "m-labs";
+    repo = "misoc";
+    rev = "6a7c670ab6120b8136f652c41d907eb0fb16ed54";
+    hash = "sha256-dLDp0xg5y5b443hD7vbJFobHxbhtnj68RdZnQ7ckgp4=";
+  };
+
+  propagatedBuildInputs = [
+    pyserial
+    asyncserial
+    jinja2
+    migen
+  ];
+
+  checkInputs = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "misoc" ];
+
+  meta = with lib; {
+    description = "The original high performance and small footprint system-on-chip based on Migen";
+    homepage = "https://github.com/m-labs/misoc";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/myhdl/default.nix
+++ b/pkgs/development/python-modules/myhdl/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, verilog
+, ghdl
+, pytest
+, pytest-xdist
+}:
+
+buildPythonPackage rec {
+  pname = "myhdl";
+  # The stable version is from 2019 and it doesn't pass tests
+  version = "unstable-2022-04-26";
+  # The pypi src doesn't contain the ci script used in checkPhase
+  src = fetchFromGitHub {
+    owner = "myhdl";
+    repo = "myhdl";
+    rev = "1a4f5cd4e9de2e7bbf1053c3c2bc9526b5cc524a";
+    hash = "sha256-Tgoem88Y6AhlCKVhMm0Khg6GPcrEktYOqV8xcMaNkl4=";
+  };
+
+  checkInputs = [
+    pytest
+    pytest-xdist
+    verilog
+    ghdl
+  ];
+  passthru = {
+    # If using myhdl as a dependency, use these if needed and not ghdl and
+    # verlog from all-packages.nix
+    inherit ghdl verilog;
+  };
+  checkPhase = ''
+    runHook preCheck
+
+    for target in {core,iverilog,ghdl}; do
+      env CI_TARGET="$target" bash ./scripts/ci.sh
+    done;
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "A free, open-source package for using Python as a hardware description and verification language.";
+    homepage = "http://www.myhdl.org/";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/pylpsd/default.nix
+++ b/pkgs/development/python-modules/pylpsd/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, numpy
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "pylpsd";
+  version = "0.1.4";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-evPL9vF75S8ATkFwzQjh4pLI/aXGXWwoypCb24nXAN8=";
+  };
+
+  # Tests fail and there are none
+  doCheck = false;
+  pythonImportsCheck = [
+    "pylpsd"
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+  ];
+
+  meta = with lib; {
+    description = "Python implementation of the LPSD algorithm for computing power spectral density with logarithmically spaced points.";
+    homepage = "https://github.com/bleykauf/py-lpsd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/pyrp3/default.nix
+++ b/pkgs/development/python-modules/pyrp3/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, buildPythonPackage
+, myhdl
+, rpyc
+, cached-property
+, numpy
+}:
+
+buildPythonPackage {
+  pname = "pyrp3";
+  version = "unstable-2022-05-09";
+  # There's no pypi source
+  src = fetchFromGitHub {
+    owner = "linien-org";
+    repo = "pyrp3";
+    rev = "f13da68d825ede3091a082edf99339c5ed736bd2";
+    hash = "sha256-hmPG7jBPUSVnsLZOS0pf2c5gibWx0al0rAso1OTAZ1E=";
+  };
+
+  patches = [
+    # https://github.com/linien-org/pyrp3/pull/2
+    (fetchpatch {
+      name = "fix-libmonitor.so-lookup.patch";
+      url = "https://github.com/doronbehar/pyrp3/commit/87e8df4be676ee52661757e11c0d2bdc3fefa82c.patch";
+      hash = "sha256-1lgfQvKa/5wakjDgfp/CY2Kne36vqK6wnFXGCDKFxzc=";
+    })
+  ];
+  # Install libmonitor.so
+  preInstall = ''
+    python setup.py lib_install --prefix=$out
+  '';
+  # No tests and these try to load libmonitor.so from /
+  doCheck = false;
+  pythonImportsCheck = [
+    "PyRedPitaya"
+    # Imported in ../linien-server/
+    "PyRedPitaya.board"
+  ];
+
+  propagatedBuildInputs = [
+    myhdl
+    rpyc
+    cached-property
+    numpy
+  ];
+
+  meta = with lib; {
+    description = "Python 3 port of PyRedPitaya library providing access to Red Pitaya registers";
+    homepage = "https://github.com/linien-org/pyrp3";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-plt/default.nix
+++ b/pkgs/development/python-modules/pytest-plt/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, matplotlib
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-plt";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-IkTNlierFXIG9WSVUfVoirfQ6z7JOYlCaa5NhnBSuxc=";
+  };
+
+  buildInputs = [
+    pytest
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    matplotlib
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "provides fixtures for quickly creating Matplotlib plots in your tests";
+    homepage = "https://www.nengo.ai/pytest-plt/";
+    changelog = "https://github.com/nengo/pytest-plt/blob/master/CHANGES.rst";
+    license = licenses.mit;
+    maintainers = [ maintainers.doronbehar ];
+  };
+}

--- a/pkgs/os-specific/linux/mdio-tool/default.nix
+++ b/pkgs/os-specific/linux/mdio-tool/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation {
+  pname = "mdio-tool";
+  # Will probably never update again
+  version = "unstable-2019-02-06";
+
+  src = fetchFromGitHub {
+    owner = "linien-org";
+    repo = "mdio-tool";
+    rev = "72bd5a915ff046a59ce4303c8de672e77622a86c";
+    sha256 = "sha256-NNLFmYzd1trh/9b90r+OdE/FloNQpMzsTgur49Ep4A0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with lib; {
+    description = "A tool to read and write MII registers from ethernet physicals under linux";
+    homepage = "https://github.com/linien-org/mdio-tool";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.doronbehar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2789,6 +2789,8 @@ with pkgs;
 
   lsix = callPackage ../tools/graphics/lsix { };
 
+  mdio-tool = callPackage ../os-specific/linux/mdio-tool { };
+
   mdr = callPackage ../tools/misc/mdr { };
 
   mobilecoin-wallet = callPackage ../applications/misc/mobilecoin-wallet { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8048,6 +8048,8 @@ self: super: with self; {
 
   pylsp-mypy = callPackage ../development/python-modules/pylsp-mypy { };
 
+  pylpsd = callPackage ../development/python-modules/pylpsd { };
+
   PyLTI = callPackage ../development/python-modules/pylti { };
 
   pylutron = callPackage ../development/python-modules/pylutron { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5299,6 +5299,10 @@ self: super: with self; {
 
   lingua = callPackage ../development/python-modules/lingua { };
 
+  linien-server = callPackage ../development/python-modules/linien/server.nix { };
+  linien-client = callPackage ../development/python-modules/linien/client.nix { };
+  linien-gui = callPackage ../development/python-modules/linien/gui.nix { };
+
   linkify-it-py = callPackage ../development/python-modules/linkify-it-py { };
 
   linode-api = callPackage ../development/python-modules/linode-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8384,6 +8384,8 @@ self: super: with self; {
 
   pyradios = callPackage ../development/python-modules/pyradios { };
 
+  pyrp3 = callPackage ../development/python-modules/pyrp3 { };
+
   py-radix = callPackage ../development/python-modules/py-radix { };
 
   pyrainbird = callPackage ../development/python-modules/pyrainbird { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5722,6 +5722,8 @@ self: super: with self; {
 
   misaka = callPackage ../development/python-modules/misaka { };
 
+  misoc = callPackage ../development/python-modules/misoc { };
+
   mistletoe = callPackage ../development/python-modules/mistletoe { };
 
   mistune = callPackage ../development/python-modules/mistune { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -682,6 +682,8 @@ self: super: with self; {
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };
 
+  asyncserial = callPackage ../development/python-modules/asyncserial { };
+
   asyncsleepiq = callPackage ../development/python-modules/asyncsleepiq { };
 
   asyncssh = callPackage ../development/python-modules/asyncssh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5949,6 +5949,10 @@ self: super: with self; {
 
   mygpoclient = callPackage ../development/python-modules/mygpoclient { };
 
+  myhdl = callPackage ../development/python-modules/myhdl {
+    inherit (pkgs) ghdl verilog;
+  };
+
   myhome = callPackage ../development/python-modules/myhome { };
 
   myjwt = callPackage ../development/python-modules/myjwt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8821,6 +8821,8 @@ self: super: with self; {
 
   pytest-param-files = callPackage ../development/python-modules/pytest-param-files { };
 
+  pytest-plt = callPackage ../development/python-modules/pytest-plt { };
+
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
   pytest-qt = callPackage ../development/python-modules/pytest-qt { };


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
