### PR TITLE
bindle: init at 0.8.1

### DIFF
--- a/pkgs/servers/bindle/default.nix
+++ b/pkgs/servers/bindle/default.nix
@@ -1,0 +1,34 @@
+{ lib, rustPlatform, fetchFromGitHub, pkgs, stdenv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "bindle";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "deislabs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Mc3LaEOWx8cN7g0r8CtWkGZ746gAXTaFmAZhEIkbWgM=";
+  };
+
+  doCheck = false; # Tests require a network
+
+  buildInputs = with pkgs; [ pkg-config openssl_3 ] ++ lib.optional stdenv.isDarwin Security;
+
+  cargoSha256 = "sha256-brsemnw/9YEsA2FEIdYGmQMdlIoT1ZEMjvOpF44gcRE=";
+
+  cargoBuildFlags = [
+    "--bin" "bindle"
+    "--bin" "bindle-server"
+    "--all-features"
+  ];
+
+  meta = with lib; {
+    description = "Bindle: Aggregate Object Storage";
+    homepage = "https://github.com/deislabs/bindle";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ endocrimes ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -195,6 +195,10 @@ with pkgs;
 
   appindicator-sharp = callPackage ../development/libraries/appindicator-sharp { };
 
+  bindle = callPackage ../servers/bindle {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   canonicalize-jar = callPackage ../build-support/java/canonicalize-jar.nix { };
   canonicalize-jars-hook = makeSetupHook {
     name = "canonicalize-jars-hook";


### PR DESCRIPTION
###### Description of changes

This adds bindle, an object store for "collections of things". It's mostly used for webassembly applications (like with https://github.com/fermyon/spin)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
