### PR TITLE
plasma5: 5.26.0 -> 5.26.1

### DIFF
--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.26.0/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.26.1/ -A '*.tar.xz' )

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -4,467 +4,467 @@
 
 {
   aura-browser = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/aura-browser-5.26.0.tar.xz";
-      sha256 = "1r43p7jjmsjhav6b3zdk9lx8cg56dapxd6sh2c6cwc1xy8pmvpm9";
-      name = "aura-browser-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/aura-browser-5.26.1.tar.xz";
+      sha256 = "16phw9v5xa9ywf549l3biqmjq47x6dr2myvf0qjpfzf1wv0vgk3q";
+      name = "aura-browser-5.26.1.tar.xz";
     };
   };
   bluedevil = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/bluedevil-5.26.0.tar.xz";
-      sha256 = "1br3vj7xxgzzc82fw1qq1zqk9gcpl5dpmlz61lqq87wnjhqb6xdj";
-      name = "bluedevil-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/bluedevil-5.26.1.tar.xz";
+      sha256 = "0s7j76q0fzvpy7qaaclxw5bzwfyjzh0gg6wsm0kjbpfcr09mnl64";
+      name = "bluedevil-5.26.1.tar.xz";
     };
   };
   breeze = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/breeze-5.26.0.tar.xz";
-      sha256 = "0z2371bwv7m1zhlgby8vjvx5qblpf94281p5l3qa22ws0k4jgv8i";
-      name = "breeze-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/breeze-5.26.1.tar.xz";
+      sha256 = "0l38wyjgmz9a3iyg8n96l8s0qa22bwv3mla1dwjk5kx4mdayq3wv";
+      name = "breeze-5.26.1.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/breeze-grub-5.26.0.tar.xz";
-      sha256 = "12fpxnddcvig9zgj3knjkarl4y2kywgqg60cdjj3shsk2q6q2lh0";
-      name = "breeze-grub-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/breeze-grub-5.26.1.tar.xz";
+      sha256 = "0640g2g8pwsvqaypvv33s25lxxymc2gvciw9l7hdjbgfci0v5vf0";
+      name = "breeze-grub-5.26.1.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/breeze-gtk-5.26.0.tar.xz";
-      sha256 = "1q3lf5sj9f0fx4ahdffd16m0ak4q742b6zpw6crvz4cymh3n9fy8";
-      name = "breeze-gtk-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/breeze-gtk-5.26.1.tar.xz";
+      sha256 = "1ppvp6ji9mzz2wd3im12zagj1ak300psrgngjy5zzmrqspnfdny6";
+      name = "breeze-gtk-5.26.1.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/breeze-plymouth-5.26.0.tar.xz";
-      sha256 = "04xhdy89p83p8dhhs40hkp2xlpj20j4l2dwiry9qaqd1yk331gz8";
-      name = "breeze-plymouth-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/breeze-plymouth-5.26.1.tar.xz";
+      sha256 = "0cg2q94jqnp6n85hsdyz2r743gk5vnb8mfqjfdyrdim7ma9w83wp";
+      name = "breeze-plymouth-5.26.1.tar.xz";
     };
   };
   discover = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/discover-5.26.0.tar.xz";
-      sha256 = "0w7i9w5y1ybd1qzzx1psgf97960bdjkbdr1p90jymqwflcr5yjyz";
-      name = "discover-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/discover-5.26.1.tar.xz";
+      sha256 = "0whsgyx00bq37sfi46r350c39p54yc5qxsrz91bv2dmkp897m82a";
+      name = "discover-5.26.1.tar.xz";
     };
   };
   drkonqi = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/drkonqi-5.26.0.tar.xz";
