### PR TITLE
parsifal: init at 2.2.0

### DIFF
--- a/pkgs/applications/science/engineering/parsifal/default.nix
+++ b/pkgs/applications/science/engineering/parsifal/default.nix
@@ -1,0 +1,121 @@
+{ lib
+, stdenv
+, buildPythonApplication
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+# requirements/local.txt
+, django-debug-toolbar
+, django_silk
+, ipython
+, towncrier
+# requirements/base.txt
+, beautifulsoup4
+, bibtexparser
+, dj-database-url
+, django
+, django-compressor
+, django-crispy-forms
+, pillow
+, psycopg2
+, python-decouple
+, python-docx
+, pytz
+, requests
+, xlwt
+# requirements/production.txt
+, gunicorn
+, sentry-sdk
+# requirements/tests.txt
+, factory_boy
+, flake8
+, isort
+}:
+
+let parsifal = buildPythonApplication rec {
+  pname = "parsifal";
+  version = "2.2.0";
+  disabled = pythonOlder "3.9";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "vitorfs";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-2Vhjv7eN+iTg7vsfscbuutw2Bai2P/HXWfvSMOxsO/0=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements/local.txt \
+      --replace "==" ">=" \
+      --replace "git+git://github.com/jazzband/django-silk.git#egg=django-silk" "django-silk"
+
+    substituteInPlace requirements/base.txt \
+      --replace "==" ">="
+
+    substituteInPlace requirements/production.txt \
+      --replace "==" ">="
+
+    substituteInPlace requirements/tests.txt \
+      --replace "==" ">="
+  '';
+
+  propagatedBuildInputs = [
+    # requirements/local.txt
+    django-debug-toolbar
+    django_silk
+    ipython
+    towncrier
+
+    # requirements/base.txt
+    beautifulsoup4
+    bibtexparser
+    dj-database-url
+    django
+    django-compressor
+    django-crispy-forms
+    pillow
+    psycopg2
+    python-decouple
+    python-docx
+    pytz
+    requests
+    xlwt
+
+    # requirements/production.txt
+    gunicorn
+    sentry-sdk
+  ];
+
+  checkInputs = [
+    factory_boy
+    flake8
+    isort
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "parsifal"
+  ];
+
+  # disabledTests = [
+  # ];
+
+  doCheck = false;
+
+  passthru.tests = {
+    default = parsifal.overridePythonAttrs (oldAttrs: {
+      doCheck = true;
+    });
+  };
+
+  meta = with lib; {
+    description = "Systematic literature review tool based on Kitchenham's software engineering guidelines";
+    homepage = "https://parsif.al/";
+    changelog = "https://github.com/vitorfs/parsifal/releases";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      yuu
+    ];
+  };
+}; in parsifal

--- a/pkgs/development/python-modules/django-crispy-forms/default.nix
+++ b/pkgs/development/python-modules/django-crispy-forms/default.nix
@@ -1,45 +1,90 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
+, fetchpatch
+# setup.py
 , django
+# requirements/dev.txt
+, pre-commit
+, twine
+, wheel
+# requirements/lint.txt
+, black
+, flake8
+, isort
+# flake8-comprehensions
+# requirements/testing.txt
 , pytestCheckHook
+, pytest-cov
 , pytest-django
 }:
 
