### PR TITLE
gnome.nautilus: use the gtk4 FileChooser settings schema (fixes crash-on-start)

### DIFF
--- a/pkgs/desktops/gnome/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome/core/nautilus/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchpatch
 , fetchurl
 , meson
 , ninja
@@ -47,6 +48,17 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Switch to GTK 4 settings schema to avoid crash when GTK 3 did not manage to contaminate environment.
+    # https://gitlab.gnome.org/GNOME/nautilus/-/merge_requests/1013
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/nautilus/-/commit/96d542a0d84da4ad6915a7727642490a5c433d4a.patch";
+      sha256 = "BO/0ifRwSTDe7RV+DI3CPZg+UQezk0tbM+UidgoJRQM=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/nautilus/-/commit/52b4daf4396fd3b21755b3a0d1fbf85c3831c6b1.patch";
+      sha256 = "+8KCw2HZUi9UgOEUBNp4kbwqOI1qz6i0Q/wvzqTb8OA=";
+    })
+
     # Allow changing extension directory using environment variable.
     ./extension_dir.patch
 


### PR DESCRIPTION
upstream PR for more context: <https://gitlab.gnome.org/GNOME/nautilus/-/merge_requests/1013>

with the recent nixpkgs bump from [GNOME 42 -> 43](https://github.com/NixOS/nixpkgs/pull/182618), we build nautilus with gtk4 (as upstream expects). if the user has nothing else in their environment providing gtk3, then nautilus fails to locate a gtk3 gsettings schema it depends on. i.e.

```console
$ nautilus
(org.gnome.Nautilus): GLib-GIO-ERROR **: Settings schema 'org.gtk.Settings.FileChooser' is not installed
```

we could solve this on our end by adding gtk3 to `gappsWrapperArgs`, but this seems like an upstream bug: i believe they mean to use the gtk4 settings schemas instead of the legacy gtk3 ones.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
