### PR TITLE
komikku: init at 1.6.1

### DIFF
--- a/pkgs/applications/misc/komikku/default.nix
+++ b/pkgs/applications/misc/komikku/default.nix
@@ -1,0 +1,103 @@
+{ lib
+, fetchFromGitLab
+, desktop-file-utils
+, gettext
+, glib
+, gobject-introspection
+, gtk4
+, libadwaita
+, libnotify
+, webkitgtk_5_0
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook4
+, nix-update-script
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "komikku";
+  version = "1.9.0";
+
+  format = "other";
+
+  src = fetchFromGitLab {
+    owner = "valos";
+    repo = "Komikku";
+    rev = "v${version}";
+    sha256 = "sha256-UFam3C9jZNuJvTlccyUvhp4z624hPByPhX7cPROv528=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    gettext
+    glib # for glib-compile-resources
+    desktop-file-utils
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+    libnotify
+    webkitgtk_5_0
+    gobject-introspection
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+    beautifulsoup4
+    brotli
+    cloudscraper
+    dateparser
+    emoji
+    keyring
+    lxml
+    python-magic
+    natsort
+    pillow
+    pure-protobuf
+    rarfile
+    unidecode
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+    pytest-steps
+  ];
+
+  # Tests require network
+  doCheck = false;
+
+  # Prevent double wrapping.
+  dontWrapGApps = true;
+
+  preCheck = ''
+    # Step out of Meson’s build directory.
+    cd ..
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+    )
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "komikku";
+    };
+  };
+
+  meta = with lib; {
+    description = "Manga reader for GNOME";
+    homepage = "https://valos.gitlab.io/Komikku/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/pure-protobuf/default.nix
+++ b/pkgs/development/python-modules/pure-protobuf/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, hatchling
+, hatch-vcs
+, toml
+, pytestCheckHook
+, pytest-benchmark
+}:
+
+buildPythonPackage rec {
+  pname = "pure-protobuf";
+  version = "2.2.0";
+
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  # PyPi lacks tests.
+  src = fetchFromGitHub {
+    owner = "eigenein";
+    repo = "protobuf";
+    rev = version;
+    hash = "sha256-9yJlPZzQ/iQcDX2lsuRk4+cMRY7FhqNIcFhgF1FzdEI=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+    hatch-vcs
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-benchmark
+  ];
+
+  # pytest-benchmark currently broken.
+  # https://github.com/ionelmc/pytest-benchmark/issues/226
+  doCheck = false;
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  pythonImportsCheck = [
+    "pure_protobuf"
+  ];
+
+  meta = with lib; {
+    description = "Python implementation of Protocol Buffers with dataclass-based schemas";
+    homepage = "https://github.com/eigenein/protobuf";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-harvest/default.nix
+++ b/pkgs/development/python-modules/pytest-harvest/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, decopatch
+, makefun
+, setuptools-scm
+, pytest
+, pytestCheckHook
+, pytest-cases
+, pandas
+, tabulate
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-harvest";
+  version = "1.10.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "+A1ylYw0lRHOtf+oolphZtHsarz93CNpBAjzG5ancSQ=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    decopatch
+    makefun
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-cases
+    pandas
+    tabulate
+  ];
+
+  pythonImportsCheck = [
+    "pytest_harvest"
+  ];
+
+  postPatch = ''
+    # Not actually needed?
+    substituteInPlace setup.cfg \
+      --replace "pytest-runner" ""
+
+    # Defining 'pytest_plugins' in a non-top-level conftest is no longer supported.
+    # https://github.com/smarie/python-pytest-harvest/pull/62
+    mv pytest_harvest/tests/conftest.py .
+  '';
+
+  meta = with lib; {
+    description = "Library for creating step-wise/incremental tests in pytest";
+    homepage = "https://github.com/smarie/python-pytest-harvest";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-steps/default.nix
+++ b/pkgs/development/python-modules/pytest-steps/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, makefun
+, wrapt
+, setuptools-scm
+, pytest
+, pytestCheckHook
+, pytest-cases
+, pytest-harvest
+, pandas
+, tabulate
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-steps";
+  version = "1.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hDfvTS9o8MY3RDRdkqQ3ttdlFuHNMP1kUqHFA5kIhc=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    makefun
+    wrapt
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-cases
+    pytest-harvest
+    pandas
+    tabulate
+  ];
+
+  pythonImportsCheck = [
+    "pytest_steps"
+  ];
+
+  postPatch = ''
+    # Not actually needed?
+    substituteInPlace setup.cfg \
+      --replace "pytest-runner" ""
+
+    # Defining 'pytest_plugins' in a non-top-level conftest is no longer supported.
+    # https://github.com/smarie/python-pytest-steps/pull/54
+    mv pytest_steps/tests/conftest.py .
+  '';
+
+  meta = with lib; {
+    description = "Library for creating step-wise/incremental tests in pytest";
+    homepage = "https://github.com/smarie/python-pytest-steps";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37278,6 +37278,8 @@ with pkgs;
 
   kmon = callPackage ../tools/system/kmon { };
 
+  komikku = callPackage ../applications/misc/komikku { };
+
   kompose = callPackage ../applications/networking/cluster/kompose { };
 
   kompute = callPackage ../development/libraries/kompute { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7572,6 +7572,8 @@ self: super: with self; {
 
   pure-pcapy3 = callPackage ../development/python-modules/pure-pcapy3 { };
 
+  pure-protobuf = callPackage ../development/python-modules/pure-protobuf { };
+
   purepng = callPackage ../development/python-modules/purepng { };
 
   pure-python-adb = callPackage ../development/python-modules/pure-python-adb { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8978,6 +8978,8 @@ self: super: with self; {
 
   pytest-golden = callPackage ../development/python-modules/pytest-golden { };
 
+  pytest-harvest = callPackage ../development/python-modules/pytest-harvest { };
+
   pytest-helpers-namespace = callPackage ../development/python-modules/pytest-helpers-namespace { };
 
   pytest-html = callPackage ../development/python-modules/pytest-html { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9062,6 +9062,8 @@ self: super: with self; {
     sanic = self.sanic.override { doCheck = false; };
   };
 
+  pytest-steps = callPackage ../development/python-modules/pytest-steps { };
+
   pytest-server-fixtures = callPackage ../development/python-modules/pytest-server-fixtures { };
 
   pytest-services = callPackage ../development/python-modules/pytest-services { };


### PR DESCRIPTION
###### Description of changes

https://valos.gitlab.io/Komikku/

A manga reader for GNOME.

Works now but needs a maintainer.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
