### PR TITLE
libcpuid: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/tools/misc/libcpuid/default.nix
+++ b/pkgs/tools/misc/libcpuid/default.nix
@@ -1,26 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "libcpuid";
-  version = "0.5.1";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "anrieff";
     repo = "libcpuid";
     rev = "v${version}";
-    sha256 = "sha256-m10LdtwBk1Lx31AJ4HixEYaCkT7EHpF9+tOV1rSA6VU=";
+    sha256 = "sha256-XX+XFd1ehahIUGONAx2iOxetU0s6vONc7m91zEOWz5o=";
   };
-
-  patches = [
-    # Work around https://github.com/anrieff/libcpuid/pull/102.
-    ./stdint.patch
-    # Fixes cross-compilation to NetBSD, remove me for libcpuid > 0.5.1
-    (fetchpatch {
-      name = "use-popcount-from-libc.patch";
-      url = "https://github.com/anrieff/libcpuid/commit/1acaf9980b55ae180cc08db218b9face28202519.patch";
-      sha256 = "0lvsv9baq0sria1f1ncn1b2783js29lfs5fv8milp54pg1wd5b7q";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/tools/misc/libcpuid/stdint.patch
+++ b/pkgs/tools/misc/libcpuid/stdint.patch
@@ -1,5 +1,0 @@
---- a/libcpuid/libcpuid.h
-+++ b/libcpuid/libcpuid.h
-@@ -88 +88 @@
--#include "libcpuid_types.h"
-+#include <stdint.h>


### PR DESCRIPTION
###### Description of changes

Update and drop unnecessary patches. (update required to bump cpu-x https://github.com/NixOS/nixpkgs/pull/195305)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
