### PR TITLE
nixos/duckdns: init

### DIFF
--- a/nixos/modules/services/misc/duckdns.nix
+++ b/nixos/modules/services/misc/duckdns.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.duckdns;
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.duckdns = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Whether to enable the DuckDNS dynamic DNS service.
+        '';
+      };
+
+      subdomain = mkOption {
+        type = types.str;
+        example = "exampledomain";
+        description = lib.mdDoc ''
+          The DuckDNS subdomain to update.
+        '';
+      };
+
+      token = mkOption {
+        type = types.str;
+        example = "a7c4d0ad-114e-40ef-ba1d-d217904a50f2";
+        description = lib.mdDoc ''
+          DuckDNS token.
+        '';
+      };
+
+      timer = mkOption {
+        type = types.str;
+        default = "*:0/5";
+        description = lib.mdDoc ''
+          How often to run the DuckDNS update.
+          Formatted calendar event expressions (systemd.time(7)).
+          The default is 5m.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.curl ];
+
+    systemd.services.duckdns = {
+      description = "DuckDNS dynamic DNS updater.";
+      serviceConfig.Type = "oneshot";
+      script = "echo url=\"https://www.duckdns.org/update?domains=${cfg.subdomain}&token=${cfg.token}&ip=\" | ${pkgs.curl}/bin/curl -k -K -";
+    };
+
+    systemd.timers.duckdns = {
+      wantedBy = [ "timers.target" ];
+      partOf = [ "duckdns.service" ];
+      timerConfig.OnCalendar = [ cfg.timer ];
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add duckdns (www.duckdns.org) module/service.

This module allows for the usage of the DuckDNS dynamic dns service. It exposes the following options:

1. Subdomain: Duckdns subdomain to update.
2. Token: Duckdns token to use.
3. Timer: How often to run the systemd timer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
