### PR TITLE
sbclPackages: fix build of Qt4 binding libraries

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13980,6 +13980,12 @@
     githubId = 928084;
     name = "Utku Demir";
   };
+  uthar = {
+    email = "galkowskikasper@gmail.com";
+    github = "uthar";
+    githubId = 15697697;
+    name = "Kasper Gałkowski";
+  };
   uvnikita = {
     email = "uv.nikita@gmail.com";
     github = "uvNikita";

--- a/pkgs/development/libraries/smokegen/default.nix
+++ b/pkgs/development/libraries/smokegen/default.nix
@@ -1,0 +1,21 @@
+{ pkgs, lib, ... }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "smokegen";
+  version = "v4.14.3";
+  src = pkgs.fetchzip {
+    url = "https://invent.kde.org/unmaintained/${pname}/-/archive/${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-finsoruPeJZLawIjNUJ25Pq54eaCByfALVraNQJPk7c=";
+  };
+  buildInputs = [ pkgs.cmake pkgs.qt4 ];
+  buildPhase = ''
+      cmake .
+    '';
+  meta = with lib; {
+    description = "A general purpose C++ parser with a plugin infrastructure";
+    homepage = "https://invent.kde.org/unmaintained/smokegen";
+    license = licenses.gpl2Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ uthar ];
+  };
+}

--- a/pkgs/development/libraries/smokeqt/default.nix
+++ b/pkgs/development/libraries/smokeqt/default.nix
@@ -1,0 +1,21 @@
+{ pkgs, lib, ... }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "smokeqt";
+  version = "v4.14.3";
+  src = pkgs.fetchzip {
+    url = "https://invent.kde.org/unmaintained/${pname}/-/archive/${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-8FiEGF8gduVw5I/bi2wExGUWmjIjYEhWpjpXKJGBNMg=";
+  };
+  cmakeFlags = [
+    "-DCMAKE_CXX_STANDARD=98"
+  ];
+  buildInputs = [ pkgs.cmake pkgs.qt4 pkgs.smokegen ];
+  meta = with lib; {
+    description = "Bindings for the Qt libraries";
+    homepage = "https://invent.kde.org/unmaintained/smokeqt";
+    license = licenses.gpl2Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ uthar ];
+  };
+}

--- a/pkgs/development/lisp-modules-new/packages.nix
+++ b/pkgs/development/lisp-modules-new/packages.nix
@@ -11,6 +11,9 @@ let
     optionals
     hasSuffix
     splitString
+    remove
+    optionalString
+    stringLength
   ;
 
   # Used by builds that would otherwise attempt to write into storeDir.
@@ -42,6 +45,11 @@ let
       # Patches are already applied in `build`
       patches = [];
       src = build;
+      # TODO(kasper): handle this with a setup hook
+      LD_LIBRARY_PATH =
+        build.LD_LIBRARY_PATH
+        + (optionalString (stringLength build.LD_LIBRARY_PATH != 0) ":")
+        + "${build}";
     });
 
   # A little hacky
@@ -331,6 +339,89 @@ let
     };
     version = "f19162e76";
   });
