### PR TITLE
qv2ray: 2.7.0 -> unstable-2022-09-25

### DIFF
--- a/pkgs/applications/networking/qv2ray/default.nix
+++ b/pkgs/applications/networking/qv2ray/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , mkDerivation
 , fetchFromGitHub
-, qmake
+, symlinkJoin
 , qttools
 , cmake
 , clang_8
@@ -15,29 +15,40 @@
 , libGL
 , zlib
 , curl
+, v2ray
+, v2ray-geoip, v2ray-domain-list-community
+, assets ? [ v2ray-geoip v2ray-domain-list-community ]
 }:
 
 mkDerivation rec {
   pname = "qv2ray";
-  version = "2.7.0";
+  version = "unstable-2022-09-25";
 
   src = fetchFromGitHub {
     owner = "Qv2ray";
     repo = "Qv2ray";
-    rev = "v${version}";
-    sha256 = "sha256-afFTGX/zrnwq/p5p1kj+ANU4WeN7jNq3ieeW+c+GO5M=";
+    rev = "fb44fb1421941ab192229ff133bc28feeb4a8ce5";
+    sha256 = "sha256-TngDgLXKyAoQFnXpBNaz4QjfkVwfZyuQwatdhEiI57U=";
     fetchSubmodules = true;
   };
 
-  patchPhase = lib.optionals stdenv.isDarwin ''
+  postPatch = lib.optionals stdenv.isDarwin ''
     substituteInPlace cmake/platforms/macos.cmake \
       --replace \''${QV2RAY_QtX_DIR}/../../../bin/macdeployqt macdeployqt
   '';
 
+  assetsDrv = symlinkJoin {
+    name = "v2ray-assets";
+    paths = assets;
+  };
+
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DQV2RAY_DISABLE_AUTO_UPDATE=on"
+    "-DQV2RAY_USE_V5_CORE=on"
     "-DQV2RAY_TRANSLATION_PATH=${placeholder "out"}/share/qv2ray/lang"
+    "-DQV2RAY_DEFAULT_VASSETS_PATH='${assetsDrv}/share/v2ray'"
+    "-DQV2RAY_DEFAULT_VCORE_PATH='${v2ray}/bin/v2ray'"
   ];
 
   preConfigure = ''
@@ -57,21 +68,17 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-
-    # The default clang_7 will result in reproducible ICE.
-    clang_8
-
     pkg-config
-    qmake
     qttools
     curl
-  ];
+    # The default clang_7 will result in reproducible ICE.
+  ] ++ lib.optional (stdenv.isDarwin) clang_8;
 
   meta = with lib; {
     description = "An GUI frontend to v2ray";
-    homepage = "https://qv2ray.github.io/en/";
+    homepage = "https://qv2ray.net";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ poscat ];
+    maintainers = with maintainers; [ poscat rewine ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

1. v2ray has been upgraded to v5 https://github.com/NixOS/nixpkgs/pull/192196, we need unstable version to get support for QV2RAY_USE_V5_CORE
2. set correct path to v2ray, not just /usr/bin/v2ray


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
