### PR TITLE
ardour: 6.9 -> 7.1

### DIFF
--- a/pkgs/applications/audio/ardour/6.nix
+++ b/pkgs/applications/audio/ardour/6.nix
@@ -56,13 +56,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "ardour";
-  version = "7.1";
+  version = "6.9";
 
   # don't fetch releases from the GitHub mirror, they are broken
   src = fetchgit {
     url = "git://git.ardour.org/ardour/ardour.git";
     rev = version;
-    sha256 = "eLF9n71tjdPA+ks0B8UonmPZqRgcZEA7ok79+m9PioU=";
+    sha256 = "0vlcbd70y0an881zv87kc3akmaiz4w7whsy3yaiiqqjww35jg1mm";
   };
 
   patches = [
@@ -156,16 +156,16 @@ stdenv.mkDerivation rec {
     # wscript does not install these for some reason
     install -vDm 644 "build/gtk2_ardour/ardour.xml" \
       -t "$out/share/mime/packages"
-    install -vDm 644 "build/gtk2_ardour/ardour7.desktop" \
+    install -vDm 644 "build/gtk2_ardour/ardour6.desktop" \
       -t "$out/share/applications"
     for size in 16 22 32 48 256 512; do
       install -vDm 644 "gtk2_ardour/resources/Ardour-icon_''${size}px.png" \
-        "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour7.png"
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour6.png"
     done
     install -vDm 644 "ardour.1"* -t "$out/share/man/man1"
   '' + lib.optionalString videoSupport ''
     # `harvid` and `xjadeo` must be accessible in `PATH` for video to work.
-    wrapProgram "$out/bin/ardour7" \
+    wrapProgram "$out/bin/ardour6" \
       --prefix PATH : "${lib.makeBinPath [ harvid xjadeo ]}"
   '';
 

--- a/pkgs/applications/audio/ardour/6.nix
+++ b/pkgs/applications/audio/ardour/6.nix
@@ -58,7 +58,8 @@ stdenv.mkDerivation rec {
   pname = "ardour";
   version = "6.9";
 
-  # don't fetch releases from the GitHub mirror, they are broken
+  # We can't use `fetchFromGitea` here, as attempting to fetch release archives from git.ardour.org
+  # result in an empty archive. See https://tracker.ardour.org/view.php?id=7328 for more info.
   src = fetchgit {
     url = "git://git.ardour.org/ardour/ardour.git";
     rev = version;

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchgit
 , alsa-lib
 , aubio
@@ -156,16 +157,16 @@ stdenv.mkDerivation rec {
     # wscript does not install these for some reason
     install -vDm 644 "build/gtk2_ardour/ardour.xml" \
       -t "$out/share/mime/packages"
-    install -vDm 644 "build/gtk2_ardour/ardour7.desktop" \
+    install -vDm 644 "build/gtk2_ardour/ardour${lib.versions.major version}.desktop" \
       -t "$out/share/applications"
     for size in 16 22 32 48 256 512; do
       install -vDm 644 "gtk2_ardour/resources/Ardour-icon_''${size}px.png" \
-        "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour7.png"
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour${lib.versions.major version}.png"
     done
     install -vDm 644 "ardour.1"* -t "$out/share/man/man1"
   '' + lib.optionalString videoSupport ''
     # `harvid` and `xjadeo` must be accessible in `PATH` for video to work.
-    wrapProgram "$out/bin/ardour7" \
+    wrapProgram "$out/bin/ardour${lib.versions.major version}" \
       --prefix PATH : "${lib.makeBinPath [ harvid xjadeo ]}"
   '';
 

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -59,7 +59,8 @@ stdenv.mkDerivation rec {
   pname = "ardour";
   version = "7.1";
 
-  # don't fetch releases from the GitHub mirror, they are broken
+  # We can't use `fetchFromGitea` here, as attempting to fetch release archives from git.ardour.org
+  # result in an empty archive. See https://tracker.ardour.org/view.php?id=7328 for more info.
   src = fetchgit {
     url = "git://git.ardour.org/ardour/ardour.git";
     rev = version;

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.ardour.org/ardour/ardour.git";
     rev = version;
-    sha256 = "eLF9n71tjdPA+ks0B8UonmPZqRgcZEA7ok79+m9PioU=";
+    hash = "sha256-eLF9n71tjdPA+ks0B8UonmPZqRgcZEA7ok79+m9PioU=";
   };
 
   patches = [

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchgit
+, fetchzip
 , alsa-lib
 , aubio
 , boost
@@ -65,6 +66,13 @@ stdenv.mkDerivation rec {
     url = "git://git.ardour.org/ardour/ardour.git";
     rev = version;
     hash = "sha256-eLF9n71tjdPA+ks0B8UonmPZqRgcZEA7ok79+m9PioU=";
+  };
+
+  bundledContent = fetchzip {
+    url = "https://web.archive.org/web/20221026200824/http://stuff.ardour.org/loops/ArdourBundledMedia.zip";
+    hash = "sha256-IbPQWFeyMuvCoghFl1ZwZNNcSvLNsH84rGArXnw+t7A=";
+    # archive does not contain a single folder at the root
+    stripRoot = false;
   };
 
   patches = [
@@ -165,6 +173,9 @@ stdenv.mkDerivation rec {
         "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour${lib.versions.major version}.png"
     done
     install -vDm 644 "ardour.1"* -t "$out/share/man/man1"
+
+    # install additional bundled beats, chords and progressions
+    cp -rp "${bundledContent}"/* "$out/share/ardour${lib.versions.major version}/media"
   '' + lib.optionalString videoSupport ''
     # `harvid` and `xjadeo` must be accessible in `PATH` for video to work.
     wrapProgram "$out/bin/ardour${lib.versions.major version}" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26939,6 +26939,7 @@ with pkgs;
 
   aqemu = libsForQt5.callPackage ../applications/virtualization/aqemu { };
 
+  ardour_6 = callPackage ../applications/audio/ardour/6.nix { };
   ardour = callPackage ../applications/audio/ardour { };
 
   arelle = with python3Packages; toPythonApplication arelle;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes for 7.1: https://ardour.org/whatsnew.html (long-term link: https://ardour.org/news/7.1.html)

**Note:** ~~I retrieved the sha256 hash by setting it to `""` and then taking the expected sum upon running the derivation. It doesn't match the same number of characters as the old hash though, so please double-check.~~ I was confused between a base32 and base64 hashes. Have updated to use the `hash` keyword.

###### Things done

Tested:

* Importing multiple songs and playing them via JACK
* Messing around with the new clip launcher
* Exporting a song to flac

Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).