### PR TITLE
nqc: init at 3.1.r6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2459,6 +2459,12 @@
       fingerprint = "4EBB 30F1 E89A 541A A7F2  52BE 830A 9728 6309 66F4";
     }];
   };
+  christophcharles = {
+    email = "23055925+christophcharles@users.noreply.github.com";
+    github = "christophcharles";
+    githubId = 23055925;
+    name = "Christoph Charles";
+  };
   christopherpoole = {
     email = "mail@christopherpoole.net";
     github = "christopherpoole";

--- a/pkgs/development/compilers/nqc/default.nix
+++ b/pkgs/development/compilers/nqc/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "nqc";
+  version = "3.1.r6";
+
+  src = fetchurl {
+    url    = "https://bricxcc.sourceforge.net/nqc/release/nqc-${version}.tgz";
+    sha256 = "sha256-v9XmVPY5r3pYjP3vTSK9Xvz/9UexClbOvr3ljvK/52Y=";
+  };
+  
+  sourceRoot = ".";
+
+  patches = [
+    ./nqc-unistd.patch
+    (fetchurl {
+      url = "https://sourceforge.net/p/bricxcc/patches/_discuss/thread/00b427dc/b84b/attachment/nqc-01-Linux_usb_and_tcp.diff";
+      sha256 = "sha256-eU1Poa9vVZiNKa3xuq4Z1FHN96YI/I4hrGoGlUvpr3w=";
+    })
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  dontConfigure = true;
+
+  meta = with lib; {
+    homepage = "https://bricxcc.sourceforge.net/nqc/";
+    description = "A programming language for several LEGO MINDSTORMS products including the RCX, CyberMaster, and Scout";
+    platforms = platforms.linux;
+    license = licenses.mpl10;
+    maintainers = with maintainers; [ christophcharles ];
+  };
+}

--- a/pkgs/development/compilers/nqc/nqc-unistd.patch
+++ b/pkgs/development/compilers/nqc/nqc-unistd.patch
@@ -1,0 +1,11 @@
+diff -ruN nqc-3.1.r6-old/compiler/lexer.cpp nqc-3.1.r6-new/compiler/lexer.cpp
+--- nqc-3.1.r6-old/compiler/lexer.cpp	2007-06-06 20:19:10.000000000 +0200
++++ nqc-3.1.r6-new/compiler/lexer.cpp	2022-10-13 07:57:08.247213954 +0200
+@@ -11,6 +11,7 @@
+ #define YY_FLEX_MINOR_VERSION 5
+ 
+ #include <stdio.h>
++#include <unistd.h>
+ 
+ #if defined(__MWERKS__) && !__MACH__ && !YY_NEVER_INTERACTIVE
+ #include <unix.h>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14612,6 +14612,8 @@ with pkgs;
 
   nasmfmt = callPackage ../development/tools/nasmfmt { };
 
+  nqc = callPackage ../development/compilers/nqc { };
+
   nvidia_cg_toolkit = callPackage ../development/compilers/nvidia-cg-toolkit { };
 
   obliv-c = callPackage ../development/compilers/obliv-c


### PR DESCRIPTION
###### Description of changes

Added package nqc ([https://bricxcc.sourceforge.net/nqc/](https://bricxcc.sourceforge.net/nqc/))

NQC is a compiler for the NQC language, a programming language for several lego mindstorms products including the RCX, CyberMaster, and Scout.

The compiler is quite old. I have included two patches:
- one from https://sourceforge.net/p/bricxcc/patches/_discuss/thread/00b427dc/b84b/attachment/nqc-01-Linux_usb_and_tcp.diff which is needed to use the modern kernel driver for the usb lego tower.
- a small one adding an include of unistd.h to solve some compilation issues when using nix.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
