### PR TITLE
pantheon.elementary-default-settings: add files dock item

### DIFF
--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/launchers/io.elementary.files.dockitem
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/launchers/io.elementary.files.dockitem
@@ -1,0 +1,2 @@
+[PlankDockItemPreferences]
+Launcher=file:///run/current-system/sw/share/applications/io.elementary.files.desktop

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/overrides/plank-dockitems.gschema.override
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/overrides/plank-dockitems.gschema.override
@@ -1,2 +1,2 @@
 [net.launchpad.plank.dock.settings]
-dock-items=['gala-multitaskingview.dockitem','org.gnome.Epiphany.dockitem','io.elementary.mail.dockitem','io.elementary.tasks.dockitem','io.elementary.calendar.dockitem','io.elementary.music.dockitem','io.elementary.videos.dockitem','io.elementary.photos.dockitem','io.elementary.switchboard.dockitem','io.elementary.appcenter.dockitem']
+dock-items=['gala-multitaskingview.dockitem','io.elementary.files.dockitem','org.gnome.Epiphany.dockitem','io.elementary.mail.dockitem','io.elementary.tasks.dockitem','io.elementary.calendar.dockitem','io.elementary.music.dockitem','io.elementary.videos.dockitem','io.elementary.photos.dockitem','io.elementary.switchboard.dockitem','io.elementary.appcenter.dockitem']


### PR DESCRIPTION
###### Description of changes

We are bumping default-settings to 7.0 in ~~https://github.com/NixOS/nixpkgs/pull/174279~~ #196511 but since we manage dock items ourselves I am addressing https://github.com/elementary/default-settings/pull/271 in a separate PR. (I plan to merge this as soon as 7.0 is tagged)

~~It is 2022 and file-based workflow is the future!~~ :laughing: 



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
