### PR TITLE
libharu: 2.4.0 -> 2.4.3

### DIFF
--- a/pkgs/development/libraries/libharu/default.nix
+++ b/pkgs/development/libraries/libharu/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libharu";
-  version = "2.4.0";
+  version = "2.4.3";
 
   src = fetchFromGitHub {
     owner = "libharu";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-85o9pb2zJVYbM0SHxCNgJuDkcsHuFuwFe6B6xivoUUg=";
+    hash = "sha256-v8eD1ZEFQFA7ceWOgOmq7hP0ZMPfxjdAp7ov4PBPaAE=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Description of changes

Fixes an issue where 2.4.0 fails to install the shared library:
```
➜  nixpkgs git:(libharu-fix-lib) ✗ ls -la /nix/store/s09kh33f9r7jndifip8j8r0rqqfj3rm6-libharu-2.4.0 
total 20
dr-xr-xr-x. 1 viraptor viraptor       76 Jan  1  1970 .
drwxrwxr-t. 1 viraptor viraptor 10556748 Oct 19 01:09 ..
dr-xr-xr-x. 1 viraptor viraptor       88 Jan  1  1970 bindings
-r--r--r--. 1 viraptor viraptor     6052 Jan  1  1970 CHANGES
dr-xr-xr-x. 1 viraptor viraptor      838 Jan  1  1970 include
-r--r--r--. 1 viraptor viraptor      337 Jan  1  1970 INSTALL
-r--r--r--. 1 viraptor viraptor     5029 Jan  1  1970 README.md
➜  nixpkgs git:(libharu-fix-lib) ✗ ls -la /nix/store/6ccdmbdhzjw4djavjxdwqdak02s5ba5i-libharu-2.4.3 
total 0
dr-xr-xr-x. 1 viraptor viraptor       30 Jan  1  1970 .
drwxrwxr-t. 1 viraptor viraptor 10556748 Oct 19 01:09 ..
dr-xr-xr-x. 1 viraptor viraptor      838 Jan  1  1970 include
dr-xr-xr-x. 1 viraptor viraptor       20 Jan  1  1970 lib
dr-xr-xr-x. 1 viraptor viraptor       14 Jan  1  1970 share
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
