### PR TITLE
treewide: switch to wrapGAppsHook4

### DIFF
--- a/pkgs/applications/audio/blanket/default.nix
+++ b/pkgs/applications/audio/blanket/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook
+, wrapGAppsHook4
 , desktop-file-utils
 , appstream-glib
 , python3Packages
@@ -30,9 +30,8 @@ python3Packages.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
     desktop-file-utils
-    appstream-glib
   ];
 
   buildInputs = [
@@ -57,6 +56,8 @@ python3Packages.buildPythonApplication rec {
 
   postPatch = ''
     patchShebangs build-aux/meson/postinstall.py
+    substituteInPlace build-aux/meson/postinstall.py \
+      --replace gtk-update-icon-cache gtk4-update-icon-cache
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/spot/default.nix
+++ b/pkgs/applications/audio/spot/default.nix
@@ -16,7 +16,7 @@
 , openssl
 , alsa-lib
 , libpulseaudio
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     rustPlatform.rust.cargo
     rustPlatform.cargoSetupHook
     rustPlatform.rust.rustc
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -67,6 +67,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     chmod +x build-aux/cargo.sh
     patchShebangs build-aux/cargo.sh build-aux/meson/postinstall.py
+    substituteInPlace build-aux/meson/postinstall.py \
+      --replace gtk-update-icon-cache gtk4-update-icon-cache
   '';
 
   passthru = {

--- a/pkgs/applications/graphics/image-roll/default.nix
+++ b/pkgs/applications/graphics/image-roll/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , glib
 , pkg-config
-, wrapGAppsHook
+, wrapGAppsHook4
 , gtk4
 }:
 
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-cUE2IZOunR/NIo/qytORRfNqCsf87LfpKA8o/v4Nkhk=";
 
-  nativeBuildInputs = [ glib pkg-config wrapGAppsHook ];
+  nativeBuildInputs = [ glib pkg-config wrapGAppsHook4 ];
 
   buildInputs = [ gtk4 ];
 
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=file_list::tests"
 
     # sometimes fails on darwin
-    "image_list::tests::save_current_image_overwrites_image_at_current_image_path_when_filename_is_set_to_none"
+    "--skip=image_list::tests::save_current_image_overwrites_image_at_current_image_path_when_filename_is_set_to_none"
   ];
 
   postInstall = ''

--- a/pkgs/applications/video/showmethekey/default.nix
+++ b/pkgs/applications/video/showmethekey/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , glib
 , meson
 , ninja
@@ -10,10 +11,11 @@
 , pango
 , libinput
 , gtk4
-, wrapGAppsHook
+, wrapGAppsHook4
 , libxkbcommon
 , pkg-config
 }:
+
 stdenv.mkDerivation rec {
   pname = "showmethekey";
   version = "1.7.3";
@@ -24,6 +26,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-hq4X4dG25YauMjsNXC6Flco9pEpVj3EM2JiFWbRrPaA=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "use-gtk4-update-icon-cache.patch";
+      url = "https://github.com/alynxzhou/showmethekey/commit/c73102dc2825d00cbaf323fcfc96736381dc67ae.patch";
+      sha256 = "sha256-6QDY5eQ9A8q3LZeD7v6WI/4vYXc/XXVY/WENA1nvIKo=";
+    })
+  ];
 
   nativeBuildInputs = [
     glib
@@ -36,7 +46,7 @@ stdenv.mkDerivation rec {
     libevdev
     libinput
     libxkbcommon
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/applications/virtualization/pods/default.nix
+++ b/pkgs/applications/virtualization/pods/default.nix
@@ -8,7 +8,7 @@
 , ninja
 , pkg-config
 , rustPlatform
-, wrapGAppsHook
+, wrapGAppsHook4
 , gtksourceview5
 , libadwaita
 }:
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     rustPlatform.cargoSetupHook
     rustPlatform.rust.cargo
     rustPlatform.rust.rustc
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/tools/misc/czkawka/default.nix
+++ b/pkgs/tools/misc/czkawka/default.nix
@@ -8,7 +8,7 @@
 , gdk-pixbuf
 , atk
 , gtk4
-, wrapGAppsHook
+, wrapGAppsHook4
 , gobject-introspection
 , xvfb-run
 , testers
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
     gobject-introspection
   ];
 

--- a/pkgs/tools/networking/iwgtk/default.nix
+++ b/pkgs/tools/networking/iwgtk/default.nix
@@ -5,7 +5,7 @@
 , ninja
 , pkg-config
 , scdoc
-, wrapGAppsHook
+, wrapGAppsHook4
 , gtk4
 , qrencode
 }:
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   # patch systemd service to pass necessary environments and use absolute paths
   patches = [ ./systemd-service.patch ];
 
-  nativeBuildInputs = [ meson ninja pkg-config scdoc wrapGAppsHook ];
+  nativeBuildInputs = [ meson ninja pkg-config scdoc wrapGAppsHook4 ];
 
   buildInputs = [ gtk4 qrencode ];
 


### PR DESCRIPTION
###### Description of changes

switches some gtk4 applications to use `wrapGAppsHook4` instead of `wrapGAppsHook`, which has a dependency on `gtk3` 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
