### PR TITLE
nixos/neovim: add note about not loading init.vim

### DIFF
--- a/nixos/modules/programs/neovim.nix
+++ b/nixos/modules/programs/neovim.nix
@@ -11,7 +11,19 @@ let
 
 in {
   options.programs.neovim = {
-    enable = mkEnableOption (lib.mdDoc "Neovim");
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = lib.mdDoc ''
+        Whether to enable Neovim.
+
+        When enabled through this option, Neovim is wrapped to use a
+        configuration managed by this module. The configuration file in the
+        user's home directory at {file}`~/.config/nvim/init.vim` is no longer
+        loaded by default.
+      '';
+    };
 
     defaultEditor = mkOption {
       type = types.bool;


### PR DESCRIPTION
Neovim does not load the user configuration when enabled through the
module, unlike when the package is added to the home or system packages
directly. I think this difference is worth mentioning in the module's
documentation, because it was confusing to some friends.
