### PR TITLE
python3Packages.requests-oauth: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/requests-oauth/default.nix
+++ b/pkgs/development/python-modules/requests-oauth/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "requests-oauth";
+  version = "0.4.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-nBsHOJZ+8cD28Osf8JpwAEmc0HpgnqjxdwtRW5U69pI=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  doCheck = false; # disabled due to Python 2 tests (?) - missing parenthesis
+
+  meta = {
+    description = "Python's Requests OAuth (Open Authentication) plugin";
+    homepage = "https://github.com/maraujop/requests-oauth";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kittywitch ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9730,6 +9730,8 @@ in {
 
   requests_ntlm = callPackage ../development/python-modules/requests_ntlm { };
 
+  requests-oauth = callPackage ../development/python-modules/requests-oauth { };
+
   requests-oauthlib = callPackage ../development/python-modules/requests-oauthlib { };
 
   requests-pkcs12 = callPackage ../development/python-modules/requests-pkcs12 { };


### PR DESCRIPTION
###### Description of changes

Added requests-oauth as it is an unpackaged python module required by another coming PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
