### PR TITLE
androidenv: fix darwin ndk symlink

### DIFF
--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -13,7 +13,7 @@ deployAndroidPackage {
     ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
   autoPatchelfIgnoreMissingDeps = true;
   buildInputs = lib.optionals (os == "linux") [ pkgs.zlib ];
-  patchInstructions = lib.optionalString (os == "linux") (''
+  patchInstructions = ''
     patchShebangs .
 
     # TODO: allow this stuff
@@ -37,9 +37,11 @@ deployAndroidPackage {
         addAutoPatchelfSearchPath $out/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/lib64
     fi
 
-    find toolchains -type d -name bin -or -name lib64 | while read dir; do
-        autoPatchelf "$dir"
-    done
+    if [ -d toolchains/llvm/prebuilt/linux-x86_64 ]; then
+        find toolchains/llvm/prebuilt/linux-x86_64 -type d -name bin -or -name lib64 | while read dir; do
+            autoPatchelf "$dir"
+        done
+    fi
 
     # fix ineffective PROGDIR / MYNDKDIR determination
     for progname in ndk-build; do
@@ -47,7 +49,9 @@ deployAndroidPackage {
     done
 
     # Patch executables
-    autoPatchelf prebuilt/linux-x86_64
+    if [ -d prebuild/linux-x86_64 ]; then
+        autoPatchelf prebuilt/linux-x86_64
+    fi
 
     # wrap
     for progname in ndk-build; do
@@ -59,6 +63,6 @@ deployAndroidPackage {
     for progname in ndk-build; do
         ln -sf ../libexec/android-sdk/ndk-bundle/$progname $out/bin/$progname
     done
-  '');
+  '';
   noAuditTmpdir = true; # Audit script gets invoked by the build/ component in the path for the make standalone script
 }


### PR DESCRIPTION
This fix was added previously for linux but is needed on all platforms. Confirmed it fixes my bazel build that looks for an NDK in the standard locations.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
