### PR TITLE
tflint-plugins.tflint-ruleset-aws: init, add tflint.withPlugins

### DIFF
--- a/pkgs/development/tools/analysis/tflint-plugins/default.nix
+++ b/pkgs/development/tools/analysis/tflint-plugins/default.nix
@@ -1,0 +1,3 @@
+{ callPackage, ... }: {
+  tflint-ruleset-aws = callPackage ./tflint-ruleset-aws.nix { };
+}

--- a/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-aws.nix
+++ b/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-aws.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "tflint-ruleset-aws";
+  version = "0.17.1";
+
+  src = fetchFromGitHub {
+    owner = "terraform-linters";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-2Qr+tG1cmDF9MdsLMOnIdSGWMVAYYVgobE/SuJZRqJg=";
+  };
+
+  vendorHash = "sha256-P3yqDqVoC6XCX5OJ8kTvIk6Qq8X02Be51TajIkZxdbI=";
+
+  # upstream Makefile also does a  go test $(go list ./... | grep -v integration)
+  preCheck = ''
+    rm integration/integration_test.go
+  '';
+
+  postInstall = ''
+    mkdir -p $out/github.com/terraform-linters/${pname}/${version}
+    mv $out/bin/${pname} $out/github.com/terraform-linters/${pname}/${version}/
+    # remove other binaries from bin
+    rm -R $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/terraform-linters/tflint-ruleset-aws";
+    description = "TFLint ruleset plugin for Terraform AWS Provider";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ flokli ];
+    license = with licenses; [ mpl20 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17630,6 +17630,10 @@ with pkgs;
 
   tflint = callPackage ../development/tools/analysis/tflint { };
 
+  tflint-plugins = recurseIntoAttrs (
+    callPackage ../development/tools/analysis/tflint-plugins { }
+  );
+
   tfsec = callPackage ../development/tools/analysis/tfsec { };
 
   todoist = callPackage ../applications/misc/todoist { };


### PR DESCRIPTION
###### Description of changes
When using `tflint` with plugins, it normally requires you to run `tflint --init`, and will then populate `~/.tflint.d` (or `TFLINT_PLUGIN_DIR`) with plugins it downloads.

This PR packages `tflint-plugins.tflint-ruleset-aws`, and adds a `tflint.withPlugins` helper, so you can manage these plugins declaratively:

```
tflint.withPlugins (tp: [
  tp.tflint-ruleset-aws
])
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
