### PR TITLE
zscroll: 1.0 -> 2.0.1

### DIFF
--- a/pkgs/applications/misc/zscroll/default.nix
+++ b/pkgs/applications/misc/zscroll/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "zscroll";
-  version = "1.0";
+  version = "2.0.1";
 
   # don't prefix with python version
   namePrefix = "";
@@ -10,8 +10,8 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "noctuid";
     repo = "zscroll";
-    rev = "v${version}";
-    sha256 = "0rf9m1czy19hzpcp8dq9c5zawk0nhwfzzjxlhk9r2n06lhb81ig5";
+    rev = "${version}";
+    sha256 = "gEluWzCbztO4N1wdFab+2xH7l9w5HqZVzp2LrdjHSRM=";
   };
 
   doCheck = false;
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "A text scroller for use with panels and shells";
     homepage = "https://github.com/noctuid/zscroll";
-    license = licenses.bsd2;
+    license = licenses.gpl3;
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/zscroll/default.nix
+++ b/pkgs/applications/misc/zscroll/default.nix
@@ -22,6 +22,7 @@ python3Packages.buildPythonApplication rec {
     description = "A text scroller for use with panels and shells";
     homepage = "https://github.com/noctuid/zscroll";
     license = licenses.gpl3;
+    changelog = "https://github.com/noctuid/zscroll/blob/${version}/Changelog.org";
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes
EDIT: 
`zscroll` changed versioning formats and also changed the license from bsd2 -> gpl3.
[changelog](https://github.com/noctuid/zscroll/blob/2.0.1/Changelog.org)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
