### PR TITLE
libfrozen: init 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15505,4 +15505,9 @@
     github = "quasigod-io";
     githubId = 62124625;
   };
+  jstranik = {
+    email = "jan@stranik.org";
+    name = "Jan Stranik";
+    githubId = 1367895;
+  };
 }

--- a/pkgs/development/libraries/libfrozen/default.nix
+++ b/pkgs/development/libraries/libfrozen/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv
+, cmake
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libfrozen";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "serge-sans-paille";
+    repo = "frozen";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-HebDTRg1+snUwu+KumrgNMt/GOWXdHM9pMgXi51eArk=";
+  };
+
+  nativeBuildInputs = [ cmake  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/serge-sans-paille/frozen";
+    description = "A consteval containers library for C++";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jstranik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20704,6 +20704,8 @@ with pkgs;
 
   libzip = callPackage ../development/libraries/libzip { };
 
+  libfrozen = callPackage ../development/libraries/libfrozen { };
+
   libzdb = callPackage ../development/libraries/libzdb { };
 
   libwacom = callPackage ../development/libraries/libwacom { };


### PR DESCRIPTION
Packages a C++ library for constant time evaluation containers

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
