### PR TITLE
vikunja-desktop: init at 0.24.6

### DIFF
--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  stdenv,
+  makeWrapper,
+  makeDesktopItem,
+  pnpm,
+  pnpmConfigHook,
+  nodejs,
+  electron,
+  unstableGitUpdater,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  vikunja,
+}:
+
+let
+  executableName = "vikunja-desktop";
+  version = "0.24.6";
+  src = fetchFromGitHub {
+    owner = "go-vikunja";
+    repo = "vikunja";
+    rev = "v${version}";
+    hash = "sha256-yUUZ6gPI2Bte36HzfUE6z8B/I1NlwWDSJA2pwkuzd34=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  name = "vikunja-desktop-${version}";
+  pname = finalAttrs.name;
+  inherit version src;
+
+  sourceRoot = "${finalAttrs.src.name}/desktop";
+  pnpmInstallFlags = [ "--shamefully-hoist" ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      pnpmInstallFlags
+      ;
+    fetcherVersion = 1;
+    hash = "sha256-orFwjmS1KF82JiQa+BE92YOtKsnYiKVzLXrpjtbe1z8=";
+  };
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm
+    pnpmConfigHook
+    vikunja.passthru.frontend
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    sed -i "s/\$${version}/${version}/g" package.json
+    sed -i "s/\"version\": \".*\"/\"version\": \"${version}\"/" package.json
+    ln -s '${vikunja.passthru.frontend}' frontend
+    pnpm run pack -c.electronDist="${electron.dist}" -c.electronVersion="${electron.version}"
+
+    runHook postBuild
+  '';
+
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/lib/vikunja-desktop"
+    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/vikunja-desktop"
+    cp -r ./node_modules "$out/share/lib/vikunja-desktop/resources"
+
+    install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/vikunja-desktop.png"
+
+    # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
+    # see https://github.com/NixOS/nixpkgs/issues/172583
+    makeShellWrapper "${lib.getExe electron}" "$out/bin/vikunja-desktop" \
+      --add-flags "$out/share/lib/vikunja-desktop/resources/app.asar" \
+      "''${gappsWrapperArgs[@]}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  # Do not attempt generating a tarball for vikunja-frontend again.
+  distPhase = ''
+    true
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "${src.meta.homepage}.git";
+  };
+
+  # The desktop item properties should be kept in sync with data from upstream:
+  desktopItem = makeDesktopItem {
+    name = "vikunja-desktop";
+    exec = executableName;
+    icon = "vikunja";
+    desktopName = "Vikunja Desktop";
+    genericName = "To-Do list app";
+    comment = finalAttrs.meta.description;
+    categories = [
+      "ProjectManagement"
+      "Office"
+    ];
+  };
+
+  meta = with lib; {
+    description = "Desktop App of the Vikunja to-do list app";
+    homepage = "https://vikunja.io/";
+    license = licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ kolaente ];
+    mainProgram = "vikunja-desktop";
+    inherit (electron.meta) platforms;
+  };
+})

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -131,7 +131,10 @@ buildGoModule {
     runHook postInstall
   '';
 
-  passthru.tests.vikunja = nixosTests.vikunja;
+  passthru = {
+    tests.vikunja = nixosTests.vikunja;
+    frontend = frontend;
+  };
 
   meta = {
     changelog = "https://kolaente.dev/vikunja/api/src/tag/v${version}/CHANGELOG.md";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the [desktop version](https://kolaente.dev/vikunja/desktop) of [Vikunja](https://vikunja.io). Since it is only an electron wrapper around the frontend and the frontend is already packaged in nixos, this package reuses that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
