### PR TITLE
ocamlPackages.lwt: 5.5.0 → 5.6.1

### DIFF
--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, fetchpatch
 , ocaml, findlib, ocamlbuild, ocaml_oasis
-, bitstring, camlzip, cmdliner, core_kernel, ezjsonm, fileutils, ocaml_lwt, ocamlgraph, ocurl, re, uri, zarith, piqi, piqi-ocaml, uuidm, llvm, frontc, ounit, ppx_jane, parsexp
+, bitstring, camlzip, cmdliner, core_kernel, ezjsonm, fileutils, mmap, lwt, ocamlgraph, ocurl, re, uri, zarith, piqi, piqi-ocaml, uuidm, llvm, frontc, ounit, ppx_jane, parsexp
 , utop, libxml2, ncurses
 , linenoise
 , ppx_bap
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
                   z3
                   utop libxml2 ncurses ];
 
-  propagatedBuildInputs = [ bitstring camlzip cmdliner ppx_bap core_kernel ezjsonm fileutils ocaml_lwt ocamlgraph ocurl re uri zarith piqi parsexp
+  propagatedBuildInputs = [ bitstring camlzip cmdliner ppx_bap core_kernel ezjsonm fileutils mmap lwt ocamlgraph ocurl re uri zarith piqi parsexp
                             piqi-ocaml uuidm frontc yojson ];
 
   installPhase = ''

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -1,29 +1,25 @@
-{ lib, fetchFromGitHub, pkg-config, ncurses, libev, buildDunePackage, ocaml
-, cppo, dune-configurator, ocplib-endian, result
-, mmap, seq
-, ocaml-syntax-shims
+{ lib, fetchFromGitHub, libev, buildDunePackage
+, cppo, dune-configurator, ocplib-endian
 }:
-
-let inherit (lib) optional versionOlder; in
 
 buildDunePackage rec {
   pname = "lwt";
-  version = "5.5.0";
+  version = "5.6.1";
+
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "lwt";
     rev = version;
-    sha256 = "sha256:1jbjz2rsz3j56k8vh5qlmm87hhkr250bs2m3dvpy9vsri8rkzj9z";
+    sha256 = "sha256-XstKs0tMwliCyXnP0Vzi5WC27HKJGnATUYtbbQmH1TE=";
   };
 
   strictDeps = true;
 
-  nativeBuildInputs = [ pkg-config cppo ]
-    ++ optional (versionOlder ocaml.version "4.08") ocaml-syntax-shims;
-  buildInputs = [ dune-configurator ]
-    ++ optional (versionOlder ocaml.version "4.07") ncurses;
-  propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];
+  nativeBuildInputs = [ cppo ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ libev ocplib-endian ];
 
   meta = {
     homepage = "https://ocsigen.org/lwt/";


### PR DESCRIPTION
###### Description of changes

Compatibility with OCaml 5: https://github.com/ocsigen/lwt/blob/5.6.1/CHANGES

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
