### PR TITLE
broadcom_sta: fix build on linux 6.0

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation {
     ./linux-5.17.patch
     # source: https://github.com/archlinux/svntogit-community/blob/2e1fd240f9ce06f500feeaa3e4a9675e65e6b967/trunk/013-linux518.patch
     ./linux-5.18.patch
+    # source: https://gist.github.com/joanbm/207210d74637870c01ef5a3c262a597d
+    ./linux-6.0.patch
     ./pedantic-fix.patch
     ./null-pointer-fix.patch
     ./gcc.patch

--- a/pkgs/os-specific/linux/broadcom-sta/linux-6.0.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-6.0.patch
@@ -1,0 +1,30 @@
+From dbee29df729e543a89b3f95c1436e982eb0047c1 Mon Sep 17 00:00:00 2001
+From: Joan Bruguera <joanbrugueram@gmail.com>
+Date: Thu, 30 Jun 2022 02:15:35 +0200
+Subject: [PATCH] Tentative patch for broadcom-wl 6.30.223.271 driver for Linux 6.0-rc1
+
+Applies on top of all the patches applied to broadcom-wl-dkms 6.30.223.271-33 on Arch Linux.
+---
+ src/wl/sys/wl_cfg80211_hybrid.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index d815b33..7faa735 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -2381,7 +2381,12 @@ wl_bss_roaming_done(struct wl_cfg80211_priv *wl, struct net_device *ndev,
+ 	bss = cfg80211_get_bss(wl_to_wiphy(wl), NULL, (s8 *)&wl->bssid,
+ 	ssid->SSID, ssid->SSID_len, WLAN_CAPABILITY_ESS, WLAN_CAPABILITY_ESS);
+ 	struct cfg80211_roam_info roam_info = {
++// Rel. commit "cfg80211: Indicate MLO connection info in connect and roam callbacks" (Veerendranath Jakkam, Wed Jun 8)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
+ 		.bss = bss,
++#else
++		.links[0].bss = bss,
++#endif
+ 		.req_ie = conn_info->req_ie,
+ 		.req_ie_len = conn_info->req_ie_len,
+ 		.resp_ie = conn_info->resp_ie,
+-- 
+2.37.0
+

--- a/pkgs/os-specific/linux/broadcom-sta/pedantic-fix.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/pedantic-fix.patch
@@ -36,8 +36,7 @@ index 2b3c290..093dce6 100644
  	bss = cfg80211_get_bss(wl_to_wiphy(wl), NULL, (s8 *)&wl->bssid,
  	ssid->SSID, ssid->SSID_len, WLAN_CAPABILITY_ESS, WLAN_CAPABILITY_ESS);
 -	struct cfg80211_roam_info roam_info = {
--// Rel. commit "cfg80211: Indicate MLO connection info in connect and roam callbacks" (Veerendranath Jakkam, Wed Jun 8)
-+	// Rel. commit "cfg80211: Indicate MLO connection info in connect and roam callbacks" (Veerendranath Jakkam, Wed Jun 8)
+ // Rel. commit "cfg80211: Indicate MLO connection info in connect and roam callbacks" (Veerendranath Jakkam, Wed Jun 8)
  #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
 -		.bss = bss,
 +	roam_info.bss = bss;

--- a/pkgs/os-specific/linux/broadcom-sta/pedantic-fix.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/pedantic-fix.patch
@@ -1,4 +1,4 @@
-diff --git a/src/shared/linux_osl.c b/shared/linux_osl.c
+diff --git a/src/shared/linux_osl.c b/src/shared/linux_osl.c
 index 711b771..5a2636a 100644
 --- a/src/shared/linux_osl.c
 +++ b/src/shared/linux_osl.c
@@ -11,8 +11,8 @@ index 711b771..5a2636a 100644
  	if (rdlen > 0)
  		fp->f_pos += rdlen;
  
-diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/wl/sys/wl_cfg80211_hybrid.c
-index 41c16d8..d39d9de 100644
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index 2b3c290..093dce6 100644
 --- a/src/wl/sys/wl_cfg80211_hybrid.c
 +++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -790,6 +790,7 @@ wl_set_auth_type(struct net_device *dev, struct cfg80211_connect_params *sme)
@@ -23,7 +23,7 @@ index 41c16d8..d39d9de 100644
  	default:
  		val = 2;
  		WL_ERR(("invalid auth type (%d)\n", sme->auth_type));
-@@ -2347,21 +2348,20 @@ wl_bss_roaming_done(struct wl_cfg80211_priv *wl, struct net_device *ndev,
+@@ -2347,26 +2348,24 @@ wl_bss_roaming_done(struct wl_cfg80211_priv *wl, struct net_device *ndev,
                      const wl_event_msg_t *e, void *data)
  {
  	struct wl_cfg80211_connect_info *conn_info = wl_to_conn(wl);
@@ -36,23 +36,29 @@ index 41c16d8..d39d9de 100644
  	bss = cfg80211_get_bss(wl_to_wiphy(wl), NULL, (s8 *)&wl->bssid,
  	ssid->SSID, ssid->SSID_len, WLAN_CAPABILITY_ESS, WLAN_CAPABILITY_ESS);
 -	struct cfg80211_roam_info roam_info = {
+-// Rel. commit "cfg80211: Indicate MLO connection info in connect and roam callbacks" (Veerendranath Jakkam, Wed Jun 8)
++	// Rel. commit "cfg80211: Indicate MLO connection info in connect and roam callbacks" (Veerendranath Jakkam, Wed Jun 8)
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
 -		.bss = bss,
++	roam_info.bss = bss;
+ #else
+-		.links[0].bss = bss,
++	roam_info.links[0].bss = bss;
+ #endif
 -		.req_ie = conn_info->req_ie,
 -		.req_ie_len = conn_info->req_ie_len,
 -		.resp_ie = conn_info->resp_ie,
 -		.resp_ie_len = conn_info->resp_ie_len,
 -	};
-+	roam_info.bss = bss;
 +	roam_info.req_ie = conn_info->req_ie;
 +	roam_info.req_ie_len = conn_info->req_ie_len;
 +	roam_info.resp_ie = conn_info->resp_ie;
-+	roam_info.resp_ie_len = conn_info->resp_ie_len;
  #endif
 -	s32 err = 0;
  
  	wl_get_assoc_ies(wl);
  	memcpy(wl->profile->bssid, &e->addr, ETHER_ADDR_LEN);
-diff --git a/src/wl/sys/wl_iw.h b/wl/sys/wl_iw.h
+diff --git a/src/wl/sys/wl_iw.h b/src/wl/sys/wl_iw.h
 index 3ab084f..471d11f 100644
 --- a/src/wl/sys/wl_iw.h
 +++ b/src/wl/sys/wl_iw.h
@@ -64,7 +70,7 @@ index 3ab084f..471d11f 100644
  #define WL_IW_SET_ACTIVE_SCAN	(SIOCIWFIRSTPRIV+1)
  #define WL_IW_GET_RSSI			(SIOCIWFIRSTPRIV+3)
  #define WL_IW_SET_PASSIVE_SCAN	(SIOCIWFIRSTPRIV+5)
-diff --git a/src/wl/sys/wl_linux.c b/wl/sys/wl_linux.c
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
 index d13fb98..97ae2a6 100644
 --- a/src/wl/sys/wl_linux.c
 +++ b/src/wl/sys/wl_linux.c


### PR DESCRIPTION
Fix build issues when building against linux 6.0

Fixes #194903

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
