### PR TITLE
doctest 0.20.1 is unbroken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -10,7 +10,6 @@ in
 
 with haskellLib;
 self: super: let
-  doctest_0_20_broken = p: checkAgainAfter self.doctest "0.20.0" "doctest broken on 9.4" (dontCheck p);
   jailbreakForCurrentVersion = p: v: checkAgainAfter p v "bad bounds" (doJailbreak p);
 in {
   llvmPackages = lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
@@ -82,21 +81,9 @@ in {
       (dontCheck super.cabal2nix);
   cabal2nix-unstable = dontCheck super.cabal2nix-unstable;
 
-  # build fails on due to ghc api changes
-  # unfinished PR that doesn't yet compile:
-  # https://github.com/sol/doctest/pull/375
-  doctest = markBroken super.doctest_0_20_0;
-  # consequences of doctest breakage follow:
-  http-types = doctest_0_20_broken super.http-types;
-  iproute = doctest_0_20_broken super.iproute;
-  foldl = doctest_0_20_broken super.foldl;
-  prettyprinter-ansi-terminal = doctest_0_20_broken super.prettyprinter-ansi-terminal;
-  pretty-simple = doctest_0_20_broken super.pretty-simple;
-  http-date = doctest_0_20_broken super.http-date;
-  network-byte-order = doctest_0_20_broken super.network-byte-order;
-  co-log-core = doctest_0_20_broken (doJailbreak super.co-log-core);
-  xml-conduit = doctest_0_20_broken (dontCheck super.xml-conduit);
-  validation-selective = doctest_0_20_broken (dontCheck super.validation-selective);
+  co-log-core = doJailbreak super.co-log-core;
+  xml-conduit = dontCheck super.xml-conduit;
+  validation-selective = dontCheck super.validation-selective;
 
   double-conversion = markBroken super.double-conversion;
   blaze-textual = checkAgainAfter super.double-conversion "2.0.4.1" "double-conversion fails to build; required for testsuite" (dontCheck super.blaze-textual);
@@ -114,7 +101,7 @@ in {
   # Jailbreaks & Version Updates
 
   aeson = self.aeson_2_1_1_0;
-  aeson-diff = doctest_0_20_broken (dontCheck super.aeson-diff);
+  aeson-diff = dontCheck super.aeson-diff;
   lens-aeson = self.lens-aeson_1_2_2;
 
   assoc = doJailbreak super.assoc;
@@ -153,7 +140,7 @@ in {
 
   # 2022-09-02: Too strict bounds on lens
   # https://github.com/GetShopTV/swagger2/pull/242
-  swagger2 = doctest_0_20_broken (dontCheck (doJailbreak super.swagger2));
+  swagger2 = dontCheck (doJailbreak super.swagger2);
 
   base-orphans = dontCheck super.base-orphans;
 


### PR DESCRIPTION
###### Description of changes

Not sure how to actually get doctest 0.20.1 in, but I'm getting an error trying to use it downstream.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
