### PR TITLE
SoliCurses: init at unstable-2022-02-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7475,6 +7475,10 @@
     githubId = 72546287;
     name = "L3af";
   };
+  laalsaas = {
+    email = "laalsaas@systemli.org";
+    name = "laalsaas";
+  };
   lach = {
     email = "iam@lach.pw";
     github = "CertainLach";

--- a/pkgs/games/solicurses/default.nix
+++ b/pkgs/games/solicurses/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, ncurses
+}:
+
+stdenv.mkDerivation {
+  pname = "solicurses";
+  version = "unstable-2020-02-13";
+
+  src = fetchFromGitHub {
+    owner = "KaylaPP";
+    repo = "SoliCurses";
+    rev = "dc89ca00fc1711dc449d0a594a4727af22fc35a0";
+    sha256 = "sha256-zWYXpvEnViT/8gsdMU9Ymi4Hw+nwkG6FT/3h5sNMCE4=";
+  };
+
+  buildInputs = [
+    ncurses
+  ];
+
+  preBuild = ''
+    cd build
+  '';
+
+  installPhase = ''
+    install -D SoliCurses.out $out/bin/solicurses
+  '';
+
+  meta = with lib; {
+    description = "A version of Solitaire written in C++ using the ncurses library";
+    homepage = "https://github.com/KaylaPP/SoliCurses";
+    maintainers = with maintainers; [ laalsaas ];
+    license = licenses.gpl3Only;
+    inherit (ncurses.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34260,6 +34260,8 @@ with pkgs;
 
   sollya = callPackage ../development/interpreters/sollya { };
 
+  solicurses = callPackage ../games/solicurses { };
+
   # You still can override by passing more arguments.
   space-orbit = callPackage ../games/space-orbit { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add SoliCurses, an ncurses solitaire game, see: https://github.com/KaylaPP/SoliCurses

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
