### PR TITLE
python-setup-hook: use buildPackages.callPackage to not change hashes

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15544,7 +15544,7 @@ with pkgs;
   update-python-libraries = callPackage ../development/interpreters/python/update-python-libraries { };
 
   # Should eventually be moved inside Python interpreters.
-  python-setup-hook = callPackage ../development/interpreters/python/setup-hook.nix { };
+  python-setup-hook = buildPackages.callPackage ../development/interpreters/python/setup-hook.nix { };
 
   pythonDocs = recurseIntoAttrs (callPackage ../development/interpreters/python/cpython/docs {});
 


### PR DESCRIPTION
this is just a hook so its safe

without this change:

we build a python3 for buildHost twice instead of only once while the result of the build is the same

```
nix-repl> pkgsCross.aarch64-multiplatform.python3.pythonForBuild
«derivation /nix/store/5sx1ng86lxzggi33rchvq0z16ywkg11b-python3-3.10.7.drv»

nix-repl> pkgsCross.aarch64-multiplatform.buildPackages.python3
«derivation /nix/store/c5rlaqdfymd3j5v41rh98pjcv3dx3sh7-python3-3.10.7.drv»
```

```
$ nix-diff $(getOutForDrv "/nix/store/5sx1ng86lxzggi33rchvq0z16ywkg11b-python3-3.10.7.drv") $(getOutForDrv "/nix/store/c5rlaqdfymd3j5v41rh98pjcv3dx3sh7-python3-3.10.7.drv") --environment
- /nix/store/3fkwg2pypsxhydgwb9m7f1v5pcgfns6p-python3-3.10.7:{out}
+ /nix/store/wyhbl43ycqn43d08v5fqj1j6ynf7nz73-python3-3.10.7:{out}
• The input derivation named `python-setup-hook.sh` differs
  - /nix/store/slvn39rh0l53c9czaf3g6a4awcj63j5r-python-setup-hook.sh.drv:{out}
  + /nix/store/bcjff6dn4gp7pf0knnja9ax4qrll78d5-python-setup-hook.sh.drv:{out}
  • The set of input source names do not match:
      - cross-file.conf
  • The input derivation named `stdenv-linux` differs
    - /nix/store/rsxsipgabvny0mc286j3vfpgaaaixdyz-stdenv-linux.drv:{out}
    + /nix/store/46ywpk0p6r22y502gi21xxghminy9lbj-stdenv-linux.drv:{out}
    • The set of input derivation names do not match:
        - hook
        + acl-2.3.1
        + attr-2.5.1
        + binutils-2.39
        + binutils-wrapper-2.39
        + ed-1.18
        + expand-response-params
        + gcc-11.3.0
        + gcc-wrapper-11.3.0
        + glibc-2.35-163
        + gmp-with-cxx-stage4-6.2.1
        + libidn2-2.3.2
        + libunistring-1.0
        + linux-headers-5.19
        + pcre-8.45
        + zlib-1.2.12
    • The set of input derivations named `bzip2-1.0.8` do not match
    • The set of input derivations named `xz-5.2.6` do not match
    • The environments do not match:
        + allowedRequisites=...
        defaultNativeBuildInputs=''
        ...
    ''
  • The environments do not match:
      cmakeFlags=''
      -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_HOST_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_PROCESSOR=x86_64
  ''
      configureFlags=''
      --build=x86_64-unknown-linux-gnu --host=aarch64-unknown-linux-gnu
  ''
      mesonFlags=''
      --cross-file=/nix/store/0d6bflf42rgrrxhp10visp67scqncd4g-cross-file.conf
  ''
      stdenv=''
      /nix/store/6ji09gqw12pnp3ylw3rrsd65f9vhhx89-stdenv-linux/nix/store/ykjm8yzjcwg2xpf640zh6jql5s8yimkp-stdenv-linux
  ''
• The environments do not match:
    setupHook=''
    /nix/store/x6rrxsai11kl9gq29ipv0jn455admav3-python-setup-hook.sh/nix/store/h7z4wvlf7n23ir86nngjn9rpk1ygc7di-python-setup-hook.sh
''
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
