### PR TITLE
ocamlPackages.class_group_vdf: init at 0.0.4

### DIFF
--- a/pkgs/development/ocaml-modules/class_group_vdf/default.nix
+++ b/pkgs/development/ocaml-modules/class_group_vdf/default.nix
@@ -1,0 +1,44 @@
+{ lib, fetchFromGitLab, buildDunePackage, ocaml
+, gmp, pkg-config, dune-configurator
+, zarith, integers
+, alcotest, bisect_ppx }:
+
+buildDunePackage rec {
+  pname = "class_group_vdf";
+  version = "0.0.4";
+  duneVersion = "3";
+
+  src = fetchFromGitLab {
+    owner = "nomadic-labs/cryptography";
+    repo = "ocaml-chia-vdf";
+    rev = "v${version}";
+    sha256 = "sha256-KvpnX2DTUyfKARNWHC2lLBGH2Ou2GfRKjw05lu4jbBs=";
+  };
+
+  minimalOCamlVersion = "4.08";
+
+  nativeBuildInputs = [
+    gmp
+    pkg-config
+    dune-configurator
+  ];
+
+  propagatedBuildInputs = [
+    zarith
+    integers
+  ];
+
+  checkInputs = [
+    alcotest
+    bisect_ppx
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Verifiable Delay Functions bindings to Chia's VDF";
+    homepage = "https://gitlab.com/nomadic-labs/tezos";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ulrikstrid ];
+  };
+}

--- a/pkgs/development/ocaml-modules/class_group_vdf/default.nix
+++ b/pkgs/development/ocaml-modules/class_group_vdf/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitLab, buildDunePackage, ocaml
+{ lib, fetchFromGitLab, buildDunePackage
 , gmp, pkg-config, dune-configurator
 , zarith, integers
 , alcotest, bisect_ppx }:

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -144,6 +144,8 @@ let
 
     camlimages = callPackage ../development/ocaml-modules/camlimages { };
 
+    class_group_vdf = callPackage ../development/ocaml-modules/class_group_vdf { };
+
     benchmark = callPackage ../development/ocaml-modules/benchmark { };
 
     biniou = callPackage ../development/ocaml-modules/biniou { };


### PR DESCRIPTION
###### Description of changes

Broken out from #195344

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
