### PR TITLE
semgrep{,-core}: 0.112.1 -> 1.0.0

### DIFF
--- a/pkgs/tools/security/semgrep/common.nix
+++ b/pkgs/tools/security/semgrep/common.nix
@@ -1,41 +1,55 @@
 { lib, fetchFromGitHub, fetchzip, stdenv }:
 
 rec {
-  version = "0.112.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "returntocorp";
     repo = "semgrep";
     rev = "v${version}";
-    sha256 = "sha256-SZtxZz4x6YUKw1uO5HQTU4lRY989SoCNsPQphJr+L0Y=";
+    sha256 = "sha256-4fNBpokHKCtMB3P0ot1TzcuzOs5hlyH8nIw+bCGqThA=";
   };
 
   # submodule dependencies
   # these are fetched so we:
   #   1. don't fetch the many submodules we don't need
   #   2. avoid fetchSubmodules since it's prone to impurities
-  langsSrc = fetchFromGitHub {
-    owner = "returntocorp";
-    repo = "semgrep-langs";
-    rev = "91e288062eb794e8a5e6967d1009624237793491";
-    sha256 = "sha256-z2t2bTRyj5zu9h/GBg2YeRFimpJsd3dA7dK8VBaKzHo=";
-  };
-
-  interfacesSrc = fetchFromGitHub {
-    owner = "returntocorp";
-    repo = "semgrep-interfaces";
-    rev = "7bc457a32e088ef21adf1529fa0ddeea634b9131";
-    sha256 = "sha256-xN8Qm1/YLa49k9fZKDoPPmHASI2ipI3mkKlwEK2ajO4=";
+  submodules = {
+    "cli/src/semgrep/lang" = fetchFromGitHub {
+      owner = "returntocorp";
+      repo = "semgrep-langs";
+      rev = "65cb2ed80e31e01b122f893fef8428d14432da75";
+      sha256 = "sha256-HdPJdOlMM1l7vNSATkEu5KrCkpt2feEAH8LFDU84KUM=";
+    };
+    "cli/src/semgrep/semgrep_interfaces" = fetchFromGitHub {
+      owner = "returntocorp";
+      repo = "semgrep-interfaces";
+      rev = "c69e30a4cf39f11cab5378700f5e193e8282079e";
+      sha256 = "sha256-Wr3/TWx/LHiTFCoGY4sqdsn3dHvMsEIVYA3RGiv88xQ=";
+    };
   };
 
   # fetch pre-built semgrep-core since the ocaml build is complex and relies on
   # the opam package manager at some point
-  coreRelease = if stdenv.isDarwin then fetchzip {
-      url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}-osx.zip";
-      sha256 = "sha256-JiOH39vMDL6r9WKuPO0CDkRwGZtzl/GIFoSegVddFpw=";
-  } else fetchzip {
-      url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}-ubuntu-16.04.tgz";
-      sha256 = "sha256-V6r+VQrgz8uVSbRa2AmW4lnLxovk63FL7LqVKD46RBw=";
+  core = rec {
+    data = {
+      x86_64-linux = {
+        suffix = "-ubuntu-16.04.tgz";
+        sha256 = "sha256-SsaAuhcDyO3nr6H2xOtdxzOoEQd6aIe0mlpehvDWzU0=";
+      };
+      x86_64-darwin = {
+        suffix = "-osx.zip";
+        sha256 = "sha256-DAcAB/q6XeljCp4mVljIJB4AUjUuzMSRMFzIuyjWMew=";
+      };
+    };
+    src = let
+      inherit (stdenv.hostPlatform) system;
+      selectSystemData = data: data.${system} or (throw "Unsupported system: ${system}");
+      inherit (selectSystemData data) suffix sha256;
+    in fetchzip {
+      url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}${suffix}";
+      inherit sha256;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/tools/security/semgrep/semgrep-core.nix
+++ b/pkgs/tools/security/semgrep/semgrep-core.nix
@@ -6,8 +6,7 @@ in
 stdenvNoCC.mkDerivation rec {
   pname = "semgrep-core";
   inherit (common) version;
-
-  src = common.coreRelease;
+  inherit (common.core) src;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/security/semgrep/update.sh
+++ b/pkgs/tools/security/semgrep/update.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused jq
+
+set -euxo pipefail
+
+# provide a github token so you don't get rate limited
+# if you use gh cli you can use:
+#     `export GITHUB_TOKEN="$(cat ~/.config/gh/config.yml | yq '.hosts."github.com".oauth_token' -r)"`
+# or just set your token by hand:
+#     `read -s -p "Enter your token: " GITHUB_TOKEN; export GITHUB_TOKEN`
+#     (we use read so it doesn't show in our shell history and in secret mode so the token you paste isn't visible)
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "no GITHUB_TOKEN provided - you could meet API request limiting" >&2
+fi
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIXPKGS_ROOT="$ROOT/../../../.."
+NIX_DRV="$ROOT/default.nix"
+
+COMMON_FILE="$ROOT/common.nix"
+
+instantiateClean() {
+    nix-instantiate -A "$1" --eval --strict | cut -d\" -f2
+}
+
+# get latest version
+NEW_VERSION=$(
+  curl -s -H
+    "Accept: application/vnd.github.v3+json" \
+    ${GITHUB_TOKEN:+ -H "Authorization: bearer $GITHUB_TOKEN"} \
+    https://api.github.com/repos/returntocorp/semgrep/releases/latest \
+  | jq -r '.tag_name'
+)
+# trim v prefix
+NEW_VERSION="${NEW_VERSION:1}"
+OLD_VERSION="$(instantiateClean semgrep.common.version)"
+
+if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+    echo "Already up to date"
+    exit
+fi
+
+replace() {
+    sed -i "s@$1@$2@g" "$3"
+}
+
+fetchgithub() {
+    set +eo pipefail
+    nix-build -A "$1" 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g'
+    set -eo pipefail
+}
+
+fetchzip() {
+    set +eo pipefail
+    nix-build -E "with import $NIXPKGS_ROOT {}; fetchzip {url = \"$1\"; sha256 = lib.fakeSha256; }" 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g'
+    set -eo pipefail
+}
+
+replace "$OLD_VERSION" "$NEW_VERSION" "$COMMON_FILE"
+
+echo "Updating src"
+
+OLD_HASH="$(instantiateClean semgrep.common.src.outputHash)"
+echo "Old hash $OLD_HASH"
+TMP_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+replace "$OLD_HASH" "$TMP_HASH" "$COMMON_FILE"
+NEW_HASH="$(fetchgithub semgrep.common.src)"
+echo "New hash $NEW_HASH"
+replace "$TMP_HASH" "$NEW_HASH" "$COMMON_FILE"
+
+echo "Updated src"
+
+# loop through platforms for core
+nix-instantiate -E "with import $NIXPKGS_ROOT {}; builtins.attrNames semgrep.common.core.data" --eval --strict --json \
+| jq '.[]' -r \
+| while read -r PLATFORM; do
+    echo "Updating core for $PLATFORM"
+    SUFFIX=$(instantiateClean semgrep.common.core.data."$1".suffix "$PLATFORM")
+    OLD_HASH=$(instantiateClean semgrep.common.core.data."$1".sha256 "$PLATFORM")
+    echo "Old hash $OLD_HASH"
+
+    NEW_URL="https://github.com/returntocorp/semgrep/releases/download/v$NEW_VERSION/semgrep-v$NEW_VERSION$SUFFIX"
+    NEW_HASH="$(fetchzip "$NEW_URL")"
+    echo "New hash $NEW_HASH"
+
+    replace "$OLD_HASH" "$NEW_HASH" "$COMMON_FILE"
+
+    echo "Updated core for $PLATFORM"
+done
+
+OLD_PWD=$PWD
+TMPDIR="$(mktemp -d)"
+# shallow clone to check submodule commits, don't actually need the submodules
+git clone https://github.com/returntocorp/semgrep "$TMPDIR/semgrep" --depth 1 --branch "v$NEW_VERSION"
+
+get_submodule_commit() {
+    OLD_PWD=$PWD
+    (
+        cd "$TMPDIR/semgrep"
+        git ls-tree --object-only HEAD "$1"
+        cd "$OLD_PWD"
+    )
+}
+
+# loop through submodules
+nix-instantiate -E "with import $NIXPKGS_ROOT {}; builtins.attrNames semgrep.passthru.common.submodules" --eval --strict --json \
+| jq '.[]' -r \
+| while read -r SUBMODULE; do
+    echo "Updating $SUBMODULE"
+    OLD_REV=$(instantiateClean semgrep.passthru.common.submodules."$SUBMODULE".rev)
+    echo "Old commit $OLD_REV"
+    OLD_HASH=$(instantiateClean semgrep.passthru.common.submodules."$SUBMODULE".outputHash)
+    echo "Old hash $OLD_HASH"
+
+    NEW_REV=$(get_submodule_commit "$SUBMODULE")
+    echo "New commit $NEW_REV"
+
+    if [[ "$OLD_REV" == "$NEW_REV" ]]; then
+      echo "$SUBMODULE already up to date"
+      continue
+    fi
+
+    NEW_URL=$(instantiateClean semgrep.passthru.common.submodules."$SUBMODULE".url | sed "s@$OLD_REV@$NEW_REV@g")
+    NEW_HASH=$(nix --experimental-features nix-command hash to-sri "sha256:$(nix-prefetch-url "$NEW_URL")")
+
+    TMP_HASH="sha256-ABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    replace "$OLD_REV" "$NEW_REV" "$COMMON_FILE"
+    replace "$OLD_HASH" "$TMP_HASH" "$COMMON_FILE"
+    NEW_HASH="$(fetchgithub semgrep.passthru.common.submodules."$SUBMODULE")"
+    echo "New hash $NEW_HASH"
+    replace "$TMP_HASH" "$NEW_HASH" "$COMMON_FILE"
+
+    echo "Updated $SUBMODULE"
+done
+
+rm -rf "$TMPDIR"
+
+echo "Finished"
+


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumped semgrep and added an update script

I have a different issue that is blocking me from checking if the issue above is fixed:
I've added `tomli` but it's not picking it up when running semgrep scan
It's also supprising that the pip hook doesn't complain if I don't include `tomli` even though setup.py asks for it...

To reproduce follow the same steps as the issue above & see issues with finding `tomli`

---

Update:

now resolves #192149
setup.py was copying semgrep-core and had issues keeping or setting the executable bit.
rather than mess about trying to fix it I went with the more desirable solution of providing semgrep-core via wrapping rather than copying it around

the `tomli` issue seems to have disappeared.

tested with https://semgrep.dev/docs/writing-rules/rule-ideas/#ban-dangerous-apis

```
λ /some/dir/nixpkgs/result/bin/semgrep scan --config=rule.yaml .
Scanning 1 file.

Blocking Findings:

  tmp.js 
     react-dangerouslysetinnerhtml
        Setting HTML from code is risky because it’s easy to inadvertently expose your users to a
        cross-site scripting (XSS) attack.

          3┆ return <div dangerouslySetInnerHTML={createMarkup()} />;

Blocking Rules Fired:
   react-dangerouslysetinnerhtml


Ran 1 rule on 1 file: 1 finding.
```

cc: @SuperSandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
