### PR TITLE
sil-padauk: 3.003 → 5.001; sil-abyssinica: 1.500 → 2.100

### DIFF
--- a/pkgs/data/fonts/sil-abyssinica/default.nix
+++ b/pkgs/data/fonts/sil-abyssinica/default.nix
@@ -1,23 +1,25 @@
 { fetchzip, lib }:
 
 let
-  version = "1.500";
+  version = "2.100";
 in
-fetchzip {
+fetchzip rec {
   name = "sil-abyssinica-${version}";
-  url = "mirror://debian/pool/main/f/fonts-sil-abyssinica/fonts-sil-abyssinica_${version}.orig.tar.xz";
-  sha256 = "sha256-fCa88wG2JfHTaHaBkuvoncbcbrh3XNzc8ewS3W+W/fM=";
+  url = "https://software.sil.org/downloads/r/abyssinica/AbyssinicaSIL-${version}.zip";
+  sha256 = "sha256-06olbIdSlhJ4hgblzzabqIs57FpsyWIdPDFXb9vK31A=";
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    tar xf $downloadedFile --strip-components=1 -C $out/share/fonts AbyssinicaSIL-${version}/AbyssinicaSIL-R.ttf
+    rm -rf $out/web
+    mkdir -p $out/share/{fonts/truetype,doc/${name}}
+    mv $out/*.ttf $out/share/fonts/truetype/
+    mv $out/*.txt $out/documentation $out/share/doc/${name}/
   '';
 
   meta = with lib; {
     description = "Unicode font for Ethiopian and Erythrean scripts (Amharic et al.)";
     homepage = "https://software.sil.org/abyssinica/";
     license = licenses.ofl;
-    maintainers = with lib.maintainers; [ serge ];
+    maintainers = with maintainers; [ serge ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/data/fonts/sil-padauk/default.nix
+++ b/pkgs/data/fonts/sil-padauk/default.nix
@@ -1,27 +1,26 @@
 { fetchzip, lib }:
 
 let
-  version = "3.003";
+  version = "5.001";
 in
-fetchzip {
+fetchzip rec {
   name = "sil-padauk-${version}";
-  url = "mirror://debian/pool/main/f/fonts-sil-padauk/fonts-sil-padauk_${version}.orig.tar.xz";
-  sha256 = "sha256-oK+EufbvsqXunTgcWj+DiNdfpRl+VPO60Wc9KYjZv5A=";
+  url = "https://software.sil.org/downloads/r/padauk/Padauk-${version}.zip";
+  sha256 = "sha256-6H9EDmXr1Ox2fgLw9sG5JrCAllK3tbjvMfLi8DTF1f0=";
 
   postFetch = ''
-    unpackDir="$TMPDIR/unpack"
-    mkdir "$unpackDir"
-    cd "$unpackDir"
-    tar xf "$downloadedFile" --strip-components=1
-    mkdir -p $out/share/fonts
-    cp *.ttf $out/share/fonts
+    mkdir -p $out/share/fonts/truetype
+    rm -rf $out/{manifest.json,web/}
+    mv $out/*.ttf $out/share/fonts/truetype/
+    mkdir -p $out/share/doc/${name}
+    mv $out/*.txt $out/documentation/ $out/share/doc/${name}/
   '';
 
   meta = with lib; {
-    description = "Burmese Unicode 6 TrueType font";
+    description = "A Unicode-based font family with broad support for writing systems that use the Myanmar script";
     homepage = "https://software.sil.org/padauk";
     license = licenses.ofl;
-    maintainers = with lib.maintainers; [ serge ];
+    maintainers = with maintainers; [ serge ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

Improvements:
  - https://software.sil.org/padauk/release-5-001/
  - https://software.sil.org/abyssinica/release-2-100/

Also fix the derivations (they currently fail to build).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
