### PR TITLE
ulauncher: 5.12.1 -> 5.15.0

### DIFF
--- a/pkgs/applications/misc/ulauncher/default.nix
+++ b/pkgs/applications/misc/ulauncher/default.nix
@@ -16,15 +16,16 @@
 , wmctrl
 , xvfb-run
 , librsvg
+, libX11
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "ulauncher";
-  version = "5.12.1";
+  version = "5.15.0";
 
   src = fetchurl {
     url = "https://github.com/Ulauncher/Ulauncher/releases/download/${version}/ulauncher_${version}.tar.gz";
-    sha256 = "sha256-Fd3IOCEeXGV8zGd/8SzrWRsSsZRVePnsDaX8WrBrCOQ=";
+    sha256 = "sha256-1Qo6ffMtVRtZDPCHvHEl7T0dPdDUxP4TP2hkSVSdQpo";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -36,7 +37,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildInputs = [
-    gdk-pixbuf
     glib
     gnome.adwaita-icon-theme
     gtk3
@@ -71,7 +71,6 @@ python3Packages.buildPythonApplication rec {
 
   patches = [
     ./fix-path.patch
-    ./0001-Adjust-get_data_path-for-NixOS.patch
     ./fix-extensions.patch
   ];
 
@@ -108,6 +107,8 @@ python3Packages.buildPythonApplication rec {
     makeWrapperArgs+=(
      "''${gappsWrapperArgs[@]}"
      --prefix PATH : "${lib.makeBinPath [ wmctrl ]}"
+     --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libX11 ]}"
+     --prefix WEBKIT_DISABLE_COMPOSITING_MODE : "1"
     )
   '';
 

--- a/pkgs/applications/misc/ulauncher/fix-path.patch
+++ b/pkgs/applications/misc/ulauncher/fix-path.patch
@@ -2,12 +2,11 @@ diff --git a/setup.py b/setup.py
 index 3616104..e9bbfda 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -112,7 +112,7 @@ class InstallAndUpdateDataDirectory(DistUtilsExtra.auto.install_auto):
-         DistUtilsExtra.auto.install_auto.run(self)
- 
-         target_data = '/' + os.path.relpath(self.install_data, self.root) + '/'
+@@ -94,7 +94,7 @@
+         # Root is undefined if not installing into an alternate root
+         root = self.root or "/"
+         target_data = '/' + os.path.relpath(self.install_data, root) + '/'
 -        target_pkgdata = target_data + 'share/ulauncher/'
 +        target_pkgdata = '@out@/share/ulauncher/'
          target_scripts = '/' + os.path.relpath(self.install_scripts,
-                                                self.root) + '/'
- 
+                                                root) + '/'


### PR DESCRIPTION
###### Description of changes

For changelog see: https://github.com/Ulauncher/Ulauncher/releases

fixes https://github.com/NixOS/nixpkgs/issues/119350.

For the fix: the `0001-Adjust-get_data_path-for-NixOS.patch` is no longer needed, the application wont start with it applied as it is not able to find the data dir. Without it, it works just fine.

I also adjusted the `fix-path.patch` to work on the latest version.

Additionally, ulauncher now depends on `libX11` so I added it to `LD_LIBRARY_PATH` as passing it to `buildInputs` or `nativeBuildInputs` did not work.

I also set `WEBKIT_DISABLE_COMPOSITING_MODE=1` because if i dont set it, the settings wont show up for me. (see [this issue](https://github.com/Ulauncher/Ulauncher/issues/114) for the source of the workaround)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
