### PR TITLE
heroic: don't use the `kdialog` top-level alias

### DIFF
--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -15,7 +15,7 @@ buildFHSUserEnv {
     curl
     gawk
     gnome.zenity
-    kdialog
+    plasma5Packages.kdialog
     mangohud
     nettools
     opencl-headers


### PR DESCRIPTION
https://hydra.nixos.org/log/ygsis1s955063im3i37cqwb9grfjyfsz-nixpkgs-release-checks.drv

(this only expands the alias, nothing gets rebuilt)