### PR TITLE
`testers`: Add `testBuildFailure` and `testEqualContents`

### DIFF
--- a/doc/builders/testers.chapter.md
+++ b/doc/builders/testers.chapter.md
@@ -75,6 +75,30 @@ environment to a minimum, some small changes are inevitable.
    `buildPackages.coreutils` and possibly more. These are not added to `PATH`
    or any other environment variable, so they should be hard to observe.
 
+## `testEqualContents` {#tester-equalContents}
+
+Check that two paths have the same contents.
+
+Example:
+
+```nix
+testers.testEqualContents {
+  assertion = "sed -e performs replacement";
+  expected = writeText "expected" ''
+    foo baz baz
+  '';
+  actual = runCommand "actual" {
+    # not really necessary for a package that's in stdenv
+    nativeBuildInputs = [ gnused ];
+    base = writeText "base" ''
+      foo bar baz
+    '';
+  } ''
+    sed -e 's/bar/baz/g' $base >$out
+  '';
+}
+```
+
 ## `testEqualDerivation` {#tester-testEqualDerivation}
 
 Checks that two packages produce the exact same build instructions.

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -13,6 +13,44 @@
 
   testEqualDerivation = callPackage ./test-equal-derivation.nix { };
 
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-testEqualContents
+  # or doc/builders/testers.chapter.md
+  testEqualContents = {
+    assertion,
+    actual,
+    expected,
+  }: runCommand "equal-contents-${lib.strings.toLower assertion}" {
+    inherit assertion actual expected;
+  } ''
+    echo "Checking:"
+    echo "$assertion"
+    if ! diff -U5 -r "$actual" "$expected" --color=always
+    then
+      echo
+      echo 'Contents must be equal, but were not!'
+      echo
+      echo "+: expected,   at $expected"
+      echo "-: unexpected, at $actual"
+      exit 1
+    else
+      find "$expected" -type f -executable > expected-executables | sort
+      find "$actual" -type f -executable > actual-executables | sort
+      if ! diff -U0 actual-executables expected-executables --color=always
+      then
+        echo
+        echo "Contents must be equal, but some files' executable bits don't match"
+        echo
+        echo "+: make this file executable in the actual contents"
+        echo "-: make this file non-executable in the actual contents"
+        exit 1
+      else
+        echo "expected $expected and actual $actual match."
+        echo 'OK'
+        touch $out
+      fi
+    fi
+  '';
+
   testVersion =
     { package,
       command ? "${package.meta.mainProgram or package.pname or package.name} --version",

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -1,6 +1,16 @@
-{ pkgs, lib, callPackage, runCommand, stdenv }:
+{ pkgs, buildPackages, lib, callPackage, runCommand, stdenv, substituteAll, }:
 # Documentation is in doc/builders/testers.chapter.md
 {
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-testBuildFailure
+  # or doc/builders/testers.chapter.md
+  testBuildFailure = drv: drv.overrideAttrs (orig: {
+    builder = buildPackages.bash;
+    args = [
+      (substituteAll { coreutils = buildPackages.coreutils; src = ./expect-failure.sh; })
+      orig.realBuilder or stdenv.shell
+    ] ++ orig.args or ["-e" (orig.builder or ../../stdenv/generic/default-builder.sh)];
+  });
+
   testEqualDerivation = callPackage ./test-equal-derivation.nix { };
 
   testVersion =

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -11,6 +11,8 @@
     ] ++ orig.args or ["-e" (orig.builder or ../../stdenv/generic/default-builder.sh)];
   });
 
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-testEqualDerivation
+  # or doc/builders/testers.chapter.md
   testEqualDerivation = callPackage ./test-equal-derivation.nix { };
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testEqualContents
@@ -51,6 +53,8 @@
     fi
   '';
 
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-testVersion
+  # or doc/builders/testers.chapter.md
   testVersion =
     { package,
       command ? "${package.meta.mainProgram or package.pname or package.name} --version",

--- a/pkgs/build-support/testers/expect-failure.sh
+++ b/pkgs/build-support/testers/expect-failure.sh
@@ -1,0 +1,62 @@
+# Run a builder, flip exit code, save log and fix outputs
+#
+# Sub-goals:
+# - Delegate to another original builder passed via args
+# - Save the build log to output for further checks
+# - Make the derivation succeed if the original builder fails
+# - Make the derivation fail if the original builder returns exit code 0
+#
+# Requirements:
+# This runs before, without and after stdenv. Do not modify the environment;
+# especially not before invoking the original builder. For example, use
+# "@" substitutions instead of PATH.
+# Do not export any variables.
+
+# Stricter bash
+set -eu
+
+# ------------------------
+# Run the original builder
+
+echo "testBuildFailure: Expecting non-zero exit from builder and args: ${*@Q}"
+
+("$@" 2>&1) | @coreutils@/bin/tee $TMPDIR/testBuildFailure.log \
+  | while read ln; do
+    echo "original builder: $ln"
+  done
+
+r=${PIPESTATUS[0]}
+if [[ $r = 0 ]]; then
+  echo "testBuildFailure: The builder did not fail, but a failure was expected!"
+  exit 1
+fi
+echo "testBuildFailure: Original builder produced exit code: $r"
+
+# -----------------------------------------
+# Write the build log to the default output
+
+outs=( $outputs )
+defOut=${outs[0]}
+defOutPath=${!defOut}
+
+if [[ ! -d $defOutPath ]]; then
+  if [[ -e $defOutPath ]]; then
+    @coreutils@/bin/mv $defOutPath $TMPDIR/out-node
+    @coreutils@/bin/mkdir $defOutPath
+    @coreutils@/bin/mv $TMPDIR/out-node $defOutPath/result
+  fi
+fi
+
+@coreutils@/bin/mkdir -p $defOutPath
+@coreutils@/bin/mv $TMPDIR/testBuildFailure.log $defOutPath/testBuildFailure.log
+echo $r >$defOutPath/testBuildFailure.exit
+
+# ------------------------------------------------------
+# Put empty directories in place for any missing outputs
+
+for outputName in ${outputs:-out}; do
+  outputPath="${!outputName}"
+  if [[ ! -e "${outputPath}" ]]; then
+    @coreutils@/bin/mkdir "${outputPath}";
+  fi
+done

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -1,4 +1,4 @@
-{ testers, lib, pkgs, ... }:
+{ testers, lib, pkgs, hello, runCommand, ... }:
 let
   pkgs-with-overlay = pkgs.extend(final: prev: {
     proof-of-overlay-hello = prev.hello;
@@ -24,4 +24,53 @@ lib.recurseIntoAttrs {
       machine.succeed("hello | figlet >/dev/console")
     '';
   });
+
+  testBuildFailure = lib.recurseIntoAttrs {
+    happy = runCommand "testBuildFailure-happy" {
+      failed = testers.testBuildFailure (runCommand "fail" {} ''
+        echo ok-ish >$out
+        echo failing though
+        echo also stderr 1>&2
+        exit 3
+      '');
+    } ''
+      grep -F 'failing though' $failed/testBuildFailure.log
+      grep -F 'also stderr' $failed/testBuildFailure.log
+      grep -F 'ok-ish' $failed/result
+      [[ 3 = $(cat $failed/testBuildFailure.exit) ]]
+      touch $out
+    '';
+
+    helloDoesNotFail = runCommand "testBuildFailure-helloDoesNotFail" {
+      failed = testers.testBuildFailure (testers.testBuildFailure hello);
+
+      # Add hello itself as a prerequisite, so we don't try to run this test if
+      # there's an actual failure in hello.
+      inherit hello;
+    } ''
+      echo "Checking $failed/testBuildFailure.log"
+      grep -F 'testBuildFailure: The builder did not fail, but a failure was expected' $failed/testBuildFailure.log
+      [[ 1 = $(cat $failed/testBuildFailure.exit) ]]
+      touch $out
+    '';
+
+    multiOutput = runCommand "testBuildFailure-multiOutput" {
+      failed = testers.testBuildFailure (runCommand "fail" {
+        # dev will be the default output
+        outputs = ["dev" "doc" "out"];
+      } ''
+        echo i am failing
+        exit 1
+      '');
+    } ''
+      grep -F 'i am failing' $failed/testBuildFailure.log >/dev/null
+      [[ 1 = $(cat $failed/testBuildFailure.exit) ]]
+
+      # Checking our note that dev is the default output
+      echo $failed/_ | grep -- '-dev/_' >/dev/null
+
+      touch $out
+    '';
+  };
+
 }


### PR DESCRIPTION
###### Description of changes

Adds testers to check that
 - a path has the same contents as another path
 - a tester or any function produces a build failure when it needs to

Tested with `nix-build -A tests.testers`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests) --> `tests.testers`
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
