### PR TITLE
containerlab: init at version 0.32.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15642,4 +15642,10 @@
     githubId = 5228243;
     name = "waelwindows";
   };
+  rwxd = {
+    name = "rwxd";
+    email = "rwxd@pm.me";
+    github = "rwxd";
+    githubId = 40308458;
+  };
 }

--- a/pkgs/tools/virtualization/containerlab/default.nix
+++ b/pkgs/tools/virtualization/containerlab/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "containerlab";
+  version = "0.32.1";
+
+  src = fetchFromGitHub {
+    owner = "srl-labs";
+    repo = "containerlab";
+    rev = "007da91652ca309d90ca557ebaaf49baab7bc413";
+    sha256 = "sha256-4phBYr2gRROpvp13G3zI8Ma7nSD9usF/UcttUJJoGI4=";
+  };
+
+  vendorSha256 = "sha256-DfjhFznWlfT/IZwq+XLP6b6Zb0fv4hZgvdgCKggFUnc=";
+  subPackages = [ "." ];
+
+  preBuild = ''
+    sed -i -E 's|(version\s+\=\ )\"\0.0.0\"|\1"${version}"|g' cmd/version.go
+    sed -i -E 's|(commit\s+\=\ )\"none\"|\1"v${version}"|g' cmd/version.go
+  '';
+
+  meta = with lib; {
+    description = "containerlab enables container-based networking labs";
+    homepage = "https://github.com/srl-labs/containerlab";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ rwxd ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37660,4 +37660,6 @@ with pkgs;
   aitrack = libsForQt5.callPackage ../applications/misc/aitrack { };
 
   widevine-cdm = callPackage ../applications/networking/browsers/misc/widevine-cdm.nix { };
+
+  containerlab = callPackage ../tools/virtualization/containerlab { };
 }


### PR DESCRIPTION
###### Description of changes

Added containerlab package

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
