### PR TITLE
goperf: init at unstable-2023-11-08

### DIFF
--- a/pkgs/development/tools/goperf/default.nix
+++ b/pkgs/development/tools/goperf/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildGoModule
+, fetchgit
+}:
+
+buildGoModule rec {
+  pname = "goperf";
+  version = "unstable-2022-09-20";
+
+  src = fetchgit {
+    url = "https://go.googlesource.com/perf";
+    rev = "e8d778a60d07b209c499efb221f76d51f63c6042";
+    hash = "sha256-UuP528n5uAWMJCakc8MP8wlmA6SwMO/IaIqR88pqL7c=";
+  };
+
+  vendorHash = "sha256-ZIkH3LBzrvqWEN6m4fpU2cmOXup9LLU3FiFooJJtiOk=";
+
+  meta = with lib; {
+    description = "Tools and packages for analyzing Go benchmark results";
+    homepage = "https://cs.opensource.google/go/x/perf";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2596,6 +2596,8 @@ with pkgs;
 
   gopacked = callPackage ../applications/misc/gopacked { };
 
+  goperf = callPackage ../development/tools/goperf { };
+
   gotktrix = callPackage ../applications/networking/instant-messengers/gotktrix { };
 
   gucci = callPackage ../tools/text/gucci { };


### PR DESCRIPTION
###### Description of changes

Project page: <https://cs.opensource.google/go/x/perf>

The package name is inspired by the package `gotools`.

This module contains command-line tools for analyzing go benchmark result data. Of interest are:

* `benchstat`, which computes statistical summaries and A/B comparisons of Go benchmarks.
* `benchsave`, which publishes benchmark results to <https://perf.golang.org>

The contents of `result`:
```
-r-xr-xr-x 2 root root 9,7M jan.   1  1970 result/bin/appengine
-r-xr-xr-x 2 root root 6,6M jan.   1  1970 result/bin/benchsave
-r-xr-xr-x 2 root root 9,0M jan.   1  1970 result/bin/benchseries
-r-xr-xr-x 2 root root 3,0M jan.   1  1970 result/bin/benchstat
-r-xr-xr-x 2 root root 9,1M jan.   1  1970 result/bin/localperf
-r-xr-xr-x 2 root root 7,9M jan.   1  1970 result/bin/localperfdata
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
