### PR TITLE
hercules-ci: Fix cross

### DIFF
--- a/pkgs/development/tools/continuous-integration/hci/default.nix
+++ b/pkgs/development/tools/continuous-integration/hci/default.nix
@@ -1,6 +1,6 @@
 { haskell, haskellPackages, lib, makeWrapper, runc, stdenv }:
 let
-  inherit (haskell.lib.compose) overrideCabal addBuildDepends justStaticExecutables;
+  inherit (haskell.lib.compose) overrideCabal addBuildTools justStaticExecutables;
   inherit (lib) makeBinPath;
   bundledBins = lib.optional stdenv.isLinux runc;
 
@@ -15,7 +15,7 @@ let
           makeWrapper $out/libexec/hci $out/bin/hci --prefix PATH : ${lib.escapeShellArg (makeBinPath bundledBins)}
         '';
       })
-      (addBuildDepends [ makeWrapper ] (justStaticExecutables haskellPackages.hercules-ci-cli));
+      (addBuildTools [ makeWrapper ] (justStaticExecutables haskellPackages.hercules-ci-cli));
 in pkg // {
     meta = pkg.meta // {
       position = toString ./default.nix + ":1";

--- a/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/hercules-ci-agent/default.nix
@@ -1,6 +1,6 @@
 { gnutar, gzip, git, haskell, haskellPackages, lib, makeWrapper, nixos, runc, stdenv }:
 let
-  inherit (haskell.lib.compose) overrideCabal addBuildDepends justStaticExecutables;
+  inherit (haskell.lib.compose) overrideCabal addBuildTools justStaticExecutables;
   inherit (lib) makeBinPath;
   bundledBins = [ gnutar gzip git ] ++ lib.optional stdenv.isLinux runc;
 
@@ -15,7 +15,7 @@ let
           makeWrapper $out/libexec/hercules-ci-agent $out/bin/hercules-ci-agent --prefix PATH : ${lib.escapeShellArg (makeBinPath bundledBins)}
         '';
       })
-      (addBuildDepends [ makeWrapper ] (justStaticExecutables haskellPackages.hercules-ci-agent));
+      (addBuildTools [ makeWrapper ] (justStaticExecutables haskellPackages.hercules-ci-agent));
 in pkg.overrideAttrs (o: {
     meta = o.meta // {
       position = toString ./default.nix + ":1";


### PR DESCRIPTION
###### Description of changes

This fixes evaluation of cross compiled `hercules-ci-agent` and `hci`. It's an incremental step towards cross compilation support.
"True" cross compilation is currently blocked by a build failure in `haskellPackages.generics-sop` template haskell.
A build with `pkgsLLVM`, which uses the cross logic, runs into other issues too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
