### PR TITLE
ldid: init at 2.1.5

### DIFF
--- a/pkgs/development/tools/ldid/default.nix
+++ b/pkgs/development/tools/ldid/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, callPackage
+, fetchgit
+, libplist
+, libxml2
+, openssl_1_1
+, CoreFoundation
+, Security
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ldid";
+  version = "2.1.5";
+
+  src = fetchgit {
+    url = "git://git.saurik.com/ldid.git";
+    rev = "v${version}";
+    sha256 = "sha256-RM5pU3mrgyvwNfWKNvCT3UYVGKtVhD7ifgp8fq9xXiM=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [
+    libplist
+    libxml2
+    openssl_1_1
+  ] ++ lib.optionals stdenv.isDarwin [
+    CoreFoundation
+    Security
+  ];
+
+  NIX_LDFLAGS = [
+    "-lcrypto"
+    "-lplist-2.0"
+    "-lxml2"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-framework CoreFoundation"
+    "-framework Security"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    cc -c -o lookup2.o lookup2.c -I.
+    c++ -std=c++11 -o ldid lookup2.o ldid.cpp -I. ${toString NIX_LDFLAGS}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 {,$out/bin/}ldid
+    ln -s $out/bin/ldid $out/bin/ldid2
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Link Identity Editor";
+    homepage = "https://cydia.saurik.com/info/ldid/";
+    maintainers = with maintainers; [ wegank ];
+    platforms = platforms.unix;
+    license = licenses.agpl3Only;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38068,6 +38068,10 @@ with pkgs;
 
   lc3tools = callPackage ../development/tools/lc3tools {};
 
+  ldid = callPackage ../development/tools/ldid {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+
   xcolor = callPackage ../tools/graphics/xcolor { };
 
   xcfun = callPackage ../development/libraries/science/chemistry/xcfun { };


### PR DESCRIPTION
###### Description of changes

ldid is a tool made by saurik for modifying a binary's entitlements easily. ldid also generates SHA1 and SHA256 hashes for the binary signature, so the iPhone kernel executes the binary.

Ping: #173467

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
