### PR TITLE
percona-xtrabackup: 2.4.20 -> 2.4.26, 8.0.13 -> 8.0.29-22

### DIFF
--- a/pkgs/tools/backup/percona-xtrabackup/2_4.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/2_4.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "2.4.20";
-  sha256 = "0awdpkcgvx2aq7pwxy8jyzkin6cyrrh3d576x9ldm851kis9n5ii";
+  version = "2.4.26";
+  sha256 = "sha256-/erBv/Asi/MfoSvAcQ647VAgOfiViPunFWmvy/W9J18=";
 })

--- a/pkgs/tools/backup/percona-xtrabackup/8_0.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/8_0.nix
@@ -1,8 +1,11 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "8.0.13";
-  sha256 = "0cj0fnjimv22ykfl0yk6w29wcjvqp8y8j2g1c6gcml65qazrswyr";
+  version = "8.0.29-22";
+  sha256 = "sha256-dGpfU+IesAyr2s1AEjfYggOEkMGQ9JdEesu5PtJHNXA=";
+
+  # includes https://github.com/Percona-Lab/libkmip.git
+  fetchSubmodules = true;
 
   extraPatches = [
     ./abi-check.patch

--- a/pkgs/tools/backup/percona-xtrabackup/abi-check.patch
+++ b/pkgs/tools/backup/percona-xtrabackup/abi-check.patch
@@ -7,11 +7,11 @@ https://github.com/NixOS/nixpkgs/issues/44530
 --- a/cmake/do_abi_check.cmake
 +++ b/cmake/do_abi_check.cmake
 @@ -68,1 +68,1 @@ FOREACH(file ${ABI_HEADERS})
--      -E -nostdinc -dI -DMYSQL_ABI_CHECK -I${SOURCE_DIR}/include
-+      -E -nostdinc -dI -DMYSQL_ABI_CHECK -I${SOURCE_DIR}/include/nostdinc -I${SOURCE_DIR}/include
+-      -E -nostdinc -dI -DMYSQL_ABI_CHECK -I${ABI_SOURCE_DIR}/include
++      -E -nostdinc -dI -DMYSQL_ABI_CHECK -I${ABI_SOURCE_DIR}/include/nostdinc -I${ABI_SOURCE_DIR}/include
 @@ -74,1 +74,1 @@ FOREACH(file ${ABI_HEADERS})
--    COMMAND sed -e "/^# /d"
-+    COMMAND sed -e "/^# /d" -e "/^#include <-nostdinc>$/d"
+-    COMMAND ${WSL_EXECUTABLE} sed -e "/^# /d"
++    COMMAND ${WSL_EXECUTABLE} sed -e "/^# /d" -e "/^#include <-nostdinc>$/d"
 --- /dev/null
 +++ b/include/nostdinc/stdint.h
 @@ -0,0 +1,1 @@

--- a/pkgs/tools/backup/percona-xtrabackup/generic.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/generic.nix
@@ -19,16 +19,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ bison boost cmake makeWrapper pkg-config ];
 
   buildInputs = [
-    (curl.override { inherit openssl; }) cyrus_sasl libaio libedit libev libevent libgcrypt libgpg-error lz4
+    (curl.override { inherit openssl; }) cyrus_sasl libaio libedit libevent libev libgcrypt libgpg-error lz4
     ncurses numactl openssl protobuf valgrind xxd zlib
   ] ++ (with perlPackages; [ perl DBI DBDmysql ]);
 
   patches = extraPatches;
-
-  # Workaround build failure on -fno-common toolchains:
-  #   ld: xbstream.c.o:(.bss+0x0): multiple definition of
-  #      `datasink_buffer'; ds_buffer.c.o:(.data.rel.local+0x0): first defined here
-  NIX_CFLAGS_COMPILE = "-fcommon";
 
   cmakeFlags = [
     "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"

--- a/pkgs/tools/backup/percona-xtrabackup/generic.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/generic.nix
@@ -2,7 +2,7 @@
 , curl, cyrus_sasl, libaio, libedit, libev, libevent, libgcrypt, libgpg-error, lz4
 , ncurses, numactl, openssl, protobuf, valgrind, xxd, zlib
 , perlPackages
-, version, sha256, extraPatches ? [], extraPostInstall ? "", ...
+, version, sha256, fetchSubmodules ? false, extraPatches ? [], extraPostInstall ? "", ...
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "percona";
     repo = "percona-xtrabackup";
     rev = "${pname}-${version}";
-    inherit sha256;
+    inherit sha256 fetchSubmodules;
   };
 
   nativeBuildInputs = [ bison boost cmake makeWrapper pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10073,7 +10073,6 @@ with pkgs;
 
   percona-xtrabackup = percona-xtrabackup_8_0;
   percona-xtrabackup_2_4 = callPackage ../tools/backup/percona-xtrabackup/2_4.nix {
-    stdenv = gcc10StdenvCompat;
     boost = boost159;
     openssl = openssl_1_1;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10078,8 +10078,7 @@ with pkgs;
     openssl = openssl_1_1;
   };
   percona-xtrabackup_8_0 = callPackage ../tools/backup/percona-xtrabackup/8_0.nix {
-    stdenv = gcc10StdenvCompat;
-    boost = boost170;
+    boost = boost177;
     openssl = openssl_1_1;
   };
 


### PR DESCRIPTION
###### Description of changes

Package update.

I have not tested the executables and the build for the 2.4 emits many warnings (but no errors).

There was a build issue in newer versions where the wrong event.h is picked up, depending on the order of libevent and libev in buildInputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
  <details>
    <summary>2 packages built:</summary>
    <ul>
      <li>percona-xtrabackup</li>
      <li>percona-xtrabackup_2_4</li>
    </ul>
  </details>
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).