### PR TITLE
nixos/doc: remove incorrect section about high-level options

### DIFF
--- a/nixos/doc/manual/configuration/customizing-packages.section.md
+++ b/nixos/doc/manual/configuration/customizing-packages.section.md
@@ -1,22 +1,9 @@
 # Customising Packages {#sec-customising-packages}
 
-Some packages in Nixpkgs have options to enable or disable optional
-functionality or change other aspects of the package. For instance, the
-Firefox wrapper package (which provides Firefox with a set of plugins
-such as the Adobe Flash player) has an option to enable the Google Talk
-plugin. It can be set in `configuration.nix` as follows:
-`nixpkgs.config.firefox.enableGoogleTalkPlugin = true;`
-
-::: {.warning}
-Unfortunately, Nixpkgs currently lacks a way to query available
-configuration options.
-:::
-
-Apart from high-level options, it's possible to tweak a package in
-almost arbitrary ways, such as changing or disabling dependencies of a
-package. For instance, the Emacs package in Nixpkgs by default has a
-dependency on GTK 2. If you want to build it against GTK 3, you can
-specify that as follows:
+It's possible to tweak a package in almost arbitrary ways, such as changing or
+disabling dependencies of a package. For instance, the Emacs package in Nixpkgs
+by default has a dependency on GTK 2. If you want to build it against GTK 3, you
+can specify that as follows:
 
 ```nix
 environment.systemPackages = [ (pkgs.emacs.override { gtk = pkgs.gtk3; }) ];

--- a/nixos/doc/manual/from_md/configuration/customizing-packages.section.xml
+++ b/nixos/doc/manual/from_md/configuration/customizing-packages.section.xml
@@ -1,26 +1,10 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-customising-packages">
   <title>Customising Packages</title>
   <para>
-    Some packages in Nixpkgs have options to enable or disable optional
-    functionality or change other aspects of the package. For instance,
-    the Firefox wrapper package (which provides Firefox with a set of
-    plugins such as the Adobe Flash player) has an option to enable the
-    Google Talk plugin. It can be set in
-    <literal>configuration.nix</literal> as follows:
-    <literal>nixpkgs.config.firefox.enableGoogleTalkPlugin = true;</literal>
-  </para>
-  <warning>
-    <para>
-      Unfortunately, Nixpkgs currently lacks a way to query available
-      configuration options.
-    </para>
-  </warning>
-  <para>
-    Apart from high-level options, it’s possible to tweak a package in
-    almost arbitrary ways, such as changing or disabling dependencies of
-    a package. For instance, the Emacs package in Nixpkgs by default has
-    a dependency on GTK 2. If you want to build it against GTK 3, you
-    can specify that as follows:
+    It’s possible to tweak a package in almost arbitrary ways, such as
+    changing or disabling dependencies of a package. For instance, the
+    Emacs package in Nixpkgs by default has a dependency on GTK 2. If
+    you want to build it against GTK 3, you can specify that as follows:
   </para>
   <programlisting language="bash">
 environment.systemPackages = [ (pkgs.emacs.override { gtk = pkgs.gtk3; }) ];


### PR DESCRIPTION
###### Description of changes

Currently the manual describes high-level options in Nixpkgs as a way to alter existing packages. It does so _very_ briefly and uses an non-existing (deprecated?) option called `nixpkgs.config.firefox.enableGoogleTalkPlugin`. Imo, this confuses the reader and potentially leads them down a non-documented rabbit-hole.

I've tried to keep the change minimal. I'd like to look into changing some other parts of "customising packages", but to avoid discussions over other parts I thought this part was obviously wrong, so it can be removed with much discussions.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

