### PR TITLE
vita3k: init at 2022-10-09

### DIFF
--- a/pkgs/by-name/vi/vita3k/package.nix
+++ b/pkgs/by-name/vi/vita3k/package.nix
@@ -1,0 +1,90 @@
+{ stdenv
+, clangStdenv
+, lib
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, cmake
+, ninja
+, openssl
+, pkg-config
+, boost
+, python3
+, SDL2
+, dbus
+, zlib
+, curl
+, discord-rpc
+}:
+
+clangStdenv.mkDerivation rec {
+  pname = "vita3k";
+  version = "unstable-2024-03-05";
+
+  src = fetchFromGitHub {
+    owner = "Vita3K";
+    repo = "Vita3K";
+    rev = "22595c5060298e246bbef02eb70d32752259ee09";
+    fetchSubmodules = true;
+    hash = "sha256-/3oDBVCEO2Fv6f5S1Sc+iXmc+h4M5yhoz1ewuwzjiWA=";
+  };
+
+  patches = [ ./patches/external/CMakeLists.txt.patch ];
+  postPatch = ''
+    # Don't force the need for a static boost
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(Boost_USE_STATIC_LIBS ON)' 'set(Boost_USE_STATIC_LIBS OFF)'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    openssl
+    boost
+    python3
+    SDL2
+    dbus
+    zlib
+    curl
+    discord-rpc
+  ];
+
+  # This thrashes ir/opt/* source code paths in external/dynarmic/src/dynarmic/CMakeLists.txt
+  dontFixCmake = true;
+
+  cmakeFlags = [
+    "-DUSE_VITA3K_UPDATE=OFF" # updates via nix
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    cp -r bin $out/lib/${pname}
+    ln -s $out/{lib/${pname},bin}/Vita3K
+    install -Dm644 ../data/image/icon.png $out/share/icons/hicolor/128x128/apps/${pname}.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "Vita3K";
+      exec = "Vita3K";
+      icon = pname;
+    })
+  ];
+
+  meta = with lib; {
+    description = "Experimental PlayStation Vita emulator";
+    homepage = "https://vita3k.org/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ annaaurora ];
+  };
+}

--- a/pkgs/by-name/vi/vita3k/patches/external/CMakeLists.txt.patch
+++ b/pkgs/by-name/vi/vita3k/patches/external/CMakeLists.txt.patch
@@ -1,0 +1,58 @@
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index 50dc2f07..4d3b1929 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -160,51 +160,8 @@ option(YAML_CPP_BUILD_CONTRIB "Enable contrib stuff in library" OFF)
+ add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
+ 
+ if(USE_DISCORD_RICH_PRESENCE)
+-	if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/discord_game_sdk.zip")
+-		message(STATUS "Downloading discord gamesdk...")
+-		file(DOWNLOAD https://dl-game-sdk.discordapp.net/latest/discord_game_sdk.zip
+-			"${CMAKE_BINARY_DIR}/external/discord_game_sdk.zip" SHOW_PROGRESS)
+-	endif()
+-endif()
+-
+-if(USE_DISCORD_RICH_PRESENCE)
+-	if(NOT EXISTS "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
+-		file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
+-		execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/external/discord_game_sdk.zip"
+-			WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/external/discord_game_sdk")
+-		file(RENAME "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.so"
+-			"${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so")
+-	endif()
+-
+-	add_library(discord-rpc STATIC
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/achievement_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/activity_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/application_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/core.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/image_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/lobby_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/network_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/overlay_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/relationship_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/storage_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/store_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/types.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/user_manager.cpp
+-		${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp/voice_manager.cpp)
+-
+-	if(APPLE)
+-		if(ARCHITECTURE STREQUAL "x86_64")
+-			target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dylib")
+-		else()
+-			target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/aarch64/discord_game_sdk.dylib")
+-		endif()
+-	elseif(WIN32)
+-		target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/discord_game_sdk.dll.lib")
+-	elseif(UNIX)
+-		target_link_libraries(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/lib/x86_64/libdiscord_game_sdk.so")
+-	endif()
+-
+-	target_include_directories(discord-rpc PUBLIC "${CMAKE_BINARY_DIR}/external/discord_game_sdk/cpp")
++	add_library(discord-rpc SHARED IMPORTED libdiscord-rpc.so)
++	target_link_libraries(discord-rpc PUBLIC)
+ endif()
+ 
+ option(BUILD_EXTERNAL "Build external dependencies in /External" OFF)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
