### PR TITLE
lnd: 0.15.1-beta -> 0.15.2-beta

### DIFF
--- a/pkgs/applications/blockchains/lnd/default.nix
+++ b/pkgs/applications/blockchains/lnd/default.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "lnd";
-  version = "0.15.1-beta";
+  version = "0.15.2-beta";
 
   src = fetchFromGitHub {
     owner = "lightningnetwork";
     repo = "lnd";
     rev = "v${version}";
-    sha256 = "sha256-E1RxFy7eRCTnzTg2B0llRt+r41K6V4VQH7Edh1As4cY=";
+    sha256 = "sha256-C7BZ6awY2v5Uvvh12YEosoEQyJoetWzH/1wIQSVjtEk=";
   };
 
-  vendorSha256 = "sha256-e72HIsS1fftJEOvjr1RQMo3+gjlBxXPHq2olGWfurJk=";
+  vendorSha256 = "sha256-rCdcPkgrFcDfLfF8wipFws7YTKEgotuVqVIJYLMOxbs=";
 
   subPackages = [ "cmd/lncli" "cmd/lnd" ];
 


### PR DESCRIPTION
###### Description of changes
Update LND to v0.15.2-beta due to a bug which is causing nodes to be unable to parse certain large blocks.

More info:
- https://github.com/lightningnetwork/lnd/releases/tag/v0.15.2-beta
- https://github.com/lightningnetwork/lnd/issues/7002
- https://twitter.com/brqgoo/status/1579216353780957185?s=20&t=uK08N1jtlLzRzlAHIGzaXw

@prusnak Could you please review? Thanks a lot!