### PR TITLE
python310Packages.aiopvapi: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/development/python-modules/aiopvapi/default.nix
+++ b/pkgs/development/python-modules/aiopvapi/default.nix
@@ -9,17 +9,16 @@
 
 buildPythonPackage rec {
   pname = "aiopvapi";
-  version = "2.0.2";
+  version = "2.0.3";
   format = "setuptools";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "sander76";
     repo = "aio-powerview-api";
-    # no tags on git, no sdist on pypi: https://github.com/sander76/aio-powerview-api/issues/12
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-OengPrUBaYzpLSWEU9Jc6GLx863YJfqRe64676oQ81Y=";
+    hash = "sha256-RBZuYgTySVL1YtyZ4ZJZly2zvWt/5pZ99/aPCwZ91xQ=";
   };
 
   propagatedBuildInputs = [
@@ -30,13 +29,6 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
   ];
-
-  postPatch = ''
-    # async_timeout 4.0.0 removes loop, https://github.com/sander76/aio-powerview-api/pull/13
-    # Patch doesn't apply due to different line endings
-    substituteInPlace aiopvapi/helpers/aiorequest.py \
-      --replace ", loop=self.loop)" ")"
-  '';
 
   pythonImportsCheck = [
     "aiopvapi"


### PR DESCRIPTION
###### Description of changes
https://github.com/sander76/aio-powerview-api/releases/tag/v2.0.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
