### PR TITLE
vimPlugins: make usage of luaPackages less confusing

### DIFF
--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -1,8 +1,6 @@
 { lib
 , stdenv
-, buildVimPluginFrom2Nix
-, buildLuarocksPackage
-, lua51Packages
+, lua
 , toVimPlugin
 }:
 let
@@ -19,16 +17,21 @@ in
     , ...
   }@attrs:
     let
-      originalLuaDrv = lua51Packages.${luaAttr};
-      luaDrv = lua51Packages.luaLib.overrideLuarocks originalLuaDrv (drv: {
+      originalLuaDrv = lua.pkgs.${luaAttr};
+
+      luaDrv = (lua.pkgs.luaLib.overrideLuarocks originalLuaDrv (drv: {
         extraConfig = ''
           -- to create a flat hierarchy
           lua_modules_path = "lua"
         '';
+        })).overrideAttrs (drv: {
+        version = attrs.version;
+        rockspecVersion = drv.rockspecVersion;
       });
-      finalDrv = toVimPlugin (luaDrv.overrideAttrs(oa: {
+
+      finalDrv = toVimPlugin (luaDrv.overrideAttrs(oa: attrs // {
           nativeBuildInputs = oa.nativeBuildInputs or [] ++ [
-            lua51Packages.luarocksMoveDataFolder
+            lua.pkgs.luarocksMoveDataFolder
           ];
         }));
     in

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -1,11 +1,11 @@
 { lib
-, buildLuarocksPackage
 , callPackage
 , vimUtils
 , nodejs
 , neovim-unwrapped
 , bundlerEnv
 , ruby
+, lua
 , python3Packages
 , writeText
 , wrapNeovimUnstable
@@ -193,7 +193,7 @@ in
   inherit legacyWrapper;
 
   buildNeovimPluginFrom2Nix = callPackage ./build-neovim-plugin.nix {
-    inherit (vimUtils) buildVimPluginFrom2Nix toVimPlugin;
-    inherit buildLuarocksPackage;
+    inherit (vimUtils) toVimPlugin;
+    inherit lua;
   };
 }

--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -8,9 +8,10 @@
 , luaLib
 }:
 
-{
-pname
+{ pname
 , version
+# we need rockspecVersion to find the .rockspec even when version changes
+, rockspecVersion ? version
 
 # by default prefix `name` e.g. "lua5.2-${name}"
 , namePrefix ? "${lua.pname}${lua.sourceVersion.major}.${lua.sourceVersion.minor}-"
@@ -72,7 +73,7 @@ pname
 # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
 
 let
-  generatedRockspecFilename = "${rockspecDir}/${pname}-${version}.rockspec";
+  generatedRockspecFilename = "${rockspecDir}/${pname}-${rockspecVersion}.rockspec";
 
   # TODO fix warnings "Couldn't load rockspec for ..." during manifest
   # construction -- from initial investigation, appears it will require
@@ -80,20 +81,6 @@ let
   # luarocks only looks for rockspecs in the default/system tree instead of all
   # configured trees)
   luarocks_config = "luarocks-config.lua";
-  luarocks_content = let
-    generatedConfig = luaLib.generateLuarocksConfig {
-      externalDeps = externalDeps ++ externalDepsGenerated;
-      inherit extraVariables;
-      inherit rocksSubdir;
-      inherit requiredLuaRocks;
-    };
-    in
-      ''
-      ${generatedConfig}
-      ${extraConfig}
-      '';
-
-  rocksSubdir = "${attrs.pname}-${version}-rocks";
 
   # Filter out the lua derivation itself from the Lua module dependency
   # closure, as it doesn't have a rock tree :)
@@ -106,15 +93,28 @@ let
     );
   externalDeps' = lib.filter (dep: !lib.isDerivation dep) externalDeps;
 
-  luarocksDrv = luaLib.toLuaModule ( lua.stdenv.mkDerivation (
-builtins.removeAttrs attrs ["disabled" "checkInputs" "externalDeps" "extraVariables"] // {
+  luarocksDrv = luaLib.toLuaModule ( lua.stdenv.mkDerivation (self: let
 
-  name = namePrefix + pname + "-" + version;
+    rocksSubdir = "${self.pname}-${self.version}-rocks";
+    luarocks_content = let
+      generatedConfig = luaLib.generateLuarocksConfig {
+        externalDeps = externalDeps ++ externalDepsGenerated;
+        inherit extraVariables rocksSubdir requiredLuaRocks;
+      };
+      in
+        ''
+        ${generatedConfig}
+        ${extraConfig}
+        '';
+    in builtins.removeAttrs attrs ["disabled" "externalDeps" "extraVariables"] // {
+
+  name = namePrefix + pname + "-" + self.version;
+  inherit rockspecVersion;
 
   nativeBuildInputs = [
     wrapLua
     luarocks
-  ] ++ lib.optionals doCheck ([ luarocksCheckHook ] ++ checkInputs);
+  ] ++ lib.optionals doCheck ([ luarocksCheckHook ] ++ self.checkInputs);
 
   buildInputs = buildInputs
     ++ (map (d: d.dep) externalDeps');

--- a/pkgs/development/interpreters/lua-5/hooks/luarocks-move-data.sh
+++ b/pkgs/development/interpreters/lua-5/hooks/luarocks-move-data.sh
@@ -5,7 +5,7 @@ echo "Sourcing luarocks-move-data-hook.sh"
 luarocksMoveDataHook () {
     echo "Executing luarocksMoveDataHook"
     if [ -d "$out/$rocksSubdir" ]; then
-        cp -rfv "$out/$rocksSubdir/$pname/$version/." "$out"
+        cp -rfv "$out/$rocksSubdir/$pname/$rockspecVersion/." "$out"
     fi
 
     echo "Finished executing luarocksMoveDataHook"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32314,7 +32314,7 @@ with pkgs;
   };
 
   neovimUtils = callPackage ../applications/editors/neovim/utils.nix {
-    inherit (lua51Packages) buildLuarocksPackage;
+    lua = lua5_1;
   };
   neovim = wrapNeovim neovim-unwrapped { };
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/185397

right now the src is ignored in:

```
  lush-nvim = buildNeovimPlugin {
    pname = "lush.nvim";
    version = "2022-08-09";
    src = fetchFromGitHub {
      owner = "rktjmp";
      repo = "lush.nvim";
      rev = "6b9f399245de7bea8dac2c3bf91096ffdedfcbb7";
      sha256 = "0rb77rwmbm438bmbjfk5hwrrcn5sihsa1413bdpc27rw3rrn8v8z";
    };
    meta.homepage = "https://github.com/rktjmp/lush.nvim/";
  };
```

which is very confusing. With this PR, we correctly override the src and the version of the package. We introduce a rockspecVersion attribute of lua package to be able to still find the rockspec when the "version" field needs to be different than "rockspecVersion".

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