+
+  qt = let
+    rev = "dffff3ee3dbd0686c85c323f579b8bbf4881e60e";
+  in build-with-compile-into-pwd rec {
+    pname = "commonqt";
+    version = builtins.substring 0 7 rev;
+
+    src = pkgs.fetchFromGitHub {
+      inherit rev;
+      owner = pname;
+      repo = pname;
+      hash = "sha256-GAgwT0D9mIkYPTHfCH/KxxIv7b6QGwcxwZE7ehH5xug=";
+    };
+
+    buildInputs = [ pkgs.qt4 ];
+    nativeBuildInputs = [ pkgs.smokegen pkgs.smokeqt ];
+    nativeLibs = [ pkgs.qt4 pkgs.smokegen pkgs.smokeqt ];
+
+    systems = [ "qt" ];
+
+    lispLibs = with ql; [
+      cffi named-readtables cl-ppcre alexandria
+      closer-mop iterate trivial-garbage bordeaux-threads
+    ];
+  };
+
+  qt-libs = build-with-compile-into-pwd {
+    inherit (ql.qt-libs) pname version src;
+    patches = [ ./patches/qt-libs-dont-download.patch ];
+    prePatch = ''
+      substituteInPlace systems/*.asd --replace ":qt+libs" ":qt"
+      echo "LD Path: $LD_LIBRARY_PATH"
+    '';
+    lispLibs = ql.qt-libs.lispLibs ++ [ qt ];
+    systems = [
+      "qt-libs"
+      "commonqt"
+      # "phonon"
+      # "qimageblitz"
+      # "qsci"
+      "qt3support"
+      "qtcore"
+      "qtdbus"
+      "qtdeclarative"
+      "qtgui"
+      "qthelp"
+      "qtnetwork"
+      "qtopengl"
+      "qtscript"
+      "qtsql"
+      "qtsvg"
+      "qttest"
+      "qtuitools"
+      # "qtwebkit"
+      "qtxml"
+      "qtxmlpatterns"
+      # "qwt"
+      "smokebase"
+    ];
+  };
+  commonqt = qt-libs;
+  qt3support = qt-libs;
+  qtcore = qt-libs;
+  qtdbus = qt-libs;
+  qtdeclarative = qt-libs;
+  qtgui = qt-libs;
+  qthelp = qt-libs;
+  qtnetwork = qt-libs;
+  qtopengl = qt-libs;
+  qtscript = qt-libs;
+  qtsql = qt-libs;
+  qtsvg = qt-libs;
+  qttest = qt-libs;
+  qtuitools = qt-libs;
+  qtxml = qt-libs;
+  qtxmlpatterns = qt-libs;
+  smokebase = qt-libs;
+
+  qtools = build-with-compile-into-pwd {
+    inherit (ql.qtools) pname version src nativeLibs;
+    lispLibs = [ qt ] ++ remove ql.qt_plus_libs ql.qtools.lispLibs ++ [ qt-libs ];
+    patches = [ ./patches/qtools-use-nix-libs.patch ];
+  };
 
   };
 

--- a/pkgs/development/lisp-modules-new/patches/qt-libs-dont-download.patch
+++ b/pkgs/development/lisp-modules-new/patches/qt-libs-dont-download.patch
@@ -1,0 +1,36 @@
+--- a/qt-libs.asd
++++ b/qt-libs.asd
+@@ -17,5 +17,4 @@
+   :components ((:file "qt-libs"))
+   :depends-on (:qt-lib-generator
+                :cl-ppcre
+-               :cffi)
+-  :perform (asdf:load-op :after (op c) (uiop:symbol-call :qt-libs :ensure-standalone-libs)))
++               :cffi))
+--- a/qt-libs.lisp
++++ b/qt-libs.lisp
+@@ -94,16 +94,14 @@
+   standalone-dir)
+
+ (defun %ensure-lib-loaded (file)
+-  (let ((file (etypecase file
+-                (pathname file)
+-                (string (installed-library-file file))))
+-        (name (intern (string-upcase (pathname-name file))))
+-        #+sbcl(sb-ext:*muffled-warnings* 'style-warning))
+-    (cffi::register-foreign-library
+-     name `((T ,file))
+-     :search-path (to-directory file))
+-    (unless (cffi:foreign-library-loaded-p name)
+-      (cffi:load-foreign-library name))))
++ (let ((name (make-pathname :name (format nil "lib~a" file)
++                             :type #+unix "so"
++                                   #+darwin "dylib")))
++    (or (find-if (lambda (lib)
++                   (equal (cffi:foreign-library-pathname lib)
++                          (namestring name)))
++                 (cffi:list-foreign-libraries))
++        (cffi:load-foreign-library name))))
+
+ (defun ensure-lib-loaded (file)
+   (cond ((pathnamep file)

--- a/pkgs/development/lisp-modules-new/patches/qtools-use-nix-libs.patch
+++ b/pkgs/development/lisp-modules-new/patches/qtools-use-nix-libs.patch
@@ -1,0 +1,19 @@
+Dont use the qt+libs system for managing Qt dependencies, because Nix provides
+them already.
+Don't build the deploy.lisp helper file, because Nix also can handle deployment.
+--- a/qtools.asd
++++ b/qtools.asd
+@@ -33,10 +33,9 @@
+                (:file "generate")
+                (:file "dynamic")
+                (:file "precompile")
+-               (:file "deploy")
+                (:file "fast-call")
+                (:file "documentation"))
+-  :depends-on (:qt+libs
++  :depends-on (:qt
+                :deploy
+                :cl-ppcre
+                :closer-mop
+
+Diff finished.  Sun Oct  2 14:38:06 2022

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4735,6 +4735,8 @@ with pkgs;
 
   smokegen = callPackage ../development/libraries/smokegen {};
 
+  smokeqt = callPackage ../development/libraries/smokeqt {};
+
   snazy = callPackage ../development/tools/snazy { };
 
   snippetpixie = callPackage ../tools/text/snippetpixie { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4733,6 +4733,8 @@ with pkgs;
 
   simg2img = callPackage ../tools/filesystems/simg2img { };
 
+  smokegen = callPackage ../development/libraries/smokegen {};
+
   snazy = callPackage ../development/tools/snazy { };
 
   snippetpixie = callPackage ../tools/text/snippetpixie { };


### PR DESCRIPTION
Fixes 64 builds in sbclPackages on Hydra https://hydra.nuddy.co/eval/320#tabs-now-succeed

I'm not sure if adding `smokegen` and `smokeqt` to `pkgs` is correct here. They are unmaintained, but are required by the Lisp binding libraries.

Mentioned in https://github.com/NixOS/nixpkgs/pull/193754