### PR TITLE
Libreoffice-fresh: 7.3. 3.2 -> 7.4.2.3, libreoffice-still: 7.2.6.2 -> 7.3.6.2

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ Stdenv
 , fetchurl
 , lib
 , pam
@@ -133,7 +133,7 @@ let
 
   langsSpaces = concatStringsSep " " langs;
 
-  mkDrv = if kdeIntegration then mkDerivation else stdenv.mkDerivation;
+  mkDrv = if kdeIntegration then mkDerivation else Stdenv.mkDerivation;
 
   srcs = {
     third_party =
@@ -195,10 +195,8 @@ in
     tar -xf ${srcs.translations}
   '';
 
-  patches = [
-    ./skip-failed-test-with-icu70.patch
-    ./gpgme-1.18.patch
-  ];
+  patches = optional (variant == "still") [ ./skip-failed-test-with-icu70.patch ./gpgme-1.18.patch ]
+  ;
 
   ### QT/KDE
   #

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -94,6 +94,7 @@
 , ncurses
 , libepoxy
 , gpgme
+, libwebp
 , abseil-cpp
 , langs ? [ "ca" "cs" "da" "de" "en-GB" "en-US" "eo" "es" "fr" "hu" "it" "ja" "nl" "pl" "pt" "pt-BR" "ro" "ru" "sl" "uk" "zh-CN" ]
 , withHelp ? true
@@ -453,6 +454,8 @@ in
     # https://github.com/NixOS/nixpkgs/commit/5c5362427a3fa9aefccfca9e531492a8735d4e6f
     "--without-system-orcus"
     "--without-system-xmlsec"
+    "--without-system-cuckoo"
+    "--without-system-zxing"
   ] ++ optionals kdeIntegration [
     "--enable-kf5"
     "--enable-qt5"
@@ -573,7 +576,8 @@ in
     gst-plugins-ugly
     gstreamer
   ])
