### PR TITLE
libvorbis: Remove flags not recognized by clang

### DIFF
--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -5,7 +5,8 @@ stdenv.mkDerivation rec {
   version = "1.3.7";
 
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/vorbis/${pname}-${version}.tar.xz";
+    url =
+      "http://downloads.xiph.org/releases/vorbis/${pname}-${version}.tar.xz";
     sha256 = "0jwmf87x5sdis64rbv0l87mdpah1rbilkkxszipbzg128f9w8g5k";
   };
 
@@ -15,6 +16,10 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libogg ];
 
   doCheck = true;
+
+  preConfigure = lib.optionalString (stdenv.cc.isClang or false) ''
+    sed s/\-mno\-ieee\-fp// -i {configure,configure.ac}
+  '';
 
   meta = with lib; {
     description = "Vorbis audio compression reference implementation";

--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  # strip -mno-ieee-fp flag from configure and configure.ac when using
+  # clang as the flag is not recognized by the compiler
   preConfigure = lib.optionalString (stdenv.cc.isClang or false) ''
     sed s/\-mno\-ieee\-fp// -i {configure,configure.ac}
   '';

--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -5,8 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.3.7";
 
   src = fetchurl {
-    url =
-      "http://downloads.xiph.org/releases/vorbis/${pname}-${version}.tar.xz";
+    url = "https://downloads.xiph.org/releases/vorbis/${pname}-${version}.tar.xz";
     sha256 = "0jwmf87x5sdis64rbv0l87mdpah1rbilkkxszipbzg128f9w8g5k";
   };
 


### PR DESCRIPTION
###### Description of changes

This issue is part of a series of bugfixes to improve the `i686` cross-compilation pipeline.

Tracking issue: https://github.com/NixOS/nixpkgs/issues/195967

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
