### PR TITLE
onlyoffice-bin: 7.1.0 -> 7.2.0

### DIFF
--- a/pkgs/applications/office/onlyoffice-bin/default.nix
+++ b/pkgs/applications/office/onlyoffice-bin/default.nix
@@ -73,11 +73,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "onlyoffice-desktopeditors";
-  version = "7.1.0";
+  version = "7.2.0";
   minor = null;
   src = fetchurl {
     url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb";
-    sha256 = "sha256-40IUAmg7PnfYrdTj7TVbfvb9ey0/zzswu+sJllAIktg=";
+    sha256 = "sha256-O9gC/b5/eZ1YImuXpEZOJhI1rzCNuFrm5IqablnYo9Y=";
   };
 
   nativeBuildInputs = [
@@ -109,6 +109,7 @@ stdenv.mkDerivation rec {
     qt5.qtbase
     qt5.qtdeclarative
     qt5.qtsvg
+    qt5.qtwayland
     xorg.libX11
     xorg.libxcb
     xorg.libXcomposite


### PR DESCRIPTION
Closes #195131

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a version bump for onlyoffice-bin. I needed to add QT5 Wayland to get it to build. I don't know what changed to make it require Wayland.

Here's the changelog (copy-pasted below): https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md#720

## All Editors

- Show warning on macros execution if connection to another host. Fix CVE-2021-43446
- Vector printing if the page does not contain gradient fills
- Removed the restriction on the minimum window size
- Top toolbar optimizations for smaller screens
- Added the ability to choose "Contrast Dark" or "System default" interface theme
- Redone of icons in header line
- Redone of settings page in the editors
- New interface languages - "Portuguese (Portugal)" and "Armenian"
- Improved color selection component
- The ability to disable the alternative menu in the editors
- Completely redesigned search inside the document
- New hotkeys for "Special Paste"
- Added "Cut" and "Select All" buttons to the toolbar next to Copy/Paste
- Major improvements in Font engine (For languages like Bengali or Sinhala) (only in Document Editor and Presentation Editor)
- Ligatures support
- Ability to insert tables as OLE object
- Support for images as a bulleted list and the ability to work with them
- Major improvements in "EMF" and "WMF" files rendering

## Document Editor

- Ability to remove Header/Footer from toolbar
- Ability to insert current heading in TOC
- New warning if there is no TOC in document
- Navigation panel renamed to "Headings"
- Major improvements in "pdf", "djvu", "xps" convert to "docx"
- Correct display greek letters as numbered list items

## Spreadsheet Editor

- Ability to "Switch rows and columns" for Chart
- New "Italiano (Svizzera)" language for regional settings
- Row number highlight for filter
- Remove "First sheet" and "Last sheet" from bottom toolbar
- Selection of copied range
- Pivot table option - "Auto-fit column widths on update"
- 1904 date system support
- Presentation Editor
- Animation with Custom path
- New advanced settings "Placement" tab for graphic images
- Added VLC libs so codecs are not required for video and audio playback

## Forms

- Search in embedded and forms mode
- Change field width for "Comb of characters"-enabled field
- Ability to set tag for field
- New "Format" and "Allowed Symbols" settings for field
- New field types - "Phone number", "Email Address" and "Complex Field"

## Fixes

- Various fixes and updates for all components

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
