### PR TITLE
igh-ethercat: init at 1.5

### DIFF
--- a/pkgs/os-specific/linux/igh-ethercat-master/default.nix
+++ b/pkgs/os-specific/linux/igh-ethercat-master/default.nix
@@ -1,0 +1,74 @@
+{ lib, stdenv, fetchFromGitLab, autoconf, automake, pkg-config, libtool, kmod, iproute2, kernel }:
+
+stdenv.mkDerivation {
+  pname = "igh-ethercat-master";
+  version = "unstable-2022-11-02-${kernel.modDirVersion}";
+
+  src = fetchFromGitLab {
+    owner = "etherlab.org";
+    repo = "ethercat";
+    rev = "2e2cef6131895336f87c57c18fe78ae01a90d3de";
+    sha256 = "sha256-f60MWcbmOGe1Zflig9gxd52HVD8hyJ9AdopCUbsfecg=";
+  };
+
+  nativeBuildInputs = [ autoconf automake pkg-config libtool ] ++ kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "all"
+    "modules"
+  ];
+
+  patches = [
+    ./ethercatctl.in.patch
+  ];
+
+  postPatch = ''
+    # Patch paths in ethercatctl script template
+    sed -i script/ethercatctl.in \
+      -e 's#LSMOD=/sbin/lsmod#LSMOD=${kmod}/bin/lsmod#' \
+      -e 's#MODPROBE=/sbin/modprobe#LSMOD=${kmod}/bin/modprobe#' \
+      -e 's#RMMOD=/sbin/rmmod#LSMOD=${kmod}/bin/rmmod#' \
+      -e 's#MODINFO=/sbin/modinfo#LSMOD=${kmod}/bin/modinfo#' \
+      -e 's#IP=/bin/ip#LSMOD=${iproute2}/bin/ip#'
+  '';
+
+  preConfigure = ''
+    bash ./bootstrap
+  '';
+
+  configureFlags = [
+    "--with-linux-dir=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build/"
+    "--disable-8139too"
+    "--disable-e100"
+    "--disable-e1000"
+    "--disable-e1000e"
+    "--disable-r8169"
+    "--disable-igb"
+    "--enable-ccat"
+  ];
+
+  postConfigure = ''
+    # Copy configured build directory, to use with erhetcat-rs (https://github.com/ethercat-rs/ethercat)
+    mkdir -p $out/build/
+    cp -r * $out/build/
+  '';
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d/
+    echo KERNEL=\"EtherCAT[0-9]*\", MODE=\"0664\" > $out/etc/udev/rules.d/99-EtherCAT.rules
+
+    mv $out/etc/ $out/templates/
+
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/misc/
+    cp devices/ec_generic.ko $out/lib/modules/${kernel.modDirVersion}/misc/
+    cp master/ec_master.ko $out/lib/modules/${kernel.modDirVersion}/misc/
+  '';
+
+  meta = with lib; {
+    description = "IgH EtherCAT Master for Linux";
+    homepage = "https://gitlab.com/etherlab.org/ethercat";
+    license = licenses.lgpl21Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.simonkampe ];
+  };
+}

--- a/pkgs/os-specific/linux/igh-ethercat-master/ethercatctl.in.patch
+++ b/pkgs/os-specific/linux/igh-ethercat-master/ethercatctl.in.patch
@@ -1,0 +1,14 @@
+diff --git a/script/ethercatctl.in b/script/ethercatctl.in
+index 2da6e95b..9eda1dd5 100755
+--- a/script/ethercatctl.in
++++ b/script/ethercatctl.in
+@@ -41,7 +41,7 @@ ETHERCAT=@bindir@/ethercat
+
+ #------------------------------------------------------------------------------
+
+-ETHERCAT_CONFIG=@sysconfdir@/ethercat.conf
++ETHERCAT_CONFIG=/etc/ethercat/ethercat.conf
+
+ if [ ! -r ${ETHERCAT_CONFIG} ]; then
+     echo ${ETHERCAT_CONFIG} not existing;
+

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -324,6 +324,8 @@ in {
 
     e1000e = if lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;
 
+    igh-ethercat-master = callPackage ../os-specific/linux/igh-ethercat-master { };
+
     intel-speed-select = if lib.versionAtLeast kernel.version "5.3" then callPackage ../os-specific/linux/intel-speed-select { } else null;
 
     ixgbevf = callPackage ../os-specific/linux/ixgbevf {};


### PR DESCRIPTION
###### Description of changes

This will add the tools and kernel modules for the IgH Ethernet Master for Linux (https://etherlab.org/en/ethercat/)

```
# To get both the tools and the modules:

boot.extraModulePackages = [ config.boot.kernelPackages.igh-ethercat-master ];

environment.systemPackages = with pkgs; [
    config.boot.kernelPackages.igh-ethercat-master
  ];
```

Is this the correct way or should the tools and modules be added separately? The tooling binaries still need the correct kernel headers to build.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
