### PR TITLE
cargo-modules: 0.5.11 -> 0.5.12

### DIFF
--- a/pkgs/development/tools/rust/cargo-modules/default.nix
+++ b/pkgs/development/tools/rust/cargo-modules/default.nix
@@ -1,30 +1,28 @@
-{ lib, rustPlatform, fetchFromGitHub, stdenv, CoreFoundation, CoreServices }:
+{ lib, rustPlatform, fetchCrate, stdenv, CoreFoundation, CoreServices }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-modules";
-  version = "0.5.11";
+  version = "0.5.12";
 
-  src = fetchFromGitHub {
-    owner = "regexident";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-dxy46ls0n7j2uax+djqB9Zy/uGgV37w5K1Zc8Wzd1Vc=";
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-Fm3D1VnudZhXpH7ymQNpViwwODvXYeO/e2xT3XXfclk=";
   };
 
-  cargoSha256 = "sha256-2Q4pGnMo4FiPPGz2XXOv6+zB5DxHA8oEqztidO2Vvyw=";
+  cargoSha256 = "sha256-PiYonf+aD+Q3mWtP+7NDu9wu3vKrMRAlYh94fXLMWD8=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     CoreFoundation
     CoreServices
   ];
 
+  # the crate version doesn't include all the files required to run tests
+  doCheck = false;
+
   meta = with lib; {
     description = "A cargo plugin for showing a tree-like overview of a crate's modules";
     homepage = "https://github.com/regexident/cargo-modules";
     license = with licenses; [ mpl20 ];
-    # all tests fail with:
-    # thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "tests run with disabled concurrency, automatic snapshot name generation is not supported.  Consider using the \"backtrace\" feature of insta which tries to recover test names from the call stack."', /private/tmp/nix-build-cargo-modules-0.5.9.drv-0/cargo-modules-0.5.9-vendor.tar.gz/insta/src/runtime.rs:908:22
-    broken = (stdenv.isDarwin && stdenv.isx86_64);
     maintainers = with maintainers; [ figsoda rvarago ];
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/regexident/cargo-modules/compare/0.5.11...194052825f835c93003dfad29874a85840588b17

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
