### PR TITLE
bfcal: 1.0 -> 1.0.1

### DIFF
--- a/pkgs/applications/misc/bfcal/default.nix
+++ b/pkgs/applications/misc/bfcal/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     description = "Quickly display a calendar";
     homepage = "https://git.sr.ht/~bitfehler/bfcal";
     license = licenses.gpl3Plus;
+    platforms = qtbase.meta.platforms;
     maintainers = with maintainers; [ laalsaas ];
   };
 }

--- a/pkgs/applications/misc/bfcal/default.nix
+++ b/pkgs/applications/misc/bfcal/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bfcal";
-  version = "1.0";
+  version = "1.0.1";
 
   src = fetchFromSourcehut {
     owner = "~bitfehler";
     repo = "bfcal";
     rev = "v${version}";
-    sha256 = "sha256-2z5ICVEZ55omwcoVWpac/HPwyKF9jDCYO78S9p21VMU=";
+    sha256 = "sha256-5xyBU+0XUNFUGgvw7U8YE64zncw6SvPmbJhc1LY2u/g=";
   };
 
   nativeBuildInputs = [
@@ -26,11 +26,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     qtbase
   ];
-
-  postInstall = ''
-    mkdir -p $out/bin
-    install bfcal $out/bin
-  '';
 
   meta = with lib; {
     description = "Quickly display a calendar";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Since my patch got to make the installation process cleaner got accepted upstream, we can simplify it here.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
