### PR TITLE
python310Packages.peewee: 3.15.1 -> 3.15.3

### DIFF
--- a/pkgs/development/python-modules/flask-admin/default.nix
+++ b/pkgs/development/python-modules/flask-admin/default.nix
@@ -1,21 +1,23 @@
 { lib
 , arrow
+, azure-storage-blob
+, boto
 , buildPythonPackage
 , colour
 , email-validator
 , enum34
 , fetchPypi
 , flask
-, flask-sqlalchemy
 , flask-babelex
 , flask-mongoengine
+, flask-sqlalchemy
 , geoalchemy2
-, isPy27
 , mongoengine
 , pillow
 , psycopg2
 , pymongo
 , pytestCheckHook
+, pythonOlder
 , shapely
 , sqlalchemy
 , sqlalchemy-citext
@@ -29,26 +31,35 @@ buildPythonPackage rec {
   version = "1.6.0";
   format = "setuptools";
 
+  disabled = pythonOlder "3.8";
+
   src = fetchPypi {
     pname = "Flask-Admin";
     inherit version;
-    sha256 = "1209qhm51d4z66mbw55cmkzqvr465shnws2m2l2zzpxhnxwzqks2";
+    hash = "sha256-Qk/8ebew3/8FFVVobqEuhuSN/6ysFL6qMZ+0UCrECYg=";
   };
 
   propagatedBuildInputs = [
     flask
     wtforms
-  ] ++ lib.optionals isPy27 [
-    enum34
   ];
+
+  passthru.optional-dependencies = {
+    aws = [
+      boto
+    ];
+    azure = [
+      azure-storage-blob
+    ];
+  };
 
   checkInputs = [
     arrow
     colour
     email-validator
-    flask-sqlalchemy
     flask-babelex
     flask-mongoengine
+    flask-sqlalchemy
     geoalchemy2
     mongoengine
     pillow
@@ -65,6 +76,13 @@ buildPythonPackage rec {
   disabledTests = [
     # Incompatible with werkzeug 2.1
     "test_mockview"
+    # Tests are outdated and don't work with peewee
+    "test_nested_flask_views"
+    "test_export_csv"
+    "test_list_row_actions"
+    "test_column_editable_list"
+    "test_column_filters"
+    "test_export_csv"
   ];
 
   disabledTestPaths = [
@@ -84,7 +102,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Simple and extensible admin interface framework for Flask";
+    description = "Admin interface framework for Flask";
     homepage = "https://github.com/flask-admin/flask-admin/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ costrouc ];

--- a/pkgs/development/python-modules/peewee/default.nix
+++ b/pkgs/development/python-modules/peewee/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "peewee";
-  version = "3.15.1";
+  version = "3.15.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "coleifer";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-2rxGOUCITEHuM83qhaKQGK4jSf4r8hcBAGxRImT/rhE=";
+    hash = "sha256-6s+JTUYmuP6Y6D+mi8YTznHbPYUS7yk259MuPpm9H/s=";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes
https://github.com/coleifer/peewee/releases/tag/3.15.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
