### PR TITLE
linuxhw-edid-fetcher: init

### DIFF
--- a/pkgs/tools/misc/linuxhw-edid-fetcher/default.nix
+++ b/pkgs/tools/misc/linuxhw-edid-fetcher/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, coreutils
+, fetchFromGitHub
+, gawk
+, stdenv
+, unixtools
+, writeShellApplication
+, displays ? { } # { PG278Q_2014 = [ "PG278Q" "2014" ]; }
+}:
+
+# Usage:
+#   let
+#     edids = (linuxhw-edid-generator.override {
+#       displays = {
+#         PG278Q_2014 = [ "PG278Q" "2014" ];
+#       };
+#     });
+#   in
+#     "${edids}/lib/firmware/edid/PG278Q_2014.bin";
+let
+  revision = "228fea5d89782402dd7f84a459df7f5248573b10";
+
+  src = fetchFromGitHub {
+    owner = "linuxhw";
+    repo = "EDID";
+    rev = revision;
+    sha256 = "sha256-HFyu/WFKGLxL1iz6wqOREpXME1PK1xcxx0ewdhf8Eac=";
+  };
+
+  fetcher = writeShellApplication {
+    name = "linuxhw-edid-fetcher";
+    runtimeInputs = [ gawk coreutils unixtools.xxd ];
+    text = ''
+      cd '${src}'
+      ${builtins.readFile ./linuxhw-edid-fetcher.sh}
+    '';
+  };
+
+  bin = "${fetcher}/bin/linuxhw-edid-fetcher";
+in
+stdenv.mkDerivation {
+  pname = "linuxhw-edid-fetcher";
+  version = revision;
+  inherit src;
+
+  configurePhase = lib.pipe displays [
+    (lib.mapAttrsToList (name: patterns: "${bin} ${lib.escapeShellArgs patterns} > '${name}.bin'"))
+    (lines: [ "set -x" ] ++ lines ++ [ "set +x" ])
+    (builtins.concatStringsSep "\n")
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    ln -s "${bin}" "$out/bin"
+    install -Dm 444 *.bin -t "$out/lib/firmware/edid"
+  '';
+
+  meta = {
+    description = "Fetcher for EDID binaries from Linux Hardware Project's EDID repository";
+    homepage = "https://github.com/linuxhw/EDID";
+    license = lib.licenses.cc-by-40;
+    maintainers = with lib.maintainers; [ nazarewk ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/tools/misc/linuxhw-edid-fetcher/linuxhw-edid-fetcher.sh
+++ b/pkgs/tools/misc/linuxhw-edid-fetcher/linuxhw-edid-fetcher.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+test -z "${DEBUG:-}" || set -x
+
+usage() {
+  cat <<'EOF'
+Example usage:
+  linuxhw-get-edid-bin PG278Q 2014 >edid.bin
+  edid-decode <edid.bin
+  parse-edid <edid.bin
+  cat edid.bin >/sys/kernel/debug/dri/0/DP-1/edid_override
+EOF
+}
+
+print() {
+  # shellcheck disable=SC2059
+  printf "${1}\n" "${@:2}"
+}
+
+log() {
+  print "${@}" >&2
+}
+
+find_displays() {
+  local script=(
+    "BEGIN { IGNORECASE=1 }"
+    "/${1}/"
+  )
+
+  for pattern in "${@:2}"; do
+    script+=('&&' "/${pattern}/")
+  done
+  cat {Analog,Digital}Display.md | awk "${script[*]}"
+}
+
+to_edid() {
+  if ! test -e "$1"; then
+    log "$1 does not exist"
+    return 1
+  fi
+
+  # https://github.com/linuxhw/EDID/blob/228fea5d89782402dd7f84a459df7f5248573b10/README.md#L42-L42
+  grep -E '^([a-f0-9]{32}|[a-f0-9 ]{47})$' <"$1" | tr -d '[:space:]' | xxd -r -p
+}
+
+extract_path() {
+  awk '{ gsub(/^.+]\(</, ""); gsub(/>).+/, ""); print }'
+}
+
+main() {
+  test $# -gt 0 || usage
+
+  log "running in $PWD"
+
+  readarray -t lines < <(find_displays "${@}")
+  case "${#lines[@]}" in
+  0)
+    log "No matches, try broader patterns?"
+    exit 1
+    ;;
+  1)
+    log "%s" "${lines[@]}"
+    log "Found exactly one pattern, continuing..."
+    ;;
+  *)
+    log "Matched entries:"
+    log "%s" "${lines[@]}"
+    log ""
+    log "More than one match, try more specific patterns?"
+    exit 2
+    ;;
+  esac
+
+  to_edid "$(extract_path <<<"${lines[0]}")"
+}
+
+main "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5985,6 +5985,8 @@ with pkgs;
 
   edid-generator = callPackage ../tools/misc/edid-generator { };
 
+  linuxhw-edid-fetcher = callPackage ../tools/misc/linuxhw-edid-fetcher { };
+
   edir = callPackage ../tools/misc/edir { };
 
   editres = callPackage ../tools/graphics/editres { };


### PR DESCRIPTION

###### Description of changes

allows fetching and building known good EDID configs for
 large number of displays from https://github.com/linuxhw/EDID

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - developed and used at https://github.com/nazarewk-iac/nix-configs/commit/4b257579
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
