### PR TITLE
guestfs-tools: fix, improvements

### DIFF
--- a/pkgs/tools/virtualization/guestfs-tools/default.nix
+++ b/pkgs/tools/virtualization/guestfs-tools/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, bash-completion
 , bison
 , cdrkit
 , cpio
@@ -56,6 +57,7 @@ stdenv.mkDerivation rec {
   ]);
 
   buildInputs = [
+    bash-completion
     hivex
     jansson
     libguestfs-with-appliance
@@ -72,6 +74,10 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "LIBGUESTFS_PATH=${libguestfs-with-appliance}/lib/guestfs"
+  ];
+
+  installFlags = [
+    "BASH_COMPLETIONS_DIR=${placeholder "out"}/share/bash-completion/completions"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/tools/virtualization/guestfs-tools/default.nix
+++ b/pkgs/tools/virtualization/guestfs-tools/default.nix
@@ -15,6 +15,7 @@
 , makeWrapper
 , ncurses
 , ocamlPackages
+, openssl
 , pcre2
 , perlPackages
 , pkg-config
@@ -64,6 +65,7 @@ stdenv.mkDerivation rec {
     libvirt
     libxml2
     ncurses
+    openssl
     pcre2
     xz
   ];

--- a/pkgs/tools/virtualization/guestfs-tools/default.nix
+++ b/pkgs/tools/virtualization/guestfs-tools/default.nix
@@ -8,7 +8,7 @@
 , getopt
 , hivex
 , jansson
-, libguestfs
+, libguestfs-with-appliance
 , libvirt
 , libxml2
 , makeWrapper
@@ -58,12 +58,16 @@ stdenv.mkDerivation rec {
   buildInputs = [
     hivex
     jansson
-    libguestfs
+    libguestfs-with-appliance
     libvirt
     libxml2
     ncurses
     pcre2
     xz
+  ];
+
+  makeFlags = [
+    "LIBGUESTFS_PATH=${libguestfs-with-appliance}/lib/guestfs"
   ];
 
   enableParallelBuilding = true;
@@ -74,7 +78,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/virt-win-reg \
-      --prefix PERL5LIB : ${with perlPackages; makeFullPerlPath [ hivex libintl-perl libguestfs ]}
+      --prefix PERL5LIB : ${with perlPackages; makeFullPerlPath [ hivex libintl-perl libguestfs-with-appliance ]}
   '';
 
   meta = with lib; {

--- a/pkgs/tools/virtualization/guestfs-tools/default.nix
+++ b/pkgs/tools/virtualization/guestfs-tools/default.nix
@@ -66,15 +66,15 @@ stdenv.mkDerivation rec {
     xz
   ];
 
+  preConfigure = ''
+    patchShebangs ocaml-dep.sh.in ocaml-link.sh.in run.in
+  '';
+
   makeFlags = [
     "LIBGUESTFS_PATH=${libguestfs-with-appliance}/lib/guestfs"
   ];
 
   enableParallelBuilding = true;
-
-  preBuild = ''
-    patchShebangs .
-  '';
 
   postInstall = ''
     wrapProgram $out/bin/virt-win-reg \


### PR DESCRIPTION
###### Description of changes

By replacing `libguestfs` by `libguestfs-with-appliance` this fixes the following error when running `virt-make-fs`:
```
libguestfs: error: cannot find any suitable libguestfs supermin, fixed or old-style appliance on LIBGUESTFS_PATH (search path: /nix/store/zax694y2jsf0l5x2glcr26xcn07psyav-libguestfs-1.48.4/lib/guestfs)
```

I added some more improvements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
