### PR TITLE
certbot: 1.29.0 -> 1.31.0

### DIFF
--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -1,10 +1,27 @@
 { lib
 , buildPythonPackage
-, python, runCommand
+, python
+, runCommand
 , fetchFromGitHub
-, configargparse, acme, configobj, cryptography, distro, josepy, parsedatetime, pyRFC3339, pyopenssl, pytz, requests, six, zope_component, zope_interface
-, dialog, gnureadline
-, pytest-xdist, pytestCheckHook, python-dateutil
+, configargparse
+, acme
+, configobj
+, cryptography
+, distro
+, josepy
+, parsedatetime
+, pyRFC3339
+, pyopenssl
+, pytz
+, requests
+, six
+, zope_component
+, zope_interface
+, dialog
+, gnureadline
+, pytest-xdist
+, pytestCheckHook
+, python-dateutil
 }:
 
 buildPythonPackage rec {
@@ -59,15 +76,17 @@ buildPythonPackage rec {
   # certbot.withPlugins has a similar calling convention as python*.withPackages
   # it gets invoked with a lambda, and invokes that lambda with the python package set matching certbot's:
   # certbot.withPlugins (cp: [ cp.certbot-dns-foo ])
-  passthru.withPlugins = f: let
-    pythonEnv = python.withPackages f;
+  passthru.withPlugins = f:
+    let
+      pythonEnv = python.withPackages f;
 
-  in runCommand "certbot-with-plugins" {
-  } ''
-    mkdir -p $out/bin
-    cd $out/bin
-    ln -s ${pythonEnv}/bin/certbot
-  '';
+    in
+    runCommand "certbot-with-plugins"
+      { } ''
+      mkdir -p $out/bin
+      cd $out/bin
+      ln -s ${pythonEnv}/bin/certbot
+    '';
 
   meta = with lib; {
     homepage = src.meta.homepage;

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -26,13 +26,13 @@
 
 buildPythonPackage rec {
   pname = "certbot";
-  version = "1.29.0";
+  version = "1.31.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-DFdXDFSqqkm4r59Kmd1wxcg2YePP3dI9squiW+iSmaU=";
+    sha256 = "sha256-JDhesUU6SQBEf0CG3vo1AhlRfGpltTEUmSqrpGIpptg=";
   };
 
   sourceRoot = "source/${pname}";


### PR DESCRIPTION
Fixes `(pkgs.certbot.withPlugins (p: [ p.certbot-dns-route53 ]))` and
`certbot-full` build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
