### PR TITLE
python310Packages.py-libzfs: init at 22.2.1

### DIFF
--- a/pkgs/development/python-modules/py-libzfs/default.nix
+++ b/pkgs/development/python-modules/py-libzfs/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, zfs
+}:
+
+buildPythonPackage rec {
+  pname = "py-libzfs";
+  version = "22.02.4";
+
+  src = fetchFromGitHub {
+    owner = "truenas";
+    repo = pname;
+    rev = "TS-${version}";
+    sha256 = "sha256-BJG+cw07Qu4aL99pVKNd7JAgr+w/6Uv2eI46EB615/I=";
+  };
+
+  nativeBuildInputs = [ cython ];
+  buildInputs = [ zfs ];
+
+  # Passing CFLAGS in configureFlags does not work, see https://github.com/truenas/py-libzfs/issues/107
+  postPatch = lib.optionalString stdenv.isLinux ''
+    substituteInPlace configure \
+      --replace \
+        'CFLAGS="-DCYTHON_FALLTHROUGH"' \
+        'CFLAGS="-DCYTHON_FALLTHROUGH -I${zfs.dev}/include/libzfs -I${zfs.dev}/include/libspl"' \
+      --replace 'zof=false' 'zof=true'
+  '';
+
+  pythonImportsCheck = [ "libzfs" ];
+
+  meta = with lib; {
+    description = "Python libzfs bindings";
+    homepage = "https://github.com/truenas/py-libzfs";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ chuangzhu ];
+    # The project also supports macOS (OpenZFS on OSX, O3X), FreeBSD and OpenSolaris
+    # I don't have a machine to test out, thus only packaged for Linux
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8111,6 +8111,8 @@ in {
 
   pylitterbot = callPackage ../development/python-modules/pylitterbot { };
 
+  py-libzfs = callPackage ../development/python-modules/py-libzfs { };
+
   py-lru-cache = callPackage ../development/python-modules/py-lru-cache { };
 
   pylnk3 = callPackage ../development/python-modules/pylnk3 { };


### PR DESCRIPTION
###### Description of changes

Python libzfs bindings. In theory it supports macOS, but that depends on a different ZFS library (OpenZFSonOSX, O3X). I don't have a Mac, so I only packaged for Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
