### PR TITLE
lua: test the interpreter

### DIFF
--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -69,6 +69,8 @@ let
         inherit executable luaversion sourceVersion;
         luaOnBuild = luaOnBuildForHost.override { inherit packageOverrides; self = luaOnBuild; };
 
+        tests = callPackage ./tests { inherit (luaPackages) wrapLua; };
+
         inherit luaAttr;
   };
 

--- a/pkgs/development/interpreters/lua-5/tests/assert.sh
+++ b/pkgs/development/interpreters/lua-5/tests/assert.sh
@@ -1,0 +1,16 @@
+# Always failing assertion with a message.
+#
+# Example:
+#     fail "It should have been but it wasn't to be"
+function fail() {
+    echo "$1"
+    exit 1
+}
+
+
+function assertStringEqual {
+
+    if ! diff <(echo "$1") <(echo "$2") ; then
+        fail "Strings differ"
+    fi
+}

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -1,0 +1,50 @@
+{ lua
+, hello
+, wrapLua
+, lib, fetchFromGitHub
+, fetchFromGitLab
+, pkgs
+}:
+let
+
+  runTest = lua: { name, command }:
+    pkgs.runCommandLocal "test-${lua.name}" ({
+      nativeBuildInputs = [lua];
+      meta.platforms = lua.meta.platforms;
+    }) (''
+      source ${./assert.sh}
+    ''
+    + command
+    + "touch $out"
+    );
+
+    wrappedHello = hello.overrideAttrs(oa: {
+      propagatedBuildInputs = [
+        wrapLua
+        lua.pkgs.cjson
+      ];
+      postFixup = ''
+        wrapLuaPrograms
+      '';
+    });
+in
+  pkgs.recurseIntoAttrs ({
+
+  checkAliases = runTest lua {
+    name = "check-aliases";
+    command = ''
+      generated=$(lua -e 'print(package.path)')
+      golden_LUA_PATH='./share/lua/${lua.luaversion}/?.lua;./?.lua;./?/init.lua'
+
+      assertStringEqual "$generated" "$golden_LUA_PATH"
+      '';
+  };
+
+  checkWrapping = pkgs.runCommandLocal "test-${lua.name}" ({
+    }) (''
+      grep -- 'LUA_PATH=' ${wrappedHello}/bin/hello
+      touch $out
+    '');
+
+})
+

--- a/pkgs/development/interpreters/lua-5/wrapper.nix
+++ b/pkgs/development/interpreters/lua-5/wrapper.nix
@@ -60,6 +60,8 @@ let
     passthru = lua.passthru // {
       interpreter = "${env}/bin/lua";
       inherit lua;
+      luaPath = lua.pkgs.lib.genLuaPathAbsStr env;
+      luaCpath = lua.pkgs.lib.genLuaCPathAbsStr env;
       env = stdenv.mkDerivation {
         name = "interactive-${lua.name}-environment";
         nativeBuildInputs = [ env ];


### PR DESCRIPTION
Test with:
nix-build -A lua.tests pass

Tests are very limited for now, goal is mostly to put the infra into place and enrich the tests when dealing with lua issues. add luaPath/luaCpath as passthrough
makes it easier to generate LUA_PATH/LUA_CPATH

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
