### PR TITLE
ucc: init at 1.1.0

### DIFF
--- a/pkgs/development/libraries/ucc/default.nix
+++ b/pkgs/development/libraries/ucc/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, fetchFromGitHub, libtool, automake, autoconf, ucx
+, enableCuda ? false
+, cudatoolkit
+, enableAvx ? stdenv.hostPlatform.avxSupport
+, enableSse41 ? stdenv.hostPlatform.sse4_1Support
+, enableSse42 ? stdenv.hostPlatform.sse4_2Support
+} :
+
+stdenv.mkDerivation rec {
+  pname = "ucc";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "openucx";
+    repo = "ucc";
+    rev = "v${version}";
+    sha256 = "sha256-5rf08SXy+vCfnz4zLJ0cMnxwso4WpZOt0jRRAUviVFU=";
+  };
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+
+    for comp in $(find src/components -name Makefile.am); do
+      substituteInPlace $comp \
+        --replace "/bin/bash" "${stdenv.shell}"
+    done
+  '';
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  nativeBuildInputs = [ libtool automake autoconf ];
+  buildInputs = [ ucx ]
+    ++ lib.optional enableCuda cudatoolkit;
+
+  configureFlags = [ ]
+   ++ lib.optional enableSse41 "--with-sse41"
+   ++ lib.optional enableSse42 "--with-sse42"
+   ++ lib.optional enableAvx "--with-avx"
+   ++ lib.optional enableCuda "--with-cuda=${cudatoolkit}";
+
+  meta = with lib; {
+    description = "Collective communication operations API";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10527,6 +10527,8 @@ with pkgs;
 
   mpi = openmpi; # this attribute should used to build MPI applications
 
+  ucc = callPackage ../development/libraries/ucc {};
+
   ucx = callPackage ../development/libraries/ucx {};
 
   openmodelica = recurseIntoAttrs (callPackage ../applications/science/misc/openmodelica {});


### PR DESCRIPTION
###### Description of changes
Collective communication operations API for high performance computing applications.
The soon-to-come openmpi upgrade to version 5.0.0 will make use of this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
