### PR TITLE
uhttpmock: 0.5.0 → 0.5.5

### DIFF
--- a/pkgs/development/libraries/uhttpmock/default.nix
+++ b/pkgs/development/libraries/uhttpmock/default.nix
@@ -1,33 +1,51 @@
-{ stdenv, lib, fetchFromGitLab, autoconf, gtk-doc, automake, libtool, pkg-config, glib, libsoup, gobject-introspection }:
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, vala
+, gtk-doc
+, docbook-xsl-nons
+, glib
+, libsoup
+}:
 
 stdenv.mkDerivation rec {
-  version="0.5.0";
   pname = "uhttpmock";
+  version = "0.5.5";
+
+  outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "pwithnall";
     repo = "uhttpmock";
-    owner = "uhttpmock";
     rev = version;
-    sha256 = "0kkf670abkq5ikm3mqls475lydfsd9by1kv5im4k757xrl1br1d4";
+    sha256 = "NuxiVVowZ8ilP9rcgapCe9OzFCpoOfZxZiSyjTeOrts=";
   };
 
-  nativeBuildInputs = [ pkg-config autoconf automake gtk-doc libtool gobject-introspection ];
-  buildInputs = [ glib libsoup ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    vala
+    gtk-doc
+    docbook-xsl-nons
+  ];
 
-  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
-
-  # while cross
-  # /build/source/tmp-introspect3xf43lf3/.libs/Uhm-0.0: error while loading shared libraries: libuhttpmock-0.0.so.0: cannot open shared object file: No such file or directory
-  preBuild = ''
-    mkdir -p ${placeholder "out"}/lib
-    ln -s $PWD/libuhttpmock/.libs/libuhttpmock-0.0.so.0 ${placeholder "out"}/lib/libuhttpmock-0.0.so.0
-  '';
+  buildInputs = [
+    glib
+    libsoup
+  ];
 
   meta = with lib; {
     description = "Project for mocking web service APIs which use HTTP or HTTPS";
-    homepage = "https://gitlab.com/groups/uhttpmock/";
-    license = licenses.lgpl21;
+    homepage = "https://gitlab.freedesktop.org/pwithnall/uhttpmock/";
+    license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ ];
-    platforms = with platforms; linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

https://gitlab.freedesktop.org/pwithnall/uhttpmock/-/compare/0.5.0...0.5.5

uhttpmock 0.5.0 is seven years old, I want to move it to a more recent release :upside_down_face:

I noticed this because I want to play with https://gitlab.gnome.org/GNOME/libgdata/-/merge_requests/28 and it requires uhttpmock 0.9.0, which is ported to libsoup_3 (we of course can't bump this to 0.9.0). https://gitlab.com/uhttpmock/uhttpmock says the project was moved.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
