### PR TITLE
SDL: Support pkg-config in sdl.m4

### DIFF
--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -109,6 +109,17 @@ stdenv.mkDerivation rec {
       url = "https://github.com/libsdl-org/SDL-1.2/commit/d7e00208738a0bc6af302723fe64908ac35b777b.patch";
       sha256 = "sha256-fuxXsqZW94/C8CKu9LakppCU4zHupj66O2MngQ4BO9o=";
     })
+    # pkg-config support in in sdl.m4.
+	  # Using unofficial mirror because git import issue:
+	  # https://github.com/libsdl-org/SDL/issues/5220
+    (fetchpatch {
+	  url = "https://github.com/spurious/SDL-mirror/commit/b8e0d8078eef79701d0a03a2d6e244212a658b5e.patch";
+      sha256 = "1xqx7ib68c2qzrx5rv662hf3pqn2f57xzglgdgp4xdzx3qkv1b6l";
+    })
+    (fetchpatch {
+      url = "https://github.com/spurious/SDL-mirror/commit/c7ec74595965a872d077a0e20377cbdb0c0e694f.patch";
+      sha256 = "0mdf1zpk99qr8ksw6nmlqdv9px4szncpjdam3c702qlab979vlqq";
+    })
   ];
 
   postInstall = ''

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/libsdl-org/SDL-1.2/commit/d7e00208738a0bc6af302723fe64908ac35b777b.patch";
       sha256 = "sha256-fuxXsqZW94/C8CKu9LakppCU4zHupj66O2MngQ4BO9o=";
     })
-    # pkg-config support in in sdl.m4.
+    # Add pkg-config support in sdl.m4
 	  # Using unofficial mirror because git import issue:
 	  # https://github.com/libsdl-org/SDL/issues/5220
     (fetchpatch {


### PR DESCRIPTION
Backport some commits

###### Description of changes

This issue is part of a series of bugfixes to improve the i686 cross-compilation pipeline.

Tracking issue: https://github.com/NixOS/nixpkgs/issues/195967

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