-      sha256 = "01zsyy4v6ss3iflman0p3m3cq3ckbwjd6928frdvdlvc5w35zrj1";
-      name = "drkonqi-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/drkonqi-5.26.1.tar.xz";
+      sha256 = "1xq39458a2pg32pm3niv2c8jh7jr9gx8fi60zfg22lqsl0xicxis";
+      name = "drkonqi-5.26.1.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kactivitymanagerd-5.26.0.tar.xz";
-      sha256 = "1l8dncc2ijwg5vxd0l05fd2x3ssbvnhk5m4hhy6k84xaxjvinqnj";
-      name = "kactivitymanagerd-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kactivitymanagerd-5.26.1.tar.xz";
+      sha256 = "1a2pqaicg1zd0cbr94ipjb0bbcrvpbg4jcvd7f061yh14agh32mq";
+      name = "kactivitymanagerd-5.26.1.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kde-cli-tools-5.26.0.tar.xz";
-      sha256 = "0w4nx2zdwaaqhm7xrqh0s5p2yp0wjwj0svyr396z8lapimgjn80l";
-      name = "kde-cli-tools-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kde-cli-tools-5.26.1.tar.xz";
+      sha256 = "0n0dzi7g8jkk2rmcp4z9jyj5s321kfdaacmqr5hffj8f5mz0hrjs";
+      name = "kde-cli-tools-5.26.1.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kde-gtk-config-5.26.0.tar.xz";
-      sha256 = "0yffhbrkh204ma8pv11256hn290gml4pmhgplygpwbn7ir9ir72p";
-      name = "kde-gtk-config-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kde-gtk-config-5.26.1.tar.xz";
+      sha256 = "1zy0ddfzkmd9z0ahkvbvxl3gz5k620digfqk7a1pfq1cqc3mypln";
+      name = "kde-gtk-config-5.26.1.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kdecoration-5.26.0.tar.xz";
-      sha256 = "0cd67mmqriqcx1xvkx7s1zz01y6gc614g0qv6i2ybd6p5r2f3qcb";
-      name = "kdecoration-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kdecoration-5.26.1.tar.xz";
+      sha256 = "0jw5xsl9vipirj864015xv0pj7szg4ppn10ppmmym8h5h4gi5k41";
+      name = "kdecoration-5.26.1.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kdeplasma-addons-5.26.0.tar.xz";
-      sha256 = "1nfnvbm27rb2sljg01m4s61yqz7pw4h7z5zjp2n1x6l1gmbsbh1h";
-      name = "kdeplasma-addons-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kdeplasma-addons-5.26.1.tar.xz";
+      sha256 = "1209s0hlr6vpdivg9iixh2dnl3wydz0xi0wjzh64a0niq8vi11an";
+      name = "kdeplasma-addons-5.26.1.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kgamma5-5.26.0.tar.xz";
-      sha256 = "117pwi6ykyhkp7vfpvgxz158m4a76b75mkynichn0b5k3q8svy4h";
-      name = "kgamma5-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kgamma5-5.26.1.tar.xz";
+      sha256 = "1kvzh3izz0rr7nc7vhyvwamdmxzlnf8kdyaf0yzqin0h953y1pix";
+      name = "kgamma5-5.26.1.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/khotkeys-5.26.0.tar.xz";
-      sha256 = "02inmqfrsp3w3pig45m3ay544vhdhmrx0alf36van561w76kkdc5";
-      name = "khotkeys-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/khotkeys-5.26.1.tar.xz";
+      sha256 = "0ypjrbjrbi1g9dj4mwrw712xzar20263wprsh3ih19kazpd1ihgn";
+      name = "khotkeys-5.26.1.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kinfocenter-5.26.0.tar.xz";
-      sha256 = "0nif06xsf7nmgyb3d1navz3vykw88xk88fzgqnax001cmrmiph82";
-      name = "kinfocenter-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kinfocenter-5.26.1.tar.xz";
+      sha256 = "0prl6z9b3nna13ynkh87w4rfv4j9pw0scsgknwninq55pgjx5hy0";
+      name = "kinfocenter-5.26.1.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kmenuedit-5.26.0.tar.xz";
-      sha256 = "1cfinj96la1c4nkz885lfybk5fw8z8d42yshb3nks66r528xgsmi";
-      name = "kmenuedit-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kmenuedit-5.26.1.tar.xz";
+      sha256 = "1xisb06ip243jz9giynil13nsf85s7hq5m2ww9n5dxzypm3iydrq";
+      name = "kmenuedit-5.26.1.tar.xz";
     };
   };
   kpipewire = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kpipewire-5.26.0.tar.xz";
