### PR TITLE
ocamlPackages.tezos-bls12-381-polynomial: init at 0.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/tezos-bls12-381-polynomial/default.nix
+++ b/pkgs/development/ocaml-modules/tezos-bls12-381-polynomial/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitLab,
+  buildDunePackage,
+  bls12-381,
+  data-encoding,
+  alcotest,
+  alcotest-lwt,
+  bisect_ppx,
+  qcheck-alcotest,
+}:
+
+buildDunePackage rec {
+  pname = "tezos-bls12-381-polynomial";
+  version = "0.1.2";
+  duneVersion = "3";
+  src = fetchFromGitLab {
+    owner = "nomadic-labs/cryptography";
+    repo = "privacy-team";
+    rev = "v${version}";
+    sha256 = "sha256-HVeKZCPBRJWQXkcI2J7Fl4qGviYLD5x+4W4pAY/W4jA=";
+  };
+
+  propagatedBuildInputs = [bls12-381 data-encoding];
+
+  checkInputs = [alcotest alcotest-lwt bisect_ppx qcheck-alcotest];
+
+  doCheck = false; # circular dependencies
+
+  meta = {
+    description = "Polynomials over BLS12-381 finite field";
+    license = lib.licenses.mit;
+    homepage = "https://gitlab.com/nomadic-labs/privacy-team";
+    maintainers = [lib.maintainers.ulrikstrid];
+  };
+}

--- a/pkgs/development/ocaml-modules/tezos-bls12-381-polynomial/plompiler.nix
+++ b/pkgs/development/ocaml-modules/tezos-bls12-381-polynomial/plompiler.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildDunePackage
+, hacl-star
+, bls12-381
+, tezos-bls12-381-polynomial
+, data-encoding
+, hex
+, stdint
+, ff
+, mec
+, alcotest
+, qcheck-alcotest
+, bisect_ppx
+}:
+
+buildDunePackage rec {
+  pname = "tezos-plompiler";
+  duneVersion = "3";
+
+  inherit (tezos-bls12-381-polynomial) version src;
+
+  propagatedBuildInputs = [
+    hacl-star
+    bls12-381
+    tezos-bls12-381-polynomial
+    data-encoding
+    hex
+    stdint
+    ff
+    mec
+  ];
+
+  checkInputs = [ alcotest qcheck-alcotest bisect_ppx ];
+
+  doCheck = false; # circular deps
+
+  meta = tezos-bls12-381-polynomial.meta // {
+    description = "Library to write arithmetic circuits for Plonk";
+  };
+}

--- a/pkgs/development/ocaml-modules/tezos-bls12-381-polynomial/plonk.nix
+++ b/pkgs/development/ocaml-modules/tezos-bls12-381-polynomial/plonk.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildDunePackage,
+  hacl-star,
+  bls12-381,
+  tezos-bls12-381-polynomial,
+  data-encoding,
+  tezos-plompiler,
+  alcotest,
+  qcheck-alcotest,
+  bisect_ppx,
+}:
+
+buildDunePackage rec {
+  pname = "tezos-plonk";
+  duneVersion = "3";
+
+  inherit (tezos-bls12-381-polynomial) version src;
+
+  propagatedBuildInputs = [
+    hacl-star
+    bls12-381
+    tezos-bls12-381-polynomial
+    data-encoding
+    tezos-plompiler
+  ];
+
+  checkInputs = [ alcotest qcheck-alcotest bisect_ppx ];
+
+  doCheck = false; # broken
+
+  meta = tezos-bls12-381-polynomial.meta // {
+    description = "Plonk zero-knowledge proving system";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1440,6 +1440,12 @@ let
 
     tezos-base58 = callPackage ../development/ocaml-modules/tezos-base58 { };
 
+    tezos-bls12-381-polynomial = callPackage ../development/ocaml-modules/tezos-bls12-381-polynomial { };
+
+    tezos-plompiler = callPackage ../development/ocaml-modules/tezos-bls12-381-polynomial/plompiler.nix { };
+
+    tezos-plonk = callPackage ../development/ocaml-modules/tezos-bls12-381-polynomial/plonk.nix { };
+
     theora = callPackage ../development/ocaml-modules/theora { };
 
     toml = callPackage ../development/ocaml-modules/toml { };


### PR DESCRIPTION
###### Description of changes

Broken out of #195344

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
