### PR TITLE
beeref: init at 0.2.0, python3Packages.rectangle-packer: init at 2.0.1

### DIFF
--- a/pkgs/applications/graphics/beeref/default.nix
+++ b/pkgs/applications/graphics/beeref/default.nix
@@ -1,0 +1,47 @@
+{ python39Packages
+, fetchFromGitHub
+, lib
+}:
+
+# Doesn't work with python 3.10 due to behavior change of extension interface.
+# https://github.com/rbreu/beeref/issues/54
+with python39Packages;
+buildPythonApplication rec {
+  pname = "beeref";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "rbreu";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-zlb+ukPMoahwQTCWq2sq5dQveqLQLtn3pKuq+0AIqho=";
+  };
+
+  prePatch = ''
+    # Relax install dependency requirements
+    substituteInPlace setup.py \
+      --replace "pyQt6>=6.1,<=6.1.1" "pyQt6" \
+      --replace "pyQt6-Qt6>=6.1,<=6.1.1" ""
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [ httpretty pytest ];
+
+  propagatedBuildInputs = [
+    setuptools
+    pyqt6
+    exif
+    rectangle-packer
+  ];
+
+  meta = with lib; {
+    homepage = "https://beeref.org/";
+    description = "A Simple Reference Image Viewer";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sifmelcara ];
+  };
+}

--- a/pkgs/development/python-modules/rectangle-packer/default.nix
+++ b/pkgs/development/python-modules/rectangle-packer/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cython
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "rectangle-packer";
+  version = "2.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-3Y5wGE0q+KGV1WjgwsPMGX8MlMKkd0dUEeXql4xnsn0=";
+  };
+
+  propagatedBuildInputs = [
+    cython
+  ];
+
+  # TODO: The test doesn't work out of the box.
+  doCheck = false;
+
+  pythonImportsCheck = [ "rpack" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/orkohunter/keep";
+    description = "Rectangle packing program";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sifmelcara ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4980,6 +4980,8 @@ with pkgs;
   beetsPackages = lib.recurseIntoAttrs (callPackage ../tools/audio/beets { });
   inherit (beetsPackages) beets beets-unstable;
 
+  beeref = qt6Packages.callPackage ../applications/graphics/beeref { };
+
   bento4 = callPackage ../tools/video/bento4 { };
 
   bepasty = callPackage ../tools/misc/bepasty { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9632,6 +9632,8 @@ in {
 
   recordlinkage = callPackage ../development/python-modules/recordlinkage { };
 
+  rectangle-packer = callPackage ../development/python-modules/rectangle-packer { };
+
   redbaron = callPackage ../development/python-modules/redbaron { };
 
   redis = callPackage ../development/python-modules/redis { };


### PR DESCRIPTION
###### Description of changes

Fixes #148122

Unfortunately upstream development is inactive and it does not work with python 3.10

Not sure if there would be enough interest to merge this into nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