-      sha256 = "1vmynvwcf2ll6hbcgdkmmdfyvib6fk1cq3yi6n0qdrqvbcrg62bs";
-      name = "kpipewire-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kpipewire-5.26.1.tar.xz";
+      sha256 = "1mqirqfaw1ndacc9n494z8npmnl12841l6w0vdjp3x0pqayfbji7";
+      name = "kpipewire-5.26.1.tar.xz";
     };
   };
   kscreen = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kscreen-5.26.0.tar.xz";
-      sha256 = "0ay5qc31b33q9h8isppga97vy1h5hrk8i44pbsr45qcjmigjkr16";
-      name = "kscreen-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kscreen-5.26.1.tar.xz";
+      sha256 = "1vmxvn36qipxgb8z1nmprxcxb6w8d2s8gpw13b2826hrvzxqvl2i";
+      name = "kscreen-5.26.1.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kscreenlocker-5.26.0.tar.xz";
-      sha256 = "0gf77s8pn8nyjmy5y8khw9l3094lnjbj6cyhcsl817yncp7v44p4";
-      name = "kscreenlocker-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kscreenlocker-5.26.1.tar.xz";
+      sha256 = "0zc6fr7qyz9y02p1fkv088vljhhblfdafmqbxbhv2283vyf5ncfy";
+      name = "kscreenlocker-5.26.1.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/ksshaskpass-5.26.0.tar.xz";
-      sha256 = "1wf5dn73g5whgf40g2irxm72lv6fhr3nillp8y6d08iw8p2mc9yc";
-      name = "ksshaskpass-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/ksshaskpass-5.26.1.tar.xz";
+      sha256 = "0mx25pcb02jcvbh8mxs7rl4wqh3sdnrgl3jphp43qd0s4ajg3xdk";
+      name = "ksshaskpass-5.26.1.tar.xz";
     };
   };
   ksystemstats = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/ksystemstats-5.26.0.tar.xz";
-      sha256 = "033b0b1qgkh27d708s6pzyra9dxy2h9fs0w4s0kvy9gkva1y2254";
-      name = "ksystemstats-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/ksystemstats-5.26.1.tar.xz";
+      sha256 = "1kxdy27rb9bb2i07kiw5yz8fzjsp21kjng5d6qk27dhh8igm7yr7";
+      name = "ksystemstats-5.26.1.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kwallet-pam-5.26.0.tar.xz";
-      sha256 = "1krcnsnyfxz7k2q9pcipv6mvzajkcgmgxsknb9g5cvrh0hla3fxq";
-      name = "kwallet-pam-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kwallet-pam-5.26.1.tar.xz";
+      sha256 = "0c3kvw7q780yd0lqvbxkvr087wmxv02bdk69a9gp0m8lkrqisacm";
+      name = "kwallet-pam-5.26.1.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kwayland-integration-5.26.0.tar.xz";
-      sha256 = "0h54mpj9z4cxb2f67lzp8zjm59xxlc35jffk2r0pyjs203a4247f";
-      name = "kwayland-integration-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kwayland-integration-5.26.1.tar.xz";
+      sha256 = "09c0f14qihrl7126b1ppf9k7mlvgfa031ypjwj1ylq6iz2s101vl";
+      name = "kwayland-integration-5.26.1.tar.xz";
     };
   };
   kwin = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kwin-5.26.0.tar.xz";
-      sha256 = "1z9980s4pz9q4wd2lgr6iahqcc6y02f02mprzfbq6mlcq1llg7rs";
-      name = "kwin-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kwin-5.26.1.tar.xz";
+      sha256 = "18vzizmnmgfn57yc0h00mwbhr6i4zbckxw34xa01f6d4mnvw9b63";
+      name = "kwin-5.26.1.tar.xz";
     };
   };
   kwrited = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/kwrited-5.26.0.tar.xz";
