### PR TITLE
dico: enable dicod wordnet module

### DIFF
--- a/pkgs/servers/dico/default.nix
+++ b/pkgs/servers/dico/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, lib, stdenv, libtool, gettext, zlib, readline, gsasl
-, guile, python3, pcre, libffi, groff }:
+, guile, python3, pcre, libffi, groff, wordnet }:
 
 stdenv.mkDerivation rec {
   pname = "dico";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ groff ];
 
   buildInputs =
-    [ libtool gettext zlib readline gsasl guile python3 pcre libffi ];
+    [ libtool gettext zlib readline gsasl guile python3 pcre libffi wordnet ];
 
   strictDeps = true;
 


### PR DESCRIPTION
###### Description of changes

Build dico with WordNet support, allowing its server to access the WN database directly through libWN.

Pulling in the new build input enables dicod's [native support for WordNet](https://www.gnu.org.ua/software/dico/manual/html_section/wordnet.html) and allows the database to be turned on with a config like the below.

```conf
load-module wordnet {
  command "wordnet";
}
database {
  name "wordnet";
  handler "wordnet merge-defs";
  languages-from "en";
  languages-to "en";
}
```

I'm using this via override in my own setup and would like to depend on it for an in-progress dicod nixos module. Let me know if it's a bad idea for some reason.

Verifying the build change directly:
```
$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/ian/.cache/nixpkgs-review/rev-8054a2933de896a40d9a466005fa718a65d96e68/build.nix
1 package built:
dico

$ nix-shell /home/ian/.cache/nixpkgs-review/rev-8054a2933de896a40d9a466005fa718a65d96e68/shell.nix

.cache/nixpkgs-review/rev-8054a2933de896a40d9a466005fa718a65d96e68 via ❄️  impure (review-shell)
$ grep WordNet logs/dico.log
WordNet ......................... yes
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
