### PR TITLE
rofi-ttv: init at 20210113

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13867,6 +13867,13 @@
     github = "twitchyliquid64";
     githubId = 6328589;
   };
+  tylerjl = {
+    email = "tyler+nixpkgs@langlois.to";
+    github = "tylerjl";
+    githubId = 1733846;
+    matrix = "@ty:tjll.net";
+    name = "Tyler Langlois";
+  };
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";

--- a/pkgs/applications/misc/rofi-ttv/default.nix
+++ b/pkgs/applications/misc/rofi-ttv/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+
+, curl
+, jq
+, mpv
+, rofi-unwrapped
+, youtube-dl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rofi-ttv";
+  version = "20210113";
+
+  src = fetchFromGitHub {
+    owner = "loiccoyle";
+    repo = pname;
+    rev = "e9c722481b740196165f840771b3ae58b7291694";
+    sha256 = "sha256-1cvjxulpfOIwipLBa9me4YGLVxSXOAsrFvFq/Q5y0tQ=";
+  };
+
+  dontBuild = true;
+  nativeBuildInputs = [ makeWrapper ];
+  installPhase = ''
+    install -vd $out/bin
+    install -vm 755 rofi-ttv $out/bin
+  '';
+  wrapperPath = with lib; makeBinPath [
+    curl jq mpv rofi-unwrapped youtube-dl
+  ];
+  fixupPhase = ''
+    patchShebangs $out/bin
+    wrapProgram $out/bin/rofi-ttv --prefix PATH : "${wrapperPath}"
+  '';
+
+  meta = with lib ; {
+    description = "Dynamic menu interface for Twitch";
+    homepage = "https://github.com/loiccoyle/rofi-ttv";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tylerjl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30055,6 +30055,8 @@ with pkgs;
 
   rofi-top = callPackage ../applications/misc/rofi-top { };
 
+  rofi-ttv = callPackage ../applications/misc/rofi-ttv { };
+
   rofi-vpn = callPackage ../applications/networking/rofi-vpn { };
 
   ympd = callPackage ../applications/audio/ympd { };


### PR DESCRIPTION
###### Description of changes

This is a very small [rofi utility for browsing twitch.tv](https://github.com/loiccoyle/rofi-ttv). I tried to mimic the other rofi applets in the panopticon of nixpkgs - it's just a script, so there's no build phase and is pretty simple.

Note that I have another PR pending in #194169 so I cherry-picked the `maintainers.nix` commit here since that PR is still waiting.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
- ~Tested, as applicable:~
  - ~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
  - ~and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)~
  - ~or, for functions and "core" functionality, tests in [lib/tests]~(https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - ~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~
- ~[ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~[22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)~
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
  - ~[ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
