### PR TITLE
at-spi2-core: make introspection unconditional

### DIFF
--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   mesonFlags = [
-    "-Dintrospection=${if stdenv.buildPlatform == stdenv.hostPlatform then "yes" else "no"}"
+    "-Dintrospection=yes"
     # Provide dbus-daemon fallback when it is not already running when
     # at-spi2-bus-launcher is executed. This allows us to avoid
     # including the entire dbus closure in libraries linked with


### PR DESCRIPTION
###### Description of changes

We don't need to make it conditional anymore. With this the (cross) gtk3 build builds again. It was failing before because it missed the gir files from Atk.

As far as I know this is a no-op for 'native' builds, so can go to master without issues.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

