### PR TITLE
mepo: 0.4.2 -> 1.0

### DIFF
--- a/pkgs/applications/misc/mepo/default.nix
+++ b/pkgs/applications/misc/mepo/default.nix
@@ -4,31 +4,45 @@
 , pkg-config
 , zig
 , makeWrapper
+, busybox
 , curl
 , SDL2
 , SDL2_gfx
 , SDL2_image
 , SDL2_ttf
+, findutils
 , jq
 , ncurses
+, util-linux
 , inconsolata-nerdfont
+, menuChoice
+, bemenu
 , dmenu
 , xdotool
-, bemenu
-, withX11 ? false
+, directfb
+, libGL
+, vis
+, gnome
+, withGpsd ? false, gpsd
+, withGeoclue ? false, geoclue2-with-demo-agent
 }:
 
 let
-  menuInputs = if withX11 then [ dmenu xdotool ] else [ bemenu ];
+  menuInputs = {
+    bemenu = [ bemenu ];
+    dmenu = [ dmenu xdotool ];
+    framebuffer = [ directfb libGL vis busybox ];
+    zenity = [ gnome.zenity ];
+  }.${menuChoice};
 in stdenv.mkDerivation rec {
   pname = "mepo";
-  version = "0.4.2";
+  version = "1.0";
 
   src = fetchFromSourcehut {
     owner = "~mil";
     repo = pname;
     rev = version;
-    hash = "sha256-k6YXaqB3EwbDPlTvijZf10q+IYwt4/MiqGXL495KIcY=";
+    hash = "sha256-x1g81J/p7P0w8MOt5Xsmshg/xSl57hBkweZMlsLLWfM=";
   };
 
   nativeBuildInputs = [ pkg-config zig makeWrapper ];
@@ -53,31 +67,97 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    zig build -Drelease-safe=true -Dcpu=baseline --prefix $out install
+    zig build -Drelease-safe=true -Dcpu=baseline --prefix $bin install
+    install -d $man/share/man/man1
+    $bin/bin/mepo -docman > $man/share/man/man1/mepo.1
 
     runHook postInstall
   '';
 
-  postInstall = ''
-    wrapProgram $out/bin/mepo_dl.sh\
-      --suffix PATH : ${lib.makeBinPath [ jq ncurses ]}
-    wrapProgram $out/bin/mepo_ui_helper_menu.sh\
-      --suffix PATH : ${lib.makeBinPath menuInputs}
-    for script in $(grep -l jq out/bin/mepo_ui_menu_*.sh); do
-      wrapProgram $script --suffix PATH : $out/bin:${lib.makeBinPath [ jq ]}
-    done
-    for prog in $out/bin/mepo*; do
-      if [ ! -f $out/bin/.$(basename $prog)-wrapped ]; then
-        wrapProgram $prog --suffix PATH : $out/bin
-      fi
-    done
-  '';
+  postInstall = let
+    inherit (lib) concatStrings makeBinPath optional;
+  in concatStrings ((optional withGeoclue ''
+    substituteInPlace $bin/bin/mepo_ui_menu_user_pin_updater.sh\
+      --replace /usr/libexec/geoclue-2.0 ${geoclue2-with-demo-agent}/libexec/geoclue-2.0
+  '') ++ [ ''
+    substituteInPlace $bin/bin/mepo_ui_central_menu.sh\
+      --replace "grep mepo_" "grep '^\.mepo_\|^mepo_'"\
+      --replace " ls " " ls -a " #circumvent wrapping for script detection
+    wrapProgram $bin/bin/mepo_dl.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ jq ncurses curl busybox util-linux ]}
+    wrapProgram $bin/bin/mepo_ui_central_menu.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox findutils ]}
+    wrapProgram $bin/bin/mepo_ui_helper_menu.sh\
+      --set PATH ${makeBinPath (menuInputs ++ [ findutils busybox ])}
+    wrapProgram $bin/bin/mepo_ui_helper_pref_pan.sh\
+      --suffix PATH : ${makeBinPath [ busybox ]}
+    wrapProgram $bin/bin/mepo_ui_menu_dbg_queuedownloadinteractive.sh\
+      --suffix PATH : $bin/bin
+    wrapProgram $bin/bin/mepo_ui_menu_pin_editor.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox ]}
+    wrapProgram $bin/bin/mepo_ui_menu_pref_fontsize.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox ]}
+    wrapProgram $bin/bin/mepo_ui_menu_pref_url.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox findutils ]}
+    wrapProgram $bin/bin/mepo_ui_menu_pref_zoom.sh\
+      --suffix PATH : ${makeBinPath [ busybox ]}
+    wrapProgram $bin/bin/mepo_ui_menu_reposition_nominatim.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox curl jq ]}
+    wrapProgram $bin/bin/mepo_ui_menu_route_graphhopper.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox curl jq]}
+    wrapProgram $bin/bin/mepo_ui_menu_route_overpassrelation.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox curl findutils jq ]}
+    wrapProgram $bin/bin/mepo_ui_menu_search_nominatim.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox curl jq ]}
+    wrapProgram $bin/bin/mepo_ui_menu_search_overpass.sh\
+      --suffix PATH : $bin/bin:${makeBinPath [ busybox curl jq ]}
+      wrapProgram $bin/bin/mepo_ui_menu_user_pin_updater.sh\
+      --suffix PATH : ${makeBinPath ([ busybox curl jq ] ++ (optional withGpsd gpsd))}
+    wrapProgram $bin/bin/mepo --suffix PATH : $bin/bin
+  '' ]);
+
+  outputs = [ "bin" "out" "man" ];
 
   meta = with lib; {
     description = "Fast, simple, and hackable OSM map viewer";
+    longDescription = ''
+      # Menu Systems
+      Mepo supports multiple programs for displaying the menu. The default here is zenity.
+      If you prefer to use another, chose the `mepo-dmenu`, `mepo-bemenu` or `mepo-framebuffer`
+      packages, respectively.
+
+      # Location
+      For getting Location data, Mepo accepts 3 Backends:
+      - GPSD
+      - Geoclue
+      - Mozilla Location Services
+
+      Both GPSD and Geoclue require extra setup, that's why they're both set to false by default.
+
+      For GPSD, you need to enable (and configure) GPSD. This means your device must have a GPS sensor.
+      If you're on NixOS, see the
+      [gpsd configuration options](https://search.nixos.org/options?type=packages&query=services.gpsd)
+      NixOS provides.
+
+      To configure geoclue, you need to install the geoclue service and allow the `where-am-i`
+      program mepo uses. To do that, on NixOS:
+      ```nix
+      services.geoclue2 = {
+        enable = true;
+        appConfig.where-am-i = {
+          isAllowed = true;
+          isSystem = false;
+        };
+      };
+
+      ```
+      Finally, you need to override this package, setting `withGeoclue`
+      and/or `withGpsd` to true, respectively, e.g. list your mepo package
+      of choice as `(mepo.override { withGpsd = true; withGeoclue = true; })`.
+    '';
     homepage = "https://sr.ht/~mil/mepo/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ sikmir McSinyx ];
+    maintainers = with maintainers; [ sikmir McSinyx laalsaas ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29842,8 +29842,19 @@ with pkgs;
 
   merkaartor = libsForQt5.callPackage ../applications/misc/merkaartor { };
 
-  mepo = callPackage ../applications/misc/mepo { };
-  mepo-x11 = callPackage ../applications/misc/mepo { withX11 = true; };
+  mepo-bemenu = callPackage ../applications/misc/mepo {
+    menuChoice = "bemenu";
+  };
+  mepo-dmenu = callPackage ../applications/misc/mepo {
+    menuChoice = "dmenu";
+  };
+  mepo-framebuffer = callPackage ../applications/misc/mepo {
+    menuChoice = "framebuffer";
+  };
+  mepo-zenity = callPackage ../applications/misc/mepo {
+    menuChoice = "zenity";
+  };
+  mepo = mepo-zenity;
 
   meshcentral = callPackage ../tools/admin/meshcentral { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://git.sr.ht/~mil/mepo/refs/1.0
(please note that this is skipping some versions in betwen 0.4.2 and 1.0)

Please review this carefully, as this is my first nixpkgs contribution. Here is a list of things I'm especially not sure about/not 100% happy with but don't know how to do better:
- mepo ships with some helper shellscripts, some of these scripts depend on `jq` being in `$PATH`, one of these scripts depends on `gpspipe` (provided py package gpsd) being in `$PATH`.

  This is solved here by putting both jq and gpsd in the `$PATH` of all scripts containing `jq`. I'm not sure whether this is considered "unclean", as it also puts gpsd into the path of the scripts depending only on jq.

- I haven't been able to add support for the geoclue location source, as this seems to require some black magic dbus fuckery which is beyond my knowledge. If sombody knows how to do this, either go ahead or point me to a ressoucce. currently the corresponding script detects that geoclue is not available and uses the alternatives gpsd and mozilla location services.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->