### PR TITLE
wwcd: init at unstable-2022-02-05r

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7475,6 +7475,10 @@
     githubId = 72546287;
     name = "L3af";
   };
+  laalsaas = {
+    email = "laalsaas@systemli.org";
+    name = "laalsaas";
+  };
   lach = {
     email = "iam@lach.pw";
     github = "CertainLach";

--- a/pkgs/tools/misc/wwcd/default.nix
+++ b/pkgs/tools/misc/wwcd/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, lib
+, fetchFromSourcehut
+, autoreconfHook
+, pkg-config
+, check
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wwcd";
+  version = "unstable-2022-02-05";
+
+  src = fetchFromSourcehut {
+    owner = "~bitfehler";
+    repo = pname;
+    rev = "cdf70bb18dc60c66c074d4810cb37b9e697811e5";
+    sha256 = "sha256-laf1DEtdEs7q+rtp5Y5rb+7AGsKUv5T413CFWJiURWw=";
+  };
+
+  autoreconfFlags = "-if";
+  nativeBuildInputs = [
+    autoreconfHook pkg-config check
+  ];
+
+  meta = with lib; {
+    description = "What would cron do? Read crontab entries from stdin and print time of next execution(s)";
+    homepage = "https://git.sr.ht/~bitfehler/wwcd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ laalsaas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1430,6 +1430,8 @@ with pkgs;
     use64 = true;
   };
 
+  wwcd = callPackage ../tools/misc/wwcd { };
+
   writedisk = callPackage ../tools/misc/writedisk { };
 
   xcd = callPackage ../tools/misc/xcd { };


### PR DESCRIPTION
cription of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
wwcd parses crontab entries and tells you when the're executed. See  https://git.sr.ht/~bitfehler/wwcd
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

