### PR TITLE
kea: various updates

### DIFF
--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -75,7 +75,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   passthru.tests = {
-    inherit (nixosTests) kea systemd-networkd-ipv6-prefix-delegation;
+    kea = nixosTests.kea;
+    prefix-delegation = nixosTests.systemd-networkd-ipv6-prefix-delegation;
+    prometheus-exporter = nixosTests.prometheus-exporters.kea;
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation rec {
     substituteInPlace ./src/bin/keactrl/Makefile.am --replace '@sysconfdir@' "$out/etc"
   '';
 
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
+
   configureFlags = [
     "--enable-perfdhcp"
     "--enable-shell"
@@ -47,7 +53,16 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+  ] ++ (with python3.pkgs; [
+    sphinxHook
+    sphinx-rtd-theme
+  ]);
+
+  sphinxBuilders = [
+    "html"
+    "man"
   ];
+  sphinxRoot = "doc/sphinx";
 
   buildInputs = [
     boost

--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -1,14 +1,20 @@
 { stdenv
 , lib
 , fetchurl
+
+# build time
 , autoreconfHook
 , pkg-config
+
+# runtime
 , boost
-, botan2
 , libmysqlclient
 , log4cplus
+, openssl
 , postgresql
 , python3
+
+# tests
 , nixosTests
 }:
 
@@ -21,7 +27,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2n2QymKncmAtrG535QcxkDhCKJWtaO6xQvFIfWfVMdI=";
   };
 
-  patches = [ ./dont-create-var.patch ];
+  patches = [
+    ./dont-create-var.patch
+  ];
 
   postPatch = ''
     substituteInPlace ./src/bin/keactrl/Makefile.am --replace '@sysconfdir@' "$out/etc"
@@ -31,6 +39,7 @@ stdenv.mkDerivation rec {
     "--enable-perfdhcp"
     "--enable-shell"
     "--localstatedir=/var"
+    "--with-openssl=${lib.getDev openssl}"
     "--with-mysql=${lib.getDev libmysqlclient}/bin/mysql_config"
     "--with-pgsql=${postgresql}/bin/pg_config"
   ];
@@ -42,9 +51,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     boost
-    botan2
     libmysqlclient
     log4cplus
+    openssl
     python3
   ];
 


### PR DESCRIPTION
###### Description of changes

- Migrates from botan to openssl
- Renders html documentation and manpages
- Updates passthru.tests

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
