### PR TITLE
swift-format: init at 0.50700.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15566,4 +15566,10 @@
     github = "quasigod-io";
     githubId = 62124625;
   };
+  scoates = {
+    email = "sean@seancoates.com";
+    name = "Sean Coates";
+    github = "scoates";
+    githubId = 71983;
+  };
 }

--- a/pkgs/development/tools/swift-format/default.nix
+++ b/pkgs/development/tools/swift-format/default.nix
@@ -1,0 +1,111 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  unzip,
+  runCommand
+}:
+
+# This derivation is impure: it relies on an Xcode toolchain being installed
+# and available in the expected place (and is Darwin only). It was copied
+# pretty heavily from swiftformat which is different from swift-format.
+
+# swift-format is available as part of the swift (compiler) nixpkg, but that
+# doesn't build on Darwin.
+
+let
+
+  versions = {
+    swift_format = "0.50700.1";
+    swift_argument_parser = "1.1.4";
+    swift_tools_support_core = "0.2.7";
+    swift_syntax = "0.50700.1";
+    swift_system = "1.1.1";
+  };
+
+  fetchAppleRepo = { repo, rev, sha256 }:
+    fetchFromGitHub {
+      owner = "apple";
+      inherit repo rev sha256;
+      name = "${repo}-${rev}-src";
+    };
+
+  sources = {
+    swift_format = fetchAppleRepo {
+      repo = "swift-format";
+      rev = "${versions.swift_format}";
+      sha256 = "sha256-AFaViBqfqvk2D2abg4a240hmBTN1zCiWR/DUy+XBp6w=";
+    };
+
+    swift_argument_parser = fetchAppleRepo {
+      repo = "swift-argument-parser";
+      rev = "${versions.swift_argument_parser}";
+      sha256 = "sha256-ibNKHxIHJWpafIggyDSChvI15+YnLwsej8B10tm8ZKU";
+    };
+
+    swift_tools_support_core = fetchAppleRepo {
+      repo = "swift-tools-support-core";
+      rev = "${versions.swift_tools_support_core}";
+      sha256 = "sha256-thYDNOpdmXUXvPpfG8yO9UVZiWZbdxePUivDJJUdbFE=";
+    };
+
+    swift_syntax = fetchAppleRepo {
+      repo = "swift-syntax";
+      rev = "${versions.swift_syntax}";
+      sha256 = "sha256-Y5F2Mi2I+fec0h3L579rmUnsHex3zPYAIB1F1KJdrtM=";
+    };
+
+    swift_system = fetchAppleRepo {
+      repo = "swift-system";
+      rev = "${versions.swift_system}";
+      sha256 = "sha256-p18QHzO+NtoY/WQzOD+PfD+bjqrIWsbeEbsJLPqEAhA";
+    };
+
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "swift-format";
+  version = "${versions.swift_format}";
+
+  unpackPhase = ''
+    cp -r ${sources.swift_format} swift-format
+    cp -r ${sources.swift_argument_parser} swift-argument-parser
+    cp -r ${sources.swift_tools_support_core} swift-tools-support-core
+    cp -r ${sources.swift_syntax} swift-syntax
+    cp -r ${sources.swift_system} swift-system
+    chmod -R +w .
+    mkdir -p swift-format/.build
+  '';
+
+  preConfigure = "LD=$CC";
+
+  nativeBuildInputs = [ unzip ];
+  buildPhase = ''
+    cd swift-format
+    SWIFTCI_USE_LOCAL_DEPS=1 /usr/bin/swift build --disable-sandbox -c release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install_name_tool -change @rpath/lib_InternalSwiftSyntaxParser.dylib $out/lib_InternalSwiftSyntaxParser.dylib .build/release/swift-format
+    install -m 0644 .build/artifacts/swift-syntax/_InternalSwiftSyntaxParser.xcframework/macos-arm64_x86_64/lib_InternalSwiftSyntaxParser.dylib $out/lib_InternalSwiftSyntaxParser.dylib
+    install -m 0755 .build/release/swift-format "$out/bin/swift-format"
+  '';
+
+  sandboxProfile = ''
+    (allow file-read* file-write* process-exec mach-lookup)
+    ; block homebrew dependencies
+    (deny file-read* file-write* process-exec mach-lookup (subpath "/usr/local") (with no-log))
+  '';
+
+  meta = with lib; {
+    description = "Formatting technology for Swift source code ";
+    homepage = "https://github.com/apple/swift-format";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ scoates ];
+    platforms = platforms.darwin;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17491,6 +17491,8 @@ with pkgs;
 
   swarm = callPackage ../development/tools/analysis/swarm { };
 
+  swift-format = callPackage ../development/tools/swift-format { };
+
   swiftformat = callPackage ../development/tools/swiftformat { };
 
   symfony-cli = callPackage ../development/tools/symfony-cli { };


### PR DESCRIPTION
###### Description of changes

Added [swift-format](https://github.com/apple/swift-format), Apple's linting/formatting tool for Swift.

This is different from `swiftformat`, which is already a nixpkg. `swift-format` is part of the `swift` pkg, but that package does not build on Darwin. This package only builds on Darwin, and is impure due to dependency on the system Xcode tooling.

(also added myself as a maintainer; the instructions on exactly where to do this were unclear to me, but I'd be happy to amend/change my PR if this is the wrong way)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
