### PR TITLE
python310Packages.stevedore: 4.0.0 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/osqp/default.nix
+++ b/pkgs/development/python-modules/osqp/default.nix
@@ -1,30 +1,37 @@
 { lib
 , buildPythonPackage
-, fetchPypi
 , cmake
+, cvxopt
+, fetchPypi
 , future
 , numpy
-, qdldl
-, setuptools-scm
-, scipy
-# check inputs
 , pytestCheckHook
-, cvxopt
+, pythonOlder
+, qdldl
+, scipy
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "osqp";
   version = "0.6.2.post5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b2fa17aae42a7ed498ec261b33f262bb4b3605e7e8464062159d9fae817f0d61";
+    hash = "sha256-svoXquQqftSY7CYbM/Jiu0s2BefoRkBiFZ2froF/DWE=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
-  nativeBuildInputs = [ cmake setuptools-scm ];
   dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    cmake
+    setuptools-scm
+  ];
 
   propagatedBuildInputs = [
     future
@@ -33,10 +40,39 @@ buildPythonPackage rec {
     scipy
   ];
 
-  pythonImportsCheck = [ "osqp" ];
-  checkInputs = [ pytestCheckHook cvxopt ];
+  checkInputs = [
+    cvxopt
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "osqp"
+  ];
+
   disabledTests = [
-    "mkl_"
+    # Test are failing due to scipy update (removal of scipy.random in 1.9.0)
+    # Is fixed upstream but requires a new release
+    "test_feasibility_problem"
+    "test_issue14"
+    "test_polish_random"
+    "test_polish_unconstrained"
+    "test_primal_and_dual_infeasible_problem"
+    "test_primal_infeasible_problem"
+    "test_solve"
+    "test_unconstrained_problem"
+    "test_update_A_allind"
+    "test_update_A"
+    "test_update_bounds"
+    "test_update_l"
+    "test_update_P_A_allind"
+    "test_update_P_A_indA"
+    "test_update_P_A_indP_indA"
+    "test_update_P_A_indP"
+    "test_update_P_allind"
+    "test_update_P"
+    "test_update_q"
+    "test_update_u"
+    "test_warm_start"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/stevedore/default.nix
+++ b/pkgs/development/python-modules/stevedore/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "stevedore";
-  version = "4.0.0";
+  version = "4.0.1";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-+CzJmh/1UjENGcN5gnwsZN2fhaOLzVVZ2yRwFhhnt4Y=";
+    sha256 = "sha256-miMRGm5hInDFkf0x/zMhxrXz1fPauxQnMXpatgj8Jho=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 4.0.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
