### PR TITLE
tbb: 2020.3 -> 2021.7.0

### DIFF
--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -1,87 +1,27 @@
 { lib
 , stdenv
-, fetchurl
 , fetchFromGitHub
+, cmake
+, pkg-config
 , fixDarwinDylibNames
 }:
 
 stdenv.mkDerivation rec {
   pname = "tbb";
-  version = "2020.3";
+  version = "2021.7.0";
 
   src = fetchFromGitHub {
     owner = "oneapi-src";
     repo = "oneTBB";
     rev = "v${version}";
-    sha256 = "prO2O5hd+Wz5iA0vfrqmyHFr0Ptzk64so5KpSpvuKmU=";
+    sha256 = "sha256-Lawhms0yq5p8BrQXMy6dPe29dpSlHdSntum+6bAkpyo=";
   };
 
-  patches = [
-    # Fixes build with Musl.
-    (fetchurl {
-      url = "https://github.com/openembedded/meta-openembedded/raw/39185eb1d1615e919e3ae14ae63b8ed7d3e5d83f/meta-oe/recipes-support/tbb/tbb/GLIBC-PREREQ-is-not-defined-on-musl.patch";
-      sha256 = "gUfXQ9OZQ82qD6brgauBCsKdjLvyHafMc18B+KxZoYs=";
-    })
-
-    # Fixes build with Musl.
-    (fetchurl {
-      url = "https://github.com/openembedded/meta-openembedded/raw/39185eb1d1615e919e3ae14ae63b8ed7d3e5d83f/meta-oe/recipes-support/tbb/tbb/0001-mallinfo-is-glibc-specific-API-mark-it-so.patch";
-      sha256 = "fhorfqO1hHKZ61uq+yTR7eQ8KYdyLwpM3K7WpwJpV74=";
-    })
-
-    # Fixes build with upcoming gcc-13:
-    #  https://github.com/oneapi-src/oneTBB/pull/833
-    (fetchurl {
-      name = "gcc-13.patch";
-      url = "https://github.com/oneapi-src/oneTBB/pull/833/commits/c18342ba667d1f33f5e9a773aa86b091a9694b97.patch";
-      sha256 = "ZUExE3nsW80Z5GPWZnDNuDiHHaD1EF7qNl/G5M+Wcxg=";
-    })
-
-    # Fixes build for aarch64-darwin
-    (fetchurl {
-      name = "aarch64-darwin.patch";
-      url = "https://github.com/oneapi-src/oneTBB/pull/258/commits/86f6dcdc17a8f5ef2382faaef860cfa5243984fe.patch";
-      sha256 = "sha256-JXqrFPCb3q1vfxk752tQu7HhApCB4YH2LoVnGRwmspk=";
-    })
-  ];
-
-  nativeBuildInputs = lib.optionals stdenv.isDarwin [
+  nativeBuildInputs = [ cmake pkg-config ] ++ (lib.optionals stdenv.isDarwin [
     fixDarwinDylibNames
-  ];
-
-  makeFlags = lib.optionals stdenv.cc.isClang [
-    "compiler=clang"
-  ];
+  ]);
 
   enableParallelBuilding = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/lib
-    cp "build/"*release*"/"*${stdenv.hostPlatform.extensions.sharedLibrary}* $out/lib/
-    mv include $out/
-    rm $out/include/index.html
-
-    runHook postInstall
-  '';
-
-  postInstall = let
-    pcTemplate = fetchurl {
-      url = "https://github.com/oneapi-src/oneTBB/raw/478de5b1887c928e52f029d706af6ea640a877be/integration/pkg-config/tbb.pc.in";
-      sha256 = "2pCad9txSpNbzac0vp/VY3x7HNySaYkbH3Rx8LK53pI=";
-    };
-  in ''
-    # Generate pkg-config file based on upstream template.
-    # It should not be necessary with tbb after 2021.2.
-    mkdir -p "$out/lib/pkgconfig"
-    substitute "${pcTemplate}" "$out/lib/pkgconfig/tbb.pc" \
-      --subst-var-by CMAKE_INSTALL_PREFIX "$out" \
-      --subst-var-by CMAKE_INSTALL_LIBDIR "lib" \
-      --subst-var-by CMAKE_INSTALL_INCLUDEDIR "include" \
-      --subst-var-by TBB_VERSION "${version}" \
-      --subst-var-by TBB_LIB_NAME "tbb"
-  '';
 
   meta = with lib; {
     description = "Intel Thread Building Blocks C++ Library";


### PR DESCRIPTION
###### Description of changes

It builds for `x86_64-linux`, but there is still an error for Musl:

```
In file included from /tmp/nix-build-tbb-2021.7.0.drv-0/source/test/common/test.h:32,
                 from /tmp/nix-build-tbb-2021.7.0.drv-0/source/test/tbbmalloc/test_malloc_overload.cpp:45:
/tmp/nix-build-tbb-2021.7.0.drv-0/source/test/tbbmalloc/test_malloc_overload.cpp: In function ‘void DOCTEST_ANON_FUNC_41()’:
/tmp/nix-build-tbb-2021.7.0.drv-0/source/test/tbbmalloc/test_malloc_overload.cpp:400:13: error: ‘mallopt’ was not declared in this scope; did you mean ‘malloc’?
  400 |     REQUIRE(mallopt(0, 0)); // add dummy mallopt call for coverage
      |             ^~~~~~~
/tmp/nix-build-tbb-2021.7.0.drv-0/source/test/common/doctest.h:1997:9: note: in definition of macro ‘DOCTEST_WRAP_IN_TRY’
 1997 |         x;                                                                                         \
      |         ^
/tmp/nix-build-tbb-2021.7.0.drv-0/source/test/common/doctest.h:2249:9: note: in expansion of macro ‘DOCTEST_ASSERT_IMPLEMENT_2’
 2249 |         DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/nix-build-tbb-2021.7.0.drv-0/source/test/common/doctest.h:2268:30: note: in expansion of macro ‘DOCTEST_ASSERT_IMPLEMENT_1’
 2268 | #define DOCTEST_REQUIRE(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_REQUIRE, __VA_ARGS__)
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/nix-build-tbb-2021.7.0.drv-0/source/test/common/doctest.h:2743:22: note: in expansion of macro ‘DOCTEST_REQUIRE’
 2743 | #define REQUIRE(...) DOCTEST_REQUIRE(__VA_ARGS__)
      |                      ^~~~~~~~~~~~~~~
/tmp/nix-build-tbb-2021.7.0.drv-0/source/test/tbbmalloc/test_malloc_overload.cpp:400:5: note: in expansion of macro ‘REQUIRE’
  400 |     REQUIRE(mallopt(0, 0)); // add dummy mallopt call for coverage
      |     ^~~~~~~
compilation terminated due to -Wfatal-errors.
make[2]: *** [test/CMakeFiles/test_malloc_overload.dir/build.make:76: test/CMakeFiles/test_malloc_overload.dir/tbbmalloc/test_malloc_overload.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4110: test/CMakeFiles/test_malloc_overload.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

Also I didn't test this on any other platform.

###### Changelogs:

- [2021.1.1](https://github.com/oneapi-src/oneTBB/blob/v2021.7.0/RELEASE_NOTES.md)
- [2021.2.0](https://github.com/oneapi-src/oneTBB/blob/v2021.7.0/RELEASE_NOTES.md)
- [2021.3.0](https://github.com/oneapi-src/oneTBB/blob/v2021.7.0/RELEASE_NOTES.md)
- [2021.4.0](https://github.com/oneapi-src/oneTBB/blob/v2021.7.0/RELEASE_NOTES.md)
- [2021.5.0](https://github.com/oneapi-src/oneTBB/blob/v2021.7.0/RELEASE_NOTES.md)
- [2021.6.0](https://github.com/oneapi-src/oneTBB/blob/v2021.7.0/RELEASE_NOTES.md)
- [2021.7.0](https://github.com/oneapi-src/oneTBB/blob/v2021.7.0/RELEASE_NOTES.md)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
