### PR TITLE
nixos/steam: Add fonts to /usr/share/fonts in the FHS

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -6,6 +6,14 @@ let
   cfg = config.programs.steam;
 
   steam = pkgs.steam.override {
+    extraPackages = pkgs: [
+      (pkgs.runCommand "share-fonts" { preferLocalBuild = true; } ''
+        mkdir -p "$out/share/fonts"
+        font_regexp='.*\.\(ttf\|ttc\|otf\|pcf\|pfa\|pfb\|bdf\)\(\.gz\)?'
+        find ${toString config.fonts.fonts} -regex "$font_regexp" \
+          -exec ln -sf -t "$out/share/fonts" '{}' \;
+      '')
+    ];
     extraLibraries = pkgs: with config.hardware.opengl;
       if pkgs.hostPlatform.is64bit
       then [ package ] ++ extraPackages

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -6,14 +6,7 @@ let
   cfg = config.programs.steam;
 
   steam = pkgs.steam.override {
-    extraPkgs = pkgs: [
-      (pkgs.runCommand "share-fonts" { preferLocalBuild = true; } ''
-        mkdir -p "$out/share/fonts"
-        font_regexp='.*\.\(ttf\|ttc\|otf\|pcf\|pfa\|pfb\|bdf\)\(\.gz\)?'
-        find ${toString config.fonts.fonts} -regex "$font_regexp" \
-          -exec ln -sf -t "$out/share/fonts" '{}' \;
-      '')
-    ];
+    extraFonts = _: config.fonts.fonts;
     extraLibraries = pkgs: with config.hardware.opengl;
       if pkgs.hostPlatform.is64bit
       then [ package ] ++ extraPackages

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -6,7 +6,7 @@ let
   cfg = config.programs.steam;
 
   steam = pkgs.steam.override {
-    extraPackages = pkgs: [
+    extraPkgs = pkgs: [
       (pkgs.runCommand "share-fonts" { preferLocalBuild = true; } ''
         mkdir -p "$out/share/fonts"
         font_regexp='.*\.\(ttf\|ttc\|otf\|pcf\|pfa\|pfb\|bdf\)\(\.gz\)?'

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -2,6 +2,7 @@
 , steam-runtime-wrapped, steam-runtime-wrapped-i686 ? null
 , extraPkgs ? pkgs: [ ] # extra packages to add to targetPkgs
 , extraLibraries ? pkgs: [ ] # extra packages to add to multiPkgs
+, extraFonts ? pkgs: [ ] # Extra fonts to include in the fhs
 , extraProfile ? "" # string to append to profile
 , extraArgs ? "" # arguments to always pass to steam
 , runtimeOnly ? false
@@ -42,6 +43,13 @@ let
       ++ lib.optional withPrimus primus
       ++ extraPkgs pkgs;
 
+  fontsPkg = (pkgs.runCommand "share-fonts" { preferLocalBuild = true; } ''
+    mkdir -p "$out/share/fonts"
+    font_regexp='.*\.\(ttf\|ttc\|otf\|pcf\|pfa\|pfb\|bdf\)\(\.gz\)?'
+    find ${toString (extraFonts pkgs)} -regex "$font_regexp" \
+      -exec ln -sf -t "$out/share/fonts" '{}' \;
+  '');
+
   ldPath = lib.optionals stdenv.is64bit [ "/lib64" ]
   ++ [ "/lib32" ]
   ++ map (x: "/steamrt/${steam-runtime-wrapped.arch}/" + x) steam-runtime-wrapped.libs
@@ -81,6 +89,7 @@ in buildFHSUserEnv rec {
     libGL
     libva
     pipewire.lib
+    fontsPkg
 
     # steamwebhelper
     harfbuzz

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -1,4 +1,4 @@
-{ config, lib, writeScript, buildFHSUserEnv, steam, glxinfo-i686
+{ config, lib, writeScript, buildFHSUserEnv, steam, glxinfo-i686, runCommand
 , steam-runtime-wrapped, steam-runtime-wrapped-i686 ? null
 , extraPkgs ? pkgs: [ ] # extra packages to add to targetPkgs
 , extraLibraries ? pkgs: [ ] # extra packages to add to multiPkgs
@@ -43,7 +43,7 @@ let
       ++ lib.optional withPrimus primus
       ++ extraPkgs pkgs;
 
-  fontsPkg = (pkgs.runCommand "share-fonts" { preferLocalBuild = true; } ''
+  fontsPkg = pkgs: (runCommand "share-fonts" { preferLocalBuild = true; } ''
     mkdir -p "$out/share/fonts"
     font_regexp='.*\.\(ttf\|ttc\|otf\|pcf\|pfa\|pfb\|bdf\)\(\.gz\)?'
     find ${toString (extraFonts pkgs)} -regex "$font_regexp" \
@@ -89,7 +89,7 @@ in buildFHSUserEnv rec {
     libGL
     libva
     pipewire.lib
-    fontsPkg
+    (fontsPkg pkgs)
 
     # steamwebhelper
     harfbuzz


### PR DESCRIPTION
Some unity games don't use fontconfig for finding fonts to use on the system, instead they manually poll /usr/share/fonts and parse the files themselves. This patch makes it so that the fonts in NixOS are passed into the FHS.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
