### PR TITLE
kubedog: init at 0.9.6

### DIFF
--- a/pkgs/applications/networking/cluster/kubedog/default.nix
+++ b/pkgs/applications/networking/cluster/kubedog/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, testers
+, kubedog
+}:
+
+buildGoModule rec {
+  pname = "kubedog";
+  version = "0.9.6";
+
+  src = fetchFromGitHub {
+    owner = "werf";
+    repo = "kubedog";
+    rev = "v${version}";
+    hash = "sha256-mwITvv2MuqzH1aB4iTVaFfZljyqOAu7vl4cORHT/OXQ=";
+  };
+
+  vendorHash = "sha256-HBo26cPiWJPDpsjPYUEBraHB2SZsUttrlBKpB9/SS6o=";
+
+  subPackages = [ "cmd/kubedog" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/werf/kubedog.Version=${src.rev}"
+  ];
+
+  # There are no tests.
+  doCheck = false;
+
+  passthru.tests.version = testers.testVersion {
+    package = kubedog;
+    command = "kubedog version";
+    version = src.rev;
+  };
+
+  meta = with lib; {
+    description = ''
+      A tool to watch and follow Kubernetes resources in CI/CD deployment
+      pipelines
+    '';
+    homepage = "https://github.com/werf/kubedog";
+    changelog = "https://github.com/werf/kubedog/releases/tag/${src.rev}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ azahi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29409,6 +29409,8 @@ with pkgs;
 
   kubedb-cli = callPackage ../applications/networking/cluster/kubedb-cli { };
 
+  kubedog = callPackage ../applications/networking/cluster/kubedog { };
+
   kubecfg = callPackage ../applications/networking/cluster/kubecfg { };
 
   kube-score = callPackage ../applications/networking/cluster/kube-score { };


### PR DESCRIPTION
###### Description of changes

A tool to watch and follow Kubernetes resources in CI/CD deployment pipelines.
https://github.com/werf/kubedog
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
