### PR TITLE
emscriptenPackges.minisat: Add minisat to emscriptenPackages.

### DIFF
--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -180,4 +180,24 @@ rec {
       '';
     });
 
+
+  minisat = (pkgs.minisat.override {
+    stdenv = pkgs.emscriptenStdenv;
+  }).overrideAttrs
+    (old: {
+      propagatedBuildInputs = [ zlib ];
+      CXXFLAGS = "-isystem ${zlib}/include";
+      LDFLAGS = "-L ${zlib}/lib";
+      configurePhase = ''
+        make config prefix="$out"
+      '';
+      buildPhase = ''
+        emmake make lr lsh
+      '';
+      installPhase = ''
+        emmake make install-lib install-headers
+      '';
+      checkPhase = ''
+      '';
+    });
 }


### PR DESCRIPTION
###### Description of changes

Created an emscripten package of the minisat library, not including the executable

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
