### PR TITLE
dendrite: Cleanup options, add global database option

### DIFF
--- a/nixos/modules/services/matrix/dendrite.nix
+++ b/nixos/modules/services/matrix/dendrite.nix
@@ -113,16 +113,6 @@ in
               ```
             '';
           };
-          trusted_third_party_id_servers = lib.mkOption {
-            type = lib.types.listOf lib.types.str;
-            example = [ "matrix.org" ];
-            default = [ "matrix.org" "vector.im" ];
-            description = lib.mdDoc ''
-              Lists of domains that the server will trust as identity
-              servers to verify third party identifiers such as phone
-              numbers and email addresses
-            '';
-          };
           database = {
             connection_string = lib.mkOption {
               type = lib.types.str;
@@ -137,16 +127,6 @@ in
                 start with `file:`.
               '';
             };
-          };
-        };
-        options.client_api = {
-          registration_disabled = lib.mkOption {
-            type = lib.types.bool;
-            default = true;
-            description = lib.mdDoc ''
-              Whether to disable user registration to the server
-              without the shared secret.
-            '';
           };
         };
         options.federation_api.database = {
@@ -214,25 +194,6 @@ in
             '';
           };
         };
-        options.sync_api.search = {
-          enable = lib.mkEnableOption (lib.mdDoc "Dendrite's full-text search engine");
-          index_path = lib.mkOption {
-            type = lib.types.str;
-            default = "${workingDir}/searchindex";
-            description = lib.mdDoc ''
-              The path the search index will be created in.
-            '';
-          };
-          language = lib.mkOption {
-            type = lib.types.str;
-            default = "en";
-            description = lib.mdDoc ''
-              The language most likely to be used on the server - used when indexing, to
-              ensure the returned results match expectations. A full list of possible languages
-              can be found at https://github.com/blevesearch/bleve/tree/master/analysis/lang
-            '';
-          };
-        };
         options.user_api = {
           account_database = {
             connection_string = lib.mkOption {
@@ -267,11 +228,12 @@ in
         for available options with which to populate settings.
       '';
     };
-    openRegistration = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
+    extraFlags = lib.mkOption {
+      default = [ ];
+      example = [ "-really-enable-open-registration" ];
+      type = lib.types.listOf lib.types.str;
       description = lib.mdDoc ''
-        Allow open registration without secondary verification (reCAPTCHA).
+        Extra arguments to use for executing dendrite.
       '';
     };
   };
@@ -349,9 +311,7 @@ in
           "--https-bind-address :${builtins.toString cfg.httpsPort}"
           "--tls-cert ${cfg.tlsCert}"
           "--tls-key ${cfg.tlsKey}"
-        ] ++ lib.optionals cfg.openRegistration [
-          "--really-enable-open-registration"
-        ]);
+        ] ++ cfg.extraFlags);
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         Restart = "on-failure";
       };


### PR DESCRIPTION
###### Description of changes

~~The `sync_api.search.enable` option is actually called `enabled` in dendrite's yaml config. https://github.com/matrix-org/dendrite/blob/39581af3ba657032fbf66ba3719a1cb334c0519b/dendrite-sample.monolith.yaml#L287~~

~~Using `enable` has no effect. Alternatively all of `sync_api.search` could be removed since I think the nixos module config has mostly only included options (w/ defaults) that are required for dendrite. Any non-required options are still supported since the module uses `pkgs.formats.yaml` generator.~~

EDIT:

  + Remove outdated `connection_string` options
  + Add `global.database.connection_string` option, force user to pick between global or sub-DBs, check that global DB is not SQLite
  + Remove non-essential options from yaml (also replace open registration flag with `extraFlags`)
  + Add defaults for `server_name` and `private_key` (required options for dendrite)
  + Generate private key if absent

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