-      sha256 = "173b5ppah5mapgx52hnkq6wfp6nn6z7mvm94mfz224r1vcr4841f";
-      name = "kwrited-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/kwrited-5.26.1.tar.xz";
+      sha256 = "17al2apif992mdqxil9qsa6ya5bi0d17i9pr9sbxcyncn87i8fh7";
+      name = "kwrited-5.26.1.tar.xz";
     };
   };
   layer-shell-qt = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/layer-shell-qt-5.26.0.tar.xz";
-      sha256 = "07mnrwk100mazrghg9biv4vlnnw92l88hwqchwkh541dgqa3s16y";
-      name = "layer-shell-qt-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/layer-shell-qt-5.26.1.tar.xz";
+      sha256 = "155l9nqjxg3hkis51f6m4mjzzy5bvidx4g0qn4ggwxa2ybd8waa8";
+      name = "layer-shell-qt-5.26.1.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/libkscreen-5.26.0.tar.xz";
-      sha256 = "092y26bn7g1a2v1jv1d7r71xrp5a8kdnfvz58szs4d4qm1iyp6jf";
-      name = "libkscreen-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/libkscreen-5.26.1.tar.xz";
+      sha256 = "09i5qwm13lsdw3kag91zq3ycxc14488lnk27vad55qmh4ys7nkys";
+      name = "libkscreen-5.26.1.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/libksysguard-5.26.0.tar.xz";
-      sha256 = "15ljaa6ypqdrb0x2b4chs7piq9pi4lm5hx36708has64xmrz9cj3";
-      name = "libksysguard-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/libksysguard-5.26.1.tar.xz";
+      sha256 = "180zdan1vs41j8n29qv10fs8yq1nm1m9pd0v99aqcd0v6aqf2x8p";
+      name = "libksysguard-5.26.1.tar.xz";
     };
   };
   milou = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/milou-5.26.0.tar.xz";
-      sha256 = "1g4ga1ylzj4zcdx3wh5y4rz84w5bwv7041bkp7b03pia2hwfgvy0";
-      name = "milou-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/milou-5.26.1.tar.xz";
+      sha256 = "1nxwf8wcbk9kklx3ccfafklil07y5n8jrshvabwrff993wd6w43p";
+      name = "milou-5.26.1.tar.xz";
     };
   };
   oxygen = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/oxygen-5.26.0.tar.xz";
-      sha256 = "0mbcdnv40j1jvc1i77rknrrs5xs6w5qaz7sliyygm2f01vgha6cz";
-      name = "oxygen-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/oxygen-5.26.1.tar.xz";
+      sha256 = "00jvb089lq7vqz387bsgdwi30mabpg4w8di2jn8jsiy4xmvcjy5s";
+      name = "oxygen-5.26.1.tar.xz";
     };
   };
   oxygen-sounds = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/oxygen-sounds-5.26.0.tar.xz";
-      sha256 = "0ww7njndc4ilwsc16l5jv7cbq8mzjm9yz7x515fhvwqzwh61vd47";
-      name = "oxygen-sounds-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/oxygen-sounds-5.26.1.tar.xz";
+      sha256 = "1dfhdsz9k1r1dlsws50fnblag3h0z6jd0xl3za87qnrgrgnvc3l3";
+      name = "oxygen-sounds-5.26.1.tar.xz";
     };
   };
   plank-player = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plank-player-5.26.0.tar.xz";
-      sha256 = "0jwhrhbbwblj8c7n13hg7ac3dbmnybsspq1gpcd16l797msdyp2k";
-      name = "plank-player-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plank-player-5.26.1.tar.xz";
+      sha256 = "1qg0psgklvz3dwkn4lhhy8a49vvqkzkz2k2fj7g7yhizh73y2nmy";
+      name = "plank-player-5.26.1.tar.xz";
     };
   };
   plasma-bigscreen = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-bigscreen-5.26.0.tar.xz";
