### PR TITLE
nix-output-monitor: 1.1.3.0 -> 2.0.0.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -226,4 +226,7 @@ self: super: {
   inline-c-cpp =
     (if isDarwin then appendConfigureFlags ["--ghc-option=-fcompact-unwind"] else x: x)
     super.inline-c-cpp;
+
+  relude = dontCheck self.relude_1_1_0_0;
+  hermes-json = doJailbreak super.hermes-json;
 }

--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -10,9 +10,8 @@
     testTarget = "unit-tests";
     buildTools = [installShellFiles];
     postInstall = ''
-      substitute "exe-sh/nom-build" "$out/bin/nom-build" \
-        --replace 'unbuffer' '${expect}/bin/unbuffer' \
-        --replace 'nom' "$out/bin/nom"
+      ln -s nom "$out/bin/nom-build"
+      ln -s nom "$out/bin/nom-shell"
       chmod a+x $out/bin/nom-build
       installShellCompletion --zsh --name _nom-build completions/completion.zsh
     '';

--- a/pkgs/tools/nix/nix-output-monitor/generated-package.nix
+++ b/pkgs/tools/nix/nix-output-monitor/generated-package.nix
@@ -15,6 +15,7 @@
   fetchzip,
   filepath,
   generic-optics,
+  hermes-json,
   HUnit,
   lib,
   lock-file,
@@ -31,17 +32,16 @@
   terminal-size,
   text,
   time,
-  unix,
-  vector,
+  typed-process,
   wcwidth,
   word8,
 }:
 mkDerivation {
   pname = "nix-output-monitor";
-  version = "1.1.3.0";
+  version = "2.0.0.0";
   src = fetchzip {
-    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v1.1.3.0.tar.gz";
-    sha256 = "085phr84m0b056mj3c09gzcwv7b1wax7nhsg2qscahfz0q8f4ym7";
+    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v2.0.0.0.tar.gz";
+    sha256 = "033582nzyi0hfis062cnz8lgx918lk1bmzfimsd78a9zzxn20frg";
   };
   isLibrary = true;
   isExecutable = true;
@@ -58,12 +58,12 @@ mkDerivation {
     extra
     filepath
     generic-optics
+    hermes-json
     lock-file
     MemoTrie
     mtl
     nix-derivation
     optics
-    random
     relude
     safe
     stm
@@ -71,8 +71,6 @@ mkDerivation {
     terminal-size
     text
     time
-    unix
-    vector
     wcwidth
     word8
   ];
@@ -89,12 +87,12 @@ mkDerivation {
     extra
     filepath
     generic-optics
+    hermes-json
     lock-file
     MemoTrie
     mtl
     nix-derivation
     optics
-    random
     relude
     safe
     stm
@@ -102,8 +100,7 @@ mkDerivation {
     terminal-size
     text
     time
-    unix
-    vector
+    typed-process
     wcwidth
     word8
   ];
@@ -120,6 +117,7 @@ mkDerivation {
     extra
     filepath
     generic-optics
+    hermes-json
     HUnit
     lock-file
     MemoTrie
@@ -135,8 +133,6 @@ mkDerivation {
     terminal-size
     text
     time
-    unix
-    vector
     wcwidth
     word8
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4541,7 +4541,7 @@ with pkgs;
 
   nixel = callPackage ../tools/nix/nixel { };
 
-  nix-output-monitor = callPackage ../tools/nix/nix-output-monitor { };
+  nix-output-monitor = callPackage ../tools/nix/nix-output-monitor { haskellPackages = haskell.packages.ghc92; };
 
   nix-template = callPackage ../tools/package-management/nix-template {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
## Changelog

### Highlights:

* **New ways to use nom**, via different aliases and options. Have a look at the README for new usage or just try `nom build`, `nom develop` or `nom-build` …
* **Full support for new-style nix commands like `nix build`** and therefor also flakes.
* Support for parsing the nix "internal-json" log format. This gives us much more information.
* The output has been massively reworked to accommodate the new information available from json output. This includes:
  * Running downloads/uploads
  * Show current build phase (only possible for local builds).
  * Remote builders are displayed more economically
  * Build summaries have been reworked to be less overwhelming
  * Log output is prefixed with build job names.
* Massive internal refactoring with significant performance improvements and less flickering.

### Further changes:

* The algorithm to layout the rendering tree has been improved.
* Improved build name display and show build platform if different from our platform.
* Better error reporting.
* Pause build time counter while system is suspended.
* Fixed a color flickering issue in the dependency graph (thx @alyssais).
* Removed some weird operators. (thx @blackheaven heaven)
* The old nom-build wrapper is obsolete and has been removed.
* Updated to use ghc 9.2 with corresponding features like GHC2021 and RecordDotSyntax.
* Added benchmarking and profiling scripts, to monitor performance.
* Most performance improvements came from replacing aeson with json-hermes.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
