### PR TITLE
roon-server: 2.0-1128 -> 2.0-1133

### DIFF
--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -9,25 +9,23 @@
 , stdenv
 , zlib
 }:
-stdenv.mkDerivation rec {
+let
+  version = "1.8-1125";
+  urlVersion = builtins.replaceStrings [ "." "-" ] [ "00" "0" ] version;
+  host = stdenv.hostPlatform.system;
+  system = if host == "x86_64-linux" then "linuxx64"
+           else if host == "aarch64-linux" then "linuxarmv8"
+           else throw "Unsupported platform ${host}";
+  src = fetchurl {
+    url = "https://download.roonlabs.com/updates/stable/RoonBridge_${system}_${urlVersion}.tar.bz2";
+    hash = if system == "linuxx64" then "sha256-DbtKPFEz2WIoKTxP+zoehzz+BjfsLZ2ZQk/FMh+zFBM="
+           else if system == "linuxarmv8" then "sha256-+przEj96R+f1z4ewETFarF4oY6tT2VW/ukSTgUBLiYk="
+           else throw "Unsupported platform ${host}";
+  };
+in
+stdenv.mkDerivation {
   pname = "roon-bridge";
-  version = "1.8-943";
-
-  src =
-    let
-      urlVersion = builtins.replaceStrings [ "." "-" ] [ "00" "00" ] version;
-      inherit (stdenv.targetPlatform) system;
-    in
-      {
-        x86_64-linux = fetchurl {
-          url = "http://download.roonlabs.com/builds/RoonBridge_linuxx64_${urlVersion}.tar.bz2";
-          hash = "sha256-knmy2zlRh+ehvYKHC7UN60pMCt8bYPuo9kTz2m0pOW0";
-        };
-        aarch64-linux = fetchurl {
-          url = "http://download.roonlabs.com/builds/RoonBridge_linuxarmv8_${urlVersion}.tar.bz2";
-          hash = "sha256-urMhtBUjP4HpV9EDZOLLnfnMqhmsWPx0M2+Xdvc8YnU=";
-        };
-      }.${system} or (throw "Unsupposed system: ${system}");
+  inherit src version;
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -15,7 +15,7 @@
 , stdenv
 }:
 let
-  version = "2.0-1128";
+  version = "2.0-1143";
   urlVersion = builtins.replaceStrings [ "." "-" ] [ "00" "0" ] version;
 in
 stdenv.mkDerivation {
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download.roonlabs.com/updates/production/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-    hash = "sha256-PR3LR7u9X6eUAyoAW1tXv3LzqoVz3RQ0MZwdF0iAXJ8=";
+    hash = "sha256-qSqSiqO3SzVmRacbbAphVLp0ablQCjR4Zn2HIQaqSPs=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