-      sha256 = "1jmv2f60pbgfs110560h4gix1hj8awmlydrikcyn0p2hhc6xdc9r";
-      name = "plasma-bigscreen-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-bigscreen-5.26.1.tar.xz";
+      sha256 = "1hl9828f5rc4vpkc9ykxa5cips7im3l98z9ar22x3la99n1z172y";
+      name = "plasma-bigscreen-5.26.1.tar.xz";
     };
   };
   plasma-browser-integration = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-browser-integration-5.26.0.tar.xz";
-      sha256 = "0vzkqhrafqwl5whqyjv1np37wzv5dm49gh4z3acv0yz83842asgl";
-      name = "plasma-browser-integration-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-browser-integration-5.26.1.tar.xz";
+      sha256 = "0qz8w1mqjsbi65snppppddcqxfzadiprk86cvwqqna0psq9xlhcn";
+      name = "plasma-browser-integration-5.26.1.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-desktop-5.26.0.tar.xz";
-      sha256 = "0x5csx29x81szmmil4mlxmfcmz3v1q0n3q3f6k3p4knhpv77x7vx";
-      name = "plasma-desktop-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-desktop-5.26.1.tar.xz";
+      sha256 = "0diaff7qhm33h9fvd7mm1s8q2rar8q5yj8b664qbhlykg59gqsay";
+      name = "plasma-desktop-5.26.1.tar.xz";
     };
   };
   plasma-disks = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-disks-5.26.0.tar.xz";
-      sha256 = "0wb31vnh8bs5wxl07wawji2l66pmnhn9li3smcygsx0qcqxsmcxm";
-      name = "plasma-disks-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-disks-5.26.1.tar.xz";
+      sha256 = "0aaf6h43bqisiclw2qb8lzjhy472zdhqvx44y606i34crr7c5fl8";
+      name = "plasma-disks-5.26.1.tar.xz";
     };
   };
   plasma-firewall = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-firewall-5.26.0.tar.xz";
-      sha256 = "08ayf84ah294q473554zlgs8ri0l20bzc6gmbfrw833byviqwppr";
-      name = "plasma-firewall-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-firewall-5.26.1.tar.xz";
+      sha256 = "0ahjh75bfa54slia8qsfs5dxk1k6bfijzdx1xpwq7y3k50mmbhs8";
+      name = "plasma-firewall-5.26.1.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-integration-5.26.0.tar.xz";
-      sha256 = "0mqv9haanmp3q29ik2x07bmcfdly1icrzdcid76rlycnsr1v0qdg";
-      name = "plasma-integration-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-integration-5.26.1.tar.xz";
+      sha256 = "02zjvh582k67xgnw13i1yn13d6dj1d5dq065l84wcxbqh943qxqx";
+      name = "plasma-integration-5.26.1.tar.xz";
     };
   };
   plasma-mobile = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-mobile-5.26.0.tar.xz";
-      sha256 = "0zw7ppg8fqqb6i2z0zacij4qzwki1ixxi3ky1qvk8q7pqb8n47y2";
-      name = "plasma-mobile-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-mobile-5.26.1.tar.xz";
+      sha256 = "1gcbyxf3m6rsv42qbbsz719wkwx33vgkcf70cgnbmkdk710qvx23";
+      name = "plasma-mobile-5.26.1.tar.xz";
     };
   };
   plasma-nano = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-nano-5.26.0.tar.xz";
-      sha256 = "0cnb1y8xwxq711ighi9zzw6x3npfwpf9865bi16hha8fk7vzn6z7";
-      name = "plasma-nano-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-nano-5.26.1.tar.xz";
+      sha256 = "1f9c6gjmxg3bdcjifwm0r6bcklkzqlii02z3hmpnz5v1dh77xs48";
+      name = "plasma-nano-5.26.1.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-nm-5.26.0.tar.xz";
-      sha256 = "1bjy4iq1v2nkhl0ib2v26anxvpl6dns1c1zqf5w24rfmpdmxz6ky";
-      name = "plasma-nm-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-nm-5.26.1.tar.xz";
+      sha256 = "1zxqd8fizdm0kcljcs8q94mik4bm541c20lf6r2iq3ywxg6pd62i";
+      name = "plasma-nm-5.26.1.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-pa-5.26.0.tar.xz";
-      sha256 = "00ajjrjyvjxhfxg9amsr009rwpg35r2c29679dypkxfldki81czz";
-      name = "plasma-pa-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-pa-5.26.1.tar.xz";
+      sha256 = "0hpvli0s6cm6lbcjqw24vaqwpzih76lyqkvb1vjb5cyhx3sg3x4a";
+      name = "plasma-pa-5.26.1.tar.xz";
     };
   };
   plasma-remotecontrollers = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-remotecontrollers-5.26.0.tar.xz";
