### PR TITLE
nixos/virtualisation/lxd: add support for OVS bridges to LXD

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -120,6 +120,11 @@
       </listitem>
       <listitem>
         <para>
+          LXD now supports creating Open vSwitch bridges.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           PHP now defaults to PHP 8.1, updated from 8.0.
         </para>
       </listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -48,6 +48,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   Alternatively, you can remove the `hostPlatform` line and use NixOS like you
   would in NixOS 22.05 and earlier.
 
+- LXD now supports creating Open vSwitch bridges.
+
 - PHP now defaults to PHP 8.1, updated from 8.0.
 
 - Perl has been updated to 5.36, and its core module `HTTP::Tiny` was patched to verify SSL/TLS certificates by default.

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -85,6 +85,17 @@ in {
           considered failed and systemd will attempt to restart it.
         '';
       };
+
+      ovsSupport = mkOption {
+        type = types.bool;
+        default = config.virtualisation.vswitch.enable;
+        defaultText = literalExpression "config.virtualisation.vswitch.enable";
+        description = lib.mdDoc ''
+          Enables lxd to use open vswitch as a network bridge for containers.
+
+          This option is enabled by default if Open vSwitch is enabled.
+        '';
+      };
     };
   };
 
@@ -133,7 +144,8 @@ in {
       requires = [ "network-online.target" "lxd.socket"  "lxcfs.service" ];
       documentation = [ "man:lxd(1)" ];
 
-      path = optional cfg.zfsSupport config.boot.zfs.package;
+      path = (optionals cfg.zfsSupport [ config.boot.zfs.package ]) ++
+             (optionals cfg.ovsSupport [ config.virtualisation.vswitch.package ]);
 
       serviceConfig = {
         ExecStart = "@${cfg.package}/bin/lxd lxd --group lxd";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -343,6 +343,7 @@ in {
   lvm2 = handleTest ./lvm2 {};
   lxd = handleTest ./lxd.nix {};
   lxd-nftables = handleTest ./lxd-nftables.nix {};
+  lxd-ovs = handleTest ./lxd-ovs.nix {};
   lxd-image-server = handleTest ./lxd-image-server.nix {};
   #logstash = handleTest ./logstash.nix {};
   lorri = handleTest ./lorri/default.nix {};

--- a/nixos/tests/lxd-ovs.nix
+++ b/nixos/tests/lxd-ovs.nix
@@ -1,0 +1,33 @@
+# This test makes sure that lxd supports creating an OVS bridge.
+
+import ./make-test-python.nix ({ pkgs, lib, ...} :
+
+{
+  name = "lxd-ovs";
+
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ patryk27 ];
+  };
+
+  nodes.machine = { lib, ... }: {
+    virtualisation = {
+      lxd.enable = true;
+      lxd.ovsSupport = true;
+      vswitch.enable = true;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("sockets.target")
+    machine.wait_for_unit("lxd.service")
+    machine.wait_for_file("/var/lib/lxd/unix.socket")
+
+    # It takes additional second for lxd to settle
+    machine.sleep(1)
+
+    with subtest("Open vSwitch bridge can be created"):
+        machine.succeed("lxc network create ovsbr0 --type=bridge bridge.driver=openvswitch")
+
+    machine.execute("lxc network list")
+  '';
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Extend LXD module to support creation of Open vSwitch bridges.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
