### PR TITLE
asn2quickder: 1.3.0 -> 1.7.1

### DIFF
--- a/pkgs/development/tools/asn2quickder/default.nix
+++ b/pkgs/development/tools/asn2quickder/default.nix
@@ -1,31 +1,43 @@
-{ lib, buildPythonApplication, fetchFromGitHub, makeWrapper, cmake
-, pytest-runner, pytest, six, pyparsing, asn1ate }:
+{ lib
+, buildPythonApplication
+, fetchFromGitLab
+, makeWrapper
+, cmake
+, six
+, pyparsing
+, asn1ate
+, colored
+}:
 
 buildPythonApplication rec {
   pname = "asn2quickder";
-  version = "1.3.0";
+  version = "1.7.1";
 
-  src = fetchFromGitHub {
-    sha256 = "15lxv8vcjnsjxg7ywcac5p6mj5vf5pxq1219yap653ci4f1liqfr";
-    rev = "version-${version}";
-    owner = "vanrein";
+  src = fetchFromGitLab {
+    owner = "arpa2";
     repo = "quick-der";
+    rev = "v${version}";
+    sha256 = "sha256-f+ph5PL+uWRkswpOLDwZFWjh938wxoJ6xocJZ2WZLEk=";
   };
 
   postPatch = ''
     patchShebangs ./python/scripts/*
+
+    # Unpin pyparsing 3.0.0. Issue resolved in latest version.
+    substituteInPlace setup.py --replace 'pyparsing==3.0.0' 'pyparsing'
   '';
 
   dontUseCmakeConfigure = true;
 
   nativeBuildInputs = [ makeWrapper cmake ];
-  checkInputs = [ pytest-runner pytest ];
 
-  propagatedBuildInputs = [ pyparsing asn1ate six ];
+  propagatedBuildInputs = [ pyparsing asn1ate six colored ];
+
+  doCheck = false; # Flaky tests
 
   meta = with lib; {
     description = "An ASN.1 compiler with a backend for Quick DER";
-    homepage = "https://github.com/vanrein/asn2quickder";
+    homepage = "https://gitlab.com/arpa2/quick-der";
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ leenaars ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16025,7 +16025,7 @@ with pkgs;
 
   arpa2common = callPackage ../development/libraries/arpa2common { };
 
-  asn2quickder = python2Packages.callPackage ../development/tools/asn2quickder {};
+  asn2quickder = python3Packages.callPackage ../development/tools/asn2quickder {};
 
   astyle = callPackage ../development/tools/misc/astyle { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
