### PR TITLE
pythonInterpreters: don't use with pkgs

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -1,6 +1,15 @@
-{ pkgs }:
-
-with pkgs;
+{ pkgs
+, callPackage
+, config
+, darwin
+, db
+, lib
+, libffiBoot
+, newScope
+, pythonPackagesExtensions
+, splicePackages
+, stdenv
+}:
 
 (let
 
@@ -79,11 +88,11 @@ with pkgs;
           extra = _: {};
           optionalExtensions = cond: as: if cond then as else [];
           python2Extension = import ../../../top-level/python2-packages.nix;
-          extensions = lib.composeManyExtensions ((optionalExtensions (!self.isPy3k) [python2Extension]) ++ pkgs.pythonPackagesExtensions ++ [ overrides ]);
+          extensions = lib.composeManyExtensions ((optionalExtensions (!self.isPy3k) [python2Extension]) ++ pythonPackagesExtensions ++ [ overrides ]);
           aliases = self: super: lib.optionalAttrs config.allowAliases (import ../../../top-level/python-aliases.nix lib self super);
         in lib.makeScopeWithSplicing
-          pkgs.splicePackages
-          pkgs.newScope
+          splicePackages
+          newScope
           otherSplices
           keep
           extra
@@ -150,7 +159,7 @@ with pkgs;
 in {
 
   python27 = callPackage ./cpython/2.7 {
-    self = python27;
+    self = pkgs.python27;
     sourceVersion = {
       major = "2";
       minor = "7";
@@ -163,7 +172,7 @@ in {
   };
 
   python37 = callPackage ./cpython {
-    self = python37;
+    self = pkgs.python37;
     sourceVersion = {
       major = "3";
       minor = "7";
@@ -176,7 +185,7 @@ in {
   };
 
   python38 = callPackage ./cpython {
-    self = python38;
+    self = pkgs.python38;
     sourceVersion = {
       major = "3";
       minor = "8";
@@ -189,19 +198,19 @@ in {
   };
 
   python39 = callPackage ./cpython ({
-    self = python39;
+    self = pkgs.python39;
     inherit (darwin) configd;
     inherit passthruFun;
   } // sources.python39);
 
   python310 = callPackage ./cpython ({
-    self = python310;
+    self = pkgs.python310;
     inherit (darwin) configd;
     inherit passthruFun;
   } // sources.python310);
 
   python311 = callPackage ./cpython {
-    self = python311;
+    self = pkgs.python311;
     sourceVersion = {
       major = "3";
       minor = "11";
@@ -215,7 +224,7 @@ in {
 
   # Minimal versions of Python (built without optional dependencies)
   python3Minimal = (callPackage ./cpython ({
-    self = python3Minimal;
+    self = pkgs.python3Minimal;
     inherit passthruFun;
     pythonAttr = "python3Minimal";
     # strip down that python version as much as possible
@@ -226,7 +235,7 @@ in {
     sqlite = null;
     configd = null;
     tzdata = null;
-    libffi = pkgs.libffiBoot; # without test suite
+    libffi = libffiBoot; # without test suite
     stripConfig = true;
     stripIdlelib = true;
     stripTests = true;
@@ -244,7 +253,7 @@ in {
   });
 
   pypy27 = callPackage ./pypy {
-    self = pypy27;
+    self = pkgs.pypy27;
     sourceVersion = {
       major = "7";
       minor = "3";
@@ -253,14 +262,14 @@ in {
     sha256 = "sha256-wERP2YcwWMHA2Z4TqTTpIoXLBZksmWi/Ujwyv5vsCp0=";
     pythonVersion = "2.7";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
-    python = python27;
+    python = pkgs.python27;
     inherit passthruFun;
     inherit (darwin) libunwind;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
   pypy38 = callPackage ./pypy {
-    self = pypy38;
+    self = pkgs.pypy38;
     sourceVersion = {
       major = "7";
       minor = "3";
@@ -269,20 +278,20 @@ in {
     sha256 = "sha256-Ia4zn09QFtbKcwAwXz47VUNzg1yzw5qQQf4w5oEcgMY=";
     pythonVersion = "3.8";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
-    python = python27;
+    python = pkgs.python27;
     inherit passthruFun;
     inherit (darwin) libunwind;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
-  pypy37 = pypy38.override {
-    self = pythonInterpreters.pypy37;
+  pypy37 = pkgs.pypy38.override {
+    self = pkgs.pythonInterpreters.pypy37;
     pythonVersion = "3.7";
     sha256 = "sha256-LtAqyecQhZxBvILer7CGGXkruaJ+6qFnbHQe3t0hTdc=";
   };
 
   pypy27_prebuilt = callPackage ./pypy/prebuilt_2_7.nix {
     # Not included at top-level
-    self = pythonInterpreters.pypy27_prebuilt;
+    self = pkgs.pythonInterpreters.pypy27_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "3";
@@ -295,7 +304,7 @@ in {
 
   pypy38_prebuilt = callPackage ./pypy/prebuilt.nix {
     # Not included at top-level
-    self = pythonInterpreters.pypy38_prebuilt;
+    self = pkgs.pythonInterpreters.pypy38_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "3";

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -1,4 +1,4 @@
-{ pkgs
+{ __splicedPackages
 , callPackage
 , config
 , darwin
@@ -159,7 +159,7 @@
 in {
 
   python27 = callPackage ./cpython/2.7 {
-    self = pkgs.python27;
+    self = __splicedPackages.python27;
     sourceVersion = {
       major = "2";
       minor = "7";
@@ -172,7 +172,7 @@ in {
   };
 
   python37 = callPackage ./cpython {
-    self = pkgs.python37;
+    self = __splicedPackages.python37;
     sourceVersion = {
       major = "3";
       minor = "7";
@@ -185,7 +185,7 @@ in {
   };
 
   python38 = callPackage ./cpython {
-    self = pkgs.python38;
+    self = __splicedPackages.python38;
     sourceVersion = {
       major = "3";
       minor = "8";
@@ -198,19 +198,19 @@ in {
   };
 
   python39 = callPackage ./cpython ({
-    self = pkgs.python39;
+    self = __splicedPackages.python39;
     inherit (darwin) configd;
     inherit passthruFun;
   } // sources.python39);
 
   python310 = callPackage ./cpython ({
-    self = pkgs.python310;
+    self = __splicedPackages.python310;
     inherit (darwin) configd;
     inherit passthruFun;
   } // sources.python310);
 
   python311 = callPackage ./cpython {
-    self = pkgs.python311;
+    self = __splicedPackages.python311;
     sourceVersion = {
       major = "3";
       minor = "11";
@@ -224,7 +224,7 @@ in {
 
   # Minimal versions of Python (built without optional dependencies)
   python3Minimal = (callPackage ./cpython ({
-    self = pkgs.python3Minimal;
+    self = __splicedPackages.python3Minimal;
     inherit passthruFun;
     pythonAttr = "python3Minimal";
     # strip down that python version as much as possible
@@ -253,7 +253,7 @@ in {
   });
 
   pypy27 = callPackage ./pypy {
-    self = pkgs.pypy27;
+    self = __splicedPackages.pypy27;
     sourceVersion = {
       major = "7";
       minor = "3";
@@ -262,14 +262,14 @@ in {
     sha256 = "sha256-wERP2YcwWMHA2Z4TqTTpIoXLBZksmWi/Ujwyv5vsCp0=";
     pythonVersion = "2.7";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
-    python = pkgs.python27;
+    python = __splicedPackages.python27;
     inherit passthruFun;
     inherit (darwin) libunwind;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
   pypy38 = callPackage ./pypy {
-    self = pkgs.pypy38;
+    self = __splicedPackages.pypy38;
     sourceVersion = {
       major = "7";
       minor = "3";
@@ -278,20 +278,20 @@ in {
     sha256 = "sha256-Ia4zn09QFtbKcwAwXz47VUNzg1yzw5qQQf4w5oEcgMY=";
     pythonVersion = "3.8";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
-    python = pkgs.python27;
+    python = __splicedPackages.python27;
     inherit passthruFun;
     inherit (darwin) libunwind;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
-  pypy37 = pkgs.pypy38.override {
-    self = pkgs.pythonInterpreters.pypy37;
+  pypy37 = __splicedPackages.pypy38.override {
+    self = __splicedPackages.pythonInterpreters.pypy37;
     pythonVersion = "3.7";
     sha256 = "sha256-LtAqyecQhZxBvILer7CGGXkruaJ+6qFnbHQe3t0hTdc=";
   };
 
   pypy27_prebuilt = callPackage ./pypy/prebuilt_2_7.nix {
     # Not included at top-level
-    self = pkgs.pythonInterpreters.pypy27_prebuilt;
+    self = __splicedPackages.pythonInterpreters.pypy27_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "3";
@@ -304,7 +304,7 @@ in {
 
   pypy38_prebuilt = callPackage ./pypy/prebuilt.nix {
     # Not included at top-level
-    self = pkgs.pythonInterpreters.pypy38_prebuilt;
+    self = __splicedPackages.pythonInterpreters.pypy38_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "3";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
