### PR TITLE
catppuccin-cursors: init at 0.2.0

### DIFF
--- a/pkgs/data/icons/catppuccin-cursors/default.nix
+++ b/pkgs/data/icons/catppuccin-cursors/default.nix
@@ -1,0 +1,33 @@
+{ stdenvNoCC, lib, fetchFromGitHub, xcursorgen, inkscape, makeFontsConf }:
+
+stdenvNoCC.mkDerivation {
+  pname = "catppuccin-cursors";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "cursors";
+    rev = "3d3023606939471c45cff7b643bffc5d5d4ff29c";
+    sha256 = "sha256-0wb84q1VtD1myIRxrfQMn9n6w1gFzMA1rHkPqXuXLP0=";
+  };
+
+  nativeBuildInputs = [ xcursorgen inkscape ];
+
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  buildPhase = ''
+    HOME="$NIX_BUILD_ROOT" PREFIX="/" DESTDIR=$out make build
+  '';
+
+  installPhase = ''
+    HOME="$NIX_BUILD_ROOT" PREFIX="/" DESTDIR=$out make install
+  '';
+
+  meta = with lib; {
+    description = "Soothing pastel mouse cursors";
+    homepage = "https://github.com/catppuccin/cursors";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nullx76 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25685,6 +25685,8 @@ with pkgs;
 
   cascadia-code = callPackage ../data/fonts/cascadia-code { };
 
+  catppuccin-cursors = callPackage ../data/icons/catppuccin-cursors { };
+
   ccsymbols = callPackage ../data/fonts/ccsymbols { };
 
   charis-sil = callPackage ../data/fonts/charis-sil { };


### PR DESCRIPTION
###### Description of changes
adds the catppuccin styled cursors. the gtk theme is already in nixpkgs and this adds the cursors as well.
[Here](https://github.com/catppuccin/cursors) is the home page. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
