### PR TITLE
llvmPackages_10.compiler-rt: Add support for i686

### DIFF
--- a/pkgs/development/compilers/llvm/10/compiler-rt/X86-support-extension.patch
+++ b/pkgs/development/compilers/llvm/10/compiler-rt/X86-support-extension.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/builtins/CMakeLists.txt b/lib/builtins/CMakeLists.txt
+index 3a66dd9c3fb..7efc85d9f9f 100644
+--- a/lib/builtins/CMakeLists.txt
++++ b/lib/builtins/CMakeLists.txt
+@@ -301,6 +301,10 @@ if (NOT MSVC)
+     i386/umoddi3.S
+   )
+ 
++  set(i486_SOURCES ${i386_SOURCES})
++  set(i586_SOURCES ${i386_SOURCES})
++  set(i686_SOURCES ${i386_SOURCES})
++
+   if (WIN32)
+     set(i386_SOURCES
+       ${i386_SOURCES}
+@@ -608,6 +612,7 @@ else ()
+   endif()
+ 
+   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
++      message("arch: ${arch}")
+     if (CAN_TARGET_${arch})
+       # For ARM archs, exclude any VFP builtins if VFP is not supported
+       if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em)$")

--- a/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
@@ -44,9 +44,7 @@ stdenv.mkDerivation {
   ] ++ lib.optionals (bareMetal) [
     "-DCOMPILER_RT_OS_DIR=baremetal"
   ] ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
-    # The compiler-rt build infrastructure sniffs supported platforms on Darwin
-    # and finds i386;x86_64;x86_64h. We only build for x86_64, so linking fails
-    # when it tries to use libc++ and libc++api for i386.
+    "-DDARWIN_macosx_OVERRIDE_SDK_VERSION=ON"
     "-DDARWIN_osx_ARCHS=${stdenv.hostPlatform.darwinArch}"
     "-DDARWIN_osx_BUILTIN_ARCHS=${stdenv.hostPlatform.darwinArch}"
   ];
@@ -68,6 +66,8 @@ stdenv.mkDerivation {
   postPatch = lib.optionalString (!stdenv.isDarwin) ''
     substituteInPlace cmake/builtin-config-ix.cmake \
       --replace 'set(X86 i386)' 'set(X86 i386 i486 i586 i686)'
+    substituteInPlace cmake/config-ix.cmake \
+      --replace 'set(X86 i386)' 'set(X86 i386 i486 i586 i686)'
   '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
@@ -86,8 +86,16 @@ stdenv.mkDerivation {
   '' + lib.optionalString (useLLVM) ''
     ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/crtbegin.o
     ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
+    ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/crtbeginS.o
+    ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtendS.o
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
+  ''
+  # See https://reviews.llvm.org/D37278 for why android exception
+  + lib.optionalString (stdenv.hostPlatform.isx86_32 && !stdenv.hostPlatform.isAndroid) ''
+    for f in $out/lib/*/*builtins-i?86*; do
+      ln -s "$f" $(echo "$f" | sed -e 's/builtins-i.86/builtins-i386/')
+    done
   '';
 
   meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation {
     ./find-darwin-sdk-version.patch # don't test for macOS being >= 10.15
     ./gnu-install-dirs.patch
     ../../common/compiler-rt/libsanitizer-no-cyclades-11.patch
+    ./X86-support-extension.patch # backported from LLVM 11
   ] ++ lib.optional stdenv.hostPlatform.isAarch32 ./armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks


### PR DESCRIPTION
###### Description of changes
This issue is part of a series of bugfixes to improve the i686 cross-compilation pipeline.

Tracking issue: https://github.com/NixOS/nixpkgs/issues/195967

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
