### PR TITLE
glibc: Don't inject CoreFoundation RUNPATH on Darwin

### DIFF
--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -38,6 +38,9 @@ callPackage ./common.nix { inherit stdenv; } {
 
       # Apparently --bindir is not respected.
       makeFlagsArray+=("bindir=$bin/bin" "sbindir=$bin/sbin" "rootsbindir=$bin/sbin")
+    '' + lib.optionalString stdenv.buildPlatform.isDarwin ''
+      # ld-wrapper will otherwise attempt to inject CoreFoundation into ld-linux's RUNPATH
+      export NIX_COREFOUNDATION_RPATH=
     '';
 
     # The pie, stackprotector and fortify hardening flags are autodetected by


### PR DESCRIPTION
###### Description of changes

ld-wrapper will otherwise attempt to inject CoreFoundation into ld-linux's RUNPATH:

```console
[macos:nixpkgs]$ nix-build -E 'with import ./. {}; pkgsCross.aarch64-multiplatform.stdenv.cc.libc.overrideAttrs (_: { dontPatchELF = 1; })'
/nix/store/rk7m7bhka5lsn9snp2zqnmpsc1bs00sy-glibc-aarch64-unknown-linux-gnu-2.35-163
[macos:nixpkgs]$ readelf -a result/lib/ld-linux-aarch64.so.1 | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [/nix/store/9rb5qaba71mkgfgd8wfqg03cmi46xarg-apple-framework-CoreFoundation-11.0.0/Library/Frameworks]
[linux:nixpkgs]$ /nix/store/rk7m7bhka5lsn9snp2zqnmpsc1bs00sy-glibc-aarch64-unknown-linux-gnu-2.35-163/lib/
ld-linux-aarch64.so.1 
Inconsistency detected by ld.so: ./get-dynamic-info.h: 118: elf_get_dynamic_info: Assertion `info[DT_RUNPATH] == NULL' failed!
```

Without `dontPatchELF = 1` the RUNPATH will become empty but still breaks rtld.

Ref: #137877

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (for aarch64-linux)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
