### PR TITLE
gnomeExtensions.gsconnect: 50 -> 54

### DIFF
--- a/pkgs/desktops/gnome/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome/extensions/gsconnect/default.nix
@@ -18,11 +18,12 @@
 , evolution-data-server-gtk4
 , gjs
 , nixosTests
+, desktop-file-utils
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-gsconnect";
-  version = "50";
+  version = "54";
 
   outputs = [ "out" "installedTests" ];
 
@@ -30,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "GSConnect";
     repo = "gnome-shell-extension-gsconnect";
     rev = "v${version}";
-    hash = "sha256-uUpdjBsVeS99AYDpGlXP9fMqGxWj+XfVubNoGJs76G0=";
+    hash = "sha256-Dt5T5luuKpSkoOs6MjOBg/yMm52hRfymKBeRklPWy+M=";
   };
 
   patches = [
@@ -42,12 +43,6 @@ stdenv.mkDerivation rec {
 
     # Allow installing installed tests to a separate output
     ./installed-tests-path.patch
-
-    # Update extension for Nautilus 43.
-    (fetchpatch {
-      url = "https://github.com/GSConnect/gnome-shell-extension-gsconnect/commit/9723ea9102f07c2c60fa065184cc58c2bc260abf.patch";
-      sha256 = "9afy/70AwW+OYML5J5IyBBiNKWkZ+wZZryZbi4uRfs4=";
-    })
   ];
 
   nativeBuildInputs = [
@@ -56,6 +51,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gobject-introspection # for locating typelibs
     wrapGAppsHook # for wrapping daemons
+    desktop-file-utils # update-desktop-database
   ];
 
   buildInputs = [
@@ -69,20 +65,16 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dgnome_shell_libdir=${gnome.gnome-shell}/lib"
-    "-Dgsettings_schemadir=${glib.makeSchemaPath (placeholder "out") "${pname}-${version}"}"
     "-Dchrome_nmhdir=${placeholder "out"}/etc/opt/chrome/native-messaging-hosts"
     "-Dchromium_nmhdir=${placeholder "out"}/etc/chromium/native-messaging-hosts"
     "-Dopenssl_path=${openssl}/bin/openssl"
     "-Dsshadd_path=${openssh}/bin/ssh-add"
     "-Dsshkeygen_path=${openssh}/bin/ssh-keygen"
     "-Dsession_bus_services_dir=${placeholder "out"}/share/dbus-1/services"
-    "-Dpost_install=true"
     "-Dinstalled_test_prefix=${placeholder "installedTests"}"
   ];
 
   postPatch = ''
-    patchShebangs meson/nmh.sh
-    patchShebangs meson/post-install.sh
     patchShebangs installed-tests/prepare-tests.sh
 
     # TODO: do not include every typelib everywhere
@@ -91,6 +83,10 @@ stdenv.mkDerivation rec {
       substituteInPlace "$file" \
         --subst-var-by typelibPath "$GI_TYPELIB_PATH"
     done
+
+    # slightly janky fix for gsettings_schemadir being removed
+    substituteInPlace data/config.js.in \
+      --subst-var-by GSETTINGS_SCHEMA_DIR ${glib.makeSchemaPath (placeholder "out") "${pname}-${version}"}
   '';
 
   postFixup = ''

--- a/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
+++ b/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
@@ -1,7 +1,7 @@
-diff --git i/data/org.gnome.Shell.Extensions.GSConnect.desktop.in w/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
+diff --git a/data/org.gnome.Shell.Extensions.GSConnect.desktop.in b/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
 index ffb23342..b405c73b 100644
---- i/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
-+++ w/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
+--- a/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
++++ b/data/org.gnome.Shell.Extensions.GSConnect.desktop.in
 @@ -1,7 +1,7 @@
  [Desktop Entry]
  Type=Application
@@ -11,10 +11,10 @@ index ffb23342..b405c73b 100644
  Terminal=false
  NoDisplay=true
  Icon=org.gnome.Shell.Extensions.GSConnect
-diff --git i/src/extension.js w/src/extension.js
-index 5f32aa68..872c0c61 100644
---- i/src/extension.js
-+++ w/src/extension.js
+diff --git a/src/extension.js b/src/extension.js
+index e7fd971a..8474bb3b 100644
+--- a/src/extension.js
++++ b/src/extension.js
 @@ -1,5 +1,7 @@
  'use strict';
  
@@ -23,15 +23,15 @@ index 5f32aa68..872c0c61 100644
  const Gio = imports.gi.Gio;
  const GObject = imports.gi.GObject;
  const Gtk = imports.gi.Gtk;
-diff --git i/src/prefs.js w/src/prefs.js
-index 07e93099..1c166710 100644
---- i/src/prefs.js
-+++ w/src/prefs.js
+diff --git a/src/prefs.js b/src/prefs.js
+index 922ea60c..2cd62eb5 100644
+--- a/src/prefs.js
++++ b/src/prefs.js
 @@ -1,5 +1,7 @@
  'use strict';
  
 +'@typelibPath@'.split(':').forEach(path => imports.gi.GIRepository.Repository.prepend_search_path(path));
 +
- const Gio = imports.gi.Gio;
- const GLib = imports.gi.GLib;
- const Gtk = imports.gi.Gtk;
+ const {Gio, GLib, Adw} = imports.gi;
+ 
+ // Bootstrap


### PR DESCRIPTION
###### Description of changes
Updated to work with gnome 43

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
