### PR TITLE
weechat: 3.6 -> 3.7 and other stuff

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -28,14 +28,14 @@ let
   in
     assert lib.all (p: p.enabled -> ! (builtins.elem null p.buildInputs)) plugins;
     stdenv.mkDerivation rec {
-      version = "3.6";
+      version = "3.7";
       pname = "weechat";
 
       hardeningEnable = [ "pie" ];
 
       src = fetchurl {
         url = "https://weechat.org/files/src/weechat-${version}.tar.bz2";
-        sha256 = "sha256-GkYN/Y4LQQr7GdSDu0ucXXM9wWPAqKD1txJXkOhJMDc=";
+        hash = "sha256-n5kvC//h85c4IvkrCVTz+F0DcCC5rdRkvj8W3fUPXI8=";
       };
 
       outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -1,20 +1,25 @@
 { stdenv, fetchurl, lib
 , ncurses, openssl, aspell, gnutls, gettext
 , zlib, curl, pkg-config, libgcrypt
-, cmake, makeWrapper, libobjc, libresolv, libiconv
+, cmake, libobjc, libresolv, libiconv
 , asciidoctor # manpages
+, enableTests ? !stdenv.isDarwin, cpputest
 , guileSupport ? true, guile
 , luaSupport ? true, lua5
 , perlSupport ? true, perl
 , pythonSupport ? true, python3Packages
 , rubySupport ? true, ruby
 , tclSupport ? true, tcl
+, phpSupport ? !stdenv.isDarwin, php, systemd, libxml2, pcre2, libargon2
 , extraBuildInputs ? []
-, fetchpatch
 }:
 
 let
   inherit (python3Packages) python;
+  php-embed = php.override {
+    embedSupport = true;
+    apxs2Support = false;
+  };
   plugins = [
     { name = "perl"; enabled = perlSupport; cmakeFlag = "ENABLE_PERL"; buildInputs = [ perl ]; }
     { name = "tcl"; enabled = tclSupport; cmakeFlag = "ENABLE_TCL"; buildInputs = [ tcl ]; }
@@ -22,6 +27,9 @@ let
     { name = "guile"; enabled = guileSupport; cmakeFlag = "ENABLE_GUILE"; buildInputs = [ guile ]; }
     { name = "lua"; enabled = luaSupport; cmakeFlag = "ENABLE_LUA"; buildInputs = [ lua5 ]; }
     { name = "python"; enabled = pythonSupport; cmakeFlag = "ENABLE_PYTHON3"; buildInputs = [ python ]; }
+    { name = "php"; enabled = phpSupport; cmakeFlag = "ENABLE_PHP"; buildInputs = [
+      php-embed.unwrapped.dev libxml2 pcre2 libargon2
+    ] ++ lib.optional stdenv.isLinux systemd; }
   ];
   enabledPlugins = builtins.filter (p: p.enabled) plugins;
 
@@ -42,15 +50,14 @@ let
 
       cmakeFlags = with lib; [
         "-DENABLE_MAN=ON"
-        "-DENABLE_DOC=OFF"         # TODO: Documentation fails to build, was deactivated to push through security update
-        "-DENABLE_JAVASCRIPT=OFF"  # Requires v8 <= 3.24.3, https://github.com/weechat/weechat/issues/360
-        "-DENABLE_PHP=OFF"
+        "-DENABLE_DOC=OFF"         # TODO(@ncfavier): Documentation fails to build, was deactivated to push through security update
+        "-DENABLE_TESTS=${if enableTests then "ON" else "OFF"}"
       ]
         ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib"]
         ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins
         ;
 
-      nativeBuildInputs = [ cmake pkg-config makeWrapper asciidoctor ];
+      nativeBuildInputs = [ cmake pkg-config asciidoctor ] ++ lib.optional enableTests cpputest;
       buildInputs = with lib; [
           ncurses openssl aspell gnutls gettext zlib curl
           libgcrypt ]
@@ -85,7 +92,7 @@ let
           on https://nixos.org/nixpkgs/manual/#sec-weechat .
         '';
         license = lib.licenses.gpl3;
-        maintainers = with lib.maintainers; [ lovek323 ];
+        maintainers = with lib.maintainers; [ ncfavier ];
         platforms = lib.platforms.unix;
       };
     }

--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -7,7 +7,11 @@ weechat:
 let
   wrapper = {
     installManPages ? true
-  , configure ? { availablePlugins, ... }: { plugins = builtins.attrValues availablePlugins; }
+  , configure ? { availablePlugins, ... }: {
+      # Do not include PHP by default, because it bloats the closure, doesn't
+      # build on Darwin, and there are no official PHP scripts.
+      plugins = builtins.attrValues (builtins.removeAttrs availablePlugins [ "php" ]);
+    }
   }:
 
   let
@@ -21,6 +25,7 @@ let
           '';
           withPackages = pkgsFun: (python // {
             extraEnv = ''
+              ${python.extraEnv}
               export PYTHONHOME="${python3Packages.python.withPackages pkgsFun}"
             '';
           });
@@ -40,6 +45,7 @@ let
         ruby = simplePlugin "ruby";
         guile = simplePlugin "guile";
         lua = simplePlugin "lua";
+        php = simplePlugin "php";
       };
 
     config = configure { inherit availablePlugins; };


### PR DESCRIPTION
https://github.com/weechat/weechat/releases/tag/v3.7

The update was also done in https://github.com/NixOS/nixpkgs/pull/195233 so feel free to merge that one first.

### Other changes unrelated to the update

Add PHP support, but do not include it in the wrapper by default, because
- it doesn't build on Darwin,
- it doubles the closure size,
- there are no official scripts written in PHP,
- it's probably broken: the [example PHP script](https://weechat.org/files/doc/stable/weechat_scripting.en.html#register_function) from the manual fails to load. If someone cares enough they can look into it.

Enable build-time tests.

Remove `-DENABLE_JAVASCRIPT=OFF`, which was made the default upstream [a long time ago](https://github.com/weechat/weechat/commit/340d6646a6371e2f224d392c9b1b44c8a20b5074).

Add myself as a maintainer since @lovek323 is now a [retired-nixpkgs-contributor](https://github.com/orgs/NixOS/teams/retired-nixpkgs-contributors).

I also have ideas on how to fix `ENABLE_DOC`, but that's for [another PR](https://github.com/NixOS/nixpkgs/pull/195245).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).