### PR TITLE
cargo-show-asm: init at 0.1.24

### DIFF
--- a/pkgs/development/tools/rust/cargo-show-asm/default.nix
+++ b/pkgs/development/tools/rust/cargo-show-asm/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, installShellFiles
+, openssl
+, nix-update-script
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-asm";
+  version = "0.1.24";
+
+  src = fetchFromGitHub {
+    owner = "pacak";
+    repo = "cargo-show-asm";
+    rev = version;
+    hash = "sha256-ahkKUtg5M88qddzEwYxPecDtBofGfPVxKuYKgmsbWYc=";
+  };
+
+  cargoHash = "sha256-S7OpHNjiTfQg7aPmHEx6Q/OV5QA9pB29F3MTIeiLAXg=";
+
+  nativeBuildInputs = [ pkg-config installShellFiles ];
+  buildInputs = [ openssl ];
+
+  postInstall = ''
+    installShellCompletion --cmd foobar \
+      --bash <($out/bin/cargo-asm --bpaf-complete-style-bash) \
+      --fish <($out/bin/cargo-asm --bpaf-complete-style-fish) \
+      --zsh  <($out/bin/cargo-asm --bpaf-complete-style-zsh )
+  '';
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
+  meta = with lib; {
+    description = "Cargo subcommand showing the assembly, LLVM-IR and MIR generated for Rust code";
+    homepage = "https://github.com/pacak/cargo-show-asm";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ oxalica ];
+    broken = stdenv.isDarwin; # FIXME: Seems to have issue compiling bundled curl.
+  };
+}

--- a/pkgs/development/tools/rust/cargo-show-asm/default.nix
+++ b/pkgs/development/tools/rust/cargo-show-asm/default.nix
@@ -6,6 +6,7 @@
 , installShellFiles
 , openssl
 , nix-update-script
+, callPackage
 }:
 rustPlatform.buildRustPackage rec {
   pname = "cargo-asm";
@@ -30,8 +31,13 @@ rustPlatform.buildRustPackage rec {
       --zsh  <($out/bin/cargo-asm --bpaf-complete-style-zsh )
   '';
 
-  passthru.updateScript = nix-update-script {
-    attrPath = pname;
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+    tests = lib.optionalAttrs stdenv.hostPlatform.isx86_64 {
+      test-basic-x86_64 = callPackage ./test-basic-x86_64.nix { };
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/rust/cargo-show-asm/test-basic-x86_64.nix
+++ b/pkgs/development/tools/rust/cargo-show-asm/test-basic-x86_64.nix
@@ -1,0 +1,18 @@
+{ runCommand, cargo, rustc, cargo-show-asm }:
+runCommand "test-basic" {
+  nativeBuildInputs = [ cargo rustc cargo-show-asm ];
+} ''
+  mkdir -p src
+  cat >Cargo.toml <<EOF
+[package]
+name = "add"
+version = "0.0.0"
+EOF
+  cat >src/lib.rs <<EOF
+pub fn add(a: u32, b: u32) -> u32 { a + b }
+EOF
+
+  [[ "$(cargo asm add::add | tee /dev/stderr)" == *"lea eax, "* ]]
+  [[ "$(cargo asm --mir add | tee /dev/stderr)" == *"= Add("* ]]
+  touch $out
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14896,6 +14896,9 @@ with pkgs;
   cargo-semver-checks = callPackage ../development/tools/rust/cargo-semver-checks {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+
+  cargo-show-asm = callPackage ../development/tools/rust/cargo-show-asm { };
+
   cargo-sort = callPackage ../development/tools/rust/cargo-sort { };
   cargo-spellcheck = callPackage ../development/tools/rust/cargo-spellcheck {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Description of changes

https://github.com/pacak/cargo-show-asm

`cargo-show-asm` is a reimpl for unmaintained `cargo-asm`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
