### PR TITLE
shortcat: init at 0.11.0

### DIFF
--- a/pkgs/os-specific/darwin/shortcat/default.nix
+++ b/pkgs/os-specific/darwin/shortcat/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchurl, unzip, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "shortcat";
+  version = "0.11.0";
+
+  src = fetchurl {
+    url = "https://files.shortcat.app/releases/v${version}/Shortcat.zip";
+    sha256 = "sha256-P8NQy9odWOD8wRHBTmaNH7OCXXvgQsMiI169KfsAABU=";
+  };
+
+  sourceRoot = "Shortcat.app";
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $out/Applications/Shortcat.app
+    cp -R . $out/Applications/Shortcat.app
+  '';
+
+  meta = with lib; {
+    description = "Manipulate macOS masterfully, minus the mouse";
+    homepage = "https://shortcat.app/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ Enzime ];
+    license = licenses.unfreeRedistributable;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25417,6 +25417,8 @@ with pkgs;
 
   shadow = callPackage ../os-specific/linux/shadow { };
 
+  shortcat = callPackage ../os-specific/darwin/shortcat { };
+
   sinit = callPackage ../os-specific/linux/sinit {
     rcinit = "/etc/rc.d/rc.init";
     rcshutdown = "/etc/rc.d/rc.shutdown";


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).