### PR TITLE
openjpeg: drop broken supports

### DIFF
--- a/pkgs/development/libraries/openjpeg/default.nix
+++ b/pkgs/development/libraries/openjpeg/default.nix
@@ -2,8 +2,6 @@
 , libdeflate, libpng, libtiff, zlib, lcms2, jpylyzer
 , jpipLibSupport ? false # JPIP library & executables
 , jpipServerSupport ? false, curl, fcgi # JPIP Server
-, opjViewerSupport ? false, wxGTK # OPJViewer executable
-, openjpegJarSupport ? false # Openjpeg jar (Java)
 , jdk
 , poppler
 }:
@@ -45,8 +43,8 @@ stdenv.mkDerivation rec {
     "-DBUILD_THIRDPARTY=OFF"
     (mkFlag jpipLibSupport "BUILD_JPIP")
     (mkFlag jpipServerSupport "BUILD_JPIP_SERVER")
-    (mkFlag opjViewerSupport "BUILD_VIEWER")
-    (mkFlag openjpegJarSupport "BUILD_JAVA")
+    "-DBUILD_VIEWER=OFF"
+    "-DBUILD_JAVA=OFF"
     (mkFlag doCheck "BUILD_TESTING")
   ];
 
@@ -54,8 +52,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libdeflate libpng libtiff zlib lcms2 ]
     ++ lib.optionals jpipServerSupport [ curl fcgi ]
-    ++ lib.optional opjViewerSupport wxGTK
-    ++ lib.optional (openjpegJarSupport || jpipLibSupport) jdk;
+    ++ lib.optional (jpipLibSupport) jdk;
 
   doCheck = (!stdenv.isAarch64 && !stdenv.hostPlatform.isPower64); # tests fail on aarch64-linux and powerpc64
 
@@ -78,7 +75,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ codyopel ];
     platforms = platforms.all;
-    # opj viewer fails to compile with lots of errors, jar requires openjpeg library already compiled and installed
-    broken = (opjViewerSupport || openjpegJarSupport);
   };
 }


### PR DESCRIPTION
###### Description of changes

As in the title. Should have zero rebuilds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
