### PR TITLE
pkg-config: set pkg-config-rs-compatible env vars

### DIFF
--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -127,6 +127,7 @@ stdenv.mkDerivation {
 
   env = {
     shell = getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";
+    inherit (targetPlatform.rust) cargoEnvVarTarget;
     wrapperName = "PKG_CONFIG_WRAPPER";
     inherit targetPrefix suffixSalt baseBinName;
   };

--- a/pkgs/build-support/pkg-config-wrapper/setup-hook.sh
+++ b/pkgs/build-support/pkg-config-wrapper/setup-hook.sh
@@ -25,5 +25,11 @@ addEnvHooks "$targetOffset" pkgConfigWrapper_addPkgConfigPath
 
 export PKG_CONFIG${role_post}=@targetPrefix@@baseBinName@
 
+# The Rust pkg-config crate does not support prefixed pkg-config executables[1],
+# but it does support checking these idiosyncratic PKG_CONFIG_${TRIPLE}
+# environment variables.
+# [1]: https://github.com/rust-lang/pkg-config-rs/issues/53
+export PKG_CONFIG_@cargoEnvVarTarget@=@targetPrefix@@baseBinName@
+
 # No local scope in sourced file
 unset -v role_post

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -15,99 +15,91 @@
   rustc,
   auditable ? !cargo-auditable.meta.broken,
   cargo-auditable,
-  pkgsBuildBuild,
 }:
 
 rustPlatform.buildRustPackage.override
   {
     cargo-auditable = cargo-auditable.bootstrap;
   }
