### PR TITLE
muon: unstable-2022-09-24 -> 0.1.0

### DIFF
--- a/pkgs/development/tools/build-managers/muon/default.nix
+++ b/pkgs/development/tools/build-managers/muon/default.nix
@@ -17,15 +17,17 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "muon"
           + lib.optionalString embedSamurai "-embedded-samurai";
-  version = "unstable-2022-09-24";
+  version = "0.1.0";
 
   src = fetchFromSourcehut {
     name = "muon-src";
     owner = "~lattis";
     repo = "muon";
-    rev = "f385c82a6104ea3341ca34756e2812d700bc43d8";
-    hash = "sha256-Cr1r/sp6iVotU+n4bTzQiQl8Y+ShaqnnaWjL6gRW8p0=";
+    rev = finalAttrs.version;
+    hash = "sha256-m382/Y+qOYk7hHdDdOpiYWNWrqpnWPCG4AKGGkmLt4o=";
   };
+
+  outputs = [ "out" ] ++ lib.optionals buildDocs [ "man" ];
 
   nativeBuildInputs = [
     pkgconf
@@ -50,8 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
     # URLs manually extracted from subprojects directory
     meson-docs-wrap = fetchurl {
       name = "meson-docs-wrap";
-      url = "https://mochiro.moe/wrap/meson-docs-0.63.0-116-g8a45c81cf.tar.gz";
-      hash = "sha256-fsXdhfBEXvw1mvqnPp2TgZnO5FaeHTNW3Nfd5qfTfxg=";
+      url = "https://mochiro.moe/wrap/meson-docs-0.63.0-239-g41a05ff93.tar.gz";
+      hash = "sha256-wg2mDkrkE1xVNXJf4sVm6cN1ozVeDbbw0CBYtixg5/Q=";
     };
 
     samurai-wrap = fetchurl {
@@ -79,14 +81,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   buildPhase = let
-    featureFlag = feature: flag:
+    muonFeatureFlag = feature: flag:
       "-D${feature}=${if flag then "enabled" else "disabled"}";
-    conditionFlag = condition: flag:
+    muonConditionFlag = condition: flag:
       "-D${condition}=${lib.boolToString flag}";
     cmdlineForMuon = lib.concatStringsSep " " [
-      (conditionFlag "static" stdenv.targetPlatform.isStatic)
-      (featureFlag "docs" buildDocs)
-      (featureFlag "samurai" embedSamurai)
+      (muonConditionFlag "static" stdenv.targetPlatform.isStatic)
+      (muonFeatureFlag "docs" buildDocs)
+      (muonFeatureFlag "samurai" embedSamurai)
     ];
     cmdlineForSamu = "-j$NIX_BUILD_CORES";
   in ''
@@ -132,7 +134,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 })
 # TODO LIST:
-# 1. setup hook
-# 2. multiple outputs
-# 3. automate sources acquisition (especially wraps)
-# 4. tests
+# 1. automate sources acquisition (especially wraps)
+# 2. setup hook
+# 3. tests


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
