### PR TITLE
fira-code: add static fonts

### DIFF
--- a/pkgs/data/fonts/fira-code/default.nix
+++ b/pkgs/data/fonts/fira-code/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchzip }:
+{ stdenv, lib, fetchzip }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "fira-code";
   version = "6.2";
-in fetchzip {
-  name = "fira-code-${version}";
+  src = fetchzip {
+    url = "https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip";
+    stripRoot = false;
+    sha256 = "sha256-UHOwZL9WpCHk6vZaqI/XfkZogKgycs5lWg1p0XdQt0A=";
+  };
 
-  url = "https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip";
-
-  # only extract the variable font because everything else is a duplicate
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile '*-VF.ttf' -d $out/share/fonts/truetype
+  # extract both static and variable fonts because
+  # programs like VS Code don't load the variable version of Fira Code *Retina*
+  # without fiddling.
+  installPhase = ''
+    source $stdenv/setup
+    dst="$out/share/fonts/truetype"
+    mkdir -p $dst
+    cp $src/ttf/* $src/variable_ttf/* $dst/
   '';
-
-  sha256 = "0l02ivxz3jbk0rhgaq83cqarqxr07xgp7n27l0fh8fbgxwi52djl";
 
   meta = with lib; {
     homepage = "https://github.com/tonsky/FiraCode";
@@ -24,7 +28,7 @@ in fetchzip {
       combinations.
     '';
     license = licenses.ofl;
-    maintainers = [ maintainers.rycee ];
+    maintainers = [ maintainers.rycee maintainers.jayesh-bhoot ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Install both static and variable fonts because some programs don't load the variable version of Fira Code *Retina*.

e.g., even if the instructions given here (https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions#font-weights) to set Retina weight for the variable version of Fira Code Retina are applied, VS Code does not really load Retina weight on *Linux* at least.

The following image compares the Variable Retina (on LHS), Static Retina (on RHS) in VS Code on Linux.

![Variable Retina on LHS, Static Retina on RHS in VS Code](https://user-images.githubusercontent.com/1915507/195970544-4b46b6eb-63c8-465a-b1bd-145fee135d66.png)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
