### PR TITLE
edid-generator: fix missing generation of binaries

### DIFF
--- a/pkgs/tools/misc/edid-generator/default.nix
+++ b/pkgs/tools/misc/edid-generator/default.nix
@@ -1,11 +1,23 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , dos2unix
 , edid-decode
 , hexdump
 , zsh
-, modelines ? [] # Modeline "1280x800"   83.50  1280 1352 1480 1680  800 803 809 831 -hsync +vsync
+, modelines ? [ ] # Modeline "1280x800"   83.50  1280 1352 1480 1680  800 803 809 831 -hsync +vsync
+, clean ? false # should it skip all, but explicitly listed modelines?
 }:
+
+# Usage:
+#   (edid-generator.override {
+#     clean = true;
+#     modelines = [
+#       ''Modeline "PG278Q_2560x1440"       241.50   2560 2608 2640 2720   1440 1443 1448 1481   -hsync +vsync''
+#       ''Modeline "PG278Q_2560x1440@120"   497.75   2560 2608 2640 2720   1440 1443 1448 1525   +hsync -vsync''
+#       ''Modeline "U2711_2560x1440"        241.50   2560 2600 2632 2720   1440 1443 1448 1481   -hsync +vsync''
+#     ];
+#   })
 
 stdenv.mkDerivation rec {
   pname = "edid-generator";
@@ -22,9 +34,15 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs modeline2edid
+    # allows makefile to discover prefixes and suffixes in addition to just `[0-9]*x[0-9]*.S`
+    awk -i inplace '/^SOURCES\t/ { print "SOURCES\t:= $(wildcard *[0-9]*x[0-9]**.S)"; next; }; { print; }' Makefile
   '';
 
-  configurePhase = (lib.concatMapStringsSep "\n" (m: "echo \"${m}\" | ./modeline2edid -") modelines);
+  configurePhase = ''
+    test '${toString clean}' != 1 || rm *x*.S
+    ${lib.concatMapStringsSep "\n" (m: "./modeline2edid - <<<'${m}'") modelines}
+    make clean all
+  '';
 
   installPhase = ''
     install -Dm 444 *.bin -t "$out/lib/firmware/edid"
@@ -34,7 +52,7 @@ stdenv.mkDerivation rec {
     description = "Hackerswork to generate an EDID blob from given Xorg Modelines";
     homepage = "https://github.com/akatrevorjay/edid-generator";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.flokli ];
+    maintainers = with lib.maintainers; [ flokli nazarewk ];
     platforms = lib.platforms.all;
     broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/edid-generator.x86_64-darwin
   };


### PR DESCRIPTION
###### Description of changes

the package was not generating *.bin files as the `make` call was missing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
	- https://github.com/nazarewk-iac/nix-configs/blob/2c9aadaf6d56a23957baedfe218a7aebd8bf0111/packages/edid-generator/default.nix
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
