### PR TITLE
pynitrokey: fix build and update to 0.4.31

### DIFF
--- a/pkgs/development/python-modules/tlv8/default.nix
+++ b/pkgs/development/python-modules/tlv8/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "tlv8";
+  version = "0.10.0";
+  format = "setuptools";
+
+  # pypi does not contain test files
+  src = fetchFromGitHub {
+    owner = "jlusiardi";
+    repo = "tlv8_python";
+    rev = "v${version}";
+    sha256 = "sha256-G35xMFYasKD3LnGi9q8wBmmFvqgtg0HPdC+y82nxRWA=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "tlv8"
+  ];
+
+  meta = with lib; {
+    description = "Type-Length-Value8 (TLV8) for Python";
+    longDescription = ''
+      Python module to handle type-length-value (TLV) encoded data 8-bit type, 8-bit length, and N-byte
+      value as described within the Apple HomeKit Accessory Protocol Specification Non-Commercial Version
+      Release R2.
+    '';
+    homepage = "https://github.com/jlusiardi/tlv8_python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jojosch ];
+  };
+}

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -33,11 +33,14 @@ buildPythonApplication rec {
     tlv8
   ];
 
-  # spsdk is patched to allow for newer cryptography
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-        --replace "cryptography >=3.4.4,<37" "cryptography"
-  '';
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "cryptography"
+    "spsdk"
+  ];
 
   # no tests
   doCheck = false;

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -4,12 +4,12 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "pynitrokey";
-  version = "0.4.27";
+  version = "0.4.30";
   format = "flit";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-aWQhMvATcDtyBtj38mGnypkKIqKQgneBzWDh5o/5Wkc=";
+    sha256 = "sha256-JmvA8Z1oFOP62TpJ0g7VO5hq3YS3/DFB/BKt2o79AOE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -4,12 +4,12 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "pynitrokey";
-  version = "0.4.30";
+  version = "0.4.31";
   format = "flit";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-JmvA8Z1oFOP62TpJ0g7VO5hq3YS3/DFB/BKt2o79AOE=";
+    sha256 = "sha256-nqw5wUzQxKCBzYBRhqB6v7WWrF1Ojf8z6Kf1YUA9+wU=";
   };
 
   propagatedBuildInputs = [
@@ -29,6 +29,8 @@ buildPythonApplication rec {
     cffi
     cbor
     nkdfu
+    fido2
+    tlv8
   ];
 
   # spsdk is patched to allow for newer cryptography

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11287,6 +11287,8 @@ self: super: with self; {
 
   tls-parser = callPackage ../development/python-modules/tls-parser { };
 
+  tlv8 = callPackage ../development/python-modules/tlv8 { };
+
   tmb = callPackage ../development/python-modules/tmb { };
 
   todoist = callPackage ../development/python-modules/todoist { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Got my Nitrokey 3 today but wasn't able to build `pynitrokey`:

```
ERROR: Could not find a version that satisfies the requirement protobuf<4.0.0,>=3.17.3 (from nrfutil) (from versions: none)
ERROR: No matching distribution found for protobuf<4.0.0,>=3.17.3
```

Updated `pynitrokey` to the latest release and updated its dependencies.

-------------------

Changelog for `pynitrokey`:
https://github.com/Nitrokey/pynitrokey/releases/tag/v0.4.28.nitrokey ([changes](https://github.com/Nitrokey/pynitrokey/compare/v0.4.27.nitrokey...v0.4.28.nitrokey))
https://github.com/Nitrokey/pynitrokey/releases/tag/v0.4.29.nitrokey ([changes](https://github.com/Nitrokey/pynitrokey/compare/v0.4.28.nitrokey...v0.4.29.nitrokey))
https://github.com/Nitrokey/pynitrokey/releases/tag/v0.4.30.nitrokey ([changes](https://github.com/Nitrokey/pynitrokey/compare/v0.4.29.nitrokey...v0.4.30.nitrokey))
https://github.com/Nitrokey/pynitrokey/releases/tag/v0.4.31.nitrokey ([changes](https://github.com/Nitrokey/pynitrokey/compare/v0.4.30.nitrokey...v0.4.31.nitrokey))

new dependency with 0.4.31: https://github.com/jlusiardi/tlv8_python

-------------------

Now pynitropy works:

```
$ ./result/bin/nitropy list
Command line tool to interact with Nitrokey devices 0.4.31
:: 'Nitrokey FIDO2' keys
:: 'Nitrokey Start' keys:
:: 'Nitrokey 3' keys
/dev/hidraw1: Nitrokey 3 ....

$ ./result/bin/nitropy nk3 rng
Command line tool to interact with Nitrokey devices 0.4.31
32d098b4d27ab74f217864d67a583bed31560f28b3bf755a5....

./result/bin/nitropy nk3 test
Command line tool to interact with Nitrokey devices 0.4.31
Found 1 Nitrokey 3 device(s):
- Nitrokey 3 at /dev/hidraw1

Running tests for Nitrokey 3 at /dev/hidraw1

[1/3]	uuid     	UUID query              	SUCCESS  	....
[2/3]	version  	Firmware version query  	SUCCESS  	v1.2.2
Please press the touch button on the device ...
Please press the touch button on the device ...
[3/3]	fido2    	FIDO2                   	SUCCESS  	

3 tests, 3 successful, 0 skipped, 0 failed

Summary: 1 device(s) tested, 1 successful, 0 failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
