### PR TITLE
yaws: 2.0.6 -> 2.1.1

### DIFF
--- a/pkgs/servers/http/yaws/default.nix
+++ b/pkgs/servers/http/yaws/default.nix
@@ -1,23 +1,19 @@
-{lib, stdenv, fetchurl, erlang, pam, perl }:
+{lib, stdenv, fetchFromGitHub, erlang, pam, perl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "yaws";
-  version = "2.0.6";
+  version = "2.1.1";
 
-  src = fetchurl {
-    url = "http://yaws.hyber.org/download/${pname}-${version}.tar.gz";
-    sha256 = "03nh97g7smsgm6sw5asssmlq7zgx6y2gnn7jn0lv2x5mkf5nzyb9";
+  src = fetchFromGitHub {
+    owner = "erlyaws";
+    repo = pname;
+    rev = "${pname}-${version}";
+    hash = "sha256-F1qhq0SEChWw/EBodXKWTqMNmGoTwP2JgkmfANUFD9I=";
   };
-
-  # The tarball includes a symlink yaws -> yaws-1.95, which seems to be
-  # necessary for importing erlang files
-  unpackPhase = ''
-    tar xzf $src
-    cd $name
-  '';
 
   configureFlags = [ "--with-extrainclude=${pam}/include/security" ];
 
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ erlang pam perl ];
 
   postInstall = ''
@@ -25,8 +21,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A high performance HTTP 1.1 server in Erlang";
-    homepage = "http://yaws.hyber.org";
+    description = "A webserver for dynamic content written in Erlang.";
+    homepage = "https://github.com/erlyaws/yaws";
     license = licenses.bsd2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ goibhniu ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24226,9 +24226,7 @@ with pkgs;
 
   xwayland = callPackage ../servers/x11/xorg/xwayland.nix { };
 
-  yaws = callPackage ../servers/http/yaws {
-    erlang = erlangR21;
-  };
+  yaws = callPackage ../servers/http/yaws { };
 
   youtrack = callPackage ../servers/jetbrains/youtrack.nix { };
 


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2020-12872, CVE-2020-24379, CVE-2020-24916
 #99871

[Changelog](https://github.com/erlyaws/yaws/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
