### PR TITLE
ImageMagick: Silence flood of deprecation warnings from GCC

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/0001-Silence-flood-of-deprecation-warnings.patch
+++ b/pkgs/applications/graphics/ImageMagick/0001-Silence-flood-of-deprecation-warnings.patch
@@ -1,0 +1,28 @@
+From 9fc749739371e4b61f38ec628fc2949814c6814f Mon Sep 17 00:00:00 2001
+From: YoshiRulz <OSSYoshiRulz@gmail.com>
+Date: Wed, 12 Oct 2022 18:15:34 +1000
+Subject: [PATCH] Silence flood of deprecation warnings
+
+message is:
+cc1: warning: '-mtune=x86-64' is deprecated; use '-mtune=k8' or '-mtune=generic'
+instead as appropriate
+[8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-Wdeprecated8;;]
+---
+ configure | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure b/configure
+index c8ca87bea..ee42666bf 100755
+--- a/configure
++++ b/configure
+@@ -9336,6 +9336,7 @@ fi
+ for flag_prefix in $flag_prefixes; do
+   for arch in $ax_gcc_arch; do
+     flag="$flag_prefix$arch"
++    if test "x$flag" = "x-mtune=x86-64"; then flag="-mtune=generic"; fi # deprecated
+     as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags__$flag" | $as_tr_sh`
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts $flag" >&5
+ printf %s "checking whether C compiler accepts $flag... " >&6; }
+-- 
+2.36.2
+

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  patches = [ ./0001-Silence-flood-of-deprecation-warnings.patch ];
+
   configureFlags = [
     "--with-frozenpaths"
     (lib.withFeatureAs (arch != null) "gcc-arch" arch)


### PR DESCRIPTION
###### Description of changes

When building ImageMagick there's a warning on seemingly every source file:
```
cc1: warning: '-mtune=x86-64' is deprecated; use '-mtune=k8' or '-mtune=generic' instead as appropriate [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-Wdeprecated8;;]
```
...obscuring "real" warnings. This PR applies the suggested fix of s/`-mtune=x86-64`/`-mtune=generic`/.
I believe this is Nix-specific as it didn't appear during a manual build on my Manjaro machine nor in upstream's CI (Ubuntu Docker image).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
