### PR TITLE
nixos/wg-quick: use nftables if enabled

### DIFF
--- a/nixos/modules/services/networking/wg-quick.nix
+++ b/nixos/modules/services/networking/wg-quick.nix
@@ -273,7 +273,11 @@ let
         after = [ "network.target" "network-online.target" ];
         wantedBy = optional values.autostart "multi-user.target";
         environment.DEVICE = name;
-        path = [ pkgs.kmod pkgs.wireguard-tools config.networking.resolvconf.package ];
+        path = [
+          pkgs.wireguard-tools
+          config.networking.firewall.package   # iptables or nftables
+          config.networking.resolvconf.package # openresolv or systemd
+        ];
 
         serviceConfig = {
           Type = "oneshot";
@@ -281,7 +285,7 @@ let
         };
 
         script = ''
-          ${optionalString (!config.boot.isContainer) "modprobe wireguard"}
+          ${optionalString (!config.boot.isContainer) "${pkgs.kmod}/bin/modprobe wireguard"}
           ${optionalString (values.configFile != null) ''
             cp ${values.configFile} ${configPath}
           ''}

--- a/nixos/tests/wireguard/basic.nix
+++ b/nixos/tests/wireguard/basic.nix
@@ -1,5 +1,4 @@
-{ kernelPackages ? null }:
-import ../make-test-python.nix ({ pkgs, lib, ...} :
+import ../make-test-python.nix ({ pkgs, lib, kernelPackages ? null, ...} :
   let
     wg-snakeoil-keys = import ./snakeoil-keys.nix;
     peer = (import ./make-peer.nix) { inherit lib; };

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -7,10 +7,11 @@
 with pkgs.lib;
 
 let
-  tests = let callTest = p: flip (import p) { inherit system pkgs; }; in {
+  tests = let callTest = p: args: import p ({ inherit system pkgs; } // args); in {
     basic = callTest ./basic.nix;
     namespaces = callTest ./namespaces.nix;
     wg-quick = callTest ./wg-quick.nix;
+    wg-quick-nftables = args: callTest ./wg-quick.nix ({ nftables = true; } // args);
     generated = callTest ./generated.nix;
   };
 in

--- a/nixos/tests/wireguard/generated.nix
+++ b/nixos/tests/wireguard/generated.nix
@@ -1,5 +1,4 @@
-{ kernelPackages ? null }:
-import ../make-test-python.nix ({ pkgs, lib, ... } : {
+import ../make-test-python.nix ({ pkgs, lib, kernelPackages ? null, ... } : {
   name = "wireguard-generated";
   meta = with pkgs.lib.maintainers; {
     maintainers = [ ma27 grahamc ];

--- a/nixos/tests/wireguard/namespaces.nix
+++ b/nixos/tests/wireguard/namespaces.nix
@@ -1,5 +1,3 @@
-{ kernelPackages ? null }:
-
 let
   listenPort = 12345;
   socketNamespace = "foo";
@@ -15,7 +13,7 @@ let
 
 in
 
-import ../make-test-python.nix ({ pkgs, lib, ... } : {
+import ../make-test-python.nix ({ pkgs, lib, kernelPackages ? null, ... } : {
   name = "wireguard-with-namespaces";
   meta = with pkgs.lib.maintainers; {
     maintainers = [ asymmetric ];

--- a/nixos/tests/wireguard/wg-quick.nix
+++ b/nixos/tests/wireguard/wg-quick.nix
@@ -1,9 +1,13 @@
-{ kernelPackages ? null }:
-
-import ../make-test-python.nix ({ pkgs, lib, ... }:
+import ../make-test-python.nix ({ pkgs, lib, kernelPackages ? null, nftables ? false, ... }:
   let
     wg-snakeoil-keys = import ./snakeoil-keys.nix;
-    peer = (import ./make-peer.nix) { inherit lib; };
+    peer = import ./make-peer.nix { inherit lib; };
+    commonConfig = {
+      boot.kernelPackages = lib.mkIf (kernelPackages != null) kernelPackages;
+      networking.nftables.enable = nftables;
+      # Make sure iptables doesn't work with nftables enabled
+      boot.blacklistedKernelModules = lib.mkIf nftables [ "nft_compat" ];
+    };
   in
   {
     name = "wg-quick";
@@ -15,47 +19,51 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
       peer0 = peer {
         ip4 = "192.168.0.1";
         ip6 = "fd00::1";
-        extraConfig = {
-          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
-          networking.firewall.allowedUDPPorts = [ 23542 ];
-          networking.wg-quick.interfaces.wg0 = {
-            address = [ "10.23.42.1/32" "fc00::1/128" ];
-            listenPort = 23542;
+        extraConfig = lib.mkMerge [
+          commonConfig
+          {
+            networking.firewall.allowedUDPPorts = [ 23542 ];
+            networking.wg-quick.interfaces.wg0 = {
+              address = [ "10.23.42.1/32" "fc00::1/128" ];
+              listenPort = 23542;
 
-            inherit (wg-snakeoil-keys.peer0) privateKey;
+              inherit (wg-snakeoil-keys.peer0) privateKey;
 
-            peers = lib.singleton {
-              allowedIPs = [ "10.23.42.2/32" "fc00::2/128" ];
+              peers = lib.singleton {
+                allowedIPs = [ "10.23.42.2/32" "fc00::2/128" ];
 
-              inherit (wg-snakeoil-keys.peer1) publicKey;
+                inherit (wg-snakeoil-keys.peer1) publicKey;
+              };
+
+              dns = [ "10.23.42.2" "fc00::2" "wg0" ];
             };
-
-            dns = [ "10.23.42.2" "fc00::2" "wg0" ];
-          };
-        };
+          }
+        ];
       };
 
       peer1 = peer {
         ip4 = "192.168.0.2";
         ip6 = "fd00::2";
-        extraConfig = {
-          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
-          networking.useNetworkd = true;
-          networking.wg-quick.interfaces.wg0 = {
-            address = [ "10.23.42.2/32" "fc00::2/128" ];
-            inherit (wg-snakeoil-keys.peer1) privateKey;
+        extraConfig = lib.mkMerge [
+          commonConfig
+          {
+            networking.useNetworkd = true;
+            networking.wg-quick.interfaces.wg0 = {
+              address = [ "10.23.42.2/32" "fc00::2/128" ];
+              inherit (wg-snakeoil-keys.peer1) privateKey;
 
-            peers = lib.singleton {
-              allowedIPs = [ "0.0.0.0/0" "::/0" ];
-              endpoint = "192.168.0.1:23542";
-              persistentKeepalive = 25;
+              peers = lib.singleton {
+                allowedIPs = [ "0.0.0.0/0" "::/0" ];
+                endpoint = "192.168.0.1:23542";
+                persistentKeepalive = 25;
 
-              inherit (wg-snakeoil-keys.peer0) publicKey;
+                inherit (wg-snakeoil-keys.peer0) publicKey;
+              };
+
+              dns = [ "10.23.42.1" "fc00::1" "wg0" ];
             };
-
-            dns = [ "10.23.42.1" "fc00::1" "wg0" ];
-          };
-        };
+          }
+        ];
       };
     };
 

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -37,10 +37,11 @@ stdenv.mkDerivation rec {
       --replace /usr/bin $out/bin
   '' + lib.optionalString stdenv.isLinux ''
     for f in $out/bin/*; do
-      # allow users to provide their own resolvconf implementation, e.g. the one provided by systemd-resolved
+      # Which firewall and resolvconf implementations to use should be determined by the
+      # environment, we provide the "default" ones as fallback.
       wrapProgram $f \
-        --prefix PATH : ${lib.makeBinPath [ procps iproute2 iptables ]} \
-        --suffix PATH : ${lib.makeBinPath [ openresolv ]}
+        --prefix PATH : ${lib.makeBinPath [ procps iproute2 ]} \
+        --suffix PATH : ${lib.makeBinPath [ iptables openresolv ]}
     done
   '';
 


### PR DESCRIPTION
Set `networking.firewall.package` to `nftables` if nftables is used, so that `wg-quick` can behave agnostically (it uses `nft` if present, otherwise falls back to `iptables`).

Tested with both iptables and nftables.