-      sha256 = "0gwmhsqdkr5ra2r7iwasggkxmd0xw08fm7fqvdqcp8m7p0fzc9ap";
-      name = "plasma-remotecontrollers-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-remotecontrollers-5.26.1.tar.xz";
+      sha256 = "19phan3vcvvb46g4jakfgz6dmqw46zh1x6g84acm9bjac8hyzq45";
+      name = "plasma-remotecontrollers-5.26.1.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-sdk-5.26.0.tar.xz";
-      sha256 = "1wsgksds7ygq6d65x1yziqnicczq780gdx1z8xsfdw66gjajxf0r";
-      name = "plasma-sdk-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-sdk-5.26.1.tar.xz";
+      sha256 = "0hkhc5ria6wp0agfjzfxq65jx32554i4j73w7qzalrn7d666g2ci";
+      name = "plasma-sdk-5.26.1.tar.xz";
     };
   };
   plasma-systemmonitor = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-systemmonitor-5.26.0.tar.xz";
-      sha256 = "1yj72qli0zjm0m20ys5djxcz2ab2v24l7grdk914x6yk4iz6pgs1";
-      name = "plasma-systemmonitor-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-systemmonitor-5.26.1.tar.xz";
+      sha256 = "1y6wrmjq1p6l6n4627lj3f597crpxdkl8brazv9qc2gvd100m4j6";
+      name = "plasma-systemmonitor-5.26.1.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-tests-5.26.0.tar.xz";
-      sha256 = "0hvklywisglygv74y2in9a8qkw00rqx78i0snw64hpmfl7n610p8";
-      name = "plasma-tests-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-tests-5.26.1.tar.xz";
+      sha256 = "0l597ib95397vbgsb99gpw0m2qa2xwyq5l3940wnl0y61sh7n769";
+      name = "plasma-tests-5.26.1.tar.xz";
     };
   };
   plasma-thunderbolt = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-thunderbolt-5.26.0.tar.xz";
-      sha256 = "07davvxifdswm6s5v8sg3gzwd9s5b46q72c7jjnryjsb3gj0w755";
-      name = "plasma-thunderbolt-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-thunderbolt-5.26.1.tar.xz";
+      sha256 = "08kw6rbz9s7f5nzpcy553lljk0qj53csliwms8v6f0klxippjg3f";
+      name = "plasma-thunderbolt-5.26.1.tar.xz";
     };
   };
   plasma-vault = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-vault-5.26.0.tar.xz";
