### PR TITLE
mysql_fdw: init at version REL-2_8_0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5240,6 +5240,12 @@
     githubId = 1742172;
     name = "Hamish Hutchings";
   };
+  hanDerPeder = {
+    email = "peder.refsnes@gmail.com";
+    github = "hanDerPeder";
+    githubId = 97645;
+    name = "Peder Refsnes";
+  };
   hanemile = {
     email = "mail@emile.space";
     github = "HanEmile";

--- a/pkgs/servers/sql/postgresql/ext/mysql_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/mysql_fdw.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, postgresql, libmysqlclient }:
+stdenv.mkDerivation rec {
+  pname = "mysql_fdw";
+  version = "REL-2_8_0";
+
+  src = fetchFromGitHub {
+    owner  = "EnterpriseDB";
+    repo   =  pname;
+    rev    = "d9860baa463cd9f4878dcaccb96dd8432d5ea36f";
+    sha256 = "sha256-P/D67rn2uNFjMt/eTyjZ1VWUCIwW6XHW5zMQkV/X6jo=";
+  };
+
+  buildPhase = "USE_PGXS=1 make";
+  installPhase = ''
+    install -D mysql_fdw.so -t $out/lib/
+    install -D ./{mysql_fdw--1.0--1.1.sql,mysql_fdw--1.0.sql,mysql_fdw--1.1.sql,mysql_fdw.control} -t $out/share/postgresql/extension
+  '';
+
+  buildInputs = [ postgresql libmysqlclient ];
+
+  meta = with lib; {
+    description = "This PostgreSQL extension implements a Foreign Data Wrapper (FDW) for MySQL";
+    homepage    = "https://github.com/EnterpriseDB/mysql_fdw";
+    maintainers = [ maintainers.hanDerPeder ];
+    platforms   = postgresql.meta.platforms;
+    license     = licenses.postgresql;
+  };
+}


### PR DESCRIPTION
###### Description of changes

MySQL Foreign Data Wrapper for PostgreSQL.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
