### PR TITLE
gsl-lite: init at 0.40.0

### DIFF
--- a/pkgs/development/libraries/gsl-lite/default.nix
+++ b/pkgs/development/libraries/gsl-lite/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, installCompatHeader ? false
+, installLegacyHeaders ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gsl-lite";
+  version = "0.40.0";
+
+  src = fetchFromGitHub {
+    owner = "gsl-lite";
+    repo = "gsl-lite";
+    rev = "v${version}";
+    hash = "sha256-80ksT8XFn2LLMr63gKGZD/0+FDLnAtFyMpuuSjtoBlk=";
+  };
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  cmakeFlags = lib.mapAttrsToList
+    (name: value: ''-DGSL_LITE_OPT_${name}:BOOL=${if value then "ON" else "OFF"}'')
+    {
+      INSTALL_COMPAT_HEADER = installCompatHeader;
+      INSTALL_LEGACY_HEADERS = installLegacyHeaders;
+      BUILD_TESTS = doCheck;
+    };
+
+  # Building tests is broken on Darwin.
+  doCheck = !stdenv.isDarwin;
+
+  meta = with lib; {
+    description = ''
+      A single-file header-only version of ISO C++ Guidelines Support Library
+      (GSL) for C++98, C++11, and later
+    '';
+    longDescription = ''
+      gsl-lite is a single-file header-only implementation of the C++ Core
+      Guidelines Support Library originally based on Microsoft GSL and adapted
+      for C++98, C++03. It also works when compiled as C++11, C++14, C++17,
+      C++20.
+    '';
+    homepage = "https://github.com/gsl-lite/gsl-lite";
+    changelog = "https://github.com/gsl-lite/gsl-lite/blob/${src.rev}/CHANGES.txt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azahi ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18953,6 +18953,8 @@ with pkgs;
 
   gsl_1 = callPackage ../development/libraries/gsl/gsl-1_16.nix { };
 
+  gsl-lite = callPackage ../development/libraries/gsl-lite { };
+
   gsm = callPackage ../development/libraries/gsm {};
 
   gsoap = callPackage ../development/libraries/gsoap { };


### PR DESCRIPTION
###### Description of changes

https://github.com/gsl-lite/gsl-lite
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
