### PR TITLE
fetchmail: add v7 and fix fetchmailconf

### DIFF
--- a/pkgs/applications/misc/fetchmail/v7.nix
+++ b/pkgs/applications/misc/fetchmail/v7.nix
@@ -1,17 +1,24 @@
-{ lib, stdenv, fetchurl, openssl, python3 }:
+{ lib, stdenv, pkgs }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "fetchmail";
-  version = "6.4.33";
+  version = "unstable-2022-05-26";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/fetchmail/fetchmail-${version}.tar.xz";
-    sha256 = "sha256-gpVOvSbHeQZGPOIK3KRcvPgGiVdEHheUG9MFKlwVQy4=";
+  src = pkgs.fetchFromGitLab {
+    owner = "fetchmail";
+    repo = "fetchmail";
+    rev = "30b368fb8660d8fec08be1cdf2606c160b4bcb80";
+    sha256 = "sha256-83D2YlFCODK2YD+oLICdim2NtNkkJU67S3YLi8Q6ga8=";
   };
 
-  buildInputs = [ openssl python3 ];
+  buildInputs = with pkgs; [ openssl python3 ];
+  nativeBuildInputs = with pkgs; [ autoreconfHook pkg-config bison flex ];
 
-  configureFlags = [ "--with-ssl=${openssl.dev}" ];
+  configureFlags = [ "--with-ssl=${pkgs.openssl.dev}" ];
+
+  postInstall = ''
+    cp -a contrib/. $out/share/fetchmail-contrib
+  '';
 
   meta = with lib; {
     homepage = "https://www.fetchmail.info/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27947,6 +27947,7 @@ with pkgs;
   fehlstart = callPackage ../applications/misc/fehlstart { };
 
   fetchmail = callPackage ../applications/misc/fetchmail { };
+  fetchmail_7 = callPackage ../applications/misc/fetchmail/v7.nix { };
 
   ff2mpv = callPackage ../applications/misc/ff2mpv { };
 


### PR DESCRIPTION
###### Description of changes

Fetchmailconf wasn't working due to missing Python dependency

v7 (next) is the development version, but it's the only version that support OAuth, which is now needed to fetch from Outlook 356

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
