### PR TITLE
[Backport release-22.05] libmicrohttpd_0_70: mark as insecure

### DIFF
--- a/pkgs/applications/misc/osmscout-server/default.nix
+++ b/pkgs/applications/misc/osmscout-server/default.nix
@@ -1,7 +1,7 @@
 { lib, mkDerivation, fetchFromGitHub, pkg-config
 , qmake, qttools, kirigami2, qtquickcontrols2, qtlocation
 , libosmscout, valhalla, libpostal, osrm-backend, protobuf
-, libmicrohttpd_0_9_70, sqlite, marisa, kyotocabinet, boost
+, libmicrohttpd, sqlite, marisa, kyotocabinet, boost
 }:
 
 let
@@ -27,7 +27,7 @@ mkDerivation rec {
   nativeBuildInputs = [ qmake pkg-config qttools ];
   buildInputs = [
     kirigami2 qtquickcontrols2 qtlocation
-    valhalla libosmscout osrm-backend libmicrohttpd_0_9_70
+    valhalla libosmscout osrm-backend libmicrohttpd
     libpostal sqlite marisa kyotocabinet boost protobuf date
   ];
 

--- a/pkgs/applications/misc/xmr-stak/default.nix
+++ b/pkgs/applications/misc/xmr-stak/default.nix
@@ -1,6 +1,7 @@
 { stdenv, stdenvGcc6, lib
-, fetchFromGitHub, cmake, libmicrohttpd_0_9_70, openssl
+, fetchFromGitHub, cmake, libmicrohttpd, openssl
 , opencl-headers, ocl-icd, hwloc, cudatoolkit
+, fetchpatch
 , devDonationLevel ? "0.0"
 , cudaSupport ? false
 , openclSupport ? true
@@ -23,11 +24,18 @@ stdenv'.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-O3";
 
+  patches = [ (fetchpatch {
+    name = "fix-libmicrohttpd-0-9-71.patch";
+    url = "https://github.com/fireice-uk/xmr-stak/compare/06e08780eab54dbc025ce3f38c948e4eef2726a0...8adb208987f5881946992ab9cd9a45e4e2a4b870.patch";
+    excludes = [ "CMakeLists.txt.user" ];
+    hash = "sha256-Yv0U5EO1P5eikn1fKvUXEwemoUIjjeTjpP9p5J8pbC0=";
+  }) ];
+
   cmakeFlags = lib.optional (!cudaSupport) "-DCUDA_ENABLE=OFF"
     ++ lib.optional (!openclSupport) "-DOpenCL_ENABLE=OFF";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ libmicrohttpd_0_9_70 openssl hwloc ]
+  buildInputs = [ libmicrohttpd openssl hwloc ]
     ++ lib.optional cudaSupport cudatoolkit
     ++ lib.optionals openclSupport [ opencl-headers ocl-icd ];
 

--- a/pkgs/development/libraries/libmicrohttpd/0.9.69.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.69.nix
@@ -1,0 +1,10 @@
+{ callPackage, fetchurl }:
+
+callPackage ./generic.nix ( rec {
+  version = "0.9.69";
+
+  src = fetchurl {
+    url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
+    sha256 = "sha256-+5trFIt4dJPmN9MINYhxHmXLy3JvoCzuLNVDxd4n434=";
+  };
+})

--- a/pkgs/development/libraries/libmicrohttpd/0.9.70.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.70.nix
@@ -7,4 +7,5 @@ callPackage ./generic.nix ( rec {
     url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
     sha256 = "01vkjy89b1ylmh22dy5yza2r414nfwcfixxh3v29nvzrjv9s7l4h";
   };
+  meta.knownVulnerabilities = [ "CVE-2021-3466" ];
 })

--- a/pkgs/development/libraries/libmicrohttpd/generic.nix
+++ b/pkgs/development/libraries/libmicrohttpd/generic.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, libgcrypt, curl, gnutls, pkg-config, libiconv, libintl, version, src }:
+{ lib, stdenv, libgcrypt, curl, gnutls, pkg-config, libiconv, libintl, version, src, meta ? {} }:
+
+let
+  meta_ = meta;
+in
 
 stdenv.mkDerivation rec {
   pname = "libmicrohttpd";
@@ -30,5 +34,5 @@ stdenv.mkDerivation rec {
 
     maintainers = with maintainers; [ eelco vrthra fpletz ];
     platforms = platforms.unix;
-  };
+  } // meta_;
 }

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch, pkg-config, musl-fts
 , musl-obstack, m4, zlib, zstd, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs
 , argp-standalone
-, enableDebuginfod ? false, sqlite, curl, libmicrohttpd_0_9_70, libarchive
+, enableDebuginfod ? false, sqlite, curl, libmicrohttpd, libarchive
 , gitUpdater
 }:
 
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableDebuginfod [
     sqlite
     curl
-    libmicrohttpd_0_9_70
+    libmicrohttpd
     libarchive
   ];
 

--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -18,7 +18,7 @@
 , libev
 , libgcrypt
 , libinjection
-, libmicrohttpd_0_9_70
+, libmicrohttpd_0_9_69
 , lz4
 , nlohmann_json
 , openssl
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
         { f = "libdaemon"; p = libdaemon; }
         { f = "libev"; p = libev; }
         { f = "libinjection"; p = libinjection; }
-        { f = "libmicrohttpd"; p = libmicrohttpd_0_9_70; }
+        { f = "libmicrohttpd"; p = libmicrohttpd_0_9_69; }
         { f = "libssl"; p = openssl; }
         { f = "lz4"; p = lz4; }
         { f = "pcre"; p = pcre; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19030,6 +19030,7 @@ with pkgs;
 
   libmemcached = callPackage ../development/libraries/libmemcached { };
 
+  libmicrohttpd_0_9_69 = callPackage ../development/libraries/libmicrohttpd/0.9.69.nix { };
   libmicrohttpd_0_9_70 = callPackage ../development/libraries/libmicrohttpd/0.9.70.nix { };
   libmicrohttpd_0_9_71 = callPackage ../development/libraries/libmicrohttpd/0.9.71.nix { };
   libmicrohttpd_0_9_72 = callPackage ../development/libraries/libmicrohttpd/0.9.72.nix { };


### PR DESCRIPTION
###### Description of changes

Backport for #195217 without the package drop.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See also #120393, #128394

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
