### PR TITLE
proxychains{,-ng}: swap priority 4 and 5 in get_config_path

### DIFF
--- a/pkgs/tools/networking/proxychains-ng/default.nix
+++ b/pkgs/tools/networking/proxychains-ng/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/rofl0r/proxychains-ng/commit/9b42da71f4df7b783cf07a58ffa095e293c43380.patch";
       sha256 = "sha256-tYv9XP51WtsjaoklwQk3D/MQceoOvtdMwBraECt6AXQ=";
     })
+    ./swap-priority-4-and-5-in-get_config_path.patch
   ];
 
   installFlags = [

--- a/pkgs/tools/networking/proxychains-ng/default.nix
+++ b/pkgs/tools/networking/proxychains-ng/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/rofl0r/proxychains-ng/commit/9b42da71f4df7b783cf07a58ffa095e293c43380.patch";
       sha256 = "sha256-tYv9XP51WtsjaoklwQk3D/MQceoOvtdMwBraECt6AXQ=";
     })
+    # https://github.com/NixOS/nixpkgs/issues/136093
     ./swap-priority-4-and-5-in-get_config_path.patch
   ];
 

--- a/pkgs/tools/networking/proxychains-ng/swap-priority-4-and-5-in-get_config_path.patch
+++ b/pkgs/tools/networking/proxychains-ng/swap-priority-4-and-5-in-get_config_path.patch
@@ -1,0 +1,25 @@
+diff --git a/src/common.c b/src/common.c
+index 1da1c45..fb68ada 100644
+--- a/src/common.c
++++ b/src/common.c
+@@ -113,13 +113,13 @@ char *get_config_path(char* default_path, char* pbuf, size_t bufsize) {
+ 	if(check_path(path))
+ 		goto have;
+ 
+-	// priority 4: $SYSCONFDIR/proxychains.conf
+-	path = SYSCONFDIR "/" PROXYCHAINS_CONF_FILE;
++	// priority 4: /etc/proxychains.conf
++	path = "/etc/" PROXYCHAINS_CONF_FILE;
+ 	if(check_path(path))
+ 		goto have;
+ 
+-	// priority 5: /etc/proxychains.conf
+-	path = "/etc/" PROXYCHAINS_CONF_FILE;
++	// priority 5: $SYSCONFDIR/proxychains.conf
++	path = SYSCONFDIR "/" PROXYCHAINS_CONF_FILE;
+ 	if(check_path(path))
+ 		goto have;
+ 
+-- 
+2.37.2
+

--- a/pkgs/tools/networking/proxychains/default.nix
+++ b/pkgs/tools/networking/proxychains/default.nix
@@ -14,7 +14,10 @@ stdenv.mkDerivation rec {
     sha256 = "083xdg6fsn8c2ns93lvy794rixxq8va6jdf99w1z0xi4j7f1nyjw";
   };
 
-  patches = [ ./swap-priority-4-and-5-in-get_config_path.patch ];
+  patches = [
+    # https://github.com/NixOS/nixpkgs/issues/136093
+    ./swap-priority-4-and-5-in-get_config_path.patch
+  ];
 
   postPatch = ''
     # Suppress compiler warning. Remove it when upstream fix arrives

--- a/pkgs/tools/networking/proxychains/default.nix
+++ b/pkgs/tools/networking/proxychains/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "083xdg6fsn8c2ns93lvy794rixxq8va6jdf99w1z0xi4j7f1nyjw";
   };
 
+  patches = [ ./swap-priority-4-and-5-in-get_config_path.patch ];
+
   postPatch = ''
     # Suppress compiler warning. Remove it when upstream fix arrives
     substituteInPlace Makefile --replace "-Werror" "-Werror -Wno-stringop-truncation"

--- a/pkgs/tools/networking/proxychains/swap-priority-4-and-5-in-get_config_path.patch
+++ b/pkgs/tools/networking/proxychains/swap-priority-4-and-5-in-get_config_path.patch
@@ -1,0 +1,25 @@
+diff --git a/src/common.c b/src/common.c
+index 1ca612a..7c21377 100644
+--- a/src/common.c
++++ b/src/common.c
+@@ -37,13 +37,13 @@ char *get_config_path(char* default_path, char* pbuf, size_t bufsize) {
+ 	if(check_path(path))
+ 		return path;
+ 
+-	// priority 4: $SYSCONFDIR/proxychains.conf
+-	path = SYSCONFDIR "/" PROXYCHAINS_CONF_FILE;
++	// priority 4: /etc/proxychains.conf
++	path = "/etc/" PROXYCHAINS_CONF_FILE;
+ 	if(check_path(path))
+ 		return path;
+ 
+-	// priority 5: /etc/proxychains.conf
+-	path = "/etc/" PROXYCHAINS_CONF_FILE;
++	// priority 5: $SYSCONFDIR/proxychains.conf
++	path = SYSCONFDIR "/" PROXYCHAINS_CONF_FILE;
+ 	if(check_path(path))
+ 		return path;
+ 
+-- 
+2.37.2
+


### PR DESCRIPTION
###### Description of changes

Prefer `/etc/proxychains.conf` to the one in Nix store. Fixes #136093.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
