### PR TITLE
parlatype: restore, 2.1 -> 3.1

### DIFF
--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-ugly
     gst_all_1.gst-libav
-    sphinxbase
-    pocketsphinx
     glib
     gsettings-desktop-schemas
     hicolor-icon-theme
@@ -46,6 +44,8 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = false;
+
+  mesonFlags = [ "-Dasr=false" ];
 
   buildPhase = ''
     export GST_PLUGIN_SYSTEM_PATH_1_0="$out/lib/gstreamer-1.0/:$GST_PLUGIN_SYSTEM_PATH_1_0"
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://gkarsay.github.io/parlatype/";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.melchips ];
+    maintainers = with maintainers; [ alexshpilkin melchips ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -1,0 +1,66 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, gtk3, at-spi2-core, dbus, gst_all_1, sphinxbase, pocketsphinx, ninja, gettext, appstream-glib, python3, glib, gobject-introspection, gsettings-desktop-schemas, itstool, wrapGAppsHook, hicolor-icon-theme }:
+
+stdenv.mkDerivation rec {
+  pname = "parlatype";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner  = "gkarsay";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "1k53q0kbwpnbgyr0lmfzf5sm4f93d8nbjrzdz9pdhzpxgihndg25";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    gettext
+    appstream-glib
+    python3
+    gobject-introspection
+    itstool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    at-spi2-core
+    dbus
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
+    sphinxbase
+    pocketsphinx
+    glib
+    gsettings-desktop-schemas
+    hicolor-icon-theme
+  ];
+
+  postPatch = ''
+    chmod +x data/meson_post_install.py
+    patchShebangs data/meson_post_install.py
+  '';
+
+  doCheck = false;
+
+  buildPhase = ''
+    export GST_PLUGIN_SYSTEM_PATH_1_0="$out/lib/gstreamer-1.0/:$GST_PLUGIN_SYSTEM_PATH_1_0"
+  '';
+
+  meta = with lib; {
+    description = "GNOME audio player for transcription";
+    longDescription = ''
+      Parlatype is a minimal audio player for manual speech transcription, written for the GNOME desktop environment.
+      It plays audio sources to transcribe them in your favourite text application.
+      It’s intended to be useful for journalists, students, scientists and whoever needs to transcribe audio files.
+    '';
+    homepage = "https://gkarsay.github.io/parlatype/";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.melchips ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, meson, gtk3, at-spi2-core, dbus, gst_all_1, sphinxbase, pocketsphinx, ninja, gettext, appstream-glib, python3, glib, gobject-introspection, gsettings-desktop-schemas, itstool, wrapGAppsHook, hicolor-icon-theme }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, gtk3, dbus, gst_all_1, ninja, gettext, appstream-glib, python3, desktop-file-utils, glib, gobject-introspection, gsettings-desktop-schemas, isocodes, itstool, libxml2, wrapGAppsHook, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "parlatype";
-  version = "2.1";
+  version = "3.1";
 
   src = fetchFromGitHub {
     owner  = "gkarsay";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "1k53q0kbwpnbgyr0lmfzf5sm4f93d8nbjrzdz9pdhzpxgihndg25";
+    sha256 = "1a4xlsbszb50vnz1g7kf7hl7aywp7s7xaravkcx13csn0a7l3x45";
   };
 
   nativeBuildInputs = [
@@ -18,14 +18,15 @@ stdenv.mkDerivation rec {
     gettext
     appstream-glib
     python3
+    desktop-file-utils
     gobject-introspection
     itstool
+    libxml2
     wrapGAppsHook
   ];
 
   buildInputs = [
     gtk3
-    at-spi2-core
     dbus
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
@@ -36,20 +37,15 @@ stdenv.mkDerivation rec {
     glib
     gsettings-desktop-schemas
     hicolor-icon-theme
+    isocodes
   ];
 
   postPatch = ''
-    chmod +x data/meson_post_install.py
     patchShebangs data/meson_post_install.py
+    patchShebangs libparlatype/tests/data/generate_config_data
   '';
 
   doCheck = false;
-
-  mesonFlags = [ "-Dasr=false" ];
-
-  buildPhase = ''
-    export GST_PLUGIN_SYSTEM_PATH_1_0="$out/lib/gstreamer-1.0/:$GST_PLUGIN_SYSTEM_PATH_1_0"
-  '';
 
   meta = with lib; {
     description = "GNOME audio player for transcription";
@@ -58,7 +54,7 @@ stdenv.mkDerivation rec {
       It plays audio sources to transcribe them in your favourite text application.
       It’s intended to be useful for journalists, students, scientists and whoever needs to transcribe audio files.
     '';
-    homepage = "https://gkarsay.github.io/parlatype/";
+    homepage = "https://www.parlatype.org/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ alexshpilkin melchips ];
     platforms = platforms.linux;

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -1,41 +1,62 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, meson, gtk3, dbus, gst_all_1, ninja, gettext, appstream-glib, python3, desktop-file-utils, glib, gobject-introspection, gsettings-desktop-schemas, isocodes, itstool, libxml2, wrapGAppsHook, hicolor-icon-theme }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, appstream-glib
+, dbus
+, desktop-file-utils
+, gettext
+, glib
+, gobject-introspection
+, gsettings-desktop-schemas
+, gst_all_1
+, gtk3
+, hicolor-icon-theme
+, isocodes
+, itstool
+, libxml2
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "parlatype";
   version = "3.1";
 
   src = fetchFromGitHub {
-    owner  = "gkarsay";
-    repo   = pname;
-    rev    = "v${version}";
+    owner = "gkarsay";
+    repo = pname;
+    rev = "v${version}";
     sha256 = "1a4xlsbszb50vnz1g7kf7hl7aywp7s7xaravkcx13csn0a7l3x45";
   };
 
   nativeBuildInputs = [
-    pkg-config
-    meson
-    ninja
-    gettext
     appstream-glib
-    python3
     desktop-file-utils
+    gettext
     gobject-introspection
     itstool
     libxml2
+    meson
+    ninja
+    pkg-config
+    python3
     wrapGAppsHook
   ];
 
   buildInputs = [
-    gtk3
     dbus
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-    gst_all_1.gst-plugins-bad
-    gst_all_1.gst-plugins-ugly
-    gst_all_1.gst-libav
     glib
     gsettings-desktop-schemas
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gstreamer
+    gtk3
     hicolor-icon-theme
     isocodes
   ];
@@ -50,9 +71,11 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "GNOME audio player for transcription";
     longDescription = ''
-      Parlatype is a minimal audio player for manual speech transcription, written for the GNOME desktop environment.
-      It plays audio sources to transcribe them in your favourite text application.
-      It’s intended to be useful for journalists, students, scientists and whoever needs to transcribe audio files.
+      Parlatype is a minimal audio player for manual speech transcription,
+      written for the GNOME desktop environment. It plays audio sources to
+      transcribe them in your favourite text application. It’s intended to be
+      useful for journalists, students, scientists and whoever needs to
+      transcribe audio files.
     '';
     homepage = "https://www.parlatype.org/";
     license = licenses.gpl3Plus;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1023,7 +1023,6 @@ mapAliases ({
   paperless-ng = paperless-ngx; # Added 2022-04-11
   parity = openethereum; # Added 2020-08-01
   parity-ui = throw "parity-ui was removed because it was broken and unmaintained by upstream"; # Added 2022-01-10
-  parlatype = throw "parlatype has been removed: unmaintained"; # Added 2022-04-24
   parquet-cpp = throw "'parquet-cpp' has been renamed to/replaced by 'arrow-cpp'"; # Converted to throw 2022-02-22
   patchmatrix = throw "'patchmatrix' has been renamed to/replaced by 'open-music-kontrollers.patchmatrix'"; # Added 2022-03-09
   pass-otp = throw "'pass-otp' has been renamed to/replaced by 'pass.withExtensions'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30019,6 +30019,8 @@ with pkgs;
 
   paraview = libsForQt5.callPackage ../applications/graphics/paraview { };
 
+  parlatype = callPackage ../applications/audio/parlatype { };
+
   packet = callPackage ../development/tools/packet { };
 
   packet-sd = callPackage ../development/tools/packet-sd { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Parlatype has been removed in https://github.com/NixOS/nixpkgs/pull/170124 due to lack of maintenance and a problematic dependency on `pocketsphinx` for speech recognition. Adopt it, remove the dependency (and thus speech recognition support as well for now), then bump to the latest upstream version.

I don't particularly need one, but given that Parlatype was removed in late April, maybe this deserves a backport to 22.05?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
