### PR TITLE
musl: add bin output

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
     "--syslibdir=${placeholder "out"}/lib"
   ];
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "bin" "dev" ];
 
   dontDisableStatic = true;
   dontAddStaticConfigureFlags = true;
@@ -108,15 +108,12 @@ stdenv.mkDerivation rec {
     # Apparently glibc provides scsi itself?
     (cd $dev/include && ln -s $(ls -d ${linuxHeaders}/include/* | grep -v "scsi$") .)
 
-    mkdir -p $out/bin
-
-
     ${lib.optionalString (stdenv.targetPlatform.libc == "musl" && stdenv.targetPlatform.isx86_32)
       "install -D libssp_nonshared.a $out/lib/libssp_nonshared.a"
     }
 
     # Create 'ldd' symlink, builtin
-    ln -rs $out/lib/libc.so $out/bin/ldd
+    ln -s $out/lib/libc.so $bin/bin/ldd
 
     # (impure) cc wrapper around musl for interactive usuage
     for i in musl-gcc musl-clang ld.musl-clang; do
@@ -127,7 +124,7 @@ stdenv.mkDerivation rec {
       --replace $out/lib/musl-gcc.specs $dev/lib/musl-gcc.specs
 
     # provide 'iconv' utility, using just-built headers, libc/ldso
-    $CC ${iconv_c} -o $out/bin/iconv \
+    $CC ${iconv_c} -o $bin/bin/iconv \
       -I$dev/include \
       -L$out/lib -Wl,-rpath=$out/lib \
       -lc \


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

I split iconv and ldd in a bin output. This follow what alpine does with [musl-utils](https://pkgs.alpinelinux.org/contents?branch=edge&name=musl-utils&arch=x86_64&repo=main) and glibc.bin in nixpkgs do. I don't know if I should put ld-musl-x86_64.so.1 here like glibc or keep in main package like musl. ld is used like a wrapper program so I tend to move to a binary output.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (built a go project so go and gcc works with this change)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


I don't get why I fail ofborg editor test:
```
$ printf "%s\n" pkgs/os-specific/linux/musl/default.nix | xargs -r editorconfig-checker -disable-indent-size; echo $?
0
```


only failure I have but I have the same on master:
```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review pr 195236"
...
error: builder for '/nix/store/ak62kfdkdpnamsg9pqzbj95nk3z48pqw-hydra-2022-09-08.drv' failed with exit code 2;
       last 10 log lines:
       > not ok 1 - Passed tests when run by yath
       > yath exited with 256FAIL: test.pl
       > ===================
       > 1 of 2 tests failed
       > ===================
       > make[2]: *** [Makefile:354: check-TESTS] Error 1
       > make[2]: Leaving directory '/build/source/t'
       > make[1]: *** [Makefile:480: check-am] Error 2
       > make[1]: Leaving directory '/build/source/t'
       > make: *** [Makefile:422: check-recursive] Error 1
       For full logs, run 'nix log /nix/store/ak62kfdkdpnamsg9pqzbj95nk3z48pqw-hydra-2022-09-08.drv'.
warning: error: SQLite database '/nix/var/nix/db/db.sqlite' is busy
error: 1 dependencies of derivation '/nix/store/766sixmknhas2gy461y05ah753jjrg30-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/vnzx8knykch58gyknyazq1x30mc9rlsy-review-shell.drv' failed to build

Link to currently reviewing PR:
https://github.com/NixOS/nixpkgs/pull/195236

2 packages marked as broken and skipped:
libsForQt512.discover libsForQt514.discover

2 packages blacklisted:
nixos-install-tools tests.nixos-functions.nixos-test

1 package failed to build:
hydra_unstable

101 packages built:
appvm bundix busybox-sandbox-shell cabal2nix cached-nix-shell cachix colmena comma common-updater-scripts crate2nix crystal2nix dep2nix dydisnix fusionInventory getoptions gnome.gnome-packagekit gnome.gnome-software simple-scan go2nix haskellPackages.cabal2nix-unstable haskellPackages.cachix haskellPackages.hercules-ci-agent haskellPackages.hercules-ci-cli haskellPackages.hercules-ci-cnix-expr haskellPackages.hercules-ci-cnix-store haskellPackages.nix-paths haskellPackages.nix-serve-ng haskellPackages.nvfetcher haskellPackages.update-nix-fetchgit hci hercules-ci-agent home-manager libnixxml libsForQt5.discover libsForQt5.packagekit-qt libsForQt512.packagekit-qt libsForQt514.packagekit-qt libsForQt5_openssl_1_1.discover libsForQt5_openssl_1_1.packagekit-qt lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info musl nil nix nix-bundle nix-direnv nix-doc nix-du nix-eval-jobs nix-index nix-pin nix-plugins nix-prefetch nix-prefetch-bzr nix-prefetch-cvs nix-prefetch-docker nix-prefetch-git nix-prefetch-hg nix-prefetch-scripts nix-prefetch-svn nix-serve nix-simple-deploy nix-template nix-update nix-update-source nixStatic nixVersions.nix_2_10 nixVersions.nix_2_3 nixVersions.nix_2_7 nixVersions.nix_2_8 nixVersions.nix_2_9 nixos-generators nixos-option nixos-rebuild nixos-shell nixpkgs-review node2nix npins nuget-to-nix nvfetcher packagekit pantheon.appcenter pantheon.elementary-onboarding pkgsMusl.stdenv pkgsStatic.stdenv prefetch-yarn-deps python310Packages.nix-kernel python310Packages.nixpkgs python310Packages.pythonix python39Packages.nix-kernel python39Packages.nixpkgs python39Packages.pythonix rnix-lsp system-config-printer terranix tests.haskell.cabalSdist.hercules-ci-cnix-store tests.testers.nixosTest-example update-nix-fetchgit vulnix wp4nix yarn2nix
```