### PR TITLE
mysql_fdw: init at version REL-2_8_0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5240,6 +5240,12 @@
     githubId = 1742172;
     name = "Hamish Hutchings";
   };
+  hanDerPeder = {
+    email = "peder.refsnes@gmail.com";
+    github = "hanDerPeder";
+    githubId = 97645;
+    name = "Peder Refsnes";
+  };
   hanemile = {
     email = "mail@emile.space";
     github = "HanEmile";

--- a/pkgs/servers/sql/postgresql/ext/mysql_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/mysql_fdw.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, postgresql, libmysqlclient }:
+stdenv.mkDerivation rec {
+  pname = "mysql_fdw";
+  version = "REL-2_8_0";
+
+  src = fetchFromGitHub {
+    owner  = "EnterpriseDB";
+    repo   =  pname;
+    rev    = "d9860baa463cd9f4878dcaccb96dd8432d5ea36f";
+    sha256 = "sha256-P/D67rn2uNFjMt/eTyjZ1VWUCIwW6XHW5zMQkV/X6jo=";
+  };
+
+  buildInputs = [ postgresql libmysqlclient ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  installPhase = ''
+    install -D -t $out/lib *.so
+    install -D -t $out/share/postgresql/extension *.control
+    install -D -t $out/share/postgresql/extension *.sql
+  '';
+
+  postFixup = ''
+    patchelf --add-rpath ${libmysqlclient}/lib/mysql $out/lib/mysql_fdw.so
+  '';
+
+  meta = with lib; {
+    description = "MySQL Foreign Data Wrapper for PostgreSQL";
+    homepage    = "https://github.com/EnterpriseDB/mysql_fdw";
+    maintainers = with maintainers; [ hanDerPeder ];
+    platforms   = postgresql.meta.platforms;
+    license     = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -71,4 +71,6 @@ self: super: {
     rum = super.callPackage ./ext/rum.nix { };
 
     wal2json = super.callPackage ./ext/wal2json.nix { };
+
+    mysql_fdw = super.callPackage ./ext/mysql_fdw.nix { };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/EnterpriseDB/mysql_fdw

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