-      sha256 = "0jx7i7xzi15hnwwscif0ilymfk2nrb93n8q5cjpr79gksmdwdajd";
-      name = "plasma-vault-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-vault-5.26.1.tar.xz";
+      sha256 = "0qx15jxf2ghcv0mn48198z4j5h923cggcby748xw9j10b1v09wif";
+      name = "plasma-vault-5.26.1.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-workspace-5.26.0.tar.xz";
-      sha256 = "1cjnalc1yyc3ijm9idjd7bsghr34mnrk7fkk8d6qr8azqm5x67w4";
-      name = "plasma-workspace-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-workspace-5.26.1.tar.xz";
+      sha256 = "0rlg1ah8nzzp8szf1n61598qg64i7chmwaqvj9pf914px7chj1yw";
+      name = "plasma-workspace-5.26.1.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plasma-workspace-wallpapers-5.26.0.tar.xz";
-      sha256 = "10da3xpm82nn971yb9zh3qls78ngcghab3ivknqc6jbqzkk9z76v";
-      name = "plasma-workspace-wallpapers-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plasma-workspace-wallpapers-5.26.1.tar.xz";
+      sha256 = "1l4ac3g5k73m7lqa04iwd1qkkdvd6bsvjpafz0nip6z0c7ywskg2";
+      name = "plasma-workspace-wallpapers-5.26.1.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/plymouth-kcm-5.26.0.tar.xz";
-      sha256 = "0y7c8wmxb9aigrs6l1rjwhx1hxyip1g4csy121kjisdxzp4fijcd";
-      name = "plymouth-kcm-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/plymouth-kcm-5.26.1.tar.xz";
+      sha256 = "093rb9ajr8d9s4phvg181bn410rc5qcm29nf3mzldqfznvwigks8";
+      name = "plymouth-kcm-5.26.1.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.26.0";
+    version = "1-5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/polkit-kde-agent-1-5.26.0.tar.xz";
-      sha256 = "1fw8qh9yg87dq3vmxhas4qpx4zb0knf9nnz96fvcmfnnrh56ahxa";
-      name = "polkit-kde-agent-1-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/polkit-kde-agent-1-5.26.1.tar.xz";
+      sha256 = "0p7jm2ijjasjc44bz0kqqil1vsgnl70fj8xpshcm5vdy90s4b9l6";
+      name = "polkit-kde-agent-1-5.26.1.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/powerdevil-5.26.0.tar.xz";
-      sha256 = "1bph5kg6w2rb5n2xwwh85zrar5cif6hcvwy4j8kazhqm2m507vkn";
-      name = "powerdevil-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/powerdevil-5.26.1.tar.xz";
+      sha256 = "0qx5c0hr0l038c0n6v4i4vf35i1lpjsbnapghl5a7w6mi7jlfv4l";
+      name = "powerdevil-5.26.1.tar.xz";
     };
   };
   qqc2-breeze-style = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/qqc2-breeze-style-5.26.0.tar.xz";
-      sha256 = "1j6y636r4s0m30d9ynwqf9p9f85ivi5pys78y24787rh5nynq519";
-      name = "qqc2-breeze-style-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/qqc2-breeze-style-5.26.1.tar.xz";
+      sha256 = "1yr0rrsqd5lxmplk78jhpw42cpv4jhn1xjlsxyz9lhriq12b2xrs";
+      name = "qqc2-breeze-style-5.26.1.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/sddm-kcm-5.26.0.tar.xz";
-      sha256 = "1hx6qrcb1sd7dhnsp6lma7wmrzkd348mcf3ya7v4daixyyasy7i7";
-      name = "sddm-kcm-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/sddm-kcm-5.26.1.tar.xz";
+      sha256 = "0gy5b9904xqw22gy4d8z27953vz32k39smp3vn7h1zqx9h1wr5d4";
+      name = "sddm-kcm-5.26.1.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/systemsettings-5.26.0.tar.xz";
-      sha256 = "1k2gi0mrd91xcjch79rmz63imc5ngiyjx4agv5kxam0lnp010bxz";
-      name = "systemsettings-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/systemsettings-5.26.1.tar.xz";
+      sha256 = "0dia2inxrqwdrg3ss8l6l7basd7m9bc8rpkhy7sydrxvx9ps5a2p";
+      name = "systemsettings-5.26.1.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.26.0";
+    version = "5.26.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.26.0/xdg-desktop-portal-kde-5.26.0.tar.xz";
-      sha256 = "17ig8yxm2iygyqg8r1jqbzhqp5sz71j05c7lsiilqpq5r4zng6ly";
-      name = "xdg-desktop-portal-kde-5.26.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.26.1/xdg-desktop-portal-kde-5.26.1.tar.xz";
+      sha256 = "0n1jvk37ai0rqc43511zhfn4f8gx6adrfwplg8mp7i2m3j18d85a";
+      name = "xdg-desktop-portal-kde-5.26.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Description of changes

https://kde.org/announcements/plasma/5/5.26.1/

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
