### PR TITLE
lavat: Init at 2.0.0

### DIFF
--- a/pkgs/tools/misc/lavat/default.nix
+++ b/pkgs/tools/misc/lavat/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+,
+}:
+let
+  version = "2.0.0";
+in
+stdenv.mkDerivation {
+  pname = "lavat";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "AngelJumbo";
+    repo = "lavat";
+    rev = "v${version}";
+    sha256 = "sha256-xDjqKhwoaqCqo7tkpcEe2MBEpVTJUOpKtu7Fi9aPOPo=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp lavat $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Lava lamp simulation in the terminal";
+    longDescription = ''
+      Lavat puts ascii metaballs in your terminal to make it look a bit like a
+      lava lamp.
+
+      Lavat contains various options, including those to change the color and
+      speed of the metaballs. For a full list, run `lavat -h`
+    '';
+    maintainers = [ maintainers.minion3665 ];
+    license = licenses.mit;
+    homepage = "https://github.com/AngelJumbo/lavat";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/lavat/default.nix
+++ b/pkgs/tools/misc/lavat/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     owner = "AngelJumbo";
     repo = "lavat";
     rev = "v${version}";
-    sha256 = "sha256-xDjqKhwoaqCqo7tkpcEe2MBEpVTJUOpKtu7Fi9aPOPo=";
+    hash = "sha256-xDjqKhwoaqCqo7tkpcEe2MBEpVTJUOpKtu7Fi9aPOPo=";
   };
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9527,6 +9527,8 @@ with pkgs;
 
   lazycli = callPackage ../tools/misc/lazycli { };
 
+  lavat = callPackage ../tools/misc/lavat { };
+
   lcdf-typetools = callPackage ../tools/misc/lcdf-typetools { };
 
   ldapdomaindump = with python3Packages; toPythonApplication ldapdomaindump;


### PR DESCRIPTION
###### Description of changes

Lavat is a program that uses metaballs to simulate a lava lamp in your terminal. This PR packages it for nix

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).