### PR TITLE
update-python-libraries: fix namespaced fetchers

### DIFF
--- a/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
+++ b/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
@@ -249,15 +249,16 @@ FORMATS = {
 
 def _determine_fetcher(text):
     # Count occurences of fetchers.
-    nfetchers = sum(text.count('src = {}'.format(fetcher)) for fetcher in FETCHERS.keys())
+    matches = {fetcher: len(re.findall(f'src = (.*\.)?{fetcher}', text)) for fetcher in FETCHERS.keys()}
+    nfetchers = sum(matches.values())
     if nfetchers == 0:
         raise ValueError("no fetcher.")
     elif nfetchers > 1:
         raise ValueError("multiple fetchers.")
     else:
         # Then we check which fetcher to use.
-        for fetcher in FETCHERS.keys():
-            if 'src = {}'.format(fetcher) in text:
+        for fetcher, count in matches.items():
+            if count > 0:
                 return fetcher
 
 


### PR DESCRIPTION
Some package expressions look like this:

	python3Packages.buildPythonApplication rec {
	  pname = "patatt";
	  version = "0.6.2";

	  src = python3Packages.fetchPypi {

These expressions, where fetchPypi is not a top-level binding, would end up with an updateScript provided by buildPythonApplication that would always fail, because update-python-libraries couldn't handle the "python3Packages." prefix to the fetcher.  And because the updateScript failed, nixpkgs-update wouldn't fall back to its default update logic, so r-ryantm would never update these packages.

Here I've fixed that with a regular expression.  It would be nicer if we could just instantiate the expression and look at the URL rather than trying to parse the expression, but I don't have the capacity to look into a big change like that at the moment.

I've tested with both `fetchPypi` and `python3Packages.fetchPypi`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
