### PR TITLE
lf: fix panic error on systems where user is not in /etc/passwd

### DIFF
--- a/pkgs/applications/file-managers/lf/default.nix
+++ b/pkgs/applications/file-managers/lf/default.nix
@@ -1,4 +1,9 @@
-{ buildGoModule, fetchFromGitHub, lib, installShellFiles }:
+{ lib
+, stdenv
+,buildGoModule
+,fetchFromGitHub
+,installShellFiles
+}:
 
 buildGoModule rec {
   pname = "lf";
@@ -16,6 +21,10 @@ buildGoModule rec {
   nativeBuildInputs = [ installShellFiles ];
 
   ldflags = [ "-s" "-w" "-X main.gVersion=r${version}" ];
+
+  # Force the use of the pure-go implementation of the os/user library.
+  # Relevant issue: https://github.com/gokcehan/lf/issues/191
+  tags = lib.optionals (!stdenv.isDarwin) [ "osusergo" ];
 
   postInstall = ''
     install -D --mode=444 lf.desktop $out/share/applications/lf.desktop

--- a/pkgs/applications/file-managers/lf/default.nix
+++ b/pkgs/applications/file-managers/lf/default.nix
@@ -1,8 +1,8 @@
 { lib
 , stdenv
-,buildGoModule
-,fetchFromGitHub
-,installShellFiles
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
 }:
 
 buildGoModule rec {


### PR DESCRIPTION
###### Description of changes

This fixes this [issue](https://github.com/gokcehan/lf/issues/191) which happens on systems where the user is not in `/etc/passwd`.
I submitted a [fix](https://github.com/gokcehan/lf/pull/972) upstream (to the lf repository) that solves this problem at the package level.
This PR adds the `osusergo` build tag to the derivation which ensures that the pure go implementation of `os/user` is used instead of the one relying on libc.
Indeed, the pure go implementations has a fallback for this case which consists in looking at the `$USER` and `$HOME` environment variables.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@dotlambda 