### PR TITLE
utm: init at 3.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11681,6 +11681,15 @@
     githubId = 373566;
     name = "Ronuk Raval";
   };
+  rrbutani = {
+    email = "rrbutani+nix@gmail.com";
+    github = "rrbutani";
+    githubId = 7833358;
+    keys = [{
+      fingerprint = "7DCA 5615 8AB2 621F 2F32  9FF4 1C7C E491 479F A273";
+    }];
+    name = "Rahul Butani";
+  };
   rski = {
     name = "rski";
     email = "rom.skiad+nix@gmail.com";

--- a/pkgs/os-specific/darwin/utm/default.nix
+++ b/pkgs/os-specific/darwin/utm/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, undmg
+, fetchurl
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "utm";
+  version = "3.2.4";
+
+  src = fetchurl {
+    url = "https://github.com/utmapp/UTM/releases/download/v${version}/UTM.dmg";
+    sha256 = "sha256-ejUfL6UHqMusVfaglGlODKtFfKbNwzZ1LmRkcSzieso=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+  '';
+
+  meta = with lib; {
+    description = "Full featured system emulator and virtual machine host for iOS and macOS";
+    longDescription = ''
+      UTM is a full featured system emulator and virtual machine host for iOS
+      and macOS. It is based off of QEMU. In short, it allows you to run
+      Windows, Linux, and more on your Mac, iPhone, and iPad.
+
+      Features:
+        - Full system emulation (MMU, devices, etc) using QEMU
+        - 30+ processors supported including x86_64, ARM64, and RISC-V
+        - VGA graphics mode using SPICE and QXL
+        - Text terminal mode
+        - USB devices
+        - JIT based acceleration using QEMU TCG
+        - Frontend designed from scratch for macOS 11 and iOS 11+ using the
+          latest and greatest APIs
+        - Create, manage, run VMs directly from your device
+        - Hardware accelerated virtualization using Hypervisor.framework and
+          QEMU
+        - Boot macOS guests with Virtualization.framework on macOS 12+
+    '';
+    homepage = "https://mac.getutm.app/";
+    changelog = "https://github.com/utmapp/${pname}/releases/tag/v${version}";
+    mainProgram = "UTM";
+    license = licenses.apsl20;
+    platforms = platforms.darwin;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ rrbutani ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32053,6 +32053,8 @@ with pkgs;
 
   uwimap = callPackage ../tools/networking/uwimap { };
 
+  utm = callPackage ../os-specific/darwin/utm { };
+
   utox = callPackage ../applications/networking/instant-messengers/utox { };
 
   valentina = libsForQt5.callPackage ../applications/misc/valentina { };


### PR DESCRIPTION
###### Description of changes

Adds [`UTM`](https://github.com/utmapp/UTM): a GUI application for managing virtual machines on macOS.

---

 I starting trying to build UTM [from source](https://github.com/utmapp/UTM/blob/main/Documentation/MacDevelopment.md) but ended up just packaging their [binary releases](https://github.com/utmapp/UTM/releases) instead. I think it's not _impossible_ to build UTM from source within the sandbox but I think it'll end up taking a fair amount of effort.

 We would need to:
   - essentially recreate most of [`build_dependencies.sh`](https://github.com/utmapp/UTM/blob/main/scripts/build_dependencies.sh) in the package
      + most of the deps are already in `nixpkgs`
      + we'd still want to use UTM's QEMU instead of the one in `nixpkgs`
      + we'd want separate derivations for the deps that we do build (at a glance this looks like: qemu, spice, angle, epoxy, virglrenderer plus some tools like depot/gclient) and then assertions in the main UTM derivation that check that the versions we built match what's [supposed to be in the UTM release](https://github.com/utmapp/UTM/blob/977c2cc9b59eedbf4d82df7bfd2ea6efc85cf369/patches/sources)
   - figure out [what to do for entitlements](https://github.com/utmapp/UTM/blob/main/Documentation/MacDevelopment.md#signed-packages)
      + despite what the UTM docs say, I think it's possible to get by with ad-hoc signing; I think this is essentially the same issue as was already solved for QEMU in nixpkgs (https://github.com/NixOS/nixpkgs/pull/139960)
   - get UTM to build with xcbuild instead of real xcodebuild
      + this is the real blocker; xcbuild doesn't seem to have real swift support and it falls over immediately on the [subcommands used in UTM's build script](https://github.com/utmapp/UTM/blob/977c2cc9b59eedbf4d82df7bfd2ea6efc85cf369/scripts/build_utm.sh#L88)

 So for now I just have this package pull the DMG from the UTM GitHub releases. FWIW, this is what [homebrew seems to do](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/utm.rb) as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
