### PR TITLE
noti: 3.5.0 -> 3.6.0

### DIFF
--- a/pkgs/tools/misc/noti/default.nix
+++ b/pkgs/tools/misc/noti/default.nix
@@ -2,30 +2,20 @@
 , lib
 , buildGoModule
 , fetchFromGitHub
-, fetchurl
 , Cocoa
 , installShellFiles
 }:
 
 buildGoModule rec {
   pname = "noti";
-  version = "3.5.0";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "variadico";
     repo = "noti";
     rev = version;
-    sha256 = "12r9wawwl6x0rfv1kahwkamfa0pjq24z60az9pn9nsi2z1rrlwkd";
+    sha256 = "sha256-FhVpw6PJcm0aYQBlN7AUjOkJgCzleOHXIXumSegtxfA=";
   };
-
-  patches = [
-    # update golang.org/x/sys to fix building on aarch64-darwin
-    # using fetchurl because fetchpatch breaks the patch
-    (fetchurl {
-      url = "https://github.com/variadico/noti/commit/a90bccfdb2e6a0adc2e92f9a4e7be64133832ba9.patch";
-      sha256 = "sha256-vSAwuAR9absMSFqGOlzmRZoOGC/jpkmh8CMCVjeleUo=";
-    })
-  ];
 
   vendorSha256 = null;
 
@@ -39,8 +29,12 @@ buildGoModule rec {
     "-X github.com/variadico/noti/internal/command.Version=${version}"
   ];
 
+  preCheck = ''
+    export PATH=$out/bin:$PATH
+  '';
+
   postInstall = ''
-    installManPage docs/man/*
+    installManPage docs/man/dist/*
   '';
 
   meta = with lib; {
@@ -48,7 +42,8 @@ buildGoModule rec {
     longDescription = ''
       Monitor a process and trigger a notification.
 
-      Never sit and wait for some long-running process to finish. Noti can alert you when it's done. You can receive messages on your computer or phone.
+      Never sit and wait for some long-running process to finish. Noti can alert
+      you when it's done. You can receive messages on your computer or phone.
     '';
     homepage = "https://github.com/variadico/noti";
     license = licenses.mit;


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/variadico/noti/releases/tag/3.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
