### PR TITLE
patchRcPath hooks: init and apply to package `root`

### DIFF
--- a/doc/hooks/index.xml
+++ b/doc/hooks/index.xml
@@ -22,6 +22,7 @@
  <xi:include href="./libxml2.section.xml" />
  <xi:include href="./meson.section.xml" />
  <xi:include href="./ninja.section.xml" />
+ <xi:include href="./patch-rc-path-hooks.section.xml" />
  <xi:include href="./perl.section.xml" />
  <xi:include href="./pkg-config.section.xml" />
  <xi:include href="./postgresql-test-hook.section.xml" />

--- a/doc/hooks/patch-rc-path-hooks.section.md
+++ b/doc/hooks/patch-rc-path-hooks.section.md
@@ -1,0 +1,50 @@
+
+# `patchRcPath` hooks {#sec-patchRcPathHooks}
+
+These hooks provide shell-specific utilities (with the same name as the hook) to patch shell scripts meant to be sourced by software users.
+
+The typical usage is to patch initialisation or [rc](https://unix.stackexchange.com/questions/3467/what-does-rc-in-bashrc-stand-for) scripts inside `$out/bin` or `$out/etc`.
+Such scripts, when being sourced, would insert the binary locations of certain commands into `PATH`, modify other environment variables or run a series of start-up commands.
+When shipped from the upstream, they sometimes use commands that might not be available in the environment they are getting sourced in.
+
+The compatible shells for each hook are:
+
+ - `patchRcPathBash`: [Bash](https://www.gnu.org/software/bash/), [ksh](http://www.kornshell.org/), [zsh](https://www.zsh.org/) and other shells supporting the Bash-like parameter expansions.
+ - `patchRcPathCsh`: Csh scripts, such as those targeting [tcsh](https://www.tcsh.org/).
+ - `patchRcPathFish`: [Fish](https://fishshell.com/) scripts.
+ - `patchRcPathPosix`: POSIX-conformant shells supporting the limited parameter expansions specified by the POSIX standard. Current implementation uses the parameter expansion `${foo-}` only.
+
+For each supported shell, it modifies the script with a `PATH` prefix that is later removed when the script ends.
+It allows nested patching, which guarantees that a patched script may source another patched script.
+
+Syntax to apply the utility to a script:
+
+```sh
+patchRcPath<shell> <file> <PATH-prefix>
+```
+
+Example usage:
+
+Given a package `foo` containing an init script `this-foo.fish` that depends on `coreutils`, `man` and `which`,
+patch the init script for users to source without having the above dependencies in their `PATH`:
+
+```nix
+{ lib, stdenv, patchRcPathFish}:
+stdenv.mkDerivation {
+
+  # ...
+
+  nativeBuildInputs = [
+    patchRcPathFish
+  ];
+
+  postFixup = ''
+    patchRcPathFish $out/bin/this-foo.fish ${lib.makeBinPath [ coreutils man which ]}
+  '';
+}
+```
+
+::: {.note}
+`patchRcPathCsh` and `patchRcPathPosix` implementation depends on `sed` to do the string processing.
+The others are in vanilla shell and have no third-party dependencies.
+:::

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, callPackage
 , fetchFromGitHub
 , fetchpatch
 , makeWrapper
@@ -70,6 +71,10 @@ in
 stdenv.mkDerivation rec {
   pname = "root";
   version = "6.26.08";
+
+  passthru = {
+    tests = import ./tests { inherit callPackage; };
+  };
 
   src = fetchFromGitHub {
     owner = "root-project";

--- a/pkgs/applications/science/misc/root/tests/default.nix
+++ b/pkgs/applications/science/misc/root/tests/default.nix
@@ -1,0 +1,4 @@
+{ callPackage }:
+{
+  test-thisroot = callPackage ./test-thisroot.nix { };
+}

--- a/pkgs/applications/science/misc/root/tests/test-thisroot.nix
+++ b/pkgs/applications/science/misc/root/tests/test-thisroot.nix
@@ -1,0 +1,49 @@
+{ lib
+, runCommand
+, root
+, bash
+, fish
+, ksh
+, tcsh
+, zsh
+}: runCommand "test-thisroot"
+{
+  meta = with lib; {
+    description = "Test for root thisroot.* sourcing";
+    maintainers = unique ((with maintainers; [ ShamrockLee ]) ++ root.meta.maintainers);
+  };
+}
+  ''
+    set -eu -o pipefail
+    declare -a shellNameArray shellOutpathArray sourcefileNameArray sourceCommandArray
+    shellNameArray=( bash zsh tcsh fish )
+    shellOutpathArray=( "${bash}" "${zsh}" "${tcsh}" "${fish}")
+    sourcefileNameArray=( thisroot.sh thisroot.sh thisroot.csh thisroot.fish )
+    sourceCommandArray=( "source" "source" "source" "source" )
+    debugFlagstrArray=( "-e" "-e" "-e" "" )
+    nShellToTest="''${#shellNameArray[@]}"
+    if [[ "''${#shellOutpathArray[@]}" -ne "$nShellToTest" ]] \
+      || [[ "''${#sourcefileNameArray[@]}" -ne "$nShellToTest" ]] \
+      || [[ "''${#sourceCommandArray[@]}" -ne "$nShellToTest" ]] \
+      || [[ "''${#debugFlagstrArray[@]}" -ne "$nShellToTest" ]]
+    then
+      echo "error: Lengths of test parameter arrays doesn't match." >&2
+      exit 1
+    fi
+    typePExpect="${root}/bin/root"
+    for ((i=0; i<$nShellToTest; ++i)); do
+      tryCommand="''${sourceCommandArray[$i]} \"${root}/bin/''${sourcefileNameArray[$i]}\""
+      echo "Testing ''${shellNameArray[$i]} $tryCommand"
+      # Home directory for Fish
+      HOME_TEMP="$(mktemp -d temporary_home_XXXXXX)"
+      binPATHGot="$(PATH="''${shellOutpathArray[$i]}/bin" HOME=$HOME_TEMP "''${shellNameArray[$i]}" ''${debugFlagstrArray[$i]} -c "$tryCommand && echo \"\$PATH\"")"
+      rm -r "$HOME_TEMP"
+      typePGot="$(PATH="$binPATHGot" type -p root)"
+      if [[ "$typePGot" != "$typePExpect" ]]; then
+        echo "error: Got PATH \"$binPATHGot\", in which the root executable path is \"$typePGot\". Expect root executable path \"$typePExpect\"." >&2
+        exit 1
+      fi
+    done
+    echo "test-thisroot pass!"
+    touch "$out"
+  ''

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/default.nix
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, callPackage
+, makeSetupHook
+, gnused
+}:
+let
+  tests = import ./test { inherit callPackage; };
+in
+{
+  patchRcPathBash = (makeSetupHook
+    {
+      name = "patch-rc-path-bash";
+      meta = with lib; {
+        description = "Setup-hook to inject source-time PATH prefix to a Bash/Ksh/Zsh script";
+        maintainers = with maintainers; [ ShamrockLee ];
+      };
+    } ./patch-rc-path-bash.sh).overrideAttrs (oldAttrs: {
+    passthru.tests = {
+      inherit (tests) test-bash;
+    };
+  });
+  patchRcPathCsh = (makeSetupHook
+    {
+      name = "patch-rc-path-csh";
+      substitutions = {
+        sed = "${gnused}/bin/sed";
+      };
+      meta = with lib; {
+        description = "Setup-hook to inject source-time PATH prefix to a Csh script";
+        maintainers = with maintainers; [ ShamrockLee ];
+      };
+    } ./patch-rc-path-csh.sh).overrideAttrs (oldAttrs: {
+    passthru.tests = {
+      inherit (tests) test-csh;
+    };
+  });
+  patchRcPathFish = (makeSetupHook
+    {
+      name = "patch-rc-path-fish";
+      meta = with lib; {
+        description = "Setup-hook to inject source-time PATH prefix to a Fish script";
+        maintainers = with maintainers; [ ShamrockLee ];
+      };
+    } ./patch-rc-path-fish.sh).overrideAttrs (oldAttrs: {
+    passthru.tests = {
+      inherit (tests) test-fish;
+    };
+  });
+  patchRcPathPosix = (makeSetupHook
+    {
+      name = "patch-rc-path-posix";
+      substitutions = {
+        sed = "${gnused}/bin/sed";
+      };
+      meta = with lib; {
+        description = "Setup-hook to inject source-time PATH prefix to a POSIX shell script";
+        maintainers = with maintainers; [ ShamrockLee ];
+      };
+    } ./patch-rc-path-posix.sh).overrideAttrs (oldAttrs: {
+    passthru.tests = {
+      inherit (tests) test-posix;
+    };
+  });
+}

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/default.nix
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/default.nix
@@ -7,19 +7,18 @@ let
   tests = import ./test { inherit callPackage; };
 in
 {
-  patchRcPathBash = (makeSetupHook
+  patchRcPathBash = makeSetupHook
     {
       name = "patch-rc-path-bash";
       meta = with lib; {
         description = "Setup-hook to inject source-time PATH prefix to a Bash/Ksh/Zsh script";
         maintainers = with maintainers; [ ShamrockLee ];
       };
-    } ./patch-rc-path-bash.sh).overrideAttrs (oldAttrs: {
-    passthru.tests = {
-      inherit (tests) test-bash;
-    };
-  });
-  patchRcPathCsh = (makeSetupHook
+      passthru.tests = {
+        inherit (tests) test-bash;
+      };
+    } ./patch-rc-path-bash.sh;
+  patchRcPathCsh = makeSetupHook
     {
       name = "patch-rc-path-csh";
       substitutions = {
@@ -29,24 +28,22 @@ in
         description = "Setup-hook to inject source-time PATH prefix to a Csh script";
         maintainers = with maintainers; [ ShamrockLee ];
       };
-    } ./patch-rc-path-csh.sh).overrideAttrs (oldAttrs: {
-    passthru.tests = {
-      inherit (tests) test-csh;
-    };
-  });
-  patchRcPathFish = (makeSetupHook
+      passthru.tests = {
+        inherit (tests) test-csh;
+      };
+    } ./patch-rc-path-csh.sh;
+  patchRcPathFish = makeSetupHook
     {
       name = "patch-rc-path-fish";
       meta = with lib; {
         description = "Setup-hook to inject source-time PATH prefix to a Fish script";
         maintainers = with maintainers; [ ShamrockLee ];
       };
-    } ./patch-rc-path-fish.sh).overrideAttrs (oldAttrs: {
-    passthru.tests = {
-      inherit (tests) test-fish;
-    };
-  });
-  patchRcPathPosix = (makeSetupHook
+      passthru.tests = {
+        inherit (tests) test-fish;
+      };
+    } ./patch-rc-path-fish.sh;
+  patchRcPathPosix = makeSetupHook
     {
       name = "patch-rc-path-posix";
       substitutions = {
@@ -56,9 +53,8 @@ in
         description = "Setup-hook to inject source-time PATH prefix to a POSIX shell script";
         maintainers = with maintainers; [ ShamrockLee ];
       };
-    } ./patch-rc-path-posix.sh).overrideAttrs (oldAttrs: {
-    passthru.tests = {
-      inherit (tests) test-posix;
-    };
-  });
+      passthru.tests = {
+        inherit (tests) test-posix;
+      };
+    } ./patch-rc-path-posix.sh;
 }

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/patch-rc-path-bash.sh
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/patch-rc-path-bash.sh
@@ -1,0 +1,50 @@
+patchRcPathBash(){
+    local FILE_TO_PATCH="$1"
+    local SOURCETIME_PATH="$2"
+    local FILE_TO_WORK_ON="$(mktemp "$(basename "$FILE_TO_PATCH").XXXXXX.tmp")"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to add to PATH the source-time utilities for Nixpkgs packaging
+if [[ -n "\${NIXPKGS_SOURCETIME_PATH-}" ]]; then
+    NIXPKGS_SOURCETIME_PATH_OLD="\$NIXPKGS_SOURCETIME_PATH;\${NIXPKGS_SOURCETIME_PATH_OLD-}"
+fi
+NIXPKGS_SOURCETIME_PATH="$SOURCETIME_PATH"
+if [[ -n "\$PATH" ]]; then
+    PATH="\$NIXPKGS_SOURCETIME_PATH:\$PATH"
+else
+    PATH="\$NIXPKGS_SOURCETIME_PATH"
+fi
+export PATH
+# End of lines to add to PATH source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_PATCH" >> "$FILE_TO_WORK_ON"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+if [[ -n "\${PATH-}" ]]; then
+    # Remove the inserted section
+    PATH="\${PATH/\$NIXPKGS_SOURCETIME_PATH}"
+    # Remove the duplicated colons
+    PATH="\${PATH//::/:}"
+    # Remove the prefixing colon
+    if [[ -n "\$PATH" && "\${PATH:0:1}" == ":" ]]; then
+        PATH="\${PATH:1}"
+    fi
+    # Remove the trailing colon
+    if [[ -n "\$PATH" && "\${PATH:\${#PATH}-1}" == ":" ]]; then
+        PATH="\${PATH::}"
+    fi
+    export PATH
+fi
+if [[ -n "\${NIXPKGS_SOURCETIME_PATH_OLD-}" ]]; then
+    IFS="" read -r -d ";" NIXPKGS_SOURCETIME_PATH <<< "\$NIXPKGS_SOURCETIME_PATH_OLD"
+    NIXPKGS_SOURCETIME_PATH_OLD="\${NIXPKGS_SOURCETIME_PATH_OLD:\${#NIXPKGS_SOURCETIME_PATH}+1}"
+else
+    unset NIXPKGS_SOURCETIME_PATH
+fi
+if [[ -z "\${NIXPKGS_SOURCETIME_PATH_OLD-}" ]]; then
+    unset NIXPKGS_SOURCETIME_PATH_OLD
+fi
+# End of lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_WORK_ON" > "$FILE_TO_PATCH"
+    rm "$FILE_TO_WORK_ON"
+}

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/patch-rc-path-csh.sh
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/patch-rc-path-csh.sh
@@ -1,0 +1,57 @@
+patchRcPathCsh(){
+    local FILE_TO_PATCH="$1"
+    local SOURCETIME_PATH="$2"
+    local FILE_TO_WORK_ON="$(mktemp "$(basename "$FILE_TO_PATCH").XXXXXX.tmp")"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to add to PATH the source-time utilities for Nixpkgs packaging
+if (\$?NIXPKGS_SOURCETIME_PATH) then
+    if ("\$NIXPKGS_SOURCETIME_PATH" != "") then
+        if (\$?NIXPKGS_SOURCETIME_PATH_OLD) then
+            if ("\$NIXPKGS_SOURCETIME_PATH_OLD" != "")
+                set NIXPKGS_SOURCETIME_PATH_OLD = (\$NIXPKGS_SOURCETIME_PATH \$NIXPKGS_SOURCETIME_PATH_OLD)
+            else
+                set NIXPKGS_SOURCETIME_PATH_OLD = \$NIXPKGS_SOURCETIME_PATH
+            endif
+        else
+            set NIXPKGS_SOURCETIME_PATH_OLD = \$NIXPKGS_SOURCETIME_PATH
+        endif
+    endif
+endif
+set NIXPKGS_SOURCETIME_PATH = "$SOURCETIME_PATH"
+if (! \$?PATH) then
+    setenv PATH ""
+endif
+if ("\$PATH" != "") then
+    setenv PATH "\${NIXPKGS_SOURCETIME_PATH}:\$PATH"
+else
+    setenv PATH "\$NIXPKGS_SOURCETIME_PATH"
+endif
+# End of lines to add to PATH source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_PATCH" >> "$FILE_TO_WORK_ON"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+if (\$?PATH) then
+    if ("\$PATH" != "") then
+        # Remove the inserted section, the duplicated colons, and the leading and trailing colon
+        setenv PATH \`echo "\$PATH" | @sed@ "s#\${NIXPKGS_SOURCETIME_PATH}##" | @sed@ "s#::#:#g" | @sed@ "s#^:##" | @sed@ 's#:\$##'\`
+    endif
+endif
+if (\$?NIXPKGS_SOURCETIME_PATH_OLD) then
+    if ("\$NIXPKGS_SOURCETIME_PATH_OLD" != "") then
+        set NIXPKGS_SOURCETIME_PATH = \$NIXPKGS_SOURCETIME_PATH_OLD[1]
+        set NIXPKGS_SOURCETIME_PATH_OLD = \$NIXPKGS_SOURCETIME_PATH_OLD[2-]
+    else
+        unset NIXPKGS_SOURCETIME_PATH
+    endif
+    if (NIXPKGS_SOURCETIME_PATH_OLD == "") then
+        unset NIXPKGS_SOURCETIME_PATH_OLD
+    endif
+else
+    unset NIXPKGS_SOURCETIME_PATH
+endif
+# End of lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_WORK_ON" > "$FILE_TO_PATCH"
+    rm "$FILE_TO_WORK_ON"
+}

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/patch-rc-path-fish.sh
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/patch-rc-path-fish.sh
@@ -1,0 +1,50 @@
+patchRcPathFish(){
+    local FILE_TO_PATCH="$1"
+    local SOURCETIME_PATH="$2"
+    local FILE_TO_WORK_ON="$(mktemp "$(basename "$FILE_TO_PATCH").XXXXXX.tmp")"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to add to PATH the source-time utilities for Nixpkgs packaging
+if set -q NIXPKGS_SOURCETIME_PATH && test (count \$NIXPKGS_SOURCETIME_PATH) -gt 0
+    set --unpath NIXPKGS_SOURCETIME_PATH_OLD "\$NIXPKGS_SOURCETIME_PATH" \$NIXPKGS_SOURCETIME_PATH_OLD
+end
+set --path NIXPKGS_SOURCETIME_PATH $SOURCETIME_PATH
+set -g --path PATH \$NIXPKGS_SOURCETIME_PATH \$PATH
+# End of lines to add to PATH source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_PATCH" >> "$FILE_TO_WORK_ON"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+if set -q PATH && test "\$PATH" != "" && test (count \$PATH) -ge (count \$NIXPKGS_SOURCETIME_PATH)
+    # Remove the inserted section
+    for i in (seq 0 (math (count \$PATH) - (count \$NIXPKGS_SOURCETIME_PATH)))
+        for j in (seq 1 (count \$NIXPKGS_SOURCETIME_PATH))
+            if test \$PATH[(math \$i + \$j)] != \$NIXPKGS_SOURCETIME_PATH[\$j]
+                set i -1
+                break
+            end
+        end
+        if test \$i -eq -1
+            continue
+        end
+        if test \$i -eq 0
+            set -g --path PATH \$PATH[(math (count \$NIXPKGS_SOURCETIME_PATH) + 1)..]
+        else
+            set -g --path PATH \$PATH[..\$i] \$PATH[(math (count \$NIXPKGS_SOURCETIME_PATH) + 1 + \$i)..]
+        end
+        break
+    end
+end
+if set -q NIXPKGS_SOURCETIME_PATH_OLD && test (count \$NIXPKGS_SOURCETIME_PATH_OLD) -gt 0
+    set --path NIXPKGS_SOURCETIME_PATH \$NIXPKGS_SOURCETIME_PATH_OLD[1]
+    set --unpath NIXPKGS_SOURCETIME_PATH_OLD \$NIXPKGS_SOURCETIME_PATH_OLD[2..]
+else
+    set -e NIXPKGS_SOURCETIME_PATH
+end
+if set -q NIXPKGS_SOURCETIME_PATH_OLD && test (count \$NIXPKGS_SOURCETIME_PATH_OLD) -eq 0
+    set -e NIXPKGS_SOURCETIME_PATH_OLD
+end
+# End of lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_WORK_ON" > "$FILE_TO_PATCH"
+    rm "$FILE_TO_WORK_ON"
+}

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/patch-rc-path-posix.sh
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/patch-rc-path-posix.sh
@@ -1,0 +1,39 @@
+patchRcPathPosix(){
+    local FILE_TO_PATCH="$1"
+    local SOURCETIME_PATH="$2"
+    local FILE_TO_WORK_ON="$(mktemp "$(basename "$FILE_TO_PATCH").XXXXXX.tmp")"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to add to PATH the source-time utilities for Nixpkgs packaging
+if [ -n "\${NIXPKGS_SOURCETIME_PATH-}" ]; then
+    NIXPKGS_SOURCETIME_PATH_OLD="\$NIXPKGS_SOURCETIME_PATH;\${NIXPKGS_SOURCETIME_PATH_OLD-}"
+fi
+NIXPKGS_SOURCETIME_PATH="$SOURCETIME_PATH"
+if [ -n "\$PATH" ]; then
+    PATH="\$NIXPKGS_SOURCETIME_PATH:\$PATH";
+else
+    PATH="\$NIXPKGS_SOURCETIME_PATH"
+fi
+export PATH
+# End of lines to add to PATH source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_PATCH" >> "$FILE_TO_WORK_ON"
+    cat <<EOF >> "$FILE_TO_WORK_ON"
+# Lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+if [ -n "\${PATH-}" ]; then
+    PATH="\$(echo "\$PATH" | @sed@ "s#\$NIXPKGS_SOURCETIME_PATH##" | @sed@ "s#::#:#g" | @sed@ "s#^:##" | @sed@ "s#:\\\$##")"
+    export PATH
+fi
+if [ -n "\${NIXPKGS_SOURCETIME_PATH_OLD-}" ]; then
+    NIXPKGS_SOURCETIME_PATH="\$(echo "\$NIXPKGS_SOURCETIME_PATH_OLD" | @sed@ "s#\\([^;]\\);.*#\\1#")"
+    NIXPKGS_SOURCETIME_PATH_OLD="\$(echo "\$NIXPKGS_SOURCETIME_PATH_OLD" | @sed@ "s#[^;];\\(.*\\)#\\1#")"
+else
+    unset NIXPKGS_SOURCETIME_PATH
+fi
+if [ -z "\${NIXPKGS_SOURCETIME_PATH_OLD-}" ]; then
+    unset NIXPKGS_SOURCETIME_PATH_OLD
+fi
+# End of lines to clean up inside PATH the source-time utilities for Nixpkgs packaging
+EOF
+    cat "$FILE_TO_WORK_ON" > "$FILE_TO_PATCH"
+    rm "$FILE_TO_WORK_ON"
+}

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/default.nix
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/default.nix
@@ -1,0 +1,442 @@
+{ callPackage }:
+
+{
+  test-bash = callPackage
+    (
+      { lib
+      , runCommandLocal
+      , bash
+      , hello
+      , ksh
+      , patchRcPathBash
+      , shellcheck
+      , zsh
+      }:
+      runCommandLocal "patch-rc-path-bash-test"
+        {
+          nativeBuildInputs = [
+            bash
+            ksh
+            patchRcPathBash
+            shellcheck
+            zsh
+          ];
+          meta = {
+            description = "Package test of patchActivateBash";
+            inherit (patchRcPathBash.meta) maintainers;
+          };
+        }
+        ''
+          set -eu -o pipefail
+
+
+          # Check the setup hook script
+
+          echo "Running shellcheck against ${./test-sourcing-bash}"
+          shellcheck -s bash --exclude SC1090 ${./test-sourcing-bash}
+          shellcheck -s ksh --exclude SC1090 ${./test-sourcing-bash}
+
+
+          # Test patching a blank file
+
+          echo > blank.bash
+
+          echo "Generating blank_patched.bash from blank.bash"
+          cp blank.bash blank_patched.bash
+          patchRcPathBash blank_patched.bash "$PWD/delta:$PWD/foxtrot"
+
+          echo "Running shellcheck against blank_patched.bash"
+          shellcheck -s bash blank_patched.bash
+          shellcheck -s ksh blank_patched.bash
+
+          echo "Testing in Bash if blank.bash and blank_patched.bash modifies PATH the same way"
+          bash ${./test-sourcing-bash} ./blank.bash ./blank_patched.bash
+
+          echo "Testing in Ksh if blank.bash and blank_patched.bash modifies PATH the same way"
+          ksh ${./test-sourcing-bash} "$PWD/blank.bash" "$PWD/blank_patched.bash"
+
+          echo "Testing in Zsh if blank.bash and blank_patched.bash modifies PATH the same way"
+          zsh ${./test-sourcing-bash} ./blank.bash ./blank_patched.bash
+
+
+          # Test patching silent_hello
+
+          echo "hello > /dev/null" > silent_hello.bash
+
+          echo "Generating silent_hello_patched.bash from silent_hello.bash"
+          cp silent_hello.bash silent_hello_patched.bash
+          patchRcPathBash silent_hello_patched.bash "${hello}/bin"
+
+          echo "Running shellcheck against silent_hello_patched.bash"
+          shellcheck -s bash silent_hello_patched.bash
+
+          echo "Testing in Bash if silent_hello_patched.bash get sourced without error"
+          bash -eu -o pipefail -c ". ./silent_hello_patched.bash"
+
+          echo "Testing in Ksh if silent_hello_patched.bash get sourced without error"
+          ksh -eu -o pipefail -c ". ./silent_hello_patched.bash"
+
+          echo "Testing in Zsh if silent_hello_patched.bash get sourced without error"
+          zsh -eu -o pipefail -c ". ./silent_hello_patched.bash"
+
+
+          # Check the sample source
+
+          echo "Running shellcheck against sample_source.bash"
+          shellcheck -s bash ${./sample_source.bash}
+          shellcheck -s ksh ${./sample_source.bash}
+
+
+          # Test patching the sample source
+
+          cp ${./sample_source.bash} sample_source_patched.bash
+          chmod u+w sample_source_patched.bash
+
+          echo "Generating sample_source_patched.bash from ./sample_source.bash"
+          patchRcPathBash sample_source_patched.bash "$PWD/delta:$PWD/foxtrot"
+
+          echo "Running shellcheck against sample_source_patched.bash"
+          shellcheck -s bash sample_source_patched.bash
+
+          echo "Testing in Bash if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+          bash ${./test-sourcing-bash} ${./sample_source.bash} ./sample_source_patched.bash
+
+          echo "Testing in Ksh if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+          ksh ${./test-sourcing-bash} ${./sample_source.bash} "$PWD/sample_source_patched.bash"
+
+          echo "Testing in Zsh if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+          zsh ${./test-sourcing-bash} ${./sample_source.bash} ./sample_source_patched.bash
+
+
+          # Test double-patching the sample source
+
+          echo "Patching again sample_source_patched.bash"
+          patchRcPathBash sample_source_patched.bash "$PWD/foxtrot:$PWD/golf"
+
+          echo "Running shellcheck against sample_source_patched.bash"
+          shellcheck -s bash sample_source_patched.bash
+          shellcheck -s ksh sample_source_patched.bash
+
+          echo "Testing in Bash if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+          bash ${./test-sourcing-bash} ${./sample_source.bash} ./sample_source_patched.bash
+
+          echo "Testing in Ksh if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+          ksh ${./test-sourcing-bash} ${./sample_source.bash} "$PWD/sample_source_patched.bash"
+
+          echo "Testing in Zsh if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+          zsh ${./test-sourcing-bash} ${./sample_source.bash} ./sample_source_patched.bash
+
+
+          # Create a dummy output
+          touch "$out"
+        ''
+    )
+    { };
+
+
+
+  test-csh = callPackage
+    (
+      { lib
+      , runCommandLocal
+      , gnused
+      , hello
+      , patchRcPathCsh
+      , tcsh
+      }:
+      runCommandLocal "patch-rc-path-csh-test"
+        {
+          nativeBuildInputs = [
+            patchRcPathCsh
+            tcsh
+          ];
+          meta = {
+            description = "Package test of patchActivateCsh";
+            inherit (patchRcPathCsh.meta) maintainers;
+          };
+        }
+        ''
+          set -eu -o pipefail
+
+
+          # Test patching a blank file
+
+          echo > blank.csh
+
+          echo "Generating blank_patched.csh from blank.csh"
+          cp blank.csh blank_patched.csh
+          patchRcPathCsh blank_patched.csh "$PWD/delta:$PWD/foxtrot"
+
+          echo "Testing in Csh if blank.csh and blank_patched.csh modifies PATH the same way"
+          tcsh -e ${./test-sourcing-csh} blank.csh blank_patched.csh
+
+
+          # Test patching silent_hello file
+
+          echo "hello > /dev/null" > silent_hello.csh
+
+          echo "Generating silent_hello_patched.csh from silent_hello.csh"
+          cp silent_hello.csh silent_hello_patched.csh
+          patchRcPathCsh silent_hello_patched.csh "${hello}/bin"
+
+          echo "Testing in Csh if silent_hello_patched.csh get sourced without errer"
+          tcsh -e -c "source silent_hello_patched.csh"
+
+
+          # Generate the sample source
+
+          substitute ${./sample_source.csh.in} sample_source.csh --replace @sed@ ${gnused}/bin/sed
+          chmod u+rw sample_source.csh
+
+
+          # Test patching the sample source
+
+          echo "Generating sample_source_patched.csh from sample_source.csh"
+          cp sample_source.csh sample_source_patched.csh
+          chmod u+w sample_source_patched.csh
+          patchRcPathCsh sample_source_patched.csh "$PWD/delta:$PWD/foxtrot"
+
+          echo "Testing in Csh if sample_source.csh and sample_source_patched.csh modifies PATH the same way"
+          tcsh -e ${./test-sourcing-csh} sample_source.csh sample_source_patched.csh
+
+
+          # Test double-patching the sample source
+
+          echo "Patching again sample_source_patched.csh from sample_source.csh"
+          patchRcPathCsh sample_source_patched.csh "$PWD/foxtrot:$PWD/golf"
+
+          echo "Testing in Csh if sample_source.csh and sample_source_patched.csh modifies PATH the same way"
+          tcsh -e ${./test-sourcing-csh} sample_source.csh sample_source_patched.csh
+
+
+          # Create a dummy output
+          touch "$out"
+        ''
+    )
+    { };
+
+
+
+  test-fish = callPackage
+    (
+      { lib
+      , runCommandLocal
+      , fish
+      , hello
+      , patchRcPathFish
+      }:
+      runCommandLocal "patch-rc-path-fish-test"
+        {
+          nativeBuildInputs = [
+            fish
+            patchRcPathFish
+          ];
+          meta = {
+            description = "Package test of patchActivateFish";
+            inherit (patchRcPathFish.meta) maintainers;
+          };
+        }
+        ''
+          set -eu -o pipefail
+
+
+          # Test patching a blank file
+
+          echo > blank.fish
+
+          echo "Generating blank_patched.fish from blank.fish"
+          cp blank.fish blank_patched.fish
+          patchRcPathFish blank_patched.fish "$PWD/delta:$PWD/foxtrot"
+
+          echo "Testing in Fish if blank.fish and blank_patched.fish modifies PATH the same way"
+          HOME_TEMP="$(mktemp -d temporary_home_XXXXXX)"
+          HOME="$HOME_TEMP" fish ${./test-sourcing-fish} blank.fish blank_patched.fish
+          rm -r "$HOME_TEMP"
+
+
+          # Test patching silent_hello file
+
+          echo "hello > /dev/null" > silent_hello.fish
+
+          echo "Generating silent_hello_patched.fish from silent_hello.fish"
+          cp silent_hello.fish silent_hello_patched.fish
+          patchRcPathFish silent_hello_patched.fish "${hello}/bin"
+
+          echo "Testing in Fish if silent_hello_patched.fish get sourced without error"
+          HOME_TEMP="$(mktemp -d temporary_home_XXXXXX)"
+          HOME="$HOME_TEMP" fish -c "source silent_hello_patched.fish"
+          rm -r "$HOME_TEMP"
+
+
+          # Test patching the sample source
+
+          cp ${./sample_source.fish} sample_source_patched.fish
+          chmod u+w sample_source_patched.fish
+
+          echo "Generating sample_source_patched.fish from ${./sample_source.fish}"
+          patchRcPathFish sample_source_patched.fish "$PWD/delta:$PWD/foxtrot"
+          echo "Testing in Fish if sample_source.fish and sample_source_patched.fish modifies PATH the same way"
+          HOME_TEMP="$(mktemp -d temporary_home_XXXXXX)"
+          HOME="$HOME_TEMP" fish ${./test-sourcing-fish} ${./sample_source.fish} sample_source_patched.fish
+          rm -r "$HOME_TEMP"
+
+
+          # Test double-patching the sample source
+
+          echo "Patching again sample_source_patched.fish from ${./sample_source.fish}"
+          patchRcPathFish sample_source_patched.fish "$PWD/foxtrot:$PWD/golf"
+
+          echo "Testing in Fish if sample_source.fish and sample_source_patched.fish modifies PATH the same way"
+          HOME_TEMP="$(mktemp -d temporary_home_XXXXXX)"
+          HOME="$HOME_TEMP" fish ${./test-sourcing-fish} ${./sample_source.fish} sample_source_patched.fish
+          rm -r "$HOME_TEMP"
+
+
+          # Create a dummy output
+          touch "$out"
+        ''
+    )
+    { };
+
+
+
+  test-posix = callPackage
+    (
+      { lib
+      , runCommandLocal
+      , bash
+      , dash
+      , gnused
+      , hello
+      , ksh
+      , patchRcPathPosix
+      , shellcheck
+      }:
+      runCommandLocal "patch-rc-path-posix-test"
+        {
+          nativeBuildInputs = [
+            bash
+            dash
+            ksh
+            patchRcPathPosix
+            shellcheck
+          ];
+          meta = {
+            description = "Package test of patchActivatePosix";
+            inherit (patchRcPathPosix.meta) maintainers;
+          };
+        }
+        ''
+          set -eu -o pipefail
+
+
+          # Check the setup hook script
+
+          echo "Running shellcheck against ${./test-sourcing-posix}"
+          shellcheck -s sh --exclude SC1090 ${./test-sourcing-posix}
+          shellcheck -s dash --exclude SC1090 ${./test-sourcing-posix}
+
+
+          # Test patching a blank file
+
+          echo > blank.sh
+
+          echo "Generating blank_patched.sh from blank.sh"
+          cp blank.sh blank_patched.sh
+          patchRcPathPosix blank_patched.sh "$PWD/delta:$PWD/foxtrot"
+
+          echo "Running shellcheck against blank_patched.sh"
+          shellcheck -s sh blank_patched.sh
+          shellcheck -s dash blank_patched.sh
+
+          echo "Testing in Bash if blank.sh and blank_patched.sh modifies PATH the same way"
+          bash --posix ${./test-sourcing-posix} ./blank.sh ./blank_patched.sh
+
+          echo "Testing in Dash if blank.sh and blank_patched.sh modifies PATH the same way"
+          dash ${./test-sourcing-posix} ./blank.sh ./blank_patched.sh
+
+          echo "Testing in Ksh if ./blank.sh and ./blank_patched.sh modifies PATH the same way"
+          ksh ${./test-sourcing-posix} "$PWD/blank.sh" "$PWD/blank_patched.sh"
+
+
+          # Test patching silent_hello file
+
+          echo "hello > /dev/null" > silent_hello.sh
+
+          echo "Generating silent_hello_patched.sh from silent_hello.sh"
+          cp silent_hello.sh silent_hello_patched.sh
+          patchRcPathPosix silent_hello_patched.sh "${hello}/bin"
+
+          echo "Running shellcheck against silent_hello_patched.sh"
+          shellcheck -s sh silent_hello_patched.sh
+          shellcheck -s dash silent_hello_patched.sh
+
+          echo "Testing in Bash if silent_hello_patched.sh get sourced without error"
+          bash --posix -eu -c ". ./silent_hello_patched.sh"
+
+          echo "Testing in Dash if silent_hello_patched.sh get sourced without error"
+          dash -eu -c ". ./silent_hello_patched.sh"
+
+          echo "Testing in Ksh if silent_hello_patched.sh get sourced without error"
+          ksh -eu -c ". $PWD/silent_hello_patched.sh"
+
+
+          # Generate the sample source "$PWD/delta:$PWD/foxtrot" "$PWD/delta:$PWD/foxtrot"
+
+          substitute ${./sample_source.sh.in} sample_source.sh --replace @sed@ ${gnused}/bin/sed
+          chmod u+rw sample_source.sh
+
+
+          # Check the sample source
+
+          echo "Running shellcheck against sample_source.sh"
+          shellcheck -s sh sample_source.sh
+          shellcheck -s dash sample_source.sh
+
+
+          # Test patching the sample source
+
+          echo "Generating sample_source_patched.sh from sample_source.sh"
+          cp sample_source.sh sample_source_patched.sh
+          chmod u+w sample_source_patched.sh
+          patchRcPathPosix sample_source_patched.sh "$PWD/delta:$PWD/foxtrot"
+
+          echo "Running shellcheck against sample_source_patched.sh"
+          shellcheck -s sh sample_source_patched.sh
+          shellcheck -s dash sample_source_patched.sh
+
+          echo "Testing in Bash if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+          bash --posix ${./test-sourcing-posix} "./sample_source.sh" "./sample_source_patched.sh"
+
+          echo "Testing in Dash if sample_source.sh and sample_source_patched.sh modifies PATH the same way"
+          dash ${./test-sourcing-posix} "./sample_source.sh" "./sample_source_patched.sh"
+
+          echo "Testing in Ksh if sample_source.sh and sample_source_patched.sh modifies PATH the same way"
+          ksh ${./test-sourcing-posix} "$PWD/sample_source.sh" "$PWD/sample_source_patched.sh"
+
+
+          # Test double-patching the sample source
+
+          echo "Patching again sample_source_patched.sh"
+          patchRcPathPosix sample_source_patched.sh "$PWD/foxtrot:$PWD/golf"
+
+          echo "Running shellcheck against sample_source_patched.sh"
+          shellcheck -s sh sample_source_patched.sh
+          shellcheck -s dash sample_source_patched.sh
+
+          echo "Testing in Bash if sample_source.bash and sample_source_patched.bash modifies PATH the same way"
+          bash --posix ${./test-sourcing-posix} "./sample_source.sh" "./sample_source_patched.sh"
+
+          echo "Testing in Dash if sample_source.sh and sample_source_patched.sh modifies PATH the same way"
+          dash ${./test-sourcing-posix} "./sample_source.sh" "./sample_source_patched.sh"
+
+          echo "Testing in Ksh if sample_source.sh and sample_source_patched.sh modifies PATH the same way"
+          ksh ${./test-sourcing-posix} "$PWD/sample_source.sh" "$PWD/sample_source_patched.sh"
+
+
+          # Create a dummy output
+          touch "$out"
+        ''
+    )
+    { };
+}

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/sample_source.bash
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/sample_source.bash
@@ -1,0 +1,2 @@
+PATH="$PWD/charlie:${PATH/:$PWD\/bravo}"
+export PATH

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/sample_source.csh.in
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/sample_source.csh.in
@@ -1,0 +1,1 @@
+setenv PATH $PWD/charlie:`echo "$PATH" | @sed@ "s#:$PWD/bravo##"`

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/sample_source.fish
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/sample_source.fish
@@ -1,0 +1,9 @@
+begin
+    for p in $PATH
+        if test $p != "$PWD/bravo"
+            set TEMPORARY_PATH $TEMPORARY_PATH $p
+        end
+    end
+    set -g PATH $TEMPORARY_PATH
+end
+set PATH "$PWD/charlie" $PATH

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/sample_source.sh.in
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/sample_source.sh.in
@@ -1,0 +1,2 @@
+PATH="$PWD/charlie:$(echo "$PATH" | @sed@ "s#:$PWD/bravo##")"
+export PATH

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/test-sourcing-bash
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/test-sourcing-bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+UNPATCHED_SOURCE_FILE="$1"
+PATCHED_SOURCE_FILE="$2"
+ORIG_PATH="$PWD/alfa:$PWD/bravo"
+RESULT_PATH_FROM_UNPATCHED="$(
+    PATH="$ORIG_PATH"; export PATH
+    . "$UNPATCHED_SOURCE_FILE"
+    echo "$PATH"
+)"
+RESULT_PATH_FROM_PATCHED="$(
+    PATH="$ORIG_PATH"; export PATH
+    . "$PATCHED_SOURCE_FILE"
+    echo "$PATH"
+)"
+if [[ "$RESULT_PATH_FROM_UNPATCHED" != "$RESULT_PATH_FROM_PATCHED" ]]; then
+    echo "Result path mismatched: $UNPATCHED_SOURCE_FILE ($RESULT_PATH_FROM_UNPATCHED) and $PATCHED_SOURCE_FILE ($RESULT_PATH_FROM_PATCHED)" >&2
+    exit 1
+fi

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/test-sourcing-csh
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/test-sourcing-csh
@@ -1,0 +1,13 @@
+#/usr/bin/env tcsh
+
+set UNPATCHED_SOURCE_FILE = "$1"
+set PATCHED_SOURCE_FILE = "$2"
+set ORIG_PATH = "${PWD}/alfa:${PWD}/bravo"
+
+set RESULT_PATH_FROM_UNPATCHED = `setenv PATH "$ORIG_PATH"; source $UNPATCHED_SOURCE_FILE; echo $PATH`
+set RESULT_PATH_FROM_PATCHED = `setenv PATH "$ORIG_PATH"; source $PATCHED_SOURCE_FILE; echo $PATH`
+
+if ($RESULT_PATH_FROM_UNPATCHED != $RESULT_PATH_FROM_PATCHED) then
+    echo "Result path mismatched: $UNPATCHED_SOURCE_FILE ($RESULT_PATH_FROM_UNPATCHED) and $PATCHED_SOURCE_FILE ($RESULT_PATH_FROM_PATCHED)" > /dev/stderr
+    exit 1
+endif

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/test-sourcing-fish
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/test-sourcing-fish
@@ -1,0 +1,13 @@
+#/usr/bin/env fish
+
+set UNPATCHED_SOURCE_FILE $argv[1]
+set PATCHED_SOURCE_FILE $argv[2]
+set ORIG_PATH "$PWD/alfa:$PWD/bravo"
+
+set RESULT_PATH_FROM_UNPATCHED (fish -c "set -g PATH \"$ORIG_PATH\"; source $UNPATCHED_SOURCE_FILE; echo \"\$PATH\"")
+set RESULT_PATH_FROM_PATCHED (fish -c "set -g PATH \"$ORIG_PATH\"; source $PATCHED_SOURCE_FILE; echo \"\$PATH\"")
+
+if test "$RESULT_PATH_FROM_UNPATCHED" != "$RESULT_PATH_FROM_PATCHED"
+    echo "Result path mismatched: $UNPATCHED_SOURCE_FILE ($RESULT_PATH_FROM_UNPATCHED) and $PATCHED_SOURCE_FILE ($RESULT_PATH_FROM_PATCHED)" >&2
+    exit 1
+end

--- a/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/test-sourcing-posix
+++ b/pkgs/build-support/setup-hooks/patch-rc-path-hooks/test/test-sourcing-posix
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+UNPATCHED_SOURCE_FILE="$1"
+PATCHED_SOURCE_FILE="$2"
+ORIG_PATH="$PWD/alfa:$PWD/bravo"
+RESULT_PATH_FROM_UNPATCHED="$(
+    PATH="$ORIG_PATH"; export PATH
+    . "$UNPATCHED_SOURCE_FILE"
+    echo "$PATH"
+)"
+RESULT_PATH_FROM_PATCHED="$(
+    PATH="$ORIG_PATH"; export PATH
+    . "$PATCHED_SOURCE_FILE"
+    echo "$PATH"
+)"
+if [ "$RESULT_PATH_FROM_UNPATCHED" != "$RESULT_PATH_FROM_PATCHED" ]; then
+    echo "Result path mismatched: $UNPATCHED_SOURCE_FILE ($RESULT_PATH_FROM_UNPATCHED) and $PATCHED_SOURCE_FILE ($RESULT_PATH_FROM_PATCHED)" > /dev/stderr
+    exit 1
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -983,6 +983,10 @@ with pkgs;
   octant-desktop = callPackage ../applications/networking/cluster/octant/desktop.nix { };
   starboard-octant-plugin = callPackage ../applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix { };
 
+  inherit (
+    callPackages ../build-support/setup-hooks/patch-rc-path-hooks { }
+  ) patchRcPathBash patchRcPathCsh patchRcPathFish patchRcPathPosix;
+
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;
 
   pruneLibtoolFiles = makeSetupHook { name = "prune-libtool-files"; }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR provides a clean way to patch an init scripts (or any shell scripts meant to be sourced). It inserts a `PATH` prefix for the sourced commands and clean it up afterward, not polluting the PATH and avoiding issues caused by find-and-replace.

Most of the files added are test cases, which ensure the main packages work as expected.

The hooks are apply to package `root` to patch its activation scripts. A package test `root.passthru.tests.test-thisroot` is also added to verify the patching. (Continuation of #169579, cc: `root` maintainer @veprbl )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
