### PR TITLE
python310Packages.pymodbus: 2.5.3 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -11,6 +11,7 @@
 , pyserial-asyncio
 , pytest-asyncio
 , pytestCheckHook
+, pythonOlder
 , redis
 , sqlalchemy
 , tornado
@@ -20,12 +21,15 @@
 buildPythonPackage rec {
   pname = "pymodbus";
   version = "3.0.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "riptideio";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-7zuFKJuKc+J4g7qoK22xed8dmXJatQbQXz4aKAOcvN8=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-7zuFKJuKc+J4g7qoK22xed8dmXJatQbQXz4aKAOcvN8=";
   };
 
   # Twisted asynchronous version is not supported due to a missing dependency
@@ -49,7 +53,9 @@ buildPythonPackage rec {
     twisted
   ];
 
-  pythonImportsCheck = [ "pymodbus" ];
+  pythonImportsCheck = [
+    "pymodbus"
+  ];
 
   meta = with lib; {
     description = "Python implementation of the Modbus protocol";
@@ -60,6 +66,7 @@ buildPythonPackage rec {
       lightweight project is needed.
     '';
     homepage = "https://github.com/riptideio/pymodbus";
+    changelog = "https://github.com/riptideio/pymodbus/releases/tag/v${version}";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -19,13 +19,13 @@
 
 buildPythonPackage rec {
   pname = "pymodbus";
-  version = "3.0.1";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "riptideio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-JoRCVbvH027+S5Lb0hnJLJSD4RuS2wzpGP3BMyEaadU=";
+    sha256 = "sha256-7zuFKJuKc+J4g7qoK22xed8dmXJatQbQXz4aKAOcvN8=";
   };
 
   # Twisted asynchronous version is not supported due to a missing dependency

--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -19,13 +19,13 @@
 
 buildPythonPackage rec {
   pname = "pymodbus";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "riptideio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lhzRtoIxhChZAZhlI7MRLn7qO0xXoHTHcYRkGFJFHks=";
+    sha256 = "sha256-JoRCVbvH027+S5Lb0hnJLJSD4RuS2wzpGP3BMyEaadU=";
   };
 
   # Twisted asynchronous version is not supported due to a missing dependency

--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -9,6 +9,7 @@
 , pygments
 , pyserial
 , pyserial-asyncio
+, pytest-asyncio
 , pytestCheckHook
 , redis
 , sqlalchemy
@@ -18,13 +19,13 @@
 
 buildPythonPackage rec {
   pname = "pymodbus";
-  version = "2.5.3";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "riptideio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-pf1TU/imBqNVYdG4XX8fnma8O8kQHuOHu6DT3E/PUk4=";
+    sha256 = "sha256-lhzRtoIxhChZAZhlI7MRLn7qO0xXoHTHcYRkGFJFHks=";
   };
 
   # Twisted asynchronous version is not supported due to a missing dependency
@@ -41,6 +42,7 @@ buildPythonPackage rec {
   checkInputs = [
     asynctest
     mock
+    pytest-asyncio
     pytestCheckHook
     redis
     sqlalchemy


### PR DESCRIPTION
###### Description of changes
https://github.com/riptideio/pymodbus/releases/tag/v3.0.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