-  ++ optionals kdeIntegration [ qtbase qtx11extras kcoreaddons kio ];
+  ++ optionals kdeIntegration [ qtbase qtx11extras kcoreaddons kio ]
+  ++ optionals (lib.versionAtLeast (lib.versions.majorMinor version) "7.4") [ libwebp ];
 
   passthru = {
     inherit srcs;

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -197,16 +197,6 @@ in
 
   patches = [
     ./skip-failed-test-with-icu70.patch
-
-    # Fix build with poppler 22.03
-    (fetchurl {
-      url = "https://github.com/archlinux/svntogit-packages/raw/f82958b9538f86e41b51f1ba7134968d2f3788d1/trunk/poppler-22.03.0.patch";
-      sha256 = "5h4qJmx6Q3Q3dHUlSi8JXBziN2mAswGVWk5aDTLTwls=";
-    })
-
-    # Fix build with poppler 22.04
-    ./poppler-22-04-0.patch
-
     ./gpgme-1.18.patch
   ];
 

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -1,4 +1,4 @@
-{ Stdenv
+{ stdenv
 , fetchurl
 , lib
 , pam
@@ -117,7 +117,7 @@ assert builtins.elem variant [ "fresh" "still" ];
 let
   inherit (lib)
     flatten flip
-    concatMapStrings concatMapStringsSep concatStringsSep
+    concatMapStrings concatStringsSep
     getDev getLib
     optional optionals optionalString;
 
@@ -129,11 +129,11 @@ let
 
   primary-src = importVariant "primary.nix" { inherit fetchurl; };
 
-  inherit (primary-src) major minor subdir version;
+  inherit (primary-src) major minor version;
 
   langsSpaces = concatStringsSep " " langs;
 
-  mkDrv = if kdeIntegration then mkDerivation else Stdenv.mkDerivation;
+  mkDrv = if kdeIntegration then mkDerivation else stdenv.mkDerivation;
 
   srcs = {
     third_party =
@@ -215,7 +215,7 @@ in
   # add the missing dependencies to it).
   postPatch = ''
     substituteInPlace shell/source/unix/exec/shellexec.cxx \
-      --replace /usr/bin/xdg-open ${if kdeIntegration then "kde-open5" else "xdg-open"}
+      --replace xdg-open ${if kdeIntegration then "kde-open5" else "xdg-open"}
 
     # configure checks for header 'gpgme++/gpgmepp_version.h',
     # and if it is found (no matter where) uses a hardcoded path
@@ -330,6 +330,7 @@ in
       sed -e '/CPPUNIT_TEST(testEmbeddedDataSource);/d' -i './sw/qa/extras/uiwriter/uiwriter.cxx'
       sed -e '/CPPUNIT_TEST(testTdf96479);/d' -i './sw/qa/extras/uiwriter/uiwriter.cxx'
       sed -e '/CPPUNIT_TEST(testInconsistentBookmark);/d' -i './sw/qa/extras/uiwriter/uiwriter.cxx'
+      sed -e /CppunitTest_sw_layoutwriter/d -i sw/Module_sw.mk
       sed -e "s/DECLARE_SW_ROUNDTRIP_TEST(\([_a-zA-Z0-9.]\+\)[, ].*, *\([_a-zA-Z0-9.]\+\))/class \\1: public \\2 { public: void verify() override; }; void \\1::verify() /" -i "sw/qa/extras/ooxmlexport/ooxmlexport9.cxx"
       sed -e "s/DECLARE_SW_ROUNDTRIP_TEST(\([_a-zA-Z0-9.]\+\)[, ].*, *\([_a-zA-Z0-9.]\+\))/class \\1: public \\2 { public: void verify() override; }; void \\1::verify() /" -i "sw/qa/extras/ooxmlexport/ooxmlencryption.cxx"
       sed -e "s/DECLARE_SW_ROUNDTRIP_TEST(\([_a-zA-Z0-9.]\+\)[, ].*, *\([_a-zA-Z0-9.]\+\))/class \\1: public \\2 { public: void verify() override; }; void \\1::verify() /" -i "sw/qa/extras/odfexport/odfexport.cxx"
@@ -362,12 +363,6 @@ in
 
     ln -s $out/bin/soffice $out/bin/libreoffice
     ln -s $out/lib/libreoffice/share/xdg $out/share/applications
-
-    for f in $out/share/applications/*.desktop; do
-      substituteInPlace "$f" \
-        --replace "Exec=libreofficedev${major}.${minor}" "Exec=libreoffice" \
-        --replace "Exec=libreoffice${major}.${minor}"    "Exec=libreoffice"
-    done
 
     cp -r sysui/desktop/icons  "$out/share"
     sed -re 's@Icon=libreoffice(dev)?[0-9.]*-?@Icon=@' -i "$out/share/applications/"*.desktop
@@ -421,7 +416,6 @@ in
     "--disable-postgresql-sdbc"
     "--disable-firebird-sdbc"
     "--without-fonts"
-    "--without-myspell-dicts"
     "--without-doxygen"
 
     # TODO: package these as system libraries
@@ -438,7 +432,7 @@ in
     "--without-system-libstaroffice"
     "--without-system-libepubgen"
     "--without-system-libqxp"
-    "--without-system-mdds" # we have mdds but our version is too new
+    "--with-system-mdds"
     # https://github.com/NixOS/nixpkgs/commit/5c5362427a3fa9aefccfca9e531492a8735d4e6f
     "--without-system-orcus"
     "--without-system-xmlsec"

--- a/pkgs/applications/office/libreoffice/src-fresh/download.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/download.nix
@@ -98,11 +98,11 @@
     md5name = "89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7-cppunit-1.15.1.tar.gz";
   }
   {
-    name = "curl-7.83.1.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/curl-7.83.1.tar.xz";
-    sha256 = "2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4";
+    name = "curl-7.85.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/curl-7.85.0.tar.xz";
+    sha256 = "88b54a6d4b9a48cb4d873c7056dcba997ddd5b7be5a2d537a4acb55c20b04be6";
     md5 = "";
-    md5name = "2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4-curl-7.83.1.tar.xz";
+    md5name = "88b54a6d4b9a48cb4d873c7056dcba997ddd5b7be5a2d537a4acb55c20b04be6-curl-7.85.0.tar.xz";
   }
   {
     name = "libe-book-0.1.3.tar.xz";
@@ -140,11 +140,11 @@
     md5name = "b430435a6e8487888b761dc848b7981626eb814884963ffe25eb26a139301e9a-libetonyek-0.1.10.tar.xz";
   }
   {
-    name = "expat-2.4.6.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/expat-2.4.6.tar.xz";
-    sha256 = "de55794b7a9bc214852fdc075beaaecd854efe1361597e6268ee87946951289b";
+    name = "expat-2.4.9.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/expat-2.4.9.tar.xz";
+    sha256 = "6e8c0728fe5c7cd3f93a6acce43046c5e4736c7b4b68e032e9350daa0efc0354";
     md5 = "";
-    md5name = "de55794b7a9bc214852fdc075beaaecd854efe1361597e6268ee87946951289b-expat-2.4.6.tar.xz";
+    md5name = "6e8c0728fe5c7cd3f93a6acce43046c5e4736c7b4b68e032e9350daa0efc0354-expat-2.4.9.tar.xz";
   }
   {
     name = "Firebird-3.0.7.33374-0.tar.bz2";
@@ -266,11 +266,11 @@
     md5name = "b98b67602a2c8880a1770f0b9e37c190f29a7e2ade5616784f0b89fbdb75bf52-alef-1.001.tar.gz";
   }
   {
-    name = "Amiri-0.111.zip";
-    url = "https://dev-www.libreoffice.org/src/Amiri-0.111.zip";
-    sha256 = "1fbfccced6348b5db2c1c21d5b319cd488e14d055702fa817a0f6cb83d882166";
+    name = "Amiri-0.117.zip";
+    url = "https://dev-www.libreoffice.org/src/Amiri-0.117.zip";
+    sha256 = "9c4e768893e0023a0ad6f488d5c84bd5add6565d3dcadb838ba5b20e75fcc9a7";
     md5 = "";
-    md5name = "1fbfccced6348b5db2c1c21d5b319cd488e14d055702fa817a0f6cb83d882166-Amiri-0.111.zip";
+    md5name = "9c4e768893e0023a0ad6f488d5c84bd5add6565d3dcadb838ba5b20e75fcc9a7-Amiri-0.117.zip";
   }
   {
     name = "ttf-kacst_2.01+mry.tar.gz";
@@ -280,11 +280,11 @@
     md5name = "dca00f5e655f2f217a766faa73a81f542c5c204aa3a47017c3c2be0b31d00a56-ttf-kacst_2.01+mry.tar.gz";
   }
   {
-    name = "ReemKufi-0.7.zip";
-    url = "https://dev-www.libreoffice.org/src/ReemKufi-0.7.zip";
-    sha256 = "f60c6508d209ce4236d2d7324256c2ffddd480be7e3d6023770b93dc391a605f";
+    name = "ReemKufi-1.2.zip";
+    url = "https://dev-www.libreoffice.org/src/ReemKufi-1.2.zip";
+    sha256 = "c4fd68a23c0ea471cc084ae7efe888da372b925cb208eeb0322c26792d2ef413";
     md5 = "";
-    md5name = "f60c6508d209ce4236d2d7324256c2ffddd480be7e3d6023770b93dc391a605f-ReemKufi-0.7.zip";
+    md5name = "c4fd68a23c0ea471cc084ae7efe888da372b925cb208eeb0322c26792d2ef413-ReemKufi-1.2.zip";
   }
   {
     name = "Scheherazade-2.100.zip";
@@ -455,11 +455,11 @@
     md5name = "09b96cb8cbff9ea556a9c2d173485fd19488844d55276ed4f42240e1e2073ce5-libjpeg-turbo-2.1.2.tar.gz";
   }
   {
-    name = "language-subtag-registry-2021-12-29.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/language-subtag-registry-2021-12-29.tar.bz2";
-    sha256 = "d9dcf20be5ad4856daef023087421bedc1477f9b4247fc8ea53bb32e07c97837";
+    name = "language-subtag-registry-2022-08-08.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/language-subtag-registry-2022-08-08.tar.bz2";
+    sha256 = "e2d9224e0e50fc8ad12a3cf47396bbcadf45b2515839d4770432653a88972c00";
     md5 = "";
-    md5name = "d9dcf20be5ad4856daef023087421bedc1477f9b4247fc8ea53bb32e07c97837-language-subtag-registry-2021-12-29.tar.bz2";
+    md5name = "e2d9224e0e50fc8ad12a3cf47396bbcadf45b2515839d4770432653a88972c00-language-subtag-registry-2022-08-08.tar.bz2";
   }
   {
     name = "lcms2-2.12.tar.gz";
@@ -532,11 +532,11 @@
     md5name = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483-ltm-1.0.zip";
   }
   {
-    name = "libwebp-1.2.2.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/libwebp-1.2.2.tar.gz";
-    sha256 = "7656532f837af5f4cec3ff6bafe552c044dc39bf453587bd5b77450802f4aee6";
+    name = "libwebp-1.2.4.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libwebp-1.2.4.tar.gz";
+    sha256 = "7bf5a8a28cc69bcfa8cb214f2c3095703c6b73ac5fba4d5480c205331d9494df";
     md5 = "";
-    md5name = "7656532f837af5f4cec3ff6bafe552c044dc39bf453587bd5b77450802f4aee6-libwebp-1.2.2.tar.gz";
+    md5name = "7bf5a8a28cc69bcfa8cb214f2c3095703c6b73ac5fba4d5480c205331d9494df-libwebp-1.2.4.tar.gz";
   }
   {
     name = "xmlsec1-1.2.34.tar.gz";
@@ -546,11 +546,11 @@
     md5name = "52ced4943f35bd7d0818a38298c1528ca4ac8a54440fd71134a07d2d1370a262-xmlsec1-1.2.34.tar.gz";
   }
   {
-    name = "libxml2-2.9.14.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libxml2-2.9.14.tar.xz";
-    sha256 = "60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee";
+    name = "libxml2-2.10.2.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libxml2-2.10.2.tar.xz";
+    sha256 = "d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265";
     md5 = "";
-    md5name = "60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee-libxml2-2.9.14.tar.xz";
+    md5name = "d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265-libxml2-2.10.2.tar.xz";
   }
   {
     name = "libxslt-1.1.35.tar.xz";
@@ -616,11 +616,11 @@
     md5name = "a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
   }
   {
-    name = "nss-3.79-with-nspr-4.34.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/nss-3.79-with-nspr-4.34.tar.gz";
-    sha256 = "5369ed274a19f480ec94e1faef04da63e3cbac1a82e15bb1751e58b2f274b835";
+    name = "nss-3.83-with-nspr-4.34.1.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/nss-3.83-with-nspr-4.34.1.tar.gz";
+    sha256 = "b1e1198fa7ee4e0fe4fa6937245c94820fd3c3c6897779493858af1bf6310b30";
     md5 = "";
-    md5name = "5369ed274a19f480ec94e1faef04da63e3cbac1a82e15bb1751e58b2f274b835-nss-3.79-with-nspr-4.34.tar.gz";
+    md5name = "b1e1198fa7ee4e0fe4fa6937245c94820fd3c3c6897779493858af1bf6310b30-nss-3.83-with-nspr-4.34.1.tar.gz";
   }
   {
     name = "libodfgen-0.1.8.tar.xz";
@@ -651,11 +651,11 @@
     md5name = "99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34-openldap-2.4.59.tgz";
   }
   {
-    name = "openssl-1.1.1m.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/openssl-1.1.1m.tar.gz";
-    sha256 = "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96";
+    name = "openssl-1.1.1q.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/openssl-1.1.1q.tar.gz";
+    sha256 = "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca";
     md5 = "";
-    md5name = "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96-openssl-1.1.1m.tar.gz";
+    md5name = "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca-openssl-1.1.1q.tar.gz";
   }
   {
     name = "liborcus-0.17.2.tar.bz2";
@@ -700,11 +700,11 @@
     md5name = "49307b510048ccc7bc40f2cba6e8439182fe6e654057c1a1683139bf2ecb1dc1-tiff-4.4.0.tar.xz";
   }
   {
-    name = "poppler-22.01.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/poppler-22.01.0.tar.xz";
-    sha256 = "7d3493056b5b86413e5c693c2cae02c5c06cd8e618d14c2c31e2c84b67b2313e";
+    name = "poppler-22.09.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/poppler-22.09.0.tar.xz";
+    sha256 = "d7a8f748211359cadb774ba3e18ecda6464b34027045c0648eb30d5852a41e2e";
     md5 = "";
-    md5name = "7d3493056b5b86413e5c693c2cae02c5c06cd8e618d14c2c31e2c84b67b2313e-poppler-22.01.0.tar.xz";
+    md5name = "d7a8f748211359cadb774ba3e18ecda6464b34027045c0648eb30d5852a41e2e-poppler-22.09.0.tar.xz";
   }
   {
     name = "poppler-data-0.4.11.tar.gz";
@@ -721,11 +721,11 @@
     md5name = "9b81067a55edbaabc418aacef457dd8477642827499560b00615a6ea6c13f6b3-postgresql-13.5.tar.bz2";
   }
   {
-    name = "Python-3.8.12.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/Python-3.8.12.tar.xz";
-    sha256 = "b1d3a76420375343b5e8a22fceb1ac65b77193e9ed27146524f0a9db058728ea";
+    name = "Python-3.8.14.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/Python-3.8.14.tar.xz";
+    sha256 = "5d77e278271ba803e9909a41a4f3baca006181c93ada682a5e5fe8dc4a24c5f3";
     md5 = "";
-    md5name = "b1d3a76420375343b5e8a22fceb1ac65b77193e9ed27146524f0a9db058728ea-Python-3.8.12.tar.xz";
+    md5name = "5d77e278271ba803e9909a41a4f3baca006181c93ada682a5e5fe8dc4a24c5f3-Python-3.8.14.tar.xz";
   }
   {
     name = "libqxp-0.0.2.tar.xz";
@@ -859,12 +859,5 @@
     sha256 = "653d9e44195d86cf64a36af9ff3a1978ec5599df3882439fefa56e7064f55e8a";
     md5 = "";
     md5name = "653d9e44195d86cf64a36af9ff3a1978ec5599df3882439fefa56e7064f55e8a-zxing-cpp-1.2.0.tar.gz";
-  }
-  {
-    name = "libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
-    sha256 = "471dd83a813ed2816c2246c373004470ad0f6612c7ce72038929dc5161cdd58e";
-    md5 = "";
-    md5name = "471dd83a813ed2816c2246c373004470ad0f6612c7ce72038929dc5161cdd58e-libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
   }
 ]

--- a/pkgs/applications/office/libreoffice/src-fresh/download.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/download.nix
@@ -7,32 +7,18 @@
     md5name = "e763a9dc21c3d2667402d66e202e3f8ef4db51b34b79ef41f56cacb86dcd6eed-libabw-0.1.3.tar.xz";
   }
   {
-    name = "apr-1.5.2.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/apr-1.5.2.tar.gz";
-    sha256 = "1af06e1720a58851d90694a984af18355b65bb0d047be03ec7d659c746d6dbdb";
+    name = "boost_1_79_0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/boost_1_79_0.tar.xz";
+    sha256 = "2058aa88758a0e1aaac1759b3c4bad2526f899c6ecc6eeea79aa5e8fd3ea95dc";
     md5 = "";
-    md5name = "1af06e1720a58851d90694a984af18355b65bb0d047be03ec7d659c746d6dbdb-apr-1.5.2.tar.gz";
+    md5name = "2058aa88758a0e1aaac1759b3c4bad2526f899c6ecc6eeea79aa5e8fd3ea95dc-boost_1_79_0.tar.xz";
   }
   {
-    name = "apr-util-1.5.4.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/apr-util-1.5.4.tar.gz";
-    sha256 = "976a12a59bc286d634a21d7be0841cc74289ea9077aa1af46be19d1a6e844c19";
+    name = "box2d-2.4.1.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/box2d-2.4.1.tar.gz";
+    sha256 = "d6b4650ff897ee1ead27cf77a5933ea197cbeef6705638dd181adc2e816b23c2";
     md5 = "";
-    md5name = "976a12a59bc286d634a21d7be0841cc74289ea9077aa1af46be19d1a6e844c19-apr-util-1.5.4.tar.gz";
-  }
-  {
-    name = "boost_1_77_0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/boost_1_77_0.tar.xz";
-    sha256 = "9b334d6c6d7af5a0687280788cd84444398b8e0b472cd88e52bbc3c3ef11d98e";
-    md5 = "";
-    md5name = "9b334d6c6d7af5a0687280788cd84444398b8e0b472cd88e52bbc3c3ef11d98e-boost_1_77_0.tar.xz";
-  }
-  {
-    name = "box2d-2.3.1.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/box2d-2.3.1.tar.gz";
-    sha256 = "58ffc8475a8650aadc351345aef696937747b40501ab78d72c197c5ff5b3035c";
-    md5 = "";
-    md5name = "58ffc8475a8650aadc351345aef696937747b40501ab78d72c197c5ff5b3035c-box2d-2.3.1.tar.gz";
+    md5name = "d6b4650ff897ee1ead27cf77a5933ea197cbeef6705638dd181adc2e816b23c2-box2d-2.4.1.tar.gz";
   }
   {
     name = "breakpad-b324760c7f53667af128a6b77b790323da04fcb9.tar.xz";
@@ -56,11 +42,11 @@
     md5name = "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269-bzip2-1.0.8.tar.gz";
   }
   {
-    name = "cairo-1.17.4.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/cairo-1.17.4.tar.xz";
-    sha256 = "74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705";
+    name = "cairo-1.17.6.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/cairo-1.17.6.tar.xz";
+    sha256 = "4eebc4c2bad0402bc3f501db184417094657d111fb6c06f076a82ea191fe1faf";
     md5 = "";
-    md5name = "74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705-cairo-1.17.4.tar.xz";
+    md5name = "4eebc4c2bad0402bc3f501db184417094657d111fb6c06f076a82ea191fe1faf-cairo-1.17.6.tar.xz";
   }
   {
     name = "libcdr-0.1.7.tar.xz";
@@ -75,6 +61,13 @@
     sha256 = "ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab";
     md5 = "48d647fbd8ef8889e5a7f422c1bfda94";
     md5name = "48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz";
+  }
+  {
+    name = "dragonbox-1.1.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/dragonbox-1.1.0.tar.gz";
+    sha256 = "293247ccba995ec47ae3abb52c3e83904a7d71efb7093d4c0d2c6367c1cc1e20";
+    md5 = "";
+    md5name = "293247ccba995ec47ae3abb52c3e83904a7d71efb7093d4c0d2c6367c1cc1e20-dragonbox-1.1.0.tar.gz";
   }
   {
     name = "dtoa-20180411.tgz";
@@ -105,18 +98,11 @@
     md5name = "89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7-cppunit-1.15.1.tar.gz";
   }
   {
-    name = "converttexttonumber-1-5-0.oxt";
-    url = "https://dev-www.libreoffice.org/src/1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
-    sha256 = "71b238efd2734be9800af07566daea8d6685aeed28db5eb5fa0e6453f4d85de3";
-    md5 = "1f467e5bb703f12cbbb09d5cf67ecf4a";
-    md5name = "1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
-  }
-  {
-    name = "curl-7.79.1.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/curl-7.79.1.tar.xz";
-    sha256 = "0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689";
+    name = "curl-7.83.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/curl-7.83.1.tar.xz";
+    sha256 = "2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4";
     md5 = "";
-    md5name = "0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689-curl-7.79.1.tar.xz";
+    md5name = "2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4-curl-7.83.1.tar.xz";
   }
   {
     name = "libe-book-0.1.3.tar.xz";
@@ -315,11 +301,11 @@
     md5name = "0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac-libfreehand-0.1.2.tar.xz";
   }
   {
-    name = "freetype-2.11.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/freetype-2.11.0.tar.xz";
-    sha256 = "8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7";
+    name = "freetype-2.11.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/freetype-2.11.1.tar.xz";
+    sha256 = "3333ae7cfda88429c97a7ae63b7d01ab398076c3b67182e960e5684050f2c5c8";
     md5 = "";
-    md5name = "8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7-freetype-2.11.0.tar.xz";
+    md5name = "3333ae7cfda88429c97a7ae63b7d01ab398076c3b67182e960e5684050f2c5c8-freetype-2.11.1.tar.xz";
   }
   {
     name = "glm-0.9.9.8.zip";
@@ -343,11 +329,11 @@
     md5name = "b8e892d8627c41888ff121e921455b9e2d26836978f2359173d19825da62b8fc-graphite2-minimal-1.3.14.tgz";
   }
   {
-    name = "harfbuzz-2.8.2.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/harfbuzz-2.8.2.tar.xz";
-    sha256 = "d58461395ce28b9dc03903254374dd70c38c8c28c5046db123c08f7ab9417be7";
+    name = "harfbuzz-4.3.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/harfbuzz-4.3.0.tar.xz";
+    sha256 = "a49628f4c4c8e6d8df95ef44935a93446cf2e46366915b0e3ca30df21fffb530";
     md5 = "";
-    md5name = "d58461395ce28b9dc03903254374dd70c38c8c28c5046db123c08f7ab9417be7-harfbuzz-2.8.2.tar.xz";
+    md5name = "a49628f4c4c8e6d8df95ef44935a93446cf2e46366915b0e3ca30df21fffb530-harfbuzz-4.3.0.tar.xz";
   }
   {
     name = "hsqldb_1_8_0.zip";
@@ -371,18 +357,18 @@
     md5name = "5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
   }
   {
-    name = "icu4c-70_1-src.tgz";
-    url = "https://dev-www.libreoffice.org/src/icu4c-70_1-src.tgz";
-    sha256 = "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5";
+    name = "icu4c-71_1-src.tgz";
+    url = "https://dev-www.libreoffice.org/src/icu4c-71_1-src.tgz";
+    sha256 = "67a7e6e51f61faf1306b6935333e13b2c48abd8da6d2f46ce6adca24b1e21ebf";
     md5 = "";
-    md5name = "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5-icu4c-70_1-src.tgz";
+    md5name = "67a7e6e51f61faf1306b6935333e13b2c48abd8da6d2f46ce6adca24b1e21ebf-icu4c-71_1-src.tgz";
   }
   {
-    name = "icu4c-70_1-data.zip";
-    url = "https://dev-www.libreoffice.org/src/icu4c-70_1-data.zip";
-    sha256 = "c72723ddba3300ffb231d6b09e2a728ea6e89de10ed5927f74bacbd77042336e";
+    name = "icu4c-71_1-data.zip";
+    url = "https://dev-www.libreoffice.org/src/icu4c-71_1-data.zip";
+    sha256 = "e3882b4fece6e5e039f22c3189b7ba224180fd26fdbfa9db284617455b93e804";
     md5 = "";
-    md5name = "c72723ddba3300ffb231d6b09e2a728ea6e89de10ed5927f74bacbd77042336e-icu4c-70_1-data.zip";
+    md5name = "e3882b4fece6e5e039f22c3189b7ba224180fd26fdbfa9db284617455b93e804-icu4c-71_1-data.zip";
   }
   {
     name = "flow-engine-0.9.4.zip";
@@ -462,11 +448,11 @@
     md5name = "39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip";
   }
   {
-    name = "libjpeg-turbo-2.1.1.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/libjpeg-turbo-2.1.1.tar.gz";
-    sha256 = "20e9cd3e5f517950dfb7a300ad344543d88719c254407ffb5ad88d891bf701c4";
+    name = "libjpeg-turbo-2.1.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libjpeg-turbo-2.1.2.tar.gz";
+    sha256 = "09b96cb8cbff9ea556a9c2d173485fd19488844d55276ed4f42240e1e2073ce5";
     md5 = "";
-    md5name = "20e9cd3e5f517950dfb7a300ad344543d88719c254407ffb5ad88d891bf701c4-libjpeg-turbo-2.1.1.tar.gz";
+    md5name = "09b96cb8cbff9ea556a9c2d173485fd19488844d55276ed4f42240e1e2073ce5-libjpeg-turbo-2.1.2.tar.gz";
   }
   {
     name = "language-subtag-registry-2021-12-29.tar.bz2";
@@ -474,13 +460,6 @@
     sha256 = "d9dcf20be5ad4856daef023087421bedc1477f9b4247fc8ea53bb32e07c97837";
     md5 = "";
     md5name = "d9dcf20be5ad4856daef023087421bedc1477f9b4247fc8ea53bb32e07c97837-language-subtag-registry-2021-12-29.tar.bz2";
-  }
-  {
-    name = "JLanguageTool-1.7.0.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
-    sha256 = "48c87e41636783bba438b65fd895821e369ed139e1465fac654323ad93c5a82d";
-    md5 = "b63e6340a02ff1cacfeadb2c42286161";
-    md5name = "b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
   }
   {
     name = "lcms2-2.12.tar.gz";
@@ -553,18 +532,25 @@
     md5name = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483-ltm-1.0.zip";
   }
   {
-    name = "xmlsec1-1.2.33.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/xmlsec1-1.2.33.tar.gz";
-    sha256 = "26041d35a20a245ed5a2fb9ee075f10825664d274220cb5190340fa87a4d0931";
+    name = "libwebp-1.2.2.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libwebp-1.2.2.tar.gz";
+    sha256 = "7656532f837af5f4cec3ff6bafe552c044dc39bf453587bd5b77450802f4aee6";
     md5 = "";
-    md5name = "26041d35a20a245ed5a2fb9ee075f10825664d274220cb5190340fa87a4d0931-xmlsec1-1.2.33.tar.gz";
+    md5name = "7656532f837af5f4cec3ff6bafe552c044dc39bf453587bd5b77450802f4aee6-libwebp-1.2.2.tar.gz";
   }
   {
-    name = "libxml2-2.9.13.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libxml2-2.9.13.tar.xz";
-    sha256 = "276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e";
+    name = "xmlsec1-1.2.34.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/xmlsec1-1.2.34.tar.gz";
+    sha256 = "52ced4943f35bd7d0818a38298c1528ca4ac8a54440fd71134a07d2d1370a262";
     md5 = "";
-    md5name = "276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e-libxml2-2.9.13.tar.xz";
+    md5name = "52ced4943f35bd7d0818a38298c1528ca4ac8a54440fd71134a07d2d1370a262-xmlsec1-1.2.34.tar.gz";
+  }
+  {
+    name = "libxml2-2.9.14.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libxml2-2.9.14.tar.xz";
+    sha256 = "60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee";
+    md5 = "";
+    md5name = "60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee-libxml2-2.9.14.tar.xz";
   }
   {
     name = "libxslt-1.1.35.tar.xz";
@@ -595,11 +581,11 @@
     md5name = "431434d3926f4bcce2e5c97240609983f60d7ff50df5a72083934759bb863f7b-mariadb-connector-c-3.1.8-src.tar.gz";
   }
   {
-    name = "mdds-2.0.1.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/mdds-2.0.1.tar.bz2";
-    sha256 = "3ab33fce58e6acf9540cc1a52264be6863ef80f55ac287194cc98cda48e71fe6";
+    name = "mdds-2.0.3.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/mdds-2.0.3.tar.bz2";
+    sha256 = "9771fe42e133443c13ca187253763e17c8bc96a1a02aec9e1e8893367ffa9ce5";
     md5 = "";
-    md5name = "3ab33fce58e6acf9540cc1a52264be6863ef80f55ac287194cc98cda48e71fe6-mdds-2.0.1.tar.bz2";
+    md5name = "9771fe42e133443c13ca187253763e17c8bc96a1a02aec9e1e8893367ffa9ce5-mdds-2.0.3.tar.bz2";
   }
   {
     name = "mDNSResponder-878.200.35.tar.gz";
@@ -630,18 +616,11 @@
     md5name = "a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
   }
   {
-    name = "neon-0.31.2.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/neon-0.31.2.tar.gz";
-    sha256 = "cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678";
+    name = "nss-3.79-with-nspr-4.34.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/nss-3.79-with-nspr-4.34.tar.gz";
+    sha256 = "5369ed274a19f480ec94e1faef04da63e3cbac1a82e15bb1751e58b2f274b835";
     md5 = "";
-    md5name = "cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678-neon-0.31.2.tar.gz";
-  }
-  {
-    name = "nss-3.73-with-nspr-4.32.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/nss-3.73-with-nspr-4.32.tar.gz";
-    sha256 = "07a9e5b70f121a62706140d4cacc3006d3efb869da40f3a2bf7a65d37847f4d9";
-    md5 = "";
-    md5name = "07a9e5b70f121a62706140d4cacc3006d3efb869da40f3a2bf7a65d37847f4d9-nss-3.73-with-nspr-4.32.tar.gz";
+    md5name = "5369ed274a19f480ec94e1faef04da63e3cbac1a82e15bb1751e58b2f274b835-nss-3.79-with-nspr-4.34.tar.gz";
   }
   {
     name = "libodfgen-0.1.8.tar.xz";
@@ -672,11 +651,11 @@
     md5name = "99f37d6747d88206c470067eda624d5e48c1011e943ec0ab217bae8712e22f34-openldap-2.4.59.tgz";
   }
   {
-    name = "openssl-1.1.1l.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/openssl-1.1.1l.tar.gz";
-    sha256 = "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1";
+    name = "openssl-1.1.1m.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/openssl-1.1.1m.tar.gz";
+    sha256 = "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96";
     md5 = "";
-    md5name = "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1-openssl-1.1.1l.tar.gz";
+    md5name = "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96-openssl-1.1.1m.tar.gz";
   }
   {
     name = "liborcus-0.17.2.tar.bz2";
@@ -693,11 +672,11 @@
     md5name = "66adacd705a7d19895e08eac46d1e851332adf2e736c566bef1164e7a442519d-libpagemaker-0.0.4.tar.xz";
   }
   {
-    name = "pdfium-4699.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/pdfium-4699.tar.bz2";
-    sha256 = "ee80fe0a3b20ef5c5babc494cd655d1b1a0bdec710acb04524789df500c563bf";
+    name = "pdfium-5058.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/pdfium-5058.tar.bz2";
+    sha256 = "eaf4ce9fad32b5d951c524139df23119b66c67720057defb97acab2dfb2582ac";
     md5 = "";
-    md5name = "ee80fe0a3b20ef5c5babc494cd655d1b1a0bdec710acb04524789df500c563bf-pdfium-4699.tar.bz2";
+    md5name = "eaf4ce9fad32b5d951c524139df23119b66c67720057defb97acab2dfb2582ac-pdfium-5058.tar.bz2";
   }
   {
     name = "pixman-0.40.0.tar.gz";
@@ -714,18 +693,25 @@
     md5name = "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca-libpng-1.6.37.tar.xz";
   }
   {
-    name = "poppler-21.11.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/poppler-21.11.0.tar.xz";
-    sha256 = "31b76b5cac0a48612fdd154c02d9eca01fd38fb8eaa77c1196840ecdeb53a584";
+    name = "tiff-4.4.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/tiff-4.4.0.tar.xz";
+    sha256 = "49307b510048ccc7bc40f2cba6e8439182fe6e654057c1a1683139bf2ecb1dc1";
     md5 = "";
-    md5name = "31b76b5cac0a48612fdd154c02d9eca01fd38fb8eaa77c1196840ecdeb53a584-poppler-21.11.0.tar.xz";
+    md5name = "49307b510048ccc7bc40f2cba6e8439182fe6e654057c1a1683139bf2ecb1dc1-tiff-4.4.0.tar.xz";
   }
   {
-    name = "poppler-data-0.4.10.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/poppler-data-0.4.10.tar.gz";
-    sha256 = "6e2fcef66ec8c44625f94292ccf8af9f1d918b410d5aa69c274ce67387967b30";
+    name = "poppler-22.01.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/poppler-22.01.0.tar.xz";
+    sha256 = "7d3493056b5b86413e5c693c2cae02c5c06cd8e618d14c2c31e2c84b67b2313e";
     md5 = "";
-    md5name = "6e2fcef66ec8c44625f94292ccf8af9f1d918b410d5aa69c274ce67387967b30-poppler-data-0.4.10.tar.gz";
+    md5name = "7d3493056b5b86413e5c693c2cae02c5c06cd8e618d14c2c31e2c84b67b2313e-poppler-22.01.0.tar.xz";
+  }
+  {
+    name = "poppler-data-0.4.11.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/poppler-data-0.4.11.tar.gz";
+    sha256 = "2cec05cd1bb03af98a8b06a1e22f6e6e1a65b1e2f3816cb3069bb0874825f08c";
+    md5 = "";
+    md5name = "2cec05cd1bb03af98a8b06a1e22f6e6e1a65b1e2f3816cb3069bb0874825f08c-poppler-data-0.4.11.tar.gz";
   }
   {
     name = "postgresql-13.5.tar.bz2";
@@ -735,11 +721,11 @@
     md5name = "9b81067a55edbaabc418aacef457dd8477642827499560b00615a6ea6c13f6b3-postgresql-13.5.tar.bz2";
   }
   {
-    name = "Python-3.8.10.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/Python-3.8.10.tar.xz";
-    sha256 = "6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9";
+    name = "Python-3.8.12.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/Python-3.8.12.tar.xz";
+    sha256 = "b1d3a76420375343b5e8a22fceb1ac65b77193e9ed27146524f0a9db058728ea";
     md5 = "";
-    md5name = "6af24a66093dd840bcccf371d4044a3027e655cf24591ce26e48022bc79219d9-Python-3.8.10.tar.xz";
+    md5name = "b1d3a76420375343b5e8a22fceb1ac65b77193e9ed27146524f0a9db058728ea-Python-3.8.12.tar.xz";
   }
   {
     name = "libqxp-0.0.2.tar.xz";
@@ -784,18 +770,11 @@
     md5name = "798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip";
   }
   {
-    name = "serf-1.3.9.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/serf-1.3.9.tar.bz2";
-    sha256 = "549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc";
+    name = "skia-m103-b301ff025004c9cd82816c86c547588e6c24b466.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/skia-m103-b301ff025004c9cd82816c86c547588e6c24b466.tar.xz";
+    sha256 = "c094a6247e44104beaaa0d00c825beb6baf1a8e532dc22214747495317a65bd9";
     md5 = "";
-    md5name = "549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc-serf-1.3.9.tar.bz2";
-  }
-  {
-    name = "skia-m97-a7230803d64ae9d44f4e1282444801119a3ae967.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/skia-m97-a7230803d64ae9d44f4e1282444801119a3ae967.tar.xz";
-    sha256 = "97e859e8467eca9d2441cd23079b61c2c3863b5687620f18cc31a9f966740177";
-    md5 = "";
-    md5name = "97e859e8467eca9d2441cd23079b61c2c3863b5687620f18cc31a9f966740177-skia-m97-a7230803d64ae9d44f4e1282444801119a3ae967.tar.xz";
+    md5name = "c094a6247e44104beaaa0d00c825beb6baf1a8e532dc22214747495317a65bd9-skia-m103-b301ff025004c9cd82816c86c547588e6c24b466.tar.xz";
   }
   {
     name = "libstaroffice-0.0.7.tar.xz";

--- a/pkgs/applications/office/libreoffice/src-fresh/override.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/override.nix
@@ -16,8 +16,7 @@ attrs:
     sed -e '/CPPUNIT_ASSERT_EQUAL(22, nEndRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
   '';
   configureFlags = attrs.configureFlags ++ [
-    (lib.enableFeature kdeIntegration "kf5")
-    "--without-system-zxing"
-    "--without-system-cuckoo"
+    "--without-system-dragonbox"
+    "--without-system-libfixmath"
   ];
 }

--- a/pkgs/applications/office/libreoffice/src-fresh/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/primary.nix
@@ -7,9 +7,9 @@ rec {
   };
 
   major = "7";
-  minor = "3";
-  patch = "3";
-  tweak = "2";
+  minor = "4";
+  patch = "0";
+  tweak = "3";
 
   subdir = "${major}.${minor}.${patch}";
 
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "sha256-7hK9vhYhwg4nRLxbbFlngQ8lpXYLmKxYEtVQqwCWhoU=";
+    hash = "sha256-rMODpDhuHOt0JmovZAbe5LOnhXa9prxxYw9inqIOPBk=";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "sha256-uRsKSC+kLVnhYF85o5FxZuf/dr+o6bYtbu8KmwSzNRw=";
+    sha256 = "sha256-5vxLi0rfbDsj9VXwokXvU1rRdxo4ZIDsFMq3HnAXnYw=";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "sha256-aIY07MuALBVklhJLOUwOxeIQWam2zQCVkw+edvnu/ps=";
+    sha256 = "sha256-qhkilAsXQqgz8078LMImfdWSNjUwdk3P01IRLJsylUc=";
   };
 }

--- a/pkgs/applications/office/libreoffice/src-fresh/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/primary.nix
@@ -8,7 +8,7 @@ rec {
 
   major = "7";
   minor = "4";
-  patch = "0";
+  patch = "2";
   tweak = "3";
 
   subdir = "${major}.${minor}.${patch}";
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    hash = "sha256-rMODpDhuHOt0JmovZAbe5LOnhXa9prxxYw9inqIOPBk=";
+    hash = "sha256-gsH/4C8u2O4UUan2fDUzWyemONtZH5vFOe/4arFN2Vo=";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "sha256-5vxLi0rfbDsj9VXwokXvU1rRdxo4ZIDsFMq3HnAXnYw=";
+    sha256 = "sha256-yAU/hjyVwxqDoHm7Lu/Ztmb/1Z5AxDRAmMBKkkpU9uE=";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "sha256-qhkilAsXQqgz8078LMImfdWSNjUwdk3P01IRLJsylUc=";
+    sha256 = "sha256-T57V3Z2LOUvkQt24b1fLeHRigtiG4Nw1rdNuizQXD1w=";
   };
 }

--- a/pkgs/applications/office/libreoffice/src-still/download.nix
+++ b/pkgs/applications/office/libreoffice/src-still/download.nix
@@ -21,11 +21,11 @@
     md5name = "976a12a59bc286d634a21d7be0841cc74289ea9077aa1af46be19d1a6e844c19-apr-util-1.5.4.tar.gz";
   }
   {
-    name = "boost_1_75_0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/boost_1_75_0.tar.xz";
-    sha256 = "cc378a036a1cfd3af289f3da24deeb8dba7a729f61ab104c7b018a622e22d21b";
+    name = "boost_1_77_0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/boost_1_77_0.tar.xz";
+    sha256 = "9b334d6c6d7af5a0687280788cd84444398b8e0b472cd88e52bbc3c3ef11d98e";
     md5 = "";
-    md5name = "cc378a036a1cfd3af289f3da24deeb8dba7a729f61ab104c7b018a622e22d21b-boost_1_75_0.tar.xz";
+    md5name = "9b334d6c6d7af5a0687280788cd84444398b8e0b472cd88e52bbc3c3ef11d98e-boost_1_77_0.tar.xz";
   }
   {
     name = "box2d-2.3.1.tar.gz";
@@ -56,11 +56,11 @@
     md5name = "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269-bzip2-1.0.8.tar.gz";
   }
   {
-    name = "cairo-1.16.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/cairo-1.16.0.tar.xz";
-    sha256 = "5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331";
+    name = "cairo-1.17.4.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/cairo-1.17.4.tar.xz";
+    sha256 = "74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705";
     md5 = "";
-    md5name = "5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331-cairo-1.16.0.tar.xz";
+    md5name = "74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705-cairo-1.17.4.tar.xz";
   }
   {
     name = "libcdr-0.1.7.tar.xz";
@@ -112,11 +112,11 @@
     md5name = "1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
   }
   {
-    name = "curl-7.79.1.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/curl-7.79.1.tar.xz";
-    sha256 = "0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689";
+    name = "curl-7.83.1.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/curl-7.83.1.tar.xz";
+    sha256 = "2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4";
     md5 = "";
-    md5name = "0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689-curl-7.79.1.tar.xz";
+    md5name = "2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4-curl-7.83.1.tar.xz";
   }
   {
     name = "libe-book-0.1.3.tar.xz";
@@ -126,11 +126,11 @@
     md5name = "7e8d8ff34f27831aca3bc6f9cc532c2f90d2057c778963b884ff3d1e34dfe1f9-libe-book-0.1.3.tar.xz";
   }
   {
-    name = "libepoxy-1.5.3.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libepoxy-1.5.3.tar.xz";
-    sha256 = "002958c5528321edd53440235d3c44e71b5b1e09b9177e8daf677450b6c4433d";
+    name = "libepoxy-1.5.9.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libepoxy-1.5.9.tar.xz";
+    sha256 = "d168a19a6edfdd9977fef1308ccf516079856a4275cf876de688fb7927e365e4";
     md5 = "";
-    md5name = "002958c5528321edd53440235d3c44e71b5b1e09b9177e8daf677450b6c4433d-libepoxy-1.5.3.tar.xz";
+    md5name = "d168a19a6edfdd9977fef1308ccf516079856a4275cf876de688fb7927e365e4-libepoxy-1.5.9.tar.xz";
   }
   {
     name = "epm-3.7.tar.gz";
@@ -168,11 +168,11 @@
     md5name = "acb85cedafa10ce106b1823fb236b1b3e5d942a5741e8f8435cc8ccfec0afe76-Firebird-3.0.7.33374-0.tar.bz2";
   }
   {
-    name = "fontconfig-2.13.91.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/fontconfig-2.13.91.tar.gz";
-    sha256 = "19e5b1bc9d013a52063a44e1307629711f0bfef35b9aca16f9c793971e2eb1e5";
+    name = "fontconfig-2.13.94.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/fontconfig-2.13.94.tar.xz";
+    sha256 = "a5f052cb73fd479ffb7b697980510903b563bbb55b8f7a2b001fcfb94026003c";
     md5 = "";
-    md5name = "19e5b1bc9d013a52063a44e1307629711f0bfef35b9aca16f9c793971e2eb1e5-fontconfig-2.13.91.tar.gz";
+    md5name = "a5f052cb73fd479ffb7b697980510903b563bbb55b8f7a2b001fcfb94026003c-fontconfig-2.13.94.tar.xz";
   }
   {
     name = "crosextrafonts-20130214.tar.gz";
@@ -315,25 +315,25 @@
     md5name = "0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac-libfreehand-0.1.2.tar.xz";
   }
   {
-    name = "freetype-2.9.1.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/freetype-2.9.1.tar.bz2";
-    sha256 = "db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d";
+    name = "freetype-2.11.0.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/freetype-2.11.0.tar.xz";
+    sha256 = "8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7";
     md5 = "";
-    md5name = "db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d-freetype-2.9.1.tar.bz2";
+    md5name = "8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7-freetype-2.11.0.tar.xz";
   }
   {
-    name = "glm-0.9.9.7.zip";
-    url = "https://dev-www.libreoffice.org/src/glm-0.9.9.7.zip";
-    sha256 = "c5e167c042afd2d7ad642ace6b643863baeb33880781983563e1ab68a30d3e95";
+    name = "glm-0.9.9.8.zip";
+    url = "https://dev-www.libreoffice.org/src/glm-0.9.9.8.zip";
+    sha256 = "6bba5f032bed47c73ad9397f2313b9acbfb56253d0d0576b5873d3dcb25e99ad";
     md5 = "";
-    md5name = "c5e167c042afd2d7ad642ace6b643863baeb33880781983563e1ab68a30d3e95-glm-0.9.9.7.zip";
+    md5name = "6bba5f032bed47c73ad9397f2313b9acbfb56253d0d0576b5873d3dcb25e99ad-glm-0.9.9.8.zip";
   }
   {
-    name = "gpgme-1.13.1.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/gpgme-1.13.1.tar.bz2";
-    sha256 = "c4e30b227682374c23cddc7fdb9324a99694d907e79242a25a4deeedb393be46";
+    name = "gpgme-1.16.0.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/gpgme-1.16.0.tar.bz2";
+    sha256 = "6c8cc4aedb10d5d4c905894ba1d850544619ee765606ac43df7405865de29ed0";
     md5 = "";
-    md5name = "c4e30b227682374c23cddc7fdb9324a99694d907e79242a25a4deeedb393be46-gpgme-1.13.1.tar.bz2";
+    md5name = "6c8cc4aedb10d5d4c905894ba1d850544619ee765606ac43df7405865de29ed0-gpgme-1.16.0.tar.bz2";
   }
   {
     name = "graphite2-minimal-1.3.14.tgz";
@@ -343,11 +343,11 @@
     md5name = "b8e892d8627c41888ff121e921455b9e2d26836978f2359173d19825da62b8fc-graphite2-minimal-1.3.14.tgz";
   }
   {
-    name = "harfbuzz-2.6.0.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/harfbuzz-2.6.0.tar.xz";
-    sha256 = "9cf7d117548265f95ca884e2f4c9fafaf4e17d45a67b11107147b79eed76c966";
+    name = "harfbuzz-2.8.2.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/harfbuzz-2.8.2.tar.xz";
+    sha256 = "d58461395ce28b9dc03903254374dd70c38c8c28c5046db123c08f7ab9417be7";
     md5 = "";
-    md5name = "9cf7d117548265f95ca884e2f4c9fafaf4e17d45a67b11107147b79eed76c966-harfbuzz-2.6.0.tar.xz";
+    md5name = "d58461395ce28b9dc03903254374dd70c38c8c28c5046db123c08f7ab9417be7-harfbuzz-2.8.2.tar.xz";
   }
   {
     name = "hsqldb_1_8_0.zip";
@@ -371,18 +371,18 @@
     md5name = "5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
   }
   {
-    name = "icu4c-69_1-src.tgz";
-    url = "https://dev-www.libreoffice.org/src/icu4c-69_1-src.tgz";
-    sha256 = "4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745";
+    name = "icu4c-70_1-src.tgz";
+    url = "https://dev-www.libreoffice.org/src/icu4c-70_1-src.tgz";
+    sha256 = "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5";
     md5 = "";
-    md5name = "4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745-icu4c-69_1-src.tgz";
+    md5name = "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5-icu4c-70_1-src.tgz";
   }
   {
-    name = "icu4c-69_1-data.zip";
-    url = "https://dev-www.libreoffice.org/src/icu4c-69_1-data.zip";
-    sha256 = "4fc2d8cfc3343673123586fca3967404abd4e346fba5515829204533b3bae4bf";
+    name = "icu4c-70_1-data.zip";
+    url = "https://dev-www.libreoffice.org/src/icu4c-70_1-data.zip";
+    sha256 = "c72723ddba3300ffb231d6b09e2a728ea6e89de10ed5927f74bacbd77042336e";
     md5 = "";
-    md5name = "4fc2d8cfc3343673123586fca3967404abd4e346fba5515829204533b3bae4bf-icu4c-69_1-data.zip";
+    md5name = "c72723ddba3300ffb231d6b09e2a728ea6e89de10ed5927f74bacbd77042336e-icu4c-70_1-data.zip";
   }
   {
     name = "flow-engine-0.9.4.zip";
@@ -462,11 +462,11 @@
     md5name = "39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip";
   }
   {
-    name = "libjpeg-turbo-1.5.3.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/libjpeg-turbo-1.5.3.tar.gz";
-    sha256 = "b24890e2bb46e12e72a79f7e965f409f4e16466d00e1dd15d93d73ee6b592523";
+    name = "libjpeg-turbo-2.1.1.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libjpeg-turbo-2.1.1.tar.gz";
+    sha256 = "20e9cd3e5f517950dfb7a300ad344543d88719c254407ffb5ad88d891bf701c4";
     md5 = "";
-    md5name = "b24890e2bb46e12e72a79f7e965f409f4e16466d00e1dd15d93d73ee6b592523-libjpeg-turbo-1.5.3.tar.gz";
+    md5name = "20e9cd3e5f517950dfb7a300ad344543d88719c254407ffb5ad88d891bf701c4-libjpeg-turbo-2.1.1.tar.gz";
   }
   {
     name = "language-subtag-registry-2021-12-29.tar.bz2";
@@ -483,18 +483,18 @@
     md5name = "b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
   }
   {
-    name = "lcms2-2.11.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/lcms2-2.11.tar.gz";
-    sha256 = "dc49b9c8e4d7cdff376040571a722902b682a795bf92985a85b48854c270772e";
+    name = "lcms2-2.12.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/lcms2-2.12.tar.gz";
+    sha256 = "18663985e864100455ac3e507625c438c3710354d85e5cbb7cd4043e11fe10f5";
     md5 = "";
-    md5name = "dc49b9c8e4d7cdff376040571a722902b682a795bf92985a85b48854c270772e-lcms2-2.11.tar.gz";
+    md5name = "18663985e864100455ac3e507625c438c3710354d85e5cbb7cd4043e11fe10f5-lcms2-2.12.tar.gz";
   }
   {
-    name = "libassuan-2.5.3.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/libassuan-2.5.3.tar.bz2";
-    sha256 = "91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702";
+    name = "libassuan-2.5.5.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libassuan-2.5.5.tar.bz2";
+    sha256 = "8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4";
     md5 = "";
-    md5name = "91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702-libassuan-2.5.3.tar.bz2";
+    md5name = "8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4-libassuan-2.5.5.tar.bz2";
   }
   {
     name = "libatomic_ops-7.6.8.tar.gz";
@@ -511,11 +511,11 @@
     md5name = "cf5091fa8e7dcdbe667335eb90a2cfdd0a3fe8f8c7c8d1ece44d9d055736a06a-libeot-0.01.tar.bz2";
   }
   {
-    name = "libexttextcat-3.4.5.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libexttextcat-3.4.5.tar.xz";
-    sha256 = "13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8";
+    name = "libexttextcat-3.4.6.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libexttextcat-3.4.6.tar.xz";
+    sha256 = "6d77eace20e9ea106c1330e268ede70c9a4a89744ddc25715682754eca3368df";
     md5 = "";
-    md5name = "13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8-libexttextcat-3.4.5.tar.xz";
+    md5name = "6d77eace20e9ea106c1330e268ede70c9a4a89744ddc25715682754eca3368df-libexttextcat-3.4.6.tar.xz";
   }
   {
     name = "libffi-3.3.tar.gz";
@@ -525,25 +525,25 @@
     md5name = "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056-libffi-3.3.tar.gz";
   }
   {
-    name = "libgpg-error-1.37.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/libgpg-error-1.37.tar.bz2";
-    sha256 = "b32d6ff72a73cf79797f7f2d039e95e9c6f92f0c1450215410840ab62aea9763";
+    name = "libgpg-error-1.43.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/libgpg-error-1.43.tar.bz2";
+    sha256 = "a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf";
     md5 = "";
-    md5name = "b32d6ff72a73cf79797f7f2d039e95e9c6f92f0c1450215410840ab62aea9763-libgpg-error-1.37.tar.bz2";
+    md5name = "a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf-libgpg-error-1.43.tar.bz2";
   }
   {
-    name = "liblangtag-0.6.2.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/liblangtag-0.6.2.tar.bz2";
-    sha256 = "d6242790324f1432fb0a6fae71b6851f520b2c5a87675497cf8ea14c2924d52e";
+    name = "liblangtag-0.6.3.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/liblangtag-0.6.3.tar.bz2";
+    sha256 = "1f12a20a02ec3a8d22e54dedb8b683a43c9c160bda1ba337bf1060607ae733bd";
     md5 = "";
-    md5name = "d6242790324f1432fb0a6fae71b6851f520b2c5a87675497cf8ea14c2924d52e-liblangtag-0.6.2.tar.bz2";
+    md5name = "1f12a20a02ec3a8d22e54dedb8b683a43c9c160bda1ba337bf1060607ae733bd-liblangtag-0.6.3.tar.bz2";
   }
   {
-    name = "libnumbertext-1.0.7.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libnumbertext-1.0.7.tar.xz";
-    sha256 = "17b8249cb89ae11ae15a85612d2665626c0e0e3e56b35654363ba6566d8b61fc";
+    name = "libnumbertext-1.0.10.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libnumbertext-1.0.10.tar.xz";
+    sha256 = "a285573864eaac8d36a0f66d946e9b1d3cf01c5d93d31fda00264a76f2633beb";
     md5 = "";
-    md5name = "17b8249cb89ae11ae15a85612d2665626c0e0e3e56b35654363ba6566d8b61fc-libnumbertext-1.0.7.tar.xz";
+    md5name = "a285573864eaac8d36a0f66d946e9b1d3cf01c5d93d31fda00264a76f2633beb-libnumbertext-1.0.10.tar.xz";
   }
   {
     name = "ltm-1.0.zip";
@@ -553,18 +553,18 @@
     md5name = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483-ltm-1.0.zip";
   }
   {
-    name = "xmlsec1-1.2.32.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/xmlsec1-1.2.32.tar.gz";
-    sha256 = "e383702853236004e5b08e424b8afe9b53fe9f31aaa7a5382f39d9533eb7c043";
+    name = "xmlsec1-1.2.33.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/xmlsec1-1.2.33.tar.gz";
+    sha256 = "26041d35a20a245ed5a2fb9ee075f10825664d274220cb5190340fa87a4d0931";
     md5 = "";
-    md5name = "e383702853236004e5b08e424b8afe9b53fe9f31aaa7a5382f39d9533eb7c043-xmlsec1-1.2.32.tar.gz";
+    md5name = "26041d35a20a245ed5a2fb9ee075f10825664d274220cb5190340fa87a4d0931-xmlsec1-1.2.33.tar.gz";
   }
   {
-    name = "libxml2-2.9.13.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libxml2-2.9.13.tar.xz";
-    sha256 = "276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e";
+    name = "libxml2-2.9.14.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libxml2-2.9.14.tar.xz";
+    sha256 = "60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee";
     md5 = "";
-    md5name = "276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e-libxml2-2.9.13.tar.xz";
+    md5name = "60d74a257d1ccec0475e749cba2f21559e48139efba6ff28224357c7c798dfee-libxml2-2.9.14.tar.xz";
   }
   {
     name = "libxslt-1.1.35.tar.xz";
@@ -595,11 +595,11 @@
     md5name = "431434d3926f4bcce2e5c97240609983f60d7ff50df5a72083934759bb863f7b-mariadb-connector-c-3.1.8-src.tar.gz";
   }
   {
-    name = "mdds-1.7.0.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/mdds-1.7.0.tar.bz2";
-    sha256 = "a66a2a8293a3abc6cd9baff7c236156e2666935cbfb69a15d64d38141638fecf";
+    name = "mdds-2.0.3.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/mdds-2.0.3.tar.bz2";
+    sha256 = "9771fe42e133443c13ca187253763e17c8bc96a1a02aec9e1e8893367ffa9ce5";
     md5 = "";
-    md5name = "a66a2a8293a3abc6cd9baff7c236156e2666935cbfb69a15d64d38141638fecf-mdds-1.7.0.tar.bz2";
+    md5name = "9771fe42e133443c13ca187253763e17c8bc96a1a02aec9e1e8893367ffa9ce5-mdds-2.0.3.tar.bz2";
   }
   {
     name = "mDNSResponder-878.200.35.tar.gz";
@@ -616,11 +616,11 @@
     md5name = "ef36c1a1aabb2ba3b0bedaaafe717bf4480be2ba8de6f3894be5fd3702b013ba-libmspub-0.1.4.tar.xz";
   }
   {
-    name = "libmwaw-0.3.19.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/libmwaw-0.3.19.tar.xz";
-    sha256 = "b272e234eefc828c4bb8344af0f047a62e070f530e9e2fba11b04c8db8eda5af";
+    name = "libmwaw-0.3.21.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libmwaw-0.3.21.tar.xz";
+    sha256 = "e8750123a78d61b943cef78b7736c8a7f20bb0a649aa112402124fba794fc21c";
     md5 = "";
-    md5name = "b272e234eefc828c4bb8344af0f047a62e070f530e9e2fba11b04c8db8eda5af-libmwaw-0.3.19.tar.xz";
+    md5name = "e8750123a78d61b943cef78b7736c8a7f20bb0a649aa112402124fba794fc21c-libmwaw-0.3.21.tar.xz";
   }
   {
     name = "mythes-1.2.4.tar.gz";
@@ -637,11 +637,11 @@
     md5name = "cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678-neon-0.31.2.tar.gz";
   }
   {
-    name = "nss-3.73-with-nspr-4.32.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/nss-3.73-with-nspr-4.32.tar.gz";
-    sha256 = "07a9e5b70f121a62706140d4cacc3006d3efb869da40f3a2bf7a65d37847f4d9";
+    name = "nss-3.79-with-nspr-4.34.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/nss-3.79-with-nspr-4.34.tar.gz";
+    sha256 = "5369ed274a19f480ec94e1faef04da63e3cbac1a82e15bb1751e58b2f274b835";
     md5 = "";
-    md5name = "07a9e5b70f121a62706140d4cacc3006d3efb869da40f3a2bf7a65d37847f4d9-nss-3.73-with-nspr-4.32.tar.gz";
+    md5name = "5369ed274a19f480ec94e1faef04da63e3cbac1a82e15bb1751e58b2f274b835-nss-3.79-with-nspr-4.34.tar.gz";
   }
   {
     name = "libodfgen-0.1.8.tar.xz";
@@ -679,11 +679,11 @@
     md5name = "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1-openssl-1.1.1l.tar.gz";
   }
   {
-    name = "liborcus-0.16.1.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/liborcus-0.16.1.tar.bz2";
-    sha256 = "c700d1325f744104d9fca0d5a019434901e9d51a16eedfb05792f90a298587a4";
+    name = "liborcus-0.17.2.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/liborcus-0.17.2.tar.bz2";
+    sha256 = "2a86c405a5929f749b27637509596421d46805753364ab258b035fd01fbde143";
     md5 = "";
-    md5name = "c700d1325f744104d9fca0d5a019434901e9d51a16eedfb05792f90a298587a4-liborcus-0.16.1.tar.bz2";
+    md5name = "2a86c405a5929f749b27637509596421d46805753364ab258b035fd01fbde143-liborcus-0.17.2.tar.bz2";
   }
   {
     name = "libpagemaker-0.0.4.tar.xz";
@@ -693,18 +693,18 @@
     md5name = "66adacd705a7d19895e08eac46d1e851332adf2e736c566bef1164e7a442519d-libpagemaker-0.0.4.tar.xz";
   }
   {
-    name = "pdfium-4500.tar.bz2";
-    url = "https://dev-www.libreoffice.org/src/pdfium-4500.tar.bz2";
-    sha256 = "26a03dd60e5ed0979cdaba9cc848242895110ddfdf347d40989ce2f14020f304";
+    name = "pdfium-4699.tar.bz2";
+    url = "https://dev-www.libreoffice.org/src/pdfium-4699.tar.bz2";
+    sha256 = "ee80fe0a3b20ef5c5babc494cd655d1b1a0bdec710acb04524789df500c563bf";
     md5 = "";
-    md5name = "26a03dd60e5ed0979cdaba9cc848242895110ddfdf347d40989ce2f14020f304-pdfium-4500.tar.bz2";
+    md5name = "ee80fe0a3b20ef5c5babc494cd655d1b1a0bdec710acb04524789df500c563bf-pdfium-4699.tar.bz2";
   }
   {
-    name = "pixman-0.34.0.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/e80ebae4da01e77f68744319f01d52a3-pixman-0.34.0.tar.gz";
-    sha256 = "21b6b249b51c6800dc9553b65106e1e37d0e25df942c90531d4c3997aa20a88e";
-    md5 = "e80ebae4da01e77f68744319f01d52a3";
-    md5name = "e80ebae4da01e77f68744319f01d52a3-pixman-0.34.0.tar.gz";
+    name = "pixman-0.40.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/pixman-0.40.0.tar.gz";
+    sha256 = "6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc";
+    md5 = "";
+    md5name = "6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc-pixman-0.40.0.tar.gz";
   }
   {
     name = "libpng-1.6.37.tar.xz";
@@ -791,11 +791,11 @@
     md5name = "549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc-serf-1.3.9.tar.bz2";
   }
   {
-    name = "skia-m90-45c57e116ee0ce214bdf78405a4762722e4507d9.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/skia-m90-45c57e116ee0ce214bdf78405a4762722e4507d9.tar.xz";
-    sha256 = "abe0b94d54edb717c58d74263f4ed3d27824d2ce9e9f2ce85a21ab38d993f94d";
+    name = "skia-m97-a7230803d64ae9d44f4e1282444801119a3ae967.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/skia-m97-a7230803d64ae9d44f4e1282444801119a3ae967.tar.xz";
+    sha256 = "97e859e8467eca9d2441cd23079b61c2c3863b5687620f18cc31a9f966740177";
     md5 = "";
-    md5name = "abe0b94d54edb717c58d74263f4ed3d27824d2ce9e9f2ce85a21ab38d993f94d-skia-m90-45c57e116ee0ce214bdf78405a4762722e4507d9.tar.xz";
+    md5name = "97e859e8467eca9d2441cd23079b61c2c3863b5687620f18cc31a9f966740177-skia-m97-a7230803d64ae9d44f4e1282444801119a3ae967.tar.xz";
   }
   {
     name = "libstaroffice-0.0.7.tar.xz";
@@ -861,11 +861,11 @@
     md5name = "a7983f859eafb2677d7ff386a023bc40-xsltml_2.1.2.zip";
   }
   {
-    name = "zlib-1.2.11.tar.xz";
-    url = "https://dev-www.libreoffice.org/src/zlib-1.2.11.tar.xz";
-    sha256 = "4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066";
+    name = "zlib-1.2.12.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/zlib-1.2.12.tar.xz";
+    sha256 = "7db46b8d7726232a621befaab4a1c870f00a90805511c0e0090441dac57def18";
     md5 = "";
-    md5name = "4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066-zlib-1.2.11.tar.xz";
+    md5name = "7db46b8d7726232a621befaab4a1c870f00a90805511c0e0090441dac57def18-zlib-1.2.12.tar.xz";
   }
   {
     name = "libzmf-0.0.2.tar.xz";
@@ -875,10 +875,17 @@
     md5name = "27051a30cb057fdb5d5de65a1f165c7153dc76e27fe62251cbb86639eb2caf22-libzmf-0.0.2.tar.xz";
   }
   {
-    name = "zxing-cpp-1.1.1.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/zxing-cpp-1.1.1.tar.gz";
-    sha256 = "e595b3fa2ec320beb0b28f6af56b1141853257c2611686685639cebb3b248c86";
+    name = "zxing-cpp-1.2.0.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/zxing-cpp-1.2.0.tar.gz";
+    sha256 = "653d9e44195d86cf64a36af9ff3a1978ec5599df3882439fefa56e7064f55e8a";
     md5 = "";
-    md5name = "e595b3fa2ec320beb0b28f6af56b1141853257c2611686685639cebb3b248c86-zxing-cpp-1.1.1.tar.gz";
+    md5name = "653d9e44195d86cf64a36af9ff3a1978ec5599df3882439fefa56e7064f55e8a-zxing-cpp-1.2.0.tar.gz";
+  }
+  {
+    name = "libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
+    url = "https://dev-www.libreoffice.org/src/libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
+    sha256 = "471dd83a813ed2816c2246c373004470ad0f6612c7ce72038929dc5161cdd58e";
+    md5 = "";
+    md5name = "471dd83a813ed2816c2246c373004470ad0f6612c7ce72038929dc5161cdd58e-libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
   }
 ]

--- a/pkgs/applications/office/libreoffice/src-still/download.nix
+++ b/pkgs/applications/office/libreoffice/src-still/download.nix
@@ -280,11 +280,11 @@
     md5name = "b98b67602a2c8880a1770f0b9e37c190f29a7e2ade5616784f0b89fbdb75bf52-alef-1.001.tar.gz";
   }
   {
-    name = "Amiri-0.111.zip";
-    url = "https://dev-www.libreoffice.org/src/Amiri-0.111.zip";
-    sha256 = "1fbfccced6348b5db2c1c21d5b319cd488e14d055702fa817a0f6cb83d882166";
+    name = "Amiri-0.117.zip";
+    url = "https://dev-www.libreoffice.org/src/Amiri-0.117.zip";
+    sha256 = "9c4e768893e0023a0ad6f488d5c84bd5add6565d3dcadb838ba5b20e75fcc9a7";
     md5 = "";
-    md5name = "1fbfccced6348b5db2c1c21d5b319cd488e14d055702fa817a0f6cb83d882166-Amiri-0.111.zip";
+    md5name = "9c4e768893e0023a0ad6f488d5c84bd5add6565d3dcadb838ba5b20e75fcc9a7-Amiri-0.117.zip";
   }
   {
     name = "ttf-kacst_2.01+mry.tar.gz";
@@ -294,11 +294,11 @@
     md5name = "dca00f5e655f2f217a766faa73a81f542c5c204aa3a47017c3c2be0b31d00a56-ttf-kacst_2.01+mry.tar.gz";
   }
   {
-    name = "ReemKufi-0.7.zip";
-    url = "https://dev-www.libreoffice.org/src/ReemKufi-0.7.zip";
-    sha256 = "f60c6508d209ce4236d2d7324256c2ffddd480be7e3d6023770b93dc391a605f";
+    name = "ReemKufi-1.2.zip";
+    url = "https://dev-www.libreoffice.org/src/ReemKufi-1.2.zip";
+    sha256 = "c4fd68a23c0ea471cc084ae7efe888da372b925cb208eeb0322c26792d2ef413";
     md5 = "";
-    md5name = "f60c6508d209ce4236d2d7324256c2ffddd480be7e3d6023770b93dc391a605f-ReemKufi-0.7.zip";
+    md5name = "c4fd68a23c0ea471cc084ae7efe888da372b925cb208eeb0322c26792d2ef413-ReemKufi-1.2.zip";
   }
   {
     name = "Scheherazade-2.100.zip";
@@ -880,12 +880,5 @@
     sha256 = "653d9e44195d86cf64a36af9ff3a1978ec5599df3882439fefa56e7064f55e8a";
     md5 = "";
     md5name = "653d9e44195d86cf64a36af9ff3a1978ec5599df3882439fefa56e7064f55e8a-zxing-cpp-1.2.0.tar.gz";
-  }
-  {
-    name = "libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
-    url = "https://dev-www.libreoffice.org/src/libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
-    sha256 = "471dd83a813ed2816c2246c373004470ad0f6612c7ce72038929dc5161cdd58e";
-    md5 = "";
-    md5name = "471dd83a813ed2816c2246c373004470ad0f6612c7ce72038929dc5161cdd58e-libcuckoo-93217f8d391718380c508a722ab9acd5e9081233.tar.gz";
   }
 ]

--- a/pkgs/applications/office/libreoffice/src-still/override.nix
+++ b/pkgs/applications/office/libreoffice/src-still/override.nix
@@ -3,46 +3,19 @@ attrs:
 {
   postConfigure = attrs.postConfigure + ''
     sed -e '/CPPUNIT_TEST(Import_Export_Import);/d' -i './sw/qa/inc/swmodeltestbase.hxx'
-    sed -e '/CPPUNIT_ASSERT_EQUAL(11148L, pOleObj->GetLogicRect().getWidth());/d ' -i sc/qa/unit/subsequent_filters-test.cxx
-    sed -e '/CPPUNIT_TEST(testChartImportXLS)/d' -i sc/qa/unit/subsequent_filters-test.cxx
-    sed -e '/CPPUNIT_TEST(testCustomColumnWidthExportXLSX)/d' -i sc/qa/unit/subsequent_export-test.cxx
-    sed -e '/CPPUNIT_TEST(testColumnWidthExportFromODStoXLSX)/d' -i sc/qa/unit/subsequent_export-test.cxx
-    sed -e '/CPPUNIT_TEST(test);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testConditionalFormatExportODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testProtectionKeyODS_UTF16LErtlSHA1);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testProtectionKeyODS_UTF8SHA1);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testProtectionKeyODS_UTF8SHA256ODF12);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testProtectionKeyODS_UTF8SHA256W3C);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testProtectionKeyODS_XL_SHA1);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testColorScaleExportODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testDataBarExportODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testNamedRangeBugfdo62729);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testRichTextExportODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testFormulaRefSheetNameODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testCellValuesExportODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testCellNoteExportODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testFormatExportODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testEmbeddedChartODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testCellAnchoredGroupXLS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testCeilingFloorODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testRelativePathsODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testSheetProtectionODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testSwappedOutImageExport);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testLinkedGraphicRT);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testImageWithSpecialID);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testAbsNamedRangeHTML);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testMoveCellAnchoredShapesODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testRefStringUnspecified);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testHeaderImageODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testTdf88657ODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testExponentWithoutSignFormatXLSX);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testHiddenRepeatedRowsODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
-    sed -e '/CPPUNIT_TEST(testHyperlinkTargetFrameODS);/d' -i './sc/qa/unit/subsequent_export-test.cxx'
+    sed -e '/CPPUNIT_ASSERT(!bRTL);/d' -i './vcl/qa/cppunit/text.cxx'
+
+    sed -e '/CPPUNIT_ASSERT_EQUAL(0, nMinRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
+    sed -e '/CPPUNIT_ASSERT_EQUAL(4, nMinRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
+    sed -e '/CPPUNIT_ASSERT_EQUAL(11, nMinRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
+    sed -e '/CPPUNIT_ASSERT_EQUAL(18, nMinRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
+
+    sed -e '/CPPUNIT_ASSERT_EQUAL(3, nEndRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
+    sed -e '/CPPUNIT_ASSERT_EQUAL(9, nEndRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
+    sed -e '/CPPUNIT_ASSERT_EQUAL(17, nEndRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
+    sed -e '/CPPUNIT_ASSERT_EQUAL(22, nEndRunPos);/d' -i './vcl/qa/cppunit/text.cxx'
   '';
-  configureFlags = attrs.configureFlags ++ [
-    (lib.enableFeature kdeIntegration "kf5")
-    "--without-system-zxing"
-  ];
+  configureFlags = attrs.configureFlags;
 
   patches = attrs.patches or [];
 }

--- a/pkgs/applications/office/libreoffice/src-still/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-still/primary.nix
@@ -8,7 +8,7 @@ rec {
 
   major = "7";
   minor = "3";
-  patch = "5";
+  patch = "6";
   tweak = "2";
 
   subdir = "${major}.${minor}.${patch}";
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    hash = "sha256-mz4Nse4VMzDqBfBBCb2BfbrCID0u7YPvVL5U1MdB6ZE=";
+    hash = "sha256-MwPWr2/7vFg0UFGgCQwTNvi5PEnHhhxlNLzuogWu1aM=";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "sha256-0v6d8U0de78W3Ux/L8kzFiJhnRjKrfYS2TJJb1LhRrI=";
+    sha256 = "sha256-vjthXfBP6vRY3lMBlithJM7b5SX3uvBwEpi30IeW/Dg=";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "sha256-lXHBlT1yl9FY3uiEn35jFbEC+wyvsigGk+YGTvgBPKI=";
+    sha256 = "sha256-b3VvaNEfnytWqJekAWOKokNoCnefXdQgYB7Hpptra0s=";
   };
 }

--- a/pkgs/applications/office/libreoffice/src-still/primary.nix
+++ b/pkgs/applications/office/libreoffice/src-still/primary.nix
@@ -7,8 +7,8 @@ rec {
   };
 
   major = "7";
-  minor = "2";
-  patch = "6";
+  minor = "3";
+  patch = "5";
   tweak = "2";
 
   subdir = "${major}.${minor}.${patch}";
@@ -17,13 +17,13 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "sha256-SDdlqYuS2Q6MjHNeCNM8KjS1/h+8jn9rH5x0rRoUHjE=";
+    hash = "sha256-mz4Nse4VMzDqBfBBCb2BfbrCID0u7YPvVL5U1MdB6ZE=";
   };
 
   # FIXME rename
   translations = fetchSrc {
     name = "translations";
-    sha256 = "sha256-fUZflmrCi4mOa6iZTm+K9IvRTlSjcI4UJ4EoyK/HHck=";
+    sha256 = "sha256-0v6d8U0de78W3Ux/L8kzFiJhnRjKrfYS2TJJb1LhRrI=";
   };
 
   # the "dictionaries" archive is not used for LO build because we already build hunspellDicts packages from
@@ -31,6 +31,6 @@ rec {
 
   help = fetchSrc {
     name = "help";
-    sha256 = "sha256-TjAgz7yV7y5VNrEuT2eElkNGZzh6J58T1TC3u2Ap2o4=";
+    sha256 = "sha256-lXHBlT1yl9FY3uiEn35jFbEC+wyvsigGk+YGTvgBPKI=";
   };
 }


### PR DESCRIPTION
###### Description of changes

Based of PR #187468 

[Release notes](https://wiki.documentfoundation.org/ReleaseNotes/7.4)

Security patch

        https://www.libreoffice.org/about-us/security/advisories/CVE-2022-3140

_Originally posted by @mweinelt in https://github.com/NixOS/nixpkgs/issues/187468#issuecomment-1279616184_
      
included. 

Also did a bit of cleanup for some unused code.

Todo:

- [x] Test `kdeIntegration`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
