### PR TITLE
torrenttools: init at 0.6.2

### DIFF
--- a/pkgs/tools/misc/torrenttools/default.nix
+++ b/pkgs/tools/misc/torrenttools/default.nix
@@ -1,0 +1,99 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, bencode
+, catch2
+, cli11
+, cmake
+, ctre
+, expected-lite
+, fmt
+, gsl-lite
+, howard-hinnant-date
+, libyamlcpp
+, ninja
+, nlohmann_json
+, openssl
+, re2
+, sigslot
+}:
+
+stdenv.mkDerivation rec {
+  pname = "torrenttools";
+  version = "0.6.2";
+
+  srcs = [
+    (fetchFromGitHub rec {
+      owner = "fbdtemme";
+      repo = "torrenttools";
+      rev = "v${version}";
+      hash = "sha256-3rAxw4JM5ruOn0ccKnpdCnUWUPTQOUvRYz8OKU/FpJ8=";
+      name = repo;
+    })
+    (fetchFromGitHub rec {
+      owner = "fbdtemme";
+      repo = "cliprogress";
+      rev = "a887519e360e44c1ef88ea4ef7df652ea049c502";
+      hash = "sha256-nVvzez5GB57qSj2SLaxdYlkSX8rRM06H2NnLQGCDWMg=";
+      name = repo;
+    })
+    (fetchFromGitHub rec {
+      owner = "fbdtemme";
+      repo = "dottorrent";
+      rev = "38ac810d6bb3628fd3ce49150c9fb641bb5e78cd";
+      hash = "sha256-0H9h0Hud0Fd64lY0pxQ96coDOEDr5wh8v1sNT1lBxb0=";
+      name = repo;
+    })
+    (fetchFromGitHub rec {
+      owner = "fbdtemme";
+      repo = "termcontrol";
+      rev = "c53eec4efe0e163871d9eb54dc074c25cd01abf0";
+      hash = "sha256-0j78QtEkhlssVivPl709o5Pf36TzhOZ6VHaqDiH0L0I=";
+      name = repo;
+    })
+  ];
+  sourceRoot = "torrenttools";
+
+  postUnpack = ''
+    cp -pr cliprogress torrenttools/external/cliprogress
+    cp -pr dottorrent torrenttools/external/dottorrent
+    cp -pr termcontrol torrenttools/external/termcontrol
+    chmod -R u+w -- "$sourceRoot"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    bencode
+    catch2
+    cli11
+    ctre
+    expected-lite
+    fmt
+    gsl-lite
+    howard-hinnant-date
+    libyamlcpp
+    nlohmann_json
+    openssl
+    re2
+    sigslot
+  ];
+
+  cmakeFlags = [
+    "-DTORRENTTOOLS_BUILD_TESTS:BOOL=ON"
+    "-DTORRENTTOOLS_TBB:BOOL=OFF" # Our TBB doesn't expose a CMake module.
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "A CLI tool for creating, inspecting and modifying BitTorrent metafiles";
+    homepage = "https://github.com/fbdtemme/torrenttools";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azahi ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32354,6 +32354,10 @@ with pkgs;
 
   torrential = callPackage ../applications/networking/p2p/torrential { };
 
+  torrenttools = callPackage ../tools/misc/torrenttools {
+    fmt = fmt_8;
+  };
+
   tortoisehg = callPackage ../applications/version-management/tortoisehg { };
 
   tonelib-gfx = callPackage ../applications/audio/tonelib-gfx { };


### PR DESCRIPTION
###### Description of changes

Fixes #195881

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
