### PR TITLE
Debug libfreefare on arm

### DIFF
--- a/pkgs/development/libraries/libfreefare/0001-check-defines.patch
+++ b/pkgs/development/libraries/libfreefare/0001-check-defines.patch
@@ -1,0 +1,36 @@
+From c215658683598eded810fc30d32af130bffe27f7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Stanis=C5=82aw=20Pitucha?= <stan.pitucha@envato.com>
+Date: Tue, 18 Oct 2022 20:56:54 +1100
+Subject: [PATCH] check defines
+
+---
+ libfreefare/freefare_internal.h | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/libfreefare/freefare_internal.h b/libfreefare/freefare_internal.h
+index 26910ed..f313740 100644
+--- a/libfreefare/freefare_internal.h
++++ b/libfreefare/freefare_internal.h
+@@ -41,6 +41,19 @@
+     #define htole32(x) CFSwapInt32HostToLittle(x)
+ #endif
+ 
++#pragma GCC warning "def:"
++#if defined(le16toh)
++#pragma GCC warning "true"
++#else
++#pragma GCC warning "false"
++#endif
++
++#pragma GCC warning "head:"
++#if defined(HAVE_COREFOUNDATION_COREFOUNDATION_H)
++#pragma GCC warning "true"
++#else
++#pragma GCC warning "false"
++#endif
+ #if !defined(le16toh) && defined(HAVE_COREFOUNDATION_COREFOUNDATION_H)
+     #define be16toh(x) CFSwapInt16BigToHost(x)
+     #define htobe16(x) CFSwapInt16HostToBig(x)
+-- 
+2.36.2
+

--- a/pkgs/development/libraries/libfreefare/default.nix
+++ b/pkgs/development/libraries/libfreefare/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation {
     sha256 = "0r5wfvwgf35lb1v65wavnwz2wlfyfdims6a9xpslf4lsm4a1v8xz";
   };
 
+  patches = [
+    ./0001-check-defines.patch
+  ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libnfc openssl ] ++ lib.optionals stdenv.isDarwin [ libobjc IOKit Security ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
