### PR TITLE
openssl: revert withdrawn releases

### DIFF
--- a/pkgs/development/libraries/openssl/3.0/openssl-disable-kernel-detection.patch
+++ b/pkgs/development/libraries/openssl/3.0/openssl-disable-kernel-detection.patch
@@ -1,25 +1,22 @@
 diff --git a/Configure b/Configure
-index a558e5ab1a..9a884f0b0f 100755
+index f0ad787bc4..a48d2008c6 100755
 --- a/Configure
 +++ b/Configure
-@@ -1714,20 +1714,6 @@ unless ($disabled{devcryptoeng}) {
- 
+@@ -1688,17 +1688,6 @@ unless ($disabled{devcryptoeng}) {
  unless ($disabled{ktls}) {
      $config{ktls}="";
--    my $cc = $config{CROSS_COMPILE}.$config{CC};
--    if ($target =~ m/^linux/) {
--        system("printf '#include <sys/types.h>\n#include <linux/tls.h>' | $cc -E - >/dev/null 2>&1");
--        if ($? != 0) {
+     if ($target =~ m/^linux/) {
+-        my $usr = "/usr/$config{cross_compile_prefix}";
+-        chop($usr);
+-        if ($config{cross_compile_prefix} eq "") {
+-            $usr = "/usr";
+-        }
+-        my $minver = (4 << 16) + (13 << 8) + 0;
+-        my @verstr = split(" ",`cat $usr/include/linux/version.h | grep LINUX_VERSION_CODE`);
+-
+-        if ($verstr[2] < $minver) {
 -            disable('too-old-kernel', 'ktls');
 -        }
--    } elsif ($target =~ m/^BSD/) {
--        system("printf '#include <sys/types.h>\n#include <sys/ktls.h>' | $cc -E - >/dev/null 2>&1");
--        if ($? != 0) {
--            disable('too-old-freebsd', 'ktls');
--        }
--    } else {
--        disable('not-linux-or-freebsd', 'ktls');
--    }
- }
- 
- push @{$config{openssl_other_defines}}, "OPENSSL_NO_KTLS" if ($disabled{ktls});
+     } elsif ($target =~ m/^BSD/) {
+         my $cc = $config{CROSS_COMPILE}.$config{CC};
+         system("printf '#include <sys/types.h>\n#include <sys/ktls.h>' | $cc -E - >/dev/null 2>&1");

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -213,8 +213,8 @@ in {
 
 
   openssl_1_1 = common rec {
-    version = "1.1.1r";
-    hash = "sha256-44k1KuPVrk04WXv4pU8dy2+zyLUPT+WKlLsb9/hdgqA=";
+    version = "1.1.1q";
+    hash = "sha256-15Oc5hQCnN/wtsIPDi5XAxWKSJpyslB7i9Ub+Mj9EMo=";
     patches = [
       ./1.1/nix-ssl-cert-file.patch
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -16,14 +16,14 @@
 # files.
 
 let
-  common = { version, hash, patches ? [], withDocs ? false, extraMeta ? {} }:
+  common = { version, sha256, patches ? [], withDocs ? false, extraMeta ? {} }:
    stdenv.mkDerivation rec {
     pname = "openssl";
     inherit version;
 
     src = fetchurl {
       url = "https://www.openssl.org/source/${pname}-${version}.tar.gz";
-      inherit hash;
+      inherit sha256;
     };
 
     inherit patches;
@@ -214,7 +214,7 @@ in {
 
   openssl_1_1 = common rec {
     version = "1.1.1q";
-    hash = "sha256-15Oc5hQCnN/wtsIPDi5XAxWKSJpyslB7i9Ub+Mj9EMo=";
+    sha256 = "sha256-15Oc5hQCnN/wtsIPDi5XAxWKSJpyslB7i9Ub+Mj9EMo=";
     patches = [
       ./1.1/nix-ssl-cert-file.patch
 
@@ -228,8 +228,8 @@ in {
   };
 
   openssl_3 = common {
-    version = "3.0.6";
-    hash = "sha256-5KEKKYaUXj8aHy69aKx4BEmhdzuWtqF0/fZQ1ryWEfE=";
+    version = "3.0.5";
+    sha256 = "sha256-qn2Nm+9xrWUlxVuhHl9Dl4ic5Jwsk0nc6m0+TwsCSno=";
     patches = [
       ./3.0/nix-ssl-cert-file.patch
 


### PR DESCRIPTION
###### Description of changes
https://mta.openssl.org/pipermail/openssl-announce/2022-October/000237.html

also https://www.openssl.org/source/openssl-1.1.1r.tar.gz 404s now

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).