### PR TITLE
qcoro: 0.4.0 -> 0.6.0 and AArch64 fix

### DIFF
--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -73,7 +73,7 @@ let
       krecorder = callPackage ./krecorder.nix {};
       ktrip = callPackage ./ktrip.nix {};
       kweather = callPackage ./kweather.nix {};
-      neochat = callPackage ./neochat.nix {};
+      neochat = callPackage ./neochat.nix { inherit srcs; };
       plasma-dialer = callPackage ./plasma-dialer.nix {};
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
       plasma-settings = callPackage ./plasma-settings.nix {};

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -78,7 +78,7 @@ let
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
       plasma-settings = callPackage ./plasma-settings.nix {};
       plasmatube = callPackage ./plasmatube.nix {};
-      spacebar = callPackage ./spacebar.nix {};
+      spacebar = callPackage ./spacebar.nix { inherit srcs; };
     };
 
 in lib.makeScope libsForQt5.newScope packages

--- a/pkgs/applications/plasma-mobile/neochat.nix
+++ b/pkgs/applications/plasma-mobile/neochat.nix
@@ -1,9 +1,13 @@
-{ mkDerivation
+{ gcc11Stdenv
 , lib
-, pkg-config
+, srcs
+
 , cmake
-, cmark
 , extra-cmake-modules
+, pkg-config
+, wrapQtAppsHook
+
+, cmark
 , kconfig
 , kdbusaddons
 , ki18n
@@ -25,10 +29,17 @@
 , sonnet
 }:
 
-mkDerivation rec {
+# Workaround for AArch64 not using GCC11 yet.
+gcc11Stdenv.mkDerivation rec {
   pname = "neochat";
+  inherit (srcs.neochat) version src;
 
-  nativeBuildInputs = [ cmake extra-cmake-modules pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     cmark

--- a/pkgs/applications/plasma-mobile/spacebar.nix
+++ b/pkgs/applications/plasma-mobile/spacebar.nix
@@ -1,8 +1,11 @@
 { lib
 , mkDerivation
+, gcc11Stdenv
+, srcs
 
 , cmake
 , extra-cmake-modules
+, wrapQtAppsHook
 
 , kcontacts
 , ki18n
@@ -18,12 +21,15 @@
 , qtquickcontrols2
 }:
 
-mkDerivation rec {
+# Workaround for AArch64 not using GCC11 yet.
+gcc11Stdenv.mkDerivation rec {
   pname = "spacebar";
+  inherit (srcs.spacebar) version src;
 
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/qcoro/default.nix
+++ b/pkgs/development/libraries/qcoro/default.nix
@@ -1,30 +1,35 @@
-{ lib
-, mkDerivation
+{ stdenv
+, gcc11Stdenv
+, lib
 , fetchFromGitHub
 , cmake
 , libpthreadstubs
 , qtbase
+, qtwebsockets
+, wrapQtAppsHook
 }:
 
-mkDerivation rec {
+gcc11Stdenv.mkDerivation rec {
   pname = "qcoro";
-  version = "0.4.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "danvratil";
     repo = "qcoro";
     rev = "v${version}";
-    sha256 = "sha256-RVpyL+BklX8Wyk9Xj9UyuvNK5Vev8ZsrOSMxX1HtcHU=";
+    sha256 = "sha256-6kRWBzspwsO0Q6/8gQUr69DJjmkPa3lWrKTmSgVn6V4=";
   };
 
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
+    wrapQtAppsHook
     cmake
   ];
 
   buildInputs = [
     qtbase
+    qtwebsockets
     libpthreadstubs
   ];
 
@@ -34,6 +39,5 @@ mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ smitop ];
     platforms = platforms.linux;
-    badPlatforms = platforms.aarch64;
   };
 }


### PR DESCRIPTION
###### Description of changes

Alternative for https://github.com/NixOS/nixpkgs/pull/185191. I preferred opening a new PR instead of "rudely" changing the semantics of the other PR.

See https://github.com/NixOS/nixpkgs/pull/185191#issuecomment-1253080004

The TLDR is it is also fixing the packages using qcoro, otherwise they still wouldn't build even though qcoro itself would build. Also changed the fix to use `gcc11Stdenv`, as suggested by @SuperSandro2000 [here](https://github.com/NixOS/nixpkgs/pull/185191#discussion_r939033533).

###### Things done

I tested with https://github.com/NixOS/nixpkgs/pull/193858, on x86_64 and AArch64, native builds for both.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

* * *

Closes #185191