### PR TITLE
python310Packages.meteofrance-api: 1.0.2 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/meteofrance-api/default.nix
+++ b/pkgs/development/python-modules/meteofrance-api/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , poetry-core
 , pytestCheckHook
 , pythonOlder
@@ -14,25 +13,17 @@
 
 buildPythonPackage rec {
   pname = "meteofrance-api";
-  version = "1.0.2";
+  version = "1.1.0";
   format = "pyproject";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "hacf-fr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-X8f0z9ZPXH7Wc3GqHmPptxpNxbHeezdOzw4gZCprumU=";
+    hash = "sha256-1ZN/9ur6uhK7M5TurmmWgUjzkc79MPqKnT637hbAAWA=";
   };
-
-  patches = [
-    (fetchpatch {
-      #  Switch to poetry-core
-      url = "https://github.com/hacf-fr/meteofrance-api/commit/7536993fe38dfe3d0833da3fd750be9277aeffa6.patch";
-      hash = "sha256-/4VgzoJxhaXoj1N1GNLJNvkQvv6IW9OcBJV6vg6kthM=";
-    })
-  ];
 
   nativeBuildInputs = [
     poetry-core
@@ -41,21 +32,14 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     pytz
     requests
-    urllib3
-  ] ++ lib.optionals (pythonOlder "3.7") [
     typing-extensions
+    urllib3
   ];
 
   checkInputs = [
     pytestCheckHook
     requests-mock
   ];
-
-  postPatch = ''
-    # https://github.com/hacf-fr/meteofrance-api/pull/378
-    substituteInPlace pyproject.toml \
-      --replace 'pytz = ">=2020.4,<2022.0"' 'pytz = ">=2020.4,<2023.0"'
-  '';
 
   pythonImportsCheck = [
     "meteofrance_api"


### PR DESCRIPTION
###### Description of changes
https://github.com/hacf-fr/meteofrance-api/releases/tag/v1.1.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
