### PR TITLE
chatty: unbreak by migrating to libsoup3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatty/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatty/default.nix
@@ -29,15 +29,16 @@
 
 stdenv.mkDerivation rec {
   pname = "chatty";
-  version = "0.6.7";
+  version = "unstable-2022-09-20";
 
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "chatty";
-    rev = "v${version}";
+    # https://source.puri.sm/Librem5/chatty/-/tree/247c53fd990f7472ddd1a92c2f9e1299ae3ef4e4
+    rev = "247c53fd990f7472ddd1a92c2f9e1299ae3ef4e4";
     fetchSubmodules = true;
-    hash = "sha256-W4w/00mRgjfyQmLQ81/EAN+80qk7kDkBmMPJnOU+AIc=";
+    hash = "sha256-9hgQC0vLmmJJxrBWTdTIrJbSSwLS23uVoJri2ieCj4E=";
   };
 
   postPatch = ''
@@ -87,7 +88,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dotlambda tomfitzhenry ];
     platforms = platforms.linux;
-    # Requires upgrade to libsoup3
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

Motivation: Fix chatty.

Background: chatty 0.6.7 depends on libsoup2 and
evolution-data-service. During the GNOME 42 -> 43 migration,
evolution-data-service changed from using libsoup2 to
libsoup3. chatty's use of libsoup2 and libsoup3 was
conflicting, and thus chatty broke.

To fix this, let's use a recent unreleased commit, which migrates Chatty to libsoup3, as Alpine did:
https://git.alpinelinux.org/aports/commit/community/chatty/APKBUILD?id=1184b834c74362df3f9963585311256ed2c6908a

Longer term, we can use chatty 0.7 when it is released:
https://source.puri.sm/Librem5/chatty/-/merge_requests/1134

The Chatty maintainer [says](https://source.puri.sm/Librem5/chatty/-/merge_requests/1134#note_213824):

> I would say it's stable enough to be uploaded to Debian though.

Tested by running this on my Pinephone and receiving an SMS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