-buildPythonPackage rec {
+let django-crispy-forms = buildPythonPackage rec {
   pname = "django-crispy-forms";
   version = "1.14.0";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = "django-crispy-forms";
-    repo = "django-crispy-forms";
+    owner = pname;
+    repo = pname;
     rev = version;
-    sha256 = "sha256-NZ2lWxsQHc7Qc4HDoWgjJTZ/bJHmjpBf3q1LVLtzA+8=";
+    hash = "sha256-NZ2lWxsQHc7Qc4HDoWgjJTZ/bJHmjpBf3q1LVLtzA+8=";
   };
+
+
+  patches = [
+    # RuntimeError: Model class source.crispy_forms.tests.forms.CrispyTestModel doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
+    # https://github.com/django-crispy-forms/django-crispy-forms/issues/803
+    (fetchpatch {
+      name = "fix-tests-add-app-label.patch";
+      url = "https://github.com/yuuyins/django-crispy-forms/commit/0c358081c2c53170badd7374181c9f277f7a7e2b.patch";
+      hash = "sha256-x6ag8MU3GDy9rYpuYO9OgeVnkqjGKwqZRGEN8uOIbQQ=";
+    })
+  ];
 
   propagatedBuildInputs = [
     django
+    pre-commit
+    twine
+    wheel
   ];
 
-  # FIXME: RuntimeError: Model class source.crispy_forms.tests.forms.CrispyTestModel doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
-  doCheck = false;
-
   checkInputs = [
+    # black
+    # flake8
+    # isort
+    # pytest-cov
+
     pytest-django
     pytestCheckHook
   ];
 
   pytestFlagsArray = [
+  # ds stands for django settings https://pytest-django.readthedocs.io/en/latest/configuring_django.html
     "--ds=crispy_forms.tests.test_settings"
     "crispy_forms/tests/"
   ];
 
-  pythonImportsCheck = [ "crispy_forms" ];
+  pythonImportsCheck = [
+    "crispy_forms"
+  ];
+
+  doCheck = false;
+
+  # FIXME
+  # RuntimeError: Conflicting 'crispytestmodel' models in application 'crispy': <class 'crispy_forms.tests.forms.CrispyTestModel'> and <class 'source.crispy_forms.tests.forms.CrispyTestModel
+  # https://github.com/django-crispy-forms/django-crispy-forms/issues/803#issuecomment-1279806968
+  passthru.tests = {
+    default = django-crispy-forms.overridePythonAttrs (oldAttrs: {
+      doCheck = true;
+    });
+  };
 
   meta = with lib; {
-    description = "The best way to have DRY Django forms.";
+    description = "Strict separation of config from code";
     homepage = "https://django-crispy-forms.readthedocs.io/en/latest/";
     license = licenses.mit;
-    maintainers = with maintainers; [ ambroisie ];
+    maintainers = with maintainers; [ ambroisite ];
   };
-}
+}; in django-crispy-forms

--- a/pkgs/development/python-modules/python-decouple/default.nix
+++ b/pkgs/development/python-modules/python-decouple/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, docutils
+, mock
+, pygments
+, twine
+, pytestCheckHook
+}:
+
+let python-decouple = buildPythonPackage rec {
+  pname = "python-decouple";
+  version = "3.6";
+
+  src = fetchFromGitHub {
+    owner = "henriquebastos";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Ll0MZb4FaNFF/jvCfj4TkuoAi4m448KaOU3ykvKPbSo=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "==" ">="
+  '';
+
+  propagatedBuildInputs = [
+    docutils
+    mock
+    pygments
+    twine
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "decouple"
+  ];
+
+  doCheck = false;
+
+  passthru.tests = {
+    default = python-decouple.overridePythonAttrs (oldAttrs: {
+      doCheck = true;
+    });
+  };
+
+  meta = with lib; {
+    description = "Strict separation of config from code";
+    homepage = "https://github.com/henriquebastos/python-decouple";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      yuu
+    ];
+  };
+}; in python-decouple

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35567,6 +35567,8 @@ with pkgs;
 
   jflap = callPackage ../applications/science/engineering/jflap { };
 
+  parsifal = python3.pkgs.callPackage ../applications/science/engineering/parsifal { };
+
   strictdoc = python3.pkgs.callPackage ../applications/science/engineering/strictdoc { };
 
   ### SCIENCE / ELECTRONICS

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9014,6 +9014,8 @@ in {
 
   python-dbusmock = callPackage ../development/python-modules/python-dbusmock { };
 
+  python-decouple = callPackage ../development/python-modules/python-decouple { };
+
   pythondialog = callPackage ../development/python-modules/pythondialog { };
 
   python-didl-lite = callPackage ../development/python-modules/python-didl-lite { };


### PR DESCRIPTION
###### Description of changes

Web application for doing systematic literature reviews. Based on Kitchenham guidelines for systematic reviews in software engineering.

- homepage: https://parsif.al/
- source: https://github.com/vitorfs/parsifal

Part of https://github.com/NixOS/nixpkgs/issues/164019

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
