### PR TITLE
silicon: 0.4.3 -> 0.5.1

### DIFF
--- a/pkgs/tools/misc/silicon/default.nix
+++ b/pkgs/tools/misc/silicon/default.nix
@@ -14,22 +14,24 @@
 , CoreText
 , Security
 , fira-code
+, fontconfig
+, harfbuzz
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "silicon";
-  version = "0.4.3";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "Aloxaf";
     repo = "silicon";
     rev = "v${version}";
-    sha256 = "sha256-yhs9BEMMFUtptd0cLsaUW02QZVhztvn8cB0nUqPnO+Y=";
+    sha256 = "sha256-RuzaRJr1n21MbHSeHBt8CjEm5AwbDbvX9Nw5PeBTl+w=";
   };
 
-  cargoSha256 = "sha256-tj5HPE9EGC7JQ3dyeMPPI0/3r/idrShqfbpnVuaEtDk=";
+  cargoSha256 = "sha256-q+CoXoNZOxDmEJ+q1vPWxBJsfHQiCxAMlCZo8C49aQA=";
 
-  buildInputs = [ llvmPackages.libclang expat freetype fira-code ]
+  buildInputs = [ llvmPackages.libclang expat freetype fira-code fontconfig harfbuzz ]
     ++ lib.optionals stdenv.isLinux [ libxcb ]
     ++ lib.optionals stdenv.isDarwin [ libiconv AppKit CoreText Security ];
 
@@ -37,6 +39,10 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optionals stdenv.isLinux [ python3 ];
 
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
 
   meta = with lib; {
     description = "Create beautiful image of your source code";

--- a/pkgs/tools/misc/silicon/default.nix
+++ b/pkgs/tools/misc/silicon/default.nix
@@ -48,6 +48,6 @@ rustPlatform.buildRustPackage rec {
     description = "Create beautiful image of your source code";
     homepage = "https://github.com/Aloxaf/silicon";
     license = with licenses; [ mit /* or */ asl20 ];
-    maintainers = with maintainers; [ evanjs ];
+    maintainers = with maintainers; [ evanjs _0x4A6F ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Upgrade to [0.5.1](https://github.com/Aloxaf/silicon/releases/tag/v0.5.1) including these [changes](https://github.com/Aloxaf/silicon/compare/v0.4.3...v0.5.1).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
