### PR TITLE
docbook_sgml_dtd_{3,4}1: factor out into a common subexpression

### DIFF
--- a/pkgs/data/sgml+xml/schemas/sgml-dtd/docbook/3.1.nix
+++ b/pkgs/data/sgml+xml/schemas/sgml-dtd/docbook/3.1.nix
@@ -1,37 +1,12 @@
-{ lib, stdenv, fetchurl, unzip }:
+{ fetchurl
+, callPackage
+}:
 
-let
+callPackage ./common.nix {
+  version = "3.1";
 
   src = fetchurl {
     url = "http://www.oasis-open.org/docbook/sgml/3.1/docbk31.zip";
     sha256 = "0f25ch7bywwhdxb1qa0hl28mgq1blqdap3rxzamm585rf4kis9i0";
-  };
-
-  isoents = fetchurl {
-    url = "http://www.oasis-open.org/cover/ISOEnts.zip";
-    sha256 = "1clrkaqnvc1ja4lj8blr0rdlphngkcda3snm7b9jzvcn76d3br6w";
-  };
-
-in
-
-stdenv.mkDerivation {
-  name = "docbook-sgml-3.1";
-
-  dontUnpack = true;
-
-  nativeBuildInputs = [ unzip ];
-
-  installPhase =
-    ''
-      o=$out/sgml/dtd/docbook-3.1
-      mkdir -p $o
-      cd $o
-      unzip ${src}
-      unzip ${isoents}
-      sed -e "s/iso-/ISO/" -e "s/.gml//" -i docbook.cat
-    '';
-
-  meta = {
-    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/data/sgml+xml/schemas/sgml-dtd/docbook/4.1.nix
+++ b/pkgs/data/sgml+xml/schemas/sgml-dtd/docbook/4.1.nix
@@ -1,37 +1,12 @@
-{ lib, stdenv, fetchurl, unzip }:
+{ fetchurl
+, callPackage
+}:
 
-let
+callPackage ./common.nix {
+  version = "4.1";
 
   src = fetchurl {
     url = "http://www.oasis-open.org/docbook/sgml/4.1/docbk41.zip";
     sha256 = "04b3gp4zkh9c5g9kvnywdkdfkcqx3kjc04j4mpkr4xk7lgqgrany";
-  };
-
-  isoents = fetchurl {
-    url = "http://www.oasis-open.org/cover/ISOEnts.zip";
-    sha256 = "1clrkaqnvc1ja4lj8blr0rdlphngkcda3snm7b9jzvcn76d3br6w";
-  };
-
-in
-
-stdenv.mkDerivation {
-  name = "docbook-sgml-4.1";
-
-  dontUnpack = true;
-
-  nativeBuildInputs = [ unzip ];
-
-  installPhase =
-    ''
-      o=$out/sgml/dtd/docbook-4.1
-      mkdir -p $o
-      cd $o
-      unzip ${src}
-      unzip ${isoents}
-      sed -e "s/iso-/ISO/" -e "s/.gml//" -i docbook.cat
-    '';
-
-  meta = {
-    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/data/sgml+xml/schemas/sgml-dtd/docbook/common.nix
+++ b/pkgs/data/sgml+xml/schemas/sgml-dtd/docbook/common.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, lib
+, fetchurl
+, unzip
+
+, version
+, src
+}:
+
+let
+  isoents = fetchurl {
+    url = "https://web.archive.org/web/20220713122518/http://xml.coverpages.org/ISOEnts.zip";
+    sha256 = "1clrkaqnvc1ja4lj8blr0rdlphngkcda3snm7b9jzvcn76d3br6w";
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "docbook-sgml";
+  inherit version;
+
+  nativeBuildInputs = [
+    unzip
+  ];
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    o=$out/sgml/dtd/docbook-${version}
+    mkdir -p "$o"
+    cd "$o"
+    unzip "${src}"
+    unzip "${isoents}"
+    sed -e "s/iso-/ISO/" -e "s/.gml//" -i docbook.cat
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "DTD schemas for SGML variant of DocBook ${version}";
+    license = lib.licenses.free;
+    maintainers = [ ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Extracted from https://github.com/NixOS/nixpkgs/pull/179962

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
