### PR TITLE
pokemonsay: init at unstable-2021-10-05

### DIFF
--- a/pkgs/tools/misc/pokemonsay/default.nix
+++ b/pkgs/tools/misc/pokemonsay/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, cowsay
+, coreutils
+, findutils
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "pokemonsay";
+  version = "unstable-2021-10-05";
+
+  src = fetchFromGitHub {
+    owner = "HRKings";
+    repo = "pokemonsay-newgenerations";
+    rev = "baccc6d2fe1897c48f60d82ff9c4d4c018f5b594";
+    hash = "sha256-IDTAZmOzkUg0kLUM0oWuVbi8EwE4sEpLWrNAtq/he+g=";
+  };
+
+  postPatch = ''
+    substituteInPlace pokemonsay.sh \
+      --replace \
+        'INSTALL_PATH=''${HOME}/.bin/pokemonsay' \
+        "" \
+      --replace \
+        'POKEMON_PATH=''${INSTALL_PATH}/pokemons' \
+        'POKEMON_PATH=${placeholder "out"}/share/pokemonsay' \
+      --replace \
+        '$(find ' \
+        '$(${findutils}/bin/find ' \
+      --replace \
+        '$(basename ' \
+        '$(${coreutils}/bin/basename ' \
+      --replace \
+        'cowsay -f ' \
+        '${cowsay}/bin/cowsay -f ' \
+      --replace \
+        'cowthink -f ' \
+        '${cowsay}/bin/cowthink -f '
+
+    substituteInPlace pokemonthink.sh \
+      --replace \
+        './pokemonsay.sh' \
+        "${placeholder "out"}/bin/pokemonsay"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/pokemonsay}
+    cp pokemonsay.sh $out/bin/pokemonsay
+    cp pokemonthink.sh $out/bin/pokemonthink
+    cp pokemons/*.cow $out/share/pokemonsay
+  '';
+
+  checkPhase = ''
+    $out/bin/pokemonsay --list-pokemon
+  '';
+
+  meta = with lib; {
+    description = "Print pokemon in the CLI! An adaptation of the classic cowsay";
+    homepage = "https://github.com/HRKings/pokemonsay-newgenerations";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30943,6 +30943,8 @@ with pkgs;
 
   poke = callPackage ../applications/editors/poke { };
 
+  pokemonsay = callPackage ../tools/misc/pokemonsay { };
+
   polar-bookshelf = callPackage ../applications/misc/polar-bookshelf { };
 
   poezio = python3Packages.poezio;


### PR DESCRIPTION
###### Description of changes

Cowsay, but with Pokemon.

    curl -s 'https://printerfacts.cetacean.club/fact' | ./result/bin/pokemonsay -p wurmple  -N

![image](https://user-images.githubusercontent.com/140964/196032935-e84f866f-260a-4ec2-87de-f6167c77da8d.png)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