-  (
-    {
-      pname = "cargo";
-      inherit (rustc.unwrapped) version src;
+  {
+    pname = "cargo";
+    inherit (rustc.unwrapped) version src;
 
-      # the rust source tarball already has all the dependencies vendored, no need to fetch them again
-      cargoVendorDir = "vendor";
-      buildAndTestSubdir = "src/tools/cargo";
+    # the rust source tarball already has all the dependencies vendored, no need to fetch them again
+    cargoVendorDir = "vendor";
+    buildAndTestSubdir = "src/tools/cargo";
 
-      inherit auditable;
+    inherit auditable;
 
-      passthru = {
-        rustc = rustc;
-        inherit (rustc.unwrapped) tests;
-      };
+    passthru = {
+      rustc = rustc;
+      inherit (rustc.unwrapped) tests;
+    };
 
-      # changes hash of vendor directory otherwise
-      dontUpdateAutotoolsGnuConfigScripts = true;
+    # changes hash of vendor directory otherwise
+    dontUpdateAutotoolsGnuConfigScripts = true;
 
-      nativeBuildInputs = [
-        pkg-config
-        cmake
-        installShellFiles
-        makeWrapper
-        (lib.getDev pkgsHostHost.curl)
-        zlib
+    nativeBuildInputs = [
+      pkg-config
+      cmake
+      installShellFiles
+      makeWrapper
+      (lib.getDev pkgsHostHost.curl)
+      zlib
+    ];
+    buildInputs = [
+      file
+      curl
+      python3
+      openssl
+      zlib
+    ];
+
+    # cargo uses git-rs which is made for a version of libgit2 from recent master that
+    # is not compatible with the current version in nixpkgs.
+    #LIBGIT2_SYS_USE_PKG_CONFIG = 1;
+
+    # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
+    RUSTC_BOOTSTRAP = 1;
+
+    postInstall = ''
+      wrapProgram "$out/bin/cargo" --suffix PATH : "${rustc}/bin"
+
+      installManPage src/tools/cargo/src/etc/man/*
+
+      installShellCompletion --bash --name cargo \
+        src/tools/cargo/src/etc/cargo.bashcomp.sh
+
+      installShellCompletion --zsh src/tools/cargo/src/etc/_cargo
+    '';
+
+    checkPhase = ''
+      # Disable cross compilation tests
+      export CFG_DISABLE_CROSS_TESTS=1
+      cargo test
+    '';
+
+    # Disable check phase as there are failures (4 tests fail)
+    doCheck = false;
+
+    doInstallCheck = !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isElf;
+    installCheckPhase = ''
+      runHook preInstallCheck
+      ${stdenv.cc.targetPrefix}readelf -a $out/bin/.cargo-wrapped | grep -F 'Shared library: [libcurl.so'
+      runHook postInstallCheck
+    '';
+
+    meta = with lib; {
+      homepage = "https://crates.io";
+      description = "Downloads your Rust project's dependencies and builds your project";
+      mainProgram = "cargo";
+      teams = [ teams.rust ];
+      license = [
+        licenses.mit
+        licenses.asl20
       ];
-      buildInputs = [
-        file
-        curl
-        python3
-        openssl
-        zlib
-      ];
-
-      # cargo uses git-rs which is made for a version of libgit2 from recent master that
-      # is not compatible with the current version in nixpkgs.
-      #LIBGIT2_SYS_USE_PKG_CONFIG = 1;
-
-      # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
-      RUSTC_BOOTSTRAP = 1;
-
-      postInstall = ''
-        wrapProgram "$out/bin/cargo" --suffix PATH : "${rustc}/bin"
-
-        installManPage src/tools/cargo/src/etc/man/*
-
-        installShellCompletion --bash --name cargo \
-          src/tools/cargo/src/etc/cargo.bashcomp.sh
-
-        installShellCompletion --zsh src/tools/cargo/src/etc/_cargo
-      '';
-
-      checkPhase = ''
-        # Disable cross compilation tests
-        export CFG_DISABLE_CROSS_TESTS=1
-        cargo test
-      '';
-
-      # Disable check phase as there are failures (4 tests fail)
-      doCheck = false;
-
-      doInstallCheck = !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isElf;
-      installCheckPhase = ''
-        runHook preInstallCheck
-        ${stdenv.cc.targetPrefix}readelf -a $out/bin/.cargo-wrapped | grep -F 'Shared library: [libcurl.so'
-        runHook postInstallCheck
-      '';
-
-      meta = with lib; {
-        homepage = "https://crates.io";
-        description = "Downloads your Rust project's dependencies and builds your project";
-        mainProgram = "cargo";
-        teams = [ teams.rust ];
-        license = [
-          licenses.mit
-          licenses.asl20
-        ];
-        platforms = platforms.unix;
-        # https://github.com/alexcrichton/nghttp2-rs/issues/2
-        broken = stdenv.hostPlatform.isx86 && stdenv.buildPlatform != stdenv.hostPlatform;
-      };
-    }
-    //
-      lib.optionalAttrs (stdenv.buildPlatform.rust.rustcTarget != stdenv.hostPlatform.rust.rustcTarget)
-        {
-          HOST_PKG_CONFIG_PATH = "${pkgsBuildBuild.pkg-config}/bin/pkg-config";
-        }
-  )
+      platforms = platforms.unix;
+      # https://github.com/alexcrichton/nghttp2-rs/issues/2
+      broken = stdenv.hostPlatform.isx86 && stdenv.buildPlatform != stdenv.hostPlatform;
+    };
+  }

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -82,13 +82,6 @@ stdenv.mkDerivation (finalAttrs: {
   # See: https://github.com/NixOS/nixpkgs/pull/56540#issuecomment-471624656
   stripDebugList = [ "bin" ];
 
-  # The Rust pkg-config crate does not support prefixed pkg-config executables[1],
-  # but it does support checking these idiosyncratic PKG_CONFIG_${TRIPLE}
-  # environment variables.
-  # [1]: https://github.com/rust-lang/pkg-config-rs/issues/53
-  "PKG_CONFIG_${builtins.replaceStrings [ "-" ] [ "_" ] stdenv.buildPlatform.rust.rustcTarget}" =
-    "${pkgsBuildHost.stdenv.cc.targetPrefix}pkg-config";
-
   NIX_LDFLAGS = toString (
     # when linking stage1 libstd: cc: undefined reference to `__cxa_begin_catch'
     # This doesn't apply to cross-building for FreeBSD because the host


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
