### PR TITLE
jugglinglab: 1.2.1 -> 1.6.3

### DIFF
--- a/pkgs/tools/misc/jugglinglab/default.nix
+++ b/pkgs/tools/misc/jugglinglab/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchFromGitHub, jre, makeWrapper, ant, jdk }:
 stdenv.mkDerivation rec {
-  version = "1.2.1";
+  version = "1.6.3";
   pname = "jugglinglab";
   src = fetchFromGitHub {
     owner = "jkboyce";
     repo = "jugglinglab";
-    rev = "1908012682d8c39a9b92248a20f285455104c510"; # v1.2.1 does not have a tag on Github
-    sha256 = "0dvcyjwynvapqbjchrln59vdskrm3w6kh0knxcn4bx61vcz3171z";
+    rev = "v${version}";
+    sha256 = "sha256-Gq8V7gLl9IakQi7xaK8TCI/B2+6LlLjoLdcv9zlalIE=";
   };
   buildInputs = [ jre ];
   nativeBuildInputs = [ ant jdk makeWrapper ];
@@ -15,14 +15,20 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     mkdir -p "$out/lib"
-    cp bin/JugglingLab.jar $out/lib/
+    cp bin/*.jar $out/lib/
+
+    # copied from the upstream shell wrapper
+    classpath=$out/lib/JugglingLab.jar:$out/lib/commons-math3-3.6.1.jar:$out/lib/protobuf.jar:$out/lib/com.google.ortools.jar
 
     makeWrapper ${jre}/bin/java $out/bin/jugglinglab \
-      --add-flags "-jar $out/lib/JugglingLab.jar"
+      --add-flags "-cp $classpath" \
+      --add-flags "-Xss2048k -Djava.library.path=ortools-lib" \
+      --add-flags jugglinglab.JugglingLab
   '';
 
   meta = with lib; {
       description = "A program to visualize different juggling pattens";
+      homepage = "https://jugglinglab.org/";
       license = licenses.gpl2;
       maintainers = with maintainers; [ wnklmnn ];
       platforms = platforms.all;


### PR DESCRIPTION
###### Description of changes



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

A discussion about the ortools jar which untermined my first approach to update this (never made a PR):
https://github.com/jkboyce/jugglinglab/issues/123

@wnklmnn I tried to update the package and mimic the arguments from the shell wrapper upstream.  
<details><summary>But I get a runtime exception because the math3 library can not be found.
</summary>

~~~
Exception in thread "AWT-EventQueue-0" java.lang.NoClassDefFoundError: org/apache/commons/math3/linear/SingularMatrixException
	at jugglinglab.jml.JMLPattern.findPositions(Unknown Source)
	at jugglinglab.jml.JMLPattern.layoutPattern(Unknown Source)
	at jugglinglab.jml.JMLPattern.scaleTimeToFitThrows(Unknown Source)
	at jugglinglab.notation.MHNPattern.asJMLPattern(Unknown Source)
	at jugglinglab.jml.JMLPattern.fromBasePattern(Unknown Source)
	at jugglinglab.core.ApplicationPanel$3.actionPerformed(Unknown Source)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2313)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:279)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6626)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3389)
	at java.desktop/java.awt.Component.processEvent(Component.java:6391)
	at java.desktop/java.awt.Container.processEvent(Container.java:2266)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5001)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4833)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4948)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4575)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4516)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2780)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4833)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:716)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:97)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:746)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:744)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:743)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.math3.linear.SingularMatrixException
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
	... 41 more
~~~

</details>

Do you think you can take it from here? I have no experience with java :(