### PR TITLE
python310Packages.rst2pdf: init at 0.99

### DIFF
--- a/pkgs/development/python-modules/rst2pdf/default.nix
+++ b/pkgs/development/python-modules/rst2pdf/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, docutils
+, importlib-metadata
+, jinja2
+, packaging
+, pygments
+, pyyaml
+, reportlab
+, smartypants
+, pillow
+, pytestCheckHook
+, pymupdf
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "rst2pdf";
+  version = "0.99";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8fa23fa93bddd1f52d058ceaeab6582c145546d80f2f8a95974f3703bd6c8152";
+  };
+
+  outputs = [ "out" "man" ];
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    docutils
+    importlib-metadata
+    jinja2
+    packaging
+    pygments
+    pyyaml
+    reportlab
+    smartypants
+    pillow
+  ];
+
+  pythonImportsCheck = [
+    "rst2pdf"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pymupdf
+    sphinx
+  ];
+
+  # Test suite fails: https://github.com/rst2pdf/rst2pdf/issues/1067
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $man/share/man/man1/
+    ${docutils}/bin/rst2man.py doc/rst2pdf.rst $man/share/man/man1/rst2pdf.1
+  '';
+
+  meta = with lib; {
+    description = "Convert reStructured Text to PDF via ReportLab";
+    homepage = "https://rst2pdf.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ marsam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9900,6 +9900,8 @@ in {
 
   rst2ansi = callPackage ../development/python-modules/rst2ansi { };
 
+  rst2pdf = callPackage ../development/python-modules/rst2pdf { };
+
   rstcheck = callPackage ../development/python-modules/rstcheck { };
 
   rstcheck-core = callPackage ../development/python-modules/rstcheck-core { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add https://rst2pdf.org/

Closes https://github.com/NixOS/nixpkgs/issues/193241.   cc: @opdavies

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
