### PR TITLE
renameutils: fix package on darwin

### DIFF
--- a/pkgs/tools/misc/renameutils/default.nix
+++ b/pkgs/tools/misc/renameutils/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, readline}:
+{lib, stdenv, fetchurl, readline, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "renameutils";
@@ -11,7 +11,23 @@ stdenv.mkDerivation rec {
 
   patches = [ ./install-exec.patch ];
 
+  preConfigure = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    export ac_cv_func_lstat64=no
+  '';
+
   nativeBuildInputs = [ readline ];
+  buildInputs = lib.optionals stdenv.isDarwin [ coreutils ];
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/apply.c \
+      --replace "command = \"mv\"" "command = \"${coreutils}/bin/mv\"" \
+      --replace "command = \"cp\"" "command = \"${coreutils}/bin/cp\""
+    substituteInPlace src/icmd.c \
+      --replace "#define MV_COMMAND \"mv\"" "#define MV_COMMAND \"${coreutils}/bin/mv\"" \
+      --replace "#define CP_COMMAND \"cp\"" "#define CP_COMMAND \"${coreutils}/bin/cp\""
+    substituteInPlace src/qcmd.c \
+      --replace "ls_program = xstrdup(\"ls\")" "ls_program = xstrdup(\"${coreutils}/bin/ls\")"
+  '';
 
   meta = {
     homepage = "https://www.nongnu.org/renameutils/";

--- a/pkgs/tools/misc/renameutils/default.nix
+++ b/pkgs/tools/misc/renameutils/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ readline ];
-  buildInputs = lib.optionals stdenv.isDarwin [ coreutils ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/apply.c \

--- a/pkgs/tools/misc/renameutils/default.nix
+++ b/pkgs/tools/misc/renameutils/default.nix
@@ -11,12 +11,6 @@ stdenv.mkDerivation rec {
 
   patches = [ ./install-exec.patch ];
 
-  preConfigure = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
-    export ac_cv_func_lstat64=no
-  '';
-
-  nativeBuildInputs = [ readline ];
-
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/apply.c \
       --replace "command = \"mv\"" "command = \"${coreutils}/bin/mv\"" \
@@ -26,6 +20,12 @@ stdenv.mkDerivation rec {
       --replace "#define CP_COMMAND \"cp\"" "#define CP_COMMAND \"${coreutils}/bin/cp\""
     substituteInPlace src/qcmd.c \
       --replace "ls_program = xstrdup(\"ls\")" "ls_program = xstrdup(\"${coreutils}/bin/ls\")"
+  '';
+
+  nativeBuildInputs = [ readline ];
+
+  preConfigure = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    export ac_cv_func_lstat64=no
   '';
 
   meta = {


### PR DESCRIPTION
###### Description of changes

Fixed the compilation of `renameutils` on aarch64 darwin, and since `renameutils` requires gnu `ls`, `mv`, `cp` at runtime, I have adapted a [patch](https://github.com/Homebrew/homebrew-core/blob/d46782e45325badc160c3f2bdf0381b64714c7b0/Formula/renameutils.rb#L37) from homebrew,  and a postPatch to put the correct paths in place.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
