### PR TITLE
handbrake: build against ffmpeg with custom patches

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -93,6 +93,51 @@ let
     sha256 = "1kk11zl1mk37d4cvbc75gfndmma7vy3vkp4gmkyl92kiz6zadhyy";
   };
 
+  # Handbrake maintains a set of ffmpeg patches. In particular, these
+  # patches are required for subtitle timing to work correctly. See:
+  # https://github.com/HandBrake/HandBrake/issues/4029
+  ffmpeg-version = "4.4.1";
+  ffmpeg-hb = ffmpeg-full.overrideAttrs (old: {
+    version = ffmpeg-version;
+    src = fetchurl {
+      url = "https://www.ffmpeg.org/releases/ffmpeg-${ffmpeg-version}.tar.bz2";
+      hash = "sha256-j8nyCsXtlRFanihWR63Q7t1cwamKA5raFMEyRS+YrEI=";
+    };
+    patches = old.patches or [] ++ [
+      "${src}/contrib/ffmpeg/A01-qsv-scale-fix-green-stripes.patch"
+      "${src}/contrib/ffmpeg/A02-qsv-interpolation.patch"
+      "${src}/contrib/ffmpeg/A03-qsv-dx11-ffmpeg44.patch"
+      "${src}/contrib/ffmpeg/A04-configure-ensure-the-right-libmfx-version-is-used-wh.patch"
+      "${src}/contrib/ffmpeg/A05-qsv-add-includedir-mfx-to-the-search-path-for-old-ve.patch"
+      "${src}/contrib/ffmpeg/A06-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch"
+      "${src}/contrib/ffmpeg/A07-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch"
+      "${src}/contrib/ffmpeg/A08-qsvenc-don-t-support-multi-frame-encode-when-MFX_VER.patch"
+      "${src}/contrib/ffmpeg/A09-qsvenc-don-t-support-MFX_RATECONTROL_LA_EXT-when-MFX.patch"
+      "${src}/contrib/ffmpeg/A10-qsv-don-t-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch"
+      "${src}/contrib/ffmpeg/A11-qsv-opaque-deinterlace.patch"
+      "${src}/contrib/ffmpeg/A12-qsv-opaque-vpp.patch"
+      "${src}/contrib/ffmpeg/A13-qsv-opaque-hwcontext_qsv.patch"
+      "${src}/contrib/ffmpeg/A14-configure-check-mfxdefs.h-instead-of-mfxvp9.h-for-MF.patch"
+      "${src}/contrib/ffmpeg/A15-configure-allow-user-to-build-FFmpeg-against-oneVPL.patch"
+      "${src}/contrib/ffmpeg/A16-qsv-add-macro-QSV_ONEVPL-for-the-oneVPL-SDK.patch"
+      "${src}/contrib/ffmpeg/A17-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch"
+      "${src}/contrib/ffmpeg/A18-qsv-new-method-hwcontext_qsv.patch"
+      "${src}/contrib/ffmpeg/A19-qsv-fix-session-for-d3d11-device.patch"
+      "${src}/contrib/ffmpeg/A20-mov-read-name-track-tag-written-by-movenc.patch"
+      "${src}/contrib/ffmpeg/A21-movenc-write-3gpp-track-titl-tag.patch"
+      "${src}/contrib/ffmpeg/A22-mov-read-3gpp-udta-tags.patch"
+      "${src}/contrib/ffmpeg/A23-movenc-write-3gpp-track-names-tags-for-all-available.patch"
+      "${src}/contrib/ffmpeg/A24-FFmpeg-devel-amfenc-Add-support-for-pict_type-field.patch"
+      "${src}/contrib/ffmpeg/A25-dvdsubdec-fix-processing-of-partial-packets.patch"
+      "${src}/contrib/ffmpeg/A26-ccaption_dec-return-number-of-bytes-used.patch"
+      "${src}/contrib/ffmpeg/A27-dvdsubdec-return-number-of-bytes-used.patch"
+      "${src}/contrib/ffmpeg/A28-dvdsubdec-use-pts-of-initial-packet.patch"
+      "${src}/contrib/ffmpeg/A29-matroskaenc-aac-extradata-updated.patch"
+      "${src}/contrib/ffmpeg/A30-ccaption_dec-fix-pts-in-real_time-mode.patch"
+      "${src}/contrib/ffmpeg/A32-qsv-fix-decode-10bit-hdr.patch"
+    ];
+  });
+
   versionFile = writeText "version.txt" ''
     BRANCH=${versions.majorMinor version}.x
     DATE=1970-01-01 00:00:01 +0000
@@ -152,7 +197,7 @@ let self = stdenv.mkDerivation rec {
   buildInputs = [
     a52dec
     dav1d
-    ffmpeg-full
+    ffmpeg-hb
     fontconfig
     freetype
     fribidi


### PR DESCRIPTION
###### Description of changes

The Handbrake project carries a set of ffmpeg patches required for things like proper subtitle timing. This change builds handbrake against a patched ffmpeg as its maintainers require.

See: https://github.com/HandBrake/HandBrake/issues/4029

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
