### PR TITLE
wordpressPackages.plugins.gutenberg: init at 14.3.0

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/languages.json
+++ b/pkgs/servers/web-apps/wordpress/packages/languages.json
@@ -1,14 +1,14 @@
 {
   "de_DE": {
     "path": "de_DE",
-    "rev": "963003",
-    "sha256": "167zar1gp2jb6nx5nb5367mxk7b8c481gmg75m1s82y4mzlprc55",
-    "version": "5.9"
+    "rev": "963451",
+    "sha256": "0zp1sz9f5vwz3ywj746la799nlaqxigja34qb83qqrsgkgaliff2",
+    "version": "5.8"
   },
   "fr_FR": {
     "path": "fr_FR",
-    "rev": "932480",
-    "sha256": "0lmbalcvwfc6331vdazmhr2lp3w418rsp78mrj1rs7a44y8f1igj",
+    "rev": "967096",
+    "sha256": "0r40kkmm7an6zdqszqcgr07ffkfif5c9446fjxba20vslhgkj9mg",
     "version": "5.8"
   }
 }

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -47,6 +47,12 @@
     "sha256": "04x5dj79bx5avx8db991nlhrpd3qv3maniqmzwnyd8ab2zblzx83",
     "version": "1.0.1"
   },
+  "gutenberg": {
+    "path": "gutenberg/tags/14.3.0",
+    "rev": "2797654",
+    "sha256": "0gf9spzsljhvmvhhqcgdcbrh95y2j0idmxjxsqnv2hk0miaka00d",
+    "version": "14.3.0"
+  },
   "jetpack": {
     "path": "jetpack/tags/11.4",
     "rev": "2794223",
@@ -90,10 +96,10 @@
     "version": "0.9.3"
   },
   "webp-converter-for-media": {
-    "path": "webp-converter-for-media/tags/5.3.0",
-    "rev": "2797448",
-    "sha256": "1w6i4z09rj9prj4skv9j2m45nsi1an092j2frfzf1wmdacvsrmvh",
-    "version": "5.3.0"
+    "path": "webp-converter-for-media/tags/5.3.1",
+    "rev": "2798010",
+    "sha256": "1flggxd6hw0ps3b0y32a2aj9g3zfpzbaiwzx1zn2s7zpxn508y1b",
+    "version": "5.3.1"
   },
   "worker": {
     "path": "worker/tags/4.9.14",

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -7,6 +7,7 @@
 , "cookie-notice"
 , "co-authors-plus"
 , "disable-xml-rpc"
+, "gutenberg"
 , "jetpack"
 , "jetpack-lite"
 , "lightbox-photoswipe"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
