### PR TITLE
etebase-server: add option withPostgres

### DIFF
--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -1,6 +1,7 @@
 { lib, fetchFromGitHub, buildPythonPackage, aiofiles, django_3
 , fastapi, msgpack, pynacl, redis, typing-extensions
-, withLdap ? true, python-ldap }:
+, withLdap ? true, python-ldap
+, withPostgres ? true, psycopg2 }:
 
 buildPythonPackage rec {
   pname = "etebase-server";
@@ -24,7 +25,8 @@ buildPythonPackage rec {
     pynacl
     redis
     typing-extensions
-  ] ++ lib.optional withLdap python-ldap;
+  ] ++ lib.optional withLdap python-ldap
+    ++ lib.optional withPostgres psycopg2;
 
   installPhase = ''
     mkdir -p $out/bin $out/lib


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

On current nixos-unstable branch, the following etebase-server config using postgresql backend
```nix
services.etebase-server = {
  enable = true;
  settings = {
    global.secret_file = config.sops.secrets."etebase/secret".path;
    allowed_hosts.allowed_host1 = "example.com";
    database = {
      engine = "django.db.backends.postgresql";
      name = "etesync";
      user = "etesync";
      host = "postgres.example.com";
      port = 5432;
    };
    database-options.passfile = config.sops.secrets."etebase/postgresql".path;
  };
};
```
fails with
```
Traceback (most recent call last):
  File "/nix/store/1bd23bjb8kirg6iz59j35155724qp2hk-python3.10-django-3.2.15/lib/python3.10/site-packages/django/db/backends/postgresql/base.py", line 25, in <module>
    import psycopg2 as Database
ModuleNotFoundError: No module named 'psycopg2'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
