### PR TITLE
kde/gear: 22.08.1 -> 22.08.2

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/release-service/22.08.1/src -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/release-service/22.08.2/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1867 +4,1867 @@
 
 {
   akonadi = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadi-22.08.1.tar.xz";
-      sha256 = "1yfy0b6kyiq82zkfkx9ldgjlbwg3lgg4di53fqjllmqhzaj1xy91";
-      name = "akonadi-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadi-22.08.2.tar.xz";
+      sha256 = "0mylc9dim1a9n58hg5k1yhd4q59ragb52nwm6l8a2h5i0r80hci6";
+      name = "akonadi-22.08.2.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadi-calendar-22.08.1.tar.xz";
-      sha256 = "1xcnlkipy2rq0bsm811y9khw7dmsgkqxgw18b3lmy29xs7wcsiv5";
-      name = "akonadi-calendar-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadi-calendar-22.08.2.tar.xz";
+      sha256 = "0v4nf42l25n8l6qa77iwfbbnbz0mvbn1wvqrbh9nkzjdp7528ig4";
+      name = "akonadi-calendar-22.08.2.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadi-calendar-tools-22.08.1.tar.xz";
-      sha256 = "1h3gh8n2hwasb1grmmy1vwlym12d0awhncnb2zy8iyvky47psj8a";
-      name = "akonadi-calendar-tools-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadi-calendar-tools-22.08.2.tar.xz";
+      sha256 = "0k1aflpmcg698fsk8vps9pwdv2qwm9glymw5gv0720arr0pil11h";
+      name = "akonadi-calendar-tools-22.08.2.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadi-contacts-22.08.1.tar.xz";
-      sha256 = "1mzlv124wa135xfbxl2ghl4n8pi1a6zd64195px1v90qnhjljw28";
-      name = "akonadi-contacts-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadi-contacts-22.08.2.tar.xz";
+      sha256 = "1spxm6kfsdyyax4brnnd9qqmlh1sqk7qgsdrw9yv9xfg2iipppri";
+      name = "akonadi-contacts-22.08.2.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadi-import-wizard-22.08.1.tar.xz";
-      sha256 = "1m3qfxbwiwskcyin44mrnm6lfplw4f1payc2s6w93k9lgz5j9cpd";
-      name = "akonadi-import-wizard-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadi-import-wizard-22.08.2.tar.xz";
+      sha256 = "1v3ny0g8cn9i4v49cca1c1bbd8acjy6wsbb0ys75asw527cnwigl";
+      name = "akonadi-import-wizard-22.08.2.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadi-mime-22.08.1.tar.xz";
-      sha256 = "19wbfkvhkyzlz5r49y7rzbn4ay7rm8zyj7d4j3x9j79nprjr4zw0";
-      name = "akonadi-mime-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadi-mime-22.08.2.tar.xz";
+      sha256 = "0n187rzy4085xxppnm1z00ac0qybvh7j0i2642vfv1y6994gxgrz";
+      name = "akonadi-mime-22.08.2.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadi-notes-22.08.1.tar.xz";
-      sha256 = "05sx7h1aw4mx93l4krv4574zpjf63vdrhaiwayqz11wrdpvdq7ww";
-      name = "akonadi-notes-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadi-notes-22.08.2.tar.xz";
+      sha256 = "1qp1p1553pz1yvbk61r4aw1rcwv06x7fsjc8pgxry97bnhmynxh3";
+      name = "akonadi-notes-22.08.2.tar.xz";
     };
   };
   akonadi-search = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadi-search-22.08.1.tar.xz";
-      sha256 = "06apb5lx7bs0lfvsnbf8kyxk7yyjrzb1f1wfckfsjaysf0xmdvfg";
-      name = "akonadi-search-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadi-search-22.08.2.tar.xz";
+      sha256 = "1zsipvf1mvyvr3khny2ymrywhzpbqzy4dp9n11wl7y944w6960i2";
+      name = "akonadi-search-22.08.2.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akonadiconsole-22.08.1.tar.xz";
-      sha256 = "06pnp57hgi972s2kkxi5na07zss3rv2lzlknbnd75j2gmfn04zrp";
-      name = "akonadiconsole-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akonadiconsole-22.08.2.tar.xz";
+      sha256 = "0gpf3j2dy71cyzq9zvw0574ycqvfdq6kamx8wzgmsx36qvqbdv3f";
+      name = "akonadiconsole-22.08.2.tar.xz";
     };
   };
   akregator = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/akregator-22.08.1.tar.xz";
-      sha256 = "01rgyl2hwjprq4z5yjc99j6jk9vrhjy608ha72j470pw6g47ac5s";
-      name = "akregator-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/akregator-22.08.2.tar.xz";
+      sha256 = "1knz3b3ivrw290dvbdn5in181gk7rsd1d2dr8khr7pd30xs731zb";
+      name = "akregator-22.08.2.tar.xz";
     };
   };
   analitza = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/analitza-22.08.1.tar.xz";
-      sha256 = "032mbws2cv6kgxcnghcxj8jwm1k8miq9r21vdqx9i00yxvh83qys";
-      name = "analitza-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/analitza-22.08.2.tar.xz";
+      sha256 = "1icvcrbp0a0azgiqdxd8zxp8v3kj6jwrpf0dkaw2prrq6hz04374";
+      name = "analitza-22.08.2.tar.xz";
     };
   };
   ark = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ark-22.08.1.tar.xz";
-      sha256 = "05qsiplkcz6fn6wdrnyliif8qzdy3kcc4nx8y8mrh6kbpv94q39r";
-      name = "ark-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ark-22.08.2.tar.xz";
+      sha256 = "0vv2d14j5zhjar7fv4m6yasfvfvs27zrckxc7xsb5y6iba9gqikr";
+      name = "ark-22.08.2.tar.xz";
     };
   };
   artikulate = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/artikulate-22.08.1.tar.xz";
-      sha256 = "0xpznzfzqj12izr2pjddb26mmmj7k9mc8kmgvgs71r86ca0yx8i2";
-      name = "artikulate-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/artikulate-22.08.2.tar.xz";
+      sha256 = "15yr9g5dirby5yl3gdlzj6qi1b8l3k71m1b83qlxwafdwl944a04";
+      name = "artikulate-22.08.2.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/audiocd-kio-22.08.1.tar.xz";
-      sha256 = "0an98whnn4dzn1n06dch8q4cr31l4lyfzvmb2q08sli8s1bdl59z";
-      name = "audiocd-kio-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/audiocd-kio-22.08.2.tar.xz";
+      sha256 = "1b8nq18vm4ysn4qlhcbkcwybc7hficph19ik1mpx2wm26560py3n";
+      name = "audiocd-kio-22.08.2.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/baloo-widgets-22.08.1.tar.xz";
-      sha256 = "02p4v8g4syk908mg7f0l5fpqn7ddsxqji1n8jqghsdkkdsvry7mn";
-      name = "baloo-widgets-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/baloo-widgets-22.08.2.tar.xz";
+      sha256 = "09ls4zw1z1cb5m67fwfc0kpi143bfxj7qpi04i0sfw40icr0yrid";
+      name = "baloo-widgets-22.08.2.tar.xz";
     };
   };
   blinken = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/blinken-22.08.1.tar.xz";
-      sha256 = "1qc9c91y7rp882dpjz94yn8aqhbnf5ax955q99hrkpzmg6mkvpg2";
-      name = "blinken-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/blinken-22.08.2.tar.xz";
+      sha256 = "011qsa57dzvn08k9qd1giivz5hpzlzrp4pi080vmp2q7a943v5vl";
+      name = "blinken-22.08.2.tar.xz";
     };
   };
   bomber = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/bomber-22.08.1.tar.xz";
-      sha256 = "14zbmwznz1hi51gyd4l767ilgp3ydvrc3b2nvn4029qhihjpaanm";
-      name = "bomber-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/bomber-22.08.2.tar.xz";
+      sha256 = "1frd2vm85caarfs1747wgcpdnq7w4czfsc60li7377pbhrhi47jz";
+      name = "bomber-22.08.2.tar.xz";
     };
   };
   bovo = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/bovo-22.08.1.tar.xz";
-      sha256 = "1r1qbrxs9i2lv7gbi6w0672dd9gq44bncdda26b3fn4s4pv2xnzr";
-      name = "bovo-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/bovo-22.08.2.tar.xz";
+      sha256 = "08as7lsp61qhmdz8sxbkcnq3vb0rpq96yph2fx5ckbayp4g01qac";
+      name = "bovo-22.08.2.tar.xz";
     };
   };
   calendarsupport = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/calendarsupport-22.08.1.tar.xz";
-      sha256 = "09fs15qckydmbs6idl5k1b6gyhjkygsa1r8frlysn1ahhfmxr33p";
-      name = "calendarsupport-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/calendarsupport-22.08.2.tar.xz";
+      sha256 = "1bk8r4a5ilphfbgxb2345nnbhfkadam4s9ms39vin8za05sljhzh";
+      name = "calendarsupport-22.08.2.tar.xz";
     };
   };
   cantor = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/cantor-22.08.1.tar.xz";
-      sha256 = "1c99xqf8jdbcyippd3kag31p0050s875fmc6l2zhr4icmxwbz3v7";
-      name = "cantor-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/cantor-22.08.2.tar.xz";
+      sha256 = "11gmiybsyalzijvfxrhkr4z2vnbbr4rgq27f5pnpnqmnif803p2k";
+      name = "cantor-22.08.2.tar.xz";
     };
   };
   cervisia = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/cervisia-22.08.1.tar.xz";
-      sha256 = "1iqpr90n7k6gnv9y0sqp11928b8yjrff6w6f7nql20rh59x8j039";
-      name = "cervisia-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/cervisia-22.08.2.tar.xz";
+      sha256 = "1cspi6l5a9mailmrfgndrb29p2kw3wsc8rgd42vh45a6g6kzk2zm";
+      name = "cervisia-22.08.2.tar.xz";
     };
   };
   dolphin = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/dolphin-22.08.1.tar.xz";
-      sha256 = "1scv3jd5qxzspvgvsk0q8d64qn6x23nn5viamlmvl4f44hfyyyq6";
-      name = "dolphin-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/dolphin-22.08.2.tar.xz";
+      sha256 = "0mivahq6wv15ir407jkg4x07s6p02a2qsyg30npjprp5gqiyxwir";
+      name = "dolphin-22.08.2.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/dolphin-plugins-22.08.1.tar.xz";
-      sha256 = "0xdwyyr812c88n1fk8y1ykgbrsq0drr9r0jl3yjqgkx0rczk8y53";
-      name = "dolphin-plugins-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/dolphin-plugins-22.08.2.tar.xz";
+      sha256 = "099r44scvanxigx060s94r3ffxqrl33wmhvkxay2sd20jb6jlvq3";
+      name = "dolphin-plugins-22.08.2.tar.xz";
     };
   };
   dragon = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/dragon-22.08.1.tar.xz";
-      sha256 = "1x6ryll5q911a5yahnj9almrzisbvrc88cw7izd091p94bg7ishr";
-      name = "dragon-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/dragon-22.08.2.tar.xz";
+      sha256 = "14sa4d3gzplq19biqcby7dz3qd6141j7riazr5lpv2v102h5qnfc";
+      name = "dragon-22.08.2.tar.xz";
     };
   };
   elisa = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/elisa-22.08.1.tar.xz";
-      sha256 = "05al0nh88zggg8rabzh31sp5kds61rd0zpaxg2arrza7c6cfz39p";
-      name = "elisa-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/elisa-22.08.2.tar.xz";
+      sha256 = "1zwcl87xfwl6q0kg2skbszzs642fbygsbmdzpr2pwdjpq51kjill";
+      name = "elisa-22.08.2.tar.xz";
     };
   };
   eventviews = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/eventviews-22.08.1.tar.xz";
-      sha256 = "0bkidva045q85z4ymhj4m9ayfbsckjl4cl7nncl48yk2dmanfg51";
-      name = "eventviews-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/eventviews-22.08.2.tar.xz";
+      sha256 = "1hj77aghar1p1vyphyg70il9p2g145xklls89hp3ygpnnmsflz3w";
+      name = "eventviews-22.08.2.tar.xz";
     };
   };
   falkon = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/falkon-22.08.1.tar.xz";
-      sha256 = "1lgb626jidyxf2a0xm87y144c72hfrdh40c31jfsx4mnf6igjamh";
-      name = "falkon-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/falkon-22.08.2.tar.xz";
+      sha256 = "034skfhn9rmqnx0bz6avq17i0bmh3b0138y58irzfi1ps19fjasd";
+      name = "falkon-22.08.2.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ffmpegthumbs-22.08.1.tar.xz";
-      sha256 = "032ccgz11yf0fwdmwadbdy10afkmxnk1l0kcf5sbm4szd8klq18d";
-      name = "ffmpegthumbs-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ffmpegthumbs-22.08.2.tar.xz";
+      sha256 = "1v1gkjiqnk03fm1a5zcmfxrcvzbpjddffqiz74h5f94cf4yw88y8";
+      name = "ffmpegthumbs-22.08.2.tar.xz";
     };
   };
   filelight = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/filelight-22.08.1.tar.xz";
-      sha256 = "1fqgmpq5dznbn5lalx1j6dyynhylijrcqw3x9hrwxcqwr275h9iw";
-      name = "filelight-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/filelight-22.08.2.tar.xz";
+      sha256 = "0n23vj6qkdxag0zm3wm7jl4lddiq9l366zgcbvq1w41yacx8wwdk";
+      name = "filelight-22.08.2.tar.xz";
     };
   };
   granatier = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/granatier-22.08.1.tar.xz";
-      sha256 = "1gd2bbdnhklqr3vdc51xf9dq80f99rq937kbgijykqh8l9jayi81";
-      name = "granatier-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/granatier-22.08.2.tar.xz";
+      sha256 = "1xlxgr437ca7ij18chn5qxl78di0z3aib051x8jzbihdanc0nsh4";
+      name = "granatier-22.08.2.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/grantlee-editor-22.08.1.tar.xz";
-      sha256 = "1qf5dhqbmgg67y2jwbxhf33d63cv1sv9qilszskv809gd8z8x0vd";
-      name = "grantlee-editor-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/grantlee-editor-22.08.2.tar.xz";
+      sha256 = "0gh5ds9kq3lg66afy1gghmclgcvqgwzfj00ricaz4a7v5x1wnmhy";
+      name = "grantlee-editor-22.08.2.tar.xz";
     };
   };
   grantleetheme = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/grantleetheme-22.08.1.tar.xz";
-      sha256 = "01ls16x6ngi43lcwffav9qig3afakrs04v4wvyfb8lm7sd65hgf9";
-      name = "grantleetheme-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/grantleetheme-22.08.2.tar.xz";
+      sha256 = "1wi0r9knlp4c8jgzw33wry98qjzv1wxxq3bidav1y2cf89g6fvv5";
+      name = "grantleetheme-22.08.2.tar.xz";
     };
   };
   gwenview = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/gwenview-22.08.1.tar.xz";
-      sha256 = "171avx587fib1ajp8spcnbi76p4gam346hxan660ix4m0g2r6iav";
-      name = "gwenview-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/gwenview-22.08.2.tar.xz";
+      sha256 = "1csf9xi551p8b0v8wgs93dm83xdlr71sibr6w544ski0givj82f1";
+      name = "gwenview-22.08.2.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/incidenceeditor-22.08.1.tar.xz";
-      sha256 = "1znbpqpxkbn79pzhcg5v77bqr345lcmy2h0a6d90rzdmnlh303ln";
-      name = "incidenceeditor-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/incidenceeditor-22.08.2.tar.xz";
+      sha256 = "16di5ib9acnxajf5253wr2rrld8b9yr59hzddbxlapcwh1h41lbb";
+      name = "incidenceeditor-22.08.2.tar.xz";
     };
   };
   itinerary = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/itinerary-22.08.1.tar.xz";
-      sha256 = "1w1gl4lz8gwf8cmxhsfyp4afiaq9anc8glrxay407bqp28andp3a";
-      name = "itinerary-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/itinerary-22.08.2.tar.xz";
+      sha256 = "0hwrrc85qyfpannnna83qgi56lblp7a5ccxq964mxdgfq2gyvpwb";
+      name = "itinerary-22.08.2.tar.xz";
     };
   };
   juk = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/juk-22.08.1.tar.xz";
-      sha256 = "0p9mkw13csxm9vp62kp657a096ncix72bsahzca9k9r4wwjwkzxa";
-      name = "juk-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/juk-22.08.2.tar.xz";
+      sha256 = "1sppq7sw28vy32v1w1is81jaka686zav43pv552h75bl51bi415g";
+      name = "juk-22.08.2.tar.xz";
     };
   };
   k3b = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/k3b-22.08.1.tar.xz";
-      sha256 = "0m4qzxcy8gd6knsiz6kjf77q156j4js2g2w2pjhapjzdwh28kbzi";
-      name = "k3b-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/k3b-22.08.2.tar.xz";
+      sha256 = "1lcr5x8hnbxfybk93k8j107fp96varawnxzap8qvvxzm2rdij2xl";
+      name = "k3b-22.08.2.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kaccounts-integration-22.08.1.tar.xz";
-      sha256 = "1q1d2a1qknfkgm63gji6ijji35d0b1jy1kvf10a7ac4l1z1fvnpl";
-      name = "kaccounts-integration-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kaccounts-integration-22.08.2.tar.xz";
+      sha256 = "163a19725a4jp6dd1djlx45hmxshd9pfhy4bpkx8z10izpqkag2q";
+      name = "kaccounts-integration-22.08.2.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kaccounts-providers-22.08.1.tar.xz";
-      sha256 = "08k627ybavyagf4iqsmzx4rp7aqkwblyvfw90y7ibm4d2mjxxbmd";
-      name = "kaccounts-providers-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kaccounts-providers-22.08.2.tar.xz";
+      sha256 = "1sz0ywmsysimphh1s4fz75bj5cdn430qh4hsl6dcqxa67b9v2n79";
+      name = "kaccounts-providers-22.08.2.tar.xz";
     };
   };
   kaddressbook = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kaddressbook-22.08.1.tar.xz";
-      sha256 = "177zgbpgignvglpvbis1q9d36pi1dvyckv3q2gcgd9425gpm0vmb";
-      name = "kaddressbook-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kaddressbook-22.08.2.tar.xz";
+      sha256 = "0acmxn672xr9ynahd4hf9ckfhj7dmw3yfgc7mf5q2i2sk6fdimka";
+      name = "kaddressbook-22.08.2.tar.xz";
     };
   };
   kajongg = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kajongg-22.08.1.tar.xz";
-      sha256 = "0k1028a2mn15197w0f7bnanmx4in6qm7zj27az1w8kp87p725vqi";
-      name = "kajongg-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kajongg-22.08.2.tar.xz";
+      sha256 = "14ymz219bcc5cmvj5mas43p16h5vbn1y8n6g5jyfwq1fq49h4hbw";
+      name = "kajongg-22.08.2.tar.xz";
     };
   };
   kalarm = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kalarm-22.08.1.tar.xz";
-      sha256 = "1kbybncccvbvmjnzdl2lrcxy34ayxcx1jwfja64sbii0lrivm25k";
-      name = "kalarm-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kalarm-22.08.2.tar.xz";
+      sha256 = "0dq01lyj0bnkx3lnshy5jjpp1lnw25i6y0b6xa2m4xgs0hmkr60p";
+      name = "kalarm-22.08.2.tar.xz";
     };
   };
   kalendar = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kalendar-22.08.1.tar.xz";
-      sha256 = "0slk9z7p1z5m2kbb8kq05afslxad8w5pjsajxawckcx0mlsd3apj";
-      name = "kalendar-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kalendar-22.08.2.tar.xz";
+      sha256 = "01h133ajhkixjrx3x1zj5mgn8mxixcsh2phbf2rygrmsa76cp9mw";
+      name = "kalendar-22.08.2.tar.xz";
     };
   };
   kalgebra = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kalgebra-22.08.1.tar.xz";
-      sha256 = "02rni6w5x4qrd2xzvbh55fxma307pn8pkx705y00kimk07hlnvzx";
-      name = "kalgebra-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kalgebra-22.08.2.tar.xz";
+      sha256 = "1mcjd442vlzpavl6f0ffnn8pq5fk8p1hq89wk3msplxm9v5lgmdq";
+      name = "kalgebra-22.08.2.tar.xz";
     };
   };
   kalzium = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kalzium-22.08.1.tar.xz";
-      sha256 = "0albsch6j1jdhq14cw70g6wsj85as74ni2ds373402va03ssl5as";
-      name = "kalzium-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kalzium-22.08.2.tar.xz";
+      sha256 = "1xj2knzc2nhnvrz6nk4qxa97z76fvrglz3rw4n6lx2v9xriyihrm";
+      name = "kalzium-22.08.2.tar.xz";
     };
   };
   kamera = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kamera-22.08.1.tar.xz";
-      sha256 = "1dc3wwl63a56az2g8swbfpfk1dnc88g4i4s2dbbnfx78shs2zg8m";
-      name = "kamera-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kamera-22.08.2.tar.xz";
+      sha256 = "1wb05kr18r6hvasjrpzgs7nbnkjsx65pvph64v70038c08jrq4vi";
+      name = "kamera-22.08.2.tar.xz";
     };
   };
   kamoso = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kamoso-22.08.1.tar.xz";
-      sha256 = "17cha6rg9v8x4iyshxmd1ahfl7cn6c090si8ga879k8h54wgzp9q";
-      name = "kamoso-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kamoso-22.08.2.tar.xz";
+      sha256 = "1ph4998vrvz5i4ndgx54ipys58ncb8fkrs9jz12imzpp6h01iq8g";
+      name = "kamoso-22.08.2.tar.xz";
     };
   };
   kanagram = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kanagram-22.08.1.tar.xz";
-      sha256 = "1rdqxz0diag4aw54fwawsa2nngkacs5fqqfq7ysvm08g21icl3qp";
-      name = "kanagram-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kanagram-22.08.2.tar.xz";
+      sha256 = "1jnsvvl076aj7qgczv8bwm59218av364jv9gkqhwcf44g1d13z1v";
+      name = "kanagram-22.08.2.tar.xz";
     };
   };
   kapman = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kapman-22.08.1.tar.xz";
-      sha256 = "0rxw397rgnqnbqd9h1vfpidw80zsmhaa8mlgq3vb89nh638c7y83";
-      name = "kapman-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kapman-22.08.2.tar.xz";
+      sha256 = "0lq84rg3v3qzihwz5alj1gbwrnk6cb1n5x7ip0d5p7fbwmlni58v";
+      name = "kapman-22.08.2.tar.xz";
     };
   };
   kapptemplate = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kapptemplate-22.08.1.tar.xz";
-      sha256 = "1vgxfcyzvrdhv930z2ywn51d954gjadj5z4isbqfs7x7gcdyygq7";
-      name = "kapptemplate-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kapptemplate-22.08.2.tar.xz";
+      sha256 = "0kvsg0xwaqm4yy4l1dgbdnnnql7199f6zj08mj67w44zllihrdfi";
+      name = "kapptemplate-22.08.2.tar.xz";
     };
   };
   kate = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kate-22.08.1.tar.xz";
-      sha256 = "0bs8qvvfqk86gi4r18jibnvb323942ix6d8mi5rksyn8xy7w0mc3";
-      name = "kate-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kate-22.08.2.tar.xz";
+      sha256 = "03vmzq1xysr1nw337dvx17b23qnnqhvs81mzhjpkvq53z3kg299p";
+      name = "kate-22.08.2.tar.xz";
     };
   };
   katomic = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/katomic-22.08.1.tar.xz";
-      sha256 = "10hrfzfqmi76ck9i0zi4583mg7znb8z8czw70pj8v47g8h13023z";
-      name = "katomic-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/katomic-22.08.2.tar.xz";
+      sha256 = "1r0hgyknq3990bq39fg4b9wb76c9rd98hv4w6hna8ca8vk47fz8b";
+      name = "katomic-22.08.2.tar.xz";
     };
   };
   kbackup = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kbackup-22.08.1.tar.xz";
-      sha256 = "0c0zdk00j9qssjdb5dg5hwc5mx7h5kvriyszia2xizqjq2m53c3k";
-      name = "kbackup-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kbackup-22.08.2.tar.xz";
+      sha256 = "168jb24n256qsn6pn3h6rz0kzfp79abrli4jlkkz7srwk9brnf7g";
+      name = "kbackup-22.08.2.tar.xz";
     };
   };
   kblackbox = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kblackbox-22.08.1.tar.xz";
-      sha256 = "15cd267xy6kibm3lj4m127pimzrrixlccbw4c840vf783mp31yyr";
-      name = "kblackbox-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kblackbox-22.08.2.tar.xz";
+      sha256 = "0l2f1nl5as4pz9z4qb081y2zmqwq6j9v2ypq11bv4bmvz8mj2jln";
+      name = "kblackbox-22.08.2.tar.xz";
     };
   };
   kblocks = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kblocks-22.08.1.tar.xz";
-      sha256 = "1dy3fyhjcfib67awjpxcf5444jl2yp4j5da2gq5zydff1ibwn3rd";
-      name = "kblocks-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kblocks-22.08.2.tar.xz";
+      sha256 = "0g6hfn10axxpbnnnsw5hp3df2h905i5rk07gl0nm1jmy09xrc22l";
+      name = "kblocks-22.08.2.tar.xz";
     };
   };
   kbounce = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kbounce-22.08.1.tar.xz";
-      sha256 = "0z4lnkiqdyby25l7ksac9g3s7b7780ikysja45g5x7y28sp64iw5";
-      name = "kbounce-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kbounce-22.08.2.tar.xz";
+      sha256 = "0d7rdfy2cp0zsknwvhhdfjcny5c3r0jy9nfj8zdw3ph7pd9c1rpc";
+      name = "kbounce-22.08.2.tar.xz";
     };
   };
   kbreakout = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kbreakout-22.08.1.tar.xz";
-      sha256 = "0xksmxiq9zdqakw8kvkdkdr6kp0jcdbvhqgbkir342pf2vffbdxl";
-      name = "kbreakout-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kbreakout-22.08.2.tar.xz";
+      sha256 = "0d2acfx477dh81pz2csj41qswlm17bndzldr54xhvjnq6yn83ij0";
+      name = "kbreakout-22.08.2.tar.xz";
     };
   };
   kbruch = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kbruch-22.08.1.tar.xz";
-      sha256 = "0hany9jskr0bbdp10knh17wkk7gvsk892kkkdy3jjvk7dhc2lyr9";
-      name = "kbruch-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kbruch-22.08.2.tar.xz";
+      sha256 = "0g2f2xkmh8081kyh2x48z7hz21il49g66a7k33f5fpdny8hqg2lw";
+      name = "kbruch-22.08.2.tar.xz";
     };
   };
   kcachegrind = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kcachegrind-22.08.1.tar.xz";
-      sha256 = "05wcnfqs0fdfhfpagn0pqky0l7014nblv8r9fv1khy4g5mdlm4hs";
-      name = "kcachegrind-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kcachegrind-22.08.2.tar.xz";
+      sha256 = "0582wk6878vya359kbnpf70r21vi9q051zgmsjgzzvkfkm30d6jc";
+      name = "kcachegrind-22.08.2.tar.xz";
     };
   };
   kcalc = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kcalc-22.08.1.tar.xz";
-      sha256 = "01rn6qy40q4b90i5mysrygkqh5fzq885dgcd11l6r8s59ijjcjlk";
-      name = "kcalc-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kcalc-22.08.2.tar.xz";
+      sha256 = "09y4a9h7v4g64mg3vbivmp6pfj3hylmk7kd62xp8h8kbk1abq9c9";
+      name = "kcalc-22.08.2.tar.xz";
     };
   };
   kcalutils = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kcalutils-22.08.1.tar.xz";
-      sha256 = "1y25csn37lp14ba18gqmw9ssimy4dqi55irx8c89p4p1lypjwfzq";
-      name = "kcalutils-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kcalutils-22.08.2.tar.xz";
+      sha256 = "16vnihxqpaf9dgx74y7q0vjmgvjcg90h9dqam8kmidbqr3556x9c";
+      name = "kcalutils-22.08.2.tar.xz";
     };
   };
   kcharselect = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kcharselect-22.08.1.tar.xz";
-      sha256 = "1gs9jkq76dkhjgjqpl5dcsx0l2qi6i0pk122y1qmwgyd6f8af35b";
-      name = "kcharselect-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kcharselect-22.08.2.tar.xz";
+      sha256 = "1i0l43nz586d6ivb4hvd112ahr12wrq4nlihw87pnccfgb2pprhr";
+      name = "kcharselect-22.08.2.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kcolorchooser-22.08.1.tar.xz";
-      sha256 = "0chxldb8m8ciivnhd1p51ag6s0s232xbmb3b5a1gmkb0hy005js7";
-      name = "kcolorchooser-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kcolorchooser-22.08.2.tar.xz";
+      sha256 = "0vi0sipyhwmzpwqpm1h9qf9sb17xx4nqlnl2lcr2qv6yljnipwwb";
+      name = "kcolorchooser-22.08.2.tar.xz";
     };
   };
   kcron = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kcron-22.08.1.tar.xz";
-      sha256 = "0f3lwa15d81bbr3yxg94yvp0h6x4ncmx0ya0jzkc86x5xbb3wcw9";
-      name = "kcron-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kcron-22.08.2.tar.xz";
+      sha256 = "079rfsfsrsydvkzzism74b0mjqw6bx8br5m7q3gzi40l3m6vi0g7";
+      name = "kcron-22.08.2.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kde-dev-scripts-22.08.1.tar.xz";
-      sha256 = "1l06yk9rsrk4xhvidwlhywdvw9mji205cayd1fzcdz7ibzfydgs4";
-      name = "kde-dev-scripts-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kde-dev-scripts-22.08.2.tar.xz";
+      sha256 = "012ml2z6y3frsxws26kd2ssf8rgn4c2av2m5125kpn5yzy3is53l";
+      name = "kde-dev-scripts-22.08.2.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kde-dev-utils-22.08.1.tar.xz";
-      sha256 = "07jj08gwbsqjvpzw7pqq6sqs6idg7qn4ainxq3jya3nrqs30bqdk";
-      name = "kde-dev-utils-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kde-dev-utils-22.08.2.tar.xz";
+      sha256 = "17m4xc6332h2jhhcmxd51pqnq8rqylarc0762gswy8bj7ywmhd5h";
+      name = "kde-dev-utils-22.08.2.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdebugsettings-22.08.1.tar.xz";
-      sha256 = "0l9q7cmzc93zz2zc5ncq3q7q6jil6ai36n2vh70s2wsi8b0gsms8";
-      name = "kdebugsettings-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdebugsettings-22.08.2.tar.xz";
+      sha256 = "0bgyhhyvrbfl1raj05gkq5a3hhb781508c7ml9rgw7gy9yyqw0ax";
+      name = "kdebugsettings-22.08.2.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdeconnect-kde-22.08.1.tar.xz";
-      sha256 = "1yzx49gcm7x2wdk53iznyjz09y2a6mrrhh68xilbcsafyiw3l3zr";
-      name = "kdeconnect-kde-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdeconnect-kde-22.08.2.tar.xz";
+      sha256 = "1489ik3bpk45w0aml07s83r9j9qlf6qpzsdpd28v6ih8vm1pkvc0";
+      name = "kdeconnect-kde-22.08.2.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdeedu-data-22.08.1.tar.xz";
-      sha256 = "1zbssqzkbwry4f9ffl1j92wp4j740vbvb05ksgbg9ys0zx4zk25y";
-      name = "kdeedu-data-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdeedu-data-22.08.2.tar.xz";
+      sha256 = "07jwrw8r8mgj6m10gqx4hd4xl1nnh5lnwmcdfpfhkwd40j1zlwha";
+      name = "kdeedu-data-22.08.2.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdegraphics-mobipocket-22.08.1.tar.xz";
-      sha256 = "1kxvzgmq83hml10pc4j66r59dsar7h92w2i0cs1nhar781mz666n";
-      name = "kdegraphics-mobipocket-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdegraphics-mobipocket-22.08.2.tar.xz";
+      sha256 = "03yjbb8rfszbhmwf5fyfwinrda610b7ghlj5l5v8yp7blba0i6ry";
+      name = "kdegraphics-mobipocket-22.08.2.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdegraphics-thumbnailers-22.08.1.tar.xz";
-      sha256 = "0akl217rw0yzqmfq339ymxkh5rgbc6l2ayhlf7kbyxwsqffqdf0r";
-      name = "kdegraphics-thumbnailers-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdegraphics-thumbnailers-22.08.2.tar.xz";
+      sha256 = "1ppgc5yh23fgfkwzjirrkv5w7y23xlpf3ijgaw8wgm7kbm61i5y0";
+      name = "kdegraphics-thumbnailers-22.08.2.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdenetwork-filesharing-22.08.1.tar.xz";
-      sha256 = "1245mvljlwxhbd4li6myipa2b43abq6z3lvj6cmxxp9g80qp2r41";
-      name = "kdenetwork-filesharing-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdenetwork-filesharing-22.08.2.tar.xz";
+      sha256 = "0m9v60j9lyan0d0mv9gvl5n4hbm1169rddl4h15k5b23a09ky6b4";
+      name = "kdenetwork-filesharing-22.08.2.tar.xz";
     };
   };
   kdenlive = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdenlive-22.08.1.tar.xz";
-      sha256 = "0h5zc0npx6vwjjz1m38y5r4ic0c8djjmq7iskxlxzjcpk0rgz7na";
-      name = "kdenlive-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdenlive-22.08.2.tar.xz";
+      sha256 = "1n2fsr9xqm027ydpjc5bmc7v22vqp16kgf3a0yh8l3i1xg539ya9";
+      name = "kdenlive-22.08.2.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdepim-addons-22.08.1.tar.xz";
-      sha256 = "140kqxr3mw78nbmiaplf968xl5hkcmrsi6si899csh0l83vm4vzk";
-      name = "kdepim-addons-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdepim-addons-22.08.2.tar.xz";
+      sha256 = "0p72h6ma7gm3cq4l9jnxfbmgvvplva24wn12fv2rc7p664hp6sj9";
+      name = "kdepim-addons-22.08.2.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdepim-runtime-22.08.1.tar.xz";
-      sha256 = "1g6bq27s7nf9rmrbl5kwycl4lzjpp3m088mji3p7qrrv01ywp4mn";
-      name = "kdepim-runtime-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdepim-runtime-22.08.2.tar.xz";
+      sha256 = "1dsdjnkfgmi7kih5adaqpd2m8ar9w2b3dpz0xviyyyyw5114810p";
+      name = "kdepim-runtime-22.08.2.tar.xz";
     };
   };
   kdesdk-kio = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdesdk-kio-22.08.1.tar.xz";
-      sha256 = "1sgfddkbydgihiz5w3p55508r3l4nmq2drx2vsg54plvznyqkmcv";
-      name = "kdesdk-kio-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdesdk-kio-22.08.2.tar.xz";
+      sha256 = "0m5nd1v7mzwnx91541rkb409wmqlw6m4536j1smxw4i8mb71l6y6";
+      name = "kdesdk-kio-22.08.2.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdesdk-thumbnailers-22.08.1.tar.xz";
-      sha256 = "1nzxyv9f4l0x2sglr32qb0gry1fijpgrfc8lpjx3l06b0mclnxy3";
-      name = "kdesdk-thumbnailers-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdesdk-thumbnailers-22.08.2.tar.xz";
+      sha256 = "1qfgrmp3pfjgniawlnqqwnnfyix479706z947rdb4hxrm3bnrr8s";
+      name = "kdesdk-thumbnailers-22.08.2.tar.xz";
     };
   };
   kdev-php = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdev-php-22.08.1.tar.xz";
-      sha256 = "1w9abs0rmsy8915y874iaadmqmn5w3027qav4zk9kx239n26dc6x";
-      name = "kdev-php-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdev-php-22.08.2.tar.xz";
+      sha256 = "1mwr7q0qc94i1vi7sjc8injda6sq3lpb71398s1j7py82644024q";
+      name = "kdev-php-22.08.2.tar.xz";
     };
   };
   kdev-python = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdev-python-22.08.1.tar.xz";
-      sha256 = "15i6q10rvwkv59nx1yncrmigf7sxnblhlbl1l9dghc058ndl9c7b";
-      name = "kdev-python-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdev-python-22.08.2.tar.xz";
+      sha256 = "02nvzjjwz6c1kq9c1sh6m6nwpkw7p0xbgnvipsbsy0bxclmz8xdp";
+      name = "kdev-python-22.08.2.tar.xz";
     };
   };
   kdevelop = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdevelop-22.08.1.tar.xz";
-      sha256 = "14a80z4sahxyzssrz605zp7ah5xdjbc22ccv0vwcnhr5lzr76v31";
-      name = "kdevelop-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdevelop-22.08.2.tar.xz";
+      sha256 = "17vk5azn58a503p99q7clnxb3nb7b6s2ycpxk5xlpmwa0cvwm9az";
+      name = "kdevelop-22.08.2.tar.xz";
     };
   };
   kdf = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdf-22.08.1.tar.xz";
-      sha256 = "0p7iqld2phc74pmhyb8bqqg9clnc7l2rh6hd0i6jcsp266cgg205";
-      name = "kdf-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdf-22.08.2.tar.xz";
+      sha256 = "1hmzv9ji50mz94qbidqvjkdxmnpwx6mpbw101ki3zpbxh0146w0c";
+      name = "kdf-22.08.2.tar.xz";
     };
   };
   kdialog = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdialog-22.08.1.tar.xz";
-      sha256 = "1lqzhfn5g16qr6ada9i0i3kshna1zxp1y20ylwmmsa82bgmyblhx";
-      name = "kdialog-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdialog-22.08.2.tar.xz";
+      sha256 = "0czin6r2anwqgx7rj3nbj4jskqck0mn47706w84k5fyxjp36y2ha";
+      name = "kdialog-22.08.2.tar.xz";
     };
   };
   kdiamond = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kdiamond-22.08.1.tar.xz";
-      sha256 = "1r4w0b41gl96i319vsph5rs5r43kkpbbzhy5k26ps6cgppzl074v";
-      name = "kdiamond-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kdiamond-22.08.2.tar.xz";
+      sha256 = "09a6nrrnfvj6468igv1igiyaqyzfqhh115nnlmqympihzqlz2k11";
+      name = "kdiamond-22.08.2.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/keditbookmarks-22.08.1.tar.xz";
-      sha256 = "0dhr17qqq9bkj1cyrxgjjrxg95mnkb4dmlhvdmr33ngm5rhi5jv3";
-      name = "keditbookmarks-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/keditbookmarks-22.08.2.tar.xz";
+      sha256 = "0j98gl02lp5z8jjlqcbzxz37nrzmjrrvp8ngfir5l37myg39r7cx";
+      name = "keditbookmarks-22.08.2.tar.xz";
     };
   };
   kfind = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kfind-22.08.1.tar.xz";
-      sha256 = "0py6ygnj7qxbwrldf2a3hqc1cqd5yvyfi1l0nji0hwn8lvidnjhc";
-      name = "kfind-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kfind-22.08.2.tar.xz";
+      sha256 = "14ldcq62yw6i4sz9sj5vfklyi4ff6kdza6kvkvsxrqdj8sp0blmv";
+      name = "kfind-22.08.2.tar.xz";
     };
   };
   kfloppy = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kfloppy-22.08.1.tar.xz";
-      sha256 = "1mb64yqrag7bvrdj4gh4vp58yw8362vpa4ga7rbbmiqllks4iy58";
-      name = "kfloppy-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kfloppy-22.08.2.tar.xz";
+      sha256 = "0yzflvbin1lrrw3jkbdr3zia56rzf8zrxagasqg1rmqiz3r2r7i5";
+      name = "kfloppy-22.08.2.tar.xz";
     };
   };
   kfourinline = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kfourinline-22.08.1.tar.xz";
-      sha256 = "1ir3bbxfg07apykfryl8dsd5fdv0dnm2v3ni3qmmx1ap514qjq0a";
-      name = "kfourinline-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kfourinline-22.08.2.tar.xz";
+      sha256 = "0ncyr8vhc4ibi2v9577x97skb437v95lyqp3q44fnw0g921rzlv6";
+      name = "kfourinline-22.08.2.tar.xz";
     };
   };
   kgeography = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kgeography-22.08.1.tar.xz";
-      sha256 = "1ya4briidmypckncnrvzmh00zy2avybaray72003y08vg6jh1had";
-      name = "kgeography-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kgeography-22.08.2.tar.xz";
+      sha256 = "1g3jzgadhjk567zr53ha8wi7kzmy3c689k3cp2hqsk1jvc6zfdz8";
+      name = "kgeography-22.08.2.tar.xz";
     };
   };
   kget = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kget-22.08.1.tar.xz";
-      sha256 = "13pya07hz0i596bk8jp6j3f24jllr9jbnpv3hr5k3nbnm6yyp8h2";
-      name = "kget-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kget-22.08.2.tar.xz";
+      sha256 = "0zglqawsqsmign2gxa0aa2pv2yxl2xbsma7ap8xnars55mzghq2j";
+      name = "kget-22.08.2.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kgoldrunner-22.08.1.tar.xz";
-      sha256 = "0hlqw2c25zdiybjzb9snv59l9ckwbm7ishhk1wrnnind0kdm9rxk";
-      name = "kgoldrunner-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kgoldrunner-22.08.2.tar.xz";
+      sha256 = "05pj8y5zgm0dpbcqd7hiinrgpbkplvw0bw340h7pbk7z8j1vl0y9";
+      name = "kgoldrunner-22.08.2.tar.xz";
     };
   };
   kgpg = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kgpg-22.08.1.tar.xz";
-      sha256 = "1xs0w6lxwq3hzs8r1cwmygcjilbgwa8zpjxwj6zz1wmbg04gqk36";
-      name = "kgpg-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kgpg-22.08.2.tar.xz";
+      sha256 = "140a3jjkwb6m7mwhikac0b7jwn2yg225l7qs52f1ivq5wy9i24h4";
+      name = "kgpg-22.08.2.tar.xz";
     };
   };
   khangman = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/khangman-22.08.1.tar.xz";
-      sha256 = "12m15kpr32svmfzvfwvp2k0hcgb8i4i0mv37vc4x2ln4cjmz7p68";
-      name = "khangman-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/khangman-22.08.2.tar.xz";
+      sha256 = "15fza1hdm66p8h735n8fkabmfjda3rgazd70xwl79ckwwiyg7dcd";
+      name = "khangman-22.08.2.tar.xz";
     };
   };
   khelpcenter = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/khelpcenter-22.08.1.tar.xz";
-      sha256 = "14di37qndpk4caxcqnjfsvl8rjvjcnbf8mgmsb8bq34l01qzjfv6";
-      name = "khelpcenter-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/khelpcenter-22.08.2.tar.xz";
+      sha256 = "1b3qcvbrdkrvcpfjgvp8qv744q1pvbhb77qvald6lpv79b14ba30";
+      name = "khelpcenter-22.08.2.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kidentitymanagement-22.08.1.tar.xz";
-      sha256 = "1h76c8k6lvf4dlh9awd4z71hkikm7x71760gljybd6fkygxpm992";
-      name = "kidentitymanagement-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kidentitymanagement-22.08.2.tar.xz";
+      sha256 = "06a0jghxxq17cvnfxbivpws1s1r9xanj321six3sfyr8z0iypkd1";
+      name = "kidentitymanagement-22.08.2.tar.xz";
     };
   };
   kig = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kig-22.08.1.tar.xz";
-      sha256 = "1zi0faypg4n3rh6w8cpnkdawcsk23h1cnxgw6nai39x9slv9lnqp";
-      name = "kig-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kig-22.08.2.tar.xz";
+      sha256 = "030sz2d9s7zawzhmilzvvqsczxhmi4zzsl91k28l4cii8qgv23bi";
+      name = "kig-22.08.2.tar.xz";
     };
   };
   kigo = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kigo-22.08.1.tar.xz";
-      sha256 = "1061fb5kllh7gsab82p6n8micy9f7wnlkzvbnf1wp1dcydb03qg8";
-      name = "kigo-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kigo-22.08.2.tar.xz";
+      sha256 = "1f2761p8ikqvaz4fjw5884i8k3cz4bv9pn7a41zad5qylfckrr4b";
+      name = "kigo-22.08.2.tar.xz";
     };
   };
   killbots = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/killbots-22.08.1.tar.xz";
-      sha256 = "1mw78a867kip26k92aqmi1yzpbx10bj1iqm63a6pwadyigzir83g";
-      name = "killbots-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/killbots-22.08.2.tar.xz";
+      sha256 = "01c0whsw9yk6v0qa1mp947z8rbw52y9hlm8jan9qwkgbx8sjy3dl";
+      name = "killbots-22.08.2.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kimagemapeditor-22.08.1.tar.xz";
-      sha256 = "09b8mn1kar5hghkd73vi3qjx4y0kr0dcsbsck52z2g1vlb3md8bc";
-      name = "kimagemapeditor-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kimagemapeditor-22.08.2.tar.xz";
+      sha256 = "1rvjqg9nhxwzs33g3kd5yxhf67zlkgl1pwbldw7gxyg1ah0znfzq";
+      name = "kimagemapeditor-22.08.2.tar.xz";
     };
   };
   kimap = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kimap-22.08.1.tar.xz";
-      sha256 = "1a3wwzwlp0zsj4brhs22sygfxh65slikapa4iipxjw78mkwhiq8h";
-      name = "kimap-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kimap-22.08.2.tar.xz";
+      sha256 = "1sxrpjjckpl26harhwvcgmxlf6q5cc6v0xydf0ryrkmh24d7cpda";
+      name = "kimap-22.08.2.tar.xz";
     };
   };
   kio-extras = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kio-extras-22.08.1.tar.xz";
-      sha256 = "0f1hlmngx51ns46n0rdd1zzgl7cd21sm72v8rfw591v6wvhl1qc9";
-      name = "kio-extras-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kio-extras-22.08.2.tar.xz";
+      sha256 = "0rm4syzvxbj1z06896dm2sz9zg5rgc834i78vqfl1c9li09nbmjx";
+      name = "kio-extras-22.08.2.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kio-gdrive-22.08.1.tar.xz";
-      sha256 = "19ms3siziyx0yf663p5s4vanqn80lx16l4yph4ymdby6bys3axii";
-      name = "kio-gdrive-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kio-gdrive-22.08.2.tar.xz";
+      sha256 = "12dajggmiz7kkrc4z59cnai25d62by098bdz9r71xg3lvsx96hhv";
+      name = "kio-gdrive-22.08.2.tar.xz";
     };
   };
   kio-zeroconf = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kio-zeroconf-22.08.1.tar.xz";
-      sha256 = "19dpnxrlpqx94xn2z8w53nz89hn55favk50igf1vphxlm3c4xzli";
-      name = "kio-zeroconf-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kio-zeroconf-22.08.2.tar.xz";
+      sha256 = "0zwjdqkiimqhjrd1pi4cjw148gah3l813276lb7jq3avhrncll25";
+      name = "kio-zeroconf-22.08.2.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kipi-plugins-22.08.1.tar.xz";
-      sha256 = "14v56h5209jmpgwhhg57dnv7jyxi6j0nsvyjdihfw7swk69hp3hf";
-      name = "kipi-plugins-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kipi-plugins-22.08.2.tar.xz";
+      sha256 = "0xk6sya14kv78qhk4fz1ng7fzghmw9cv0ybf5y2q5nvwdmv71c2p";
+      name = "kipi-plugins-22.08.2.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kirigami-gallery-22.08.1.tar.xz";
-      sha256 = "0nngnnmh6ywj3vndz76954l3abk51jfylrs76206ad7h6v50ly1s";
-      name = "kirigami-gallery-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kirigami-gallery-22.08.2.tar.xz";
+      sha256 = "07fvk0xmajxyx15rrbdp7zwyagxq6dqzls3x770rfx8la42v91fp";
+      name = "kirigami-gallery-22.08.2.tar.xz";
     };
   };
   kiriki = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kiriki-22.08.1.tar.xz";
-      sha256 = "0hjvyslw2qxf9sf6350mg2k8813rdq5wklh2q4p7dndq73k6ba97";
-      name = "kiriki-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kiriki-22.08.2.tar.xz";
+      sha256 = "14akhdsr2m42d7my0vc1lzk656a1hphgnr1qr5vi4h8wz5aaamx7";
+      name = "kiriki-22.08.2.tar.xz";
     };
   };
   kiten = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kiten-22.08.1.tar.xz";
-      sha256 = "1f208z37cx202wqpnviipd9vdgj9l3pwc33mxrpx2khv1yh3869q";
-      name = "kiten-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kiten-22.08.2.tar.xz";
+      sha256 = "1w8k6hj3m5445qdng69z1wylp2jibxw37pjnhqkm5c7bcbhv3wms";
+      name = "kiten-22.08.2.tar.xz";
     };
   };
   kitinerary = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kitinerary-22.08.1.tar.xz";
-      sha256 = "1knxyn9imj4vfvsqya740l36d8sczj2fh35qfnqh88j5xjbhiys3";
-      name = "kitinerary-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kitinerary-22.08.2.tar.xz";
+      sha256 = "0b0l0d0apyqjvw503q2kzxyk4dd5qcxkrfgzlg83hvkazy27gd90";
+      name = "kitinerary-22.08.2.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kjumpingcube-22.08.1.tar.xz";
-      sha256 = "1s88s0z4j9d20lnfmf3zsn96hgvydghr9j2yycsbr7gk6s6wzp2l";
-      name = "kjumpingcube-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kjumpingcube-22.08.2.tar.xz";
+      sha256 = "1hmn792wb3w3fb4dsiv6pwx8azxcg92y36zn29jivbm7g2p14852";
+      name = "kjumpingcube-22.08.2.tar.xz";
     };
   };
   kldap = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kldap-22.08.1.tar.xz";
-      sha256 = "0hqvf939d2sqb2frizw9pnhgpc8vi627882d30ssymw5p5nm58il";
-      name = "kldap-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kldap-22.08.2.tar.xz";
+      sha256 = "0jnybrfbgbvmz6am8mg3bq1j80yayfzmjqyr6qr5lwzw21prbzmd";
+      name = "kldap-22.08.2.tar.xz";
     };
   };
   kleopatra = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kleopatra-22.08.1.tar.xz";
-      sha256 = "1vay6cdrx1l7qyg0rrc7z7rwv1jjpwksqzadka7rpshfqhf3r9y8";
-      name = "kleopatra-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kleopatra-22.08.2.tar.xz";
+      sha256 = "0dxwaav96ghs8wns61xijwvj7d4g94kf290iv3x1dcdys19fqmw2";
+      name = "kleopatra-22.08.2.tar.xz";
     };
   };
   klettres = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/klettres-22.08.1.tar.xz";
-      sha256 = "1441smdlbx8vmpf98acclmbpsivbwzzi2fh8kca3ph4szz8jnq0i";
-      name = "klettres-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/klettres-22.08.2.tar.xz";
+      sha256 = "1xl131llc3fdn9pqc9b7d4im7qfwr5aj4ifvvyyf96yqinzp0zj7";
+      name = "klettres-22.08.2.tar.xz";
     };
   };
   klickety = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/klickety-22.08.1.tar.xz";
-      sha256 = "1mfwjcaq9bf41mfsfv6ycjf5a99xmx860bw4q3f6d5hay5wjif9f";
-      name = "klickety-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/klickety-22.08.2.tar.xz";
+      sha256 = "11bnzjr644kmnc2y2r6zjkia5xc7b4bylrxp42wlbgkzrs231xbv";
+      name = "klickety-22.08.2.tar.xz";
     };
   };
   klines = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/klines-22.08.1.tar.xz";
-      sha256 = "1hvmh0ycjb4vf4gamw4yzp5c4rvvxrb078iqq3h90jvczal8zd1j";
-      name = "klines-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/klines-22.08.2.tar.xz";
+      sha256 = "040xqlbikmw2kiv3r7ygpccfqj706073ai22drvrky7h5is4fqac";
+      name = "klines-22.08.2.tar.xz";
     };
   };
   kmag = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmag-22.08.1.tar.xz";
-      sha256 = "09g1r88dbkzwv8imhxx0mfp0b3r7w68yn94iac2gsi461zwp3bzs";
-      name = "kmag-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmag-22.08.2.tar.xz";
+      sha256 = "0drihlib1kdlhacp3z3mbqamyzzjwc75883432sdn9p27nqv2q1d";
+      name = "kmag-22.08.2.tar.xz";
     };
   };
   kmahjongg = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmahjongg-22.08.1.tar.xz";
-      sha256 = "1qjjxblzspp874smg75d3xx3mkqjjvv61q7fydd7isp2q52kmwi6";
-      name = "kmahjongg-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmahjongg-22.08.2.tar.xz";
+      sha256 = "1dzwbzpygz78r76r8afi9ycpy7cldl1gckl0klpzg7c6af9dzxag";
+      name = "kmahjongg-22.08.2.tar.xz";
     };
   };
   kmail = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmail-22.08.1.tar.xz";
-      sha256 = "1q7d2jazc6792dhwxb2zx66bghdnn43sw6lvdg44a7d9zgik1qzb";
-      name = "kmail-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmail-22.08.2.tar.xz";
+      sha256 = "0216qpq980da4wxh8sdns7vkym7mgspdn4p3rcn2wx0dsid950rn";
+      name = "kmail-22.08.2.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmail-account-wizard-22.08.1.tar.xz";
-      sha256 = "0mmlximx6406gwpg004dms3d8i76x0jxq3wngw0qfi7wl2irmk3b";
-      name = "kmail-account-wizard-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmail-account-wizard-22.08.2.tar.xz";
+      sha256 = "1dlbf7sjdzarpdn8kpnkgy7yibr4akd5ly6g19vpn9icniy3dkbv";
+      name = "kmail-account-wizard-22.08.2.tar.xz";
     };
   };
   kmailtransport = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmailtransport-22.08.1.tar.xz";
-      sha256 = "0hhd1m1kfagyiwwfmsxhpin5c25dsiwbzg188khppn6fp2dh79dg";
-      name = "kmailtransport-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmailtransport-22.08.2.tar.xz";
+      sha256 = "03vbplx7ih2kd3fq59qcph4avpz5k75d4v7bjixn6krz44l4mjn0";
+      name = "kmailtransport-22.08.2.tar.xz";
     };
   };
   kmbox = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmbox-22.08.1.tar.xz";
-      sha256 = "0n49xqgyx40hml9554zvnycff26qki9fdy32awx9v9l8jbnrmm6p";
-      name = "kmbox-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmbox-22.08.2.tar.xz";
+      sha256 = "0rwk1fsd16cjmsz9b6md6d2yw8h6bpx0g49f4lyp0acpl84nvik1";
+      name = "kmbox-22.08.2.tar.xz";
     };
   };
   kmime = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmime-22.08.1.tar.xz";
-      sha256 = "1vz5gw33ncc5lx8fx2nnp8ayxpdhfjwwx226gwa94vhxxkfcnmh4";
-      name = "kmime-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmime-22.08.2.tar.xz";
+      sha256 = "16mmkqmwni9bvf4409fdmnsvgizzbw1mq26vvbnn56yxjvqv9p3q";
+      name = "kmime-22.08.2.tar.xz";
     };
   };
   kmines = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmines-22.08.1.tar.xz";
-      sha256 = "019mgqf20ygmi0ibqjh4idw5ff8wmdxg82c4c3djljv6ir15i59i";
-      name = "kmines-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmines-22.08.2.tar.xz";
+      sha256 = "0pvdlnwn7f8yla0pjbkjvdljqlc7vz61qpvrb0ika0c6mz2gn1hf";
+      name = "kmines-22.08.2.tar.xz";
     };
   };
   kmix = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmix-22.08.1.tar.xz";
-      sha256 = "1dmcch538vi0inxs6gv4va31g22255bb9c5rvpf81ivmjcsfczqd";
-      name = "kmix-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmix-22.08.2.tar.xz";
+      sha256 = "17cvcfm0n8qhzxfacvfb9m0ifi1n8qp04nv3r7x9ncr7bzr0xcsi";
+      name = "kmix-22.08.2.tar.xz";
     };
   };
   kmousetool = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmousetool-22.08.1.tar.xz";
-      sha256 = "12gh8k4zmysw97n9dxn2158xcwn5s4wxmnj9x1kcfqi29p5pgjpn";
-      name = "kmousetool-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmousetool-22.08.2.tar.xz";
+      sha256 = "0m2nli3fn8ql104zsqvkjldpynjw3jcp23prfg75jdvdbywhcy2d";
+      name = "kmousetool-22.08.2.tar.xz";
     };
   };
   kmouth = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmouth-22.08.1.tar.xz";
-      sha256 = "0m5h0fiqvqjlip8pzxcmda0mzdaga7ymdqb0kwyiwprrn1f6bj0x";
-      name = "kmouth-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmouth-22.08.2.tar.xz";
+      sha256 = "1njqk67gpwml88hmc00y18v96ybpk1wpj0ii77fi8gparn6jr8sj";
+      name = "kmouth-22.08.2.tar.xz";
     };
   };
   kmplot = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kmplot-22.08.1.tar.xz";
-      sha256 = "0aa7h9bf2pwnp1w2gaa7fxcrmqdi8zpmrrzhizdibmy3yvniagbg";
-      name = "kmplot-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kmplot-22.08.2.tar.xz";
+      sha256 = "0zc3r5663k9hknjfhpg2afs1xwfpryi2y1fk6vpa5y3b4v2mmrm3";
+      name = "kmplot-22.08.2.tar.xz";
     };
   };
   knavalbattle = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/knavalbattle-22.08.1.tar.xz";
-      sha256 = "0ka1ciydyk8icwypq4kwd57hhgagj7knfrzlf3yjm2f033mwfy8c";
-      name = "knavalbattle-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/knavalbattle-22.08.2.tar.xz";
+      sha256 = "0cq1wx71ff99bdi1swjgfzfgcf2pfq2smqnli2kb2swj9hxcmags";
+      name = "knavalbattle-22.08.2.tar.xz";
     };
   };
   knetwalk = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/knetwalk-22.08.1.tar.xz";
-      sha256 = "17l0mrp900r50s4xa6n3i9hcpp3xyk2pqfzgbaj2plbkgkx2mf5h";
-      name = "knetwalk-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/knetwalk-22.08.2.tar.xz";
+      sha256 = "00a82ac2ky5mrkzqxvafawic9w3dqf6ljlknjsw191bvc36niaiw";
+      name = "knetwalk-22.08.2.tar.xz";
     };
   };
   knights = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/knights-22.08.1.tar.xz";
-      sha256 = "0ilcswywgwfqp9nfd1na737258y6n882ni3k2259rh3gbv3rdwyi";
-      name = "knights-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/knights-22.08.2.tar.xz";
+      sha256 = "17cwh08cl2zngipmryfrzk212q7drj4v7sb9g92xqgld6a6hhvcv";
+      name = "knights-22.08.2.tar.xz";
     };
   };
   knotes = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/knotes-22.08.1.tar.xz";
-      sha256 = "076rwgkwx67rn6z0mj0sj77h1jngcpbvrwka3ijg2309r9f2wg8h";
-      name = "knotes-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/knotes-22.08.2.tar.xz";
+      sha256 = "12davidg9s4a3j006wi1hvh4d93jgdfdb7z4bqili30sq6hzfc56";
+      name = "knotes-22.08.2.tar.xz";
     };
   };
   kolf = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kolf-22.08.1.tar.xz";
-      sha256 = "0mbgddjjakj41pmirsrjxz6845ps3jb5v581hhjrwnca96vix616";
-      name = "kolf-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kolf-22.08.2.tar.xz";
+      sha256 = "0r0sbbk3f9bwk7pnmxgdrpy6ya8rj3yiynw37j5s6cljzbd2bmkp";
+      name = "kolf-22.08.2.tar.xz";
     };
   };
   kollision = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kollision-22.08.1.tar.xz";
-      sha256 = "1f35jqpvma701kxpgg1i5qi8f0jif3df0w7ja8x1j102q1h92xks";
-      name = "kollision-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kollision-22.08.2.tar.xz";
+      sha256 = "0mcilhynxrlka9lfg01f3awcl5563q8mqfrxfsplxxxsnhkrnd46";
+      name = "kollision-22.08.2.tar.xz";
     };
   };
   kolourpaint = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kolourpaint-22.08.1.tar.xz";
-      sha256 = "02qny9r2h9g9arfwb5s0gcmydmmb0lblv37ngcfg5kjy4ila3j3s";
-      name = "kolourpaint-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kolourpaint-22.08.2.tar.xz";
+      sha256 = "12xgr6zg1sjcqmg8jn7fryimf8qd0nc1lpjzhd1i8gimm4dv0xkb";
+      name = "kolourpaint-22.08.2.tar.xz";
     };
   };
   kompare = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kompare-22.08.1.tar.xz";
-      sha256 = "0qrj91vjpajx7qlx6fw05mppxsh3iw2jyvd115qn6l01jx08cw4m";
-      name = "kompare-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kompare-22.08.2.tar.xz";
+      sha256 = "1fqsgynnqm0gmzcn4hb72ag6rragp7h7ln3n0ca55m7nh9pwqhy5";
+      name = "kompare-22.08.2.tar.xz";
     };
   };
   konqueror = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/konqueror-22.08.1.tar.xz";
-      sha256 = "0qf113ji4479ymmbj2fgwpikmbsgssz1a4qdyavr2rahrzw4a4yz";
-      name = "konqueror-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/konqueror-22.08.2.tar.xz";
+      sha256 = "128db1pcq608m336swhdzrlbwy316yxh1hccy7lm74p67yy3n4pv";
+      name = "konqueror-22.08.2.tar.xz";
     };
   };
   konquest = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/konquest-22.08.1.tar.xz";
-      sha256 = "1gxg5h9bvnif8dkrq48a94yzpbf7gq0c3pz3ghz121m0qy6pq2nq";
-      name = "konquest-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/konquest-22.08.2.tar.xz";
+      sha256 = "1gc6hj0i89xkcx351aznixpy6579z1mq3a7z6zfinwy4m8h6r1nv";
+      name = "konquest-22.08.2.tar.xz";
     };
   };
   konsole = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/konsole-22.08.1.tar.xz";
-      sha256 = "0091vi7ihqgrpvw77biccld450zgxkm00d8anx28pifdg54ra97i";
-      name = "konsole-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/konsole-22.08.2.tar.xz";
+      sha256 = "0v79pnm0r15pn5p0q6hifp9b9w14qsikn10x8hwam9ij6bi78dcy";
+      name = "konsole-22.08.2.tar.xz";
     };
   };
   kontact = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kontact-22.08.1.tar.xz";
-      sha256 = "0g86qkkqsi6scff17dgw5xv0vynfmzf37ahcfchc8wpy5f0h66jv";
-      name = "kontact-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kontact-22.08.2.tar.xz";
+      sha256 = "18y4dqswrykj27p5k9kav2ayd7aqakdcc4d557lf76x0n2w11ldj";
+      name = "kontact-22.08.2.tar.xz";
     };
   };
   kontactinterface = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kontactinterface-22.08.1.tar.xz";
-      sha256 = "0j7cck262j8z7m7fm55qa5i936x81ljn3cijrk5c5h881152h4fs";
-      name = "kontactinterface-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kontactinterface-22.08.2.tar.xz";
+      sha256 = "1pkf8yhxdfbzk04vjj8xjpsrjyg58by97yxyb5a40avgq2s136n7";
+      name = "kontactinterface-22.08.2.tar.xz";
     };
   };
   kontrast = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kontrast-22.08.1.tar.xz";
-      sha256 = "03y3y5p29zx4nmqi7hp3abxq2n2bgwbz2knhn9vhl3im3ghp7lmp";
-      name = "kontrast-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kontrast-22.08.2.tar.xz";
+      sha256 = "1xkx810kzm7bs6c2b7kh08v5dkq3rx3hdi7pad06jqv75l5k0dbn";
+      name = "kontrast-22.08.2.tar.xz";
     };
   };
   konversation = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/konversation-22.08.1.tar.xz";
-      sha256 = "0aa71wxznd4js9f653f2x72k4cbzpspbq5p0lzx8sk5xf31pl4kv";
-      name = "konversation-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/konversation-22.08.2.tar.xz";
+      sha256 = "0b0asdm3ykjbjm2g4wmzxz6p6f2wh43rd3lmd3c7g5hsjvlf6nq4";
+      name = "konversation-22.08.2.tar.xz";
     };
   };
   kopeninghours = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kopeninghours-22.08.1.tar.xz";
-      sha256 = "03hslgx4zgg7gsnz2xhx4wnchvqfc5n8c6ihgwz3972fkxsjfdvq";
-      name = "kopeninghours-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kopeninghours-22.08.2.tar.xz";
+      sha256 = "0hfjrkwxb6p06d1a4db2qcn24lxw7jw1xi1ba0hhwxg4c2xwrlfw";
+      name = "kopeninghours-22.08.2.tar.xz";
     };
   };
   kopete = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kopete-22.08.1.tar.xz";
-      sha256 = "0r9pqfv0vndaz8x3f9x1ik4xa0mr9scjqnkp6v0jfcnnzmwagvwm";
-      name = "kopete-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kopete-22.08.2.tar.xz";
+      sha256 = "1k59v6zbc9drdy5kwrx099frpm1rlb0g62j3s2cyp2893h2q9qjf";
+      name = "kopete-22.08.2.tar.xz";
     };
   };
   korganizer = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/korganizer-22.08.1.tar.xz";
-      sha256 = "0pcyij50k96mrm9vkq0pzr7n0nrgy1d51zrcb3hly7fpl4gvkx4x";
-      name = "korganizer-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/korganizer-22.08.2.tar.xz";
+      sha256 = "1622fq9qi75r2csnb3r2gs5ncd5qbg0bs55i7ab6dypm8q2rsnaf";
+      name = "korganizer-22.08.2.tar.xz";
     };
   };
   kosmindoormap = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kosmindoormap-22.08.1.tar.xz";
-      sha256 = "042axwxa1497snr8f0m6a61gl9ypdkvllnhnlw4h5ffah7yl5n3s";
-      name = "kosmindoormap-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kosmindoormap-22.08.2.tar.xz";
+      sha256 = "11mhn00zlj60zi9hms33i2r8w66wnw883g6sb9l0fxm5q7ijbqvr";
+      name = "kosmindoormap-22.08.2.tar.xz";
     };
   };
   kpat = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kpat-22.08.1.tar.xz";
-      sha256 = "1bmwha8smi6ibg4q7rbwrl5vzavgkg657h6wx0h1vr59w10vf90d";
-      name = "kpat-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kpat-22.08.2.tar.xz";
+      sha256 = "1kw26nbnk6s95jkfbxxhnibsiwif877ggbs0arwmqssfqv9lj046";
+      name = "kpat-22.08.2.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kpimtextedit-22.08.1.tar.xz";
-      sha256 = "1dxdlspqssxnvha202bgh9yaszs77cph5qd9wcbd45xj07dqgbw1";
-      name = "kpimtextedit-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kpimtextedit-22.08.2.tar.xz";
+      sha256 = "1ayax6yfq1xim8yyfi3kdy0hj4jhj764s3ywjyjzwxk9k8k8bvkb";
+      name = "kpimtextedit-22.08.2.tar.xz";
     };
   };
   kpkpass = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kpkpass-22.08.1.tar.xz";
-      sha256 = "09l6c7nsgfnffgkm0yzjhsfkm79fv9izasislrlzdvca5xninrgb";
-      name = "kpkpass-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kpkpass-22.08.2.tar.xz";
+      sha256 = "0s5jl9h2wsjs935zh2g84l8fdk22z2926xp361461v55ma287z1w";
+      name = "kpkpass-22.08.2.tar.xz";
     };
   };
   kpmcore = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kpmcore-22.08.1.tar.xz";
-      sha256 = "1y28dnmbnkkjar4kl033fkmcnazgczc3pgdac2q1ry2hjzkcbnpa";
-      name = "kpmcore-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kpmcore-22.08.2.tar.xz";
+      sha256 = "1vnay6gbnmmyi4a4j8gxynmawjnly7mxlmk3xmfx96a20d4jsy7x";
+      name = "kpmcore-22.08.2.tar.xz";
     };
   };
   kpublictransport = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kpublictransport-22.08.1.tar.xz";
-      sha256 = "0z7zyyiq4815m74s6p841k1c4pxbrss7hnkag8kr5qa3q4264kg9";
-      name = "kpublictransport-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kpublictransport-22.08.2.tar.xz";
+      sha256 = "0w38b9ji9jhn2lphcsbfayipcxj56ls9dvbb73saddbrh8vazyyp";
+      name = "kpublictransport-22.08.2.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kqtquickcharts-22.08.1.tar.xz";
-      sha256 = "0x92wgw2ghafwy1bpdl2nfwxr2vqmdjgqljszhhlx3hys500zbr8";
-      name = "kqtquickcharts-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kqtquickcharts-22.08.2.tar.xz";
+      sha256 = "0frsjwcbr8080yhpx55fri0km30bx5ylyvsj71il05bdjsbcrd43";
+      name = "kqtquickcharts-22.08.2.tar.xz";
     };
   };
   krdc = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/krdc-22.08.1.tar.xz";
-      sha256 = "04mr75qxjnwxxycarmlvhgv05rkqwmb6y8g1c8ssqppafnknf006";
-      name = "krdc-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/krdc-22.08.2.tar.xz";
+      sha256 = "012g6dk80i8y5aicygh420346yh9jrrr3dm7czp7wgdnw837sf60";
+      name = "krdc-22.08.2.tar.xz";
     };
   };
   kreversi = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kreversi-22.08.1.tar.xz";
-      sha256 = "00wp7nhvkpz0vq41kjhnnbb8mxh56sy50fmvigjqcckb269gqlkl";
-      name = "kreversi-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kreversi-22.08.2.tar.xz";
+      sha256 = "04d0nzgcha67kysz4c4kn95qiwb2qvr0b0rnazjr8fzmn8il120s";
+      name = "kreversi-22.08.2.tar.xz";
     };
   };
   krfb = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/krfb-22.08.1.tar.xz";
-      sha256 = "17bb7dmp1xzmxk3hm2jf6ag4vz8plhkpxsvij9nhqvib17i5qas5";
-      name = "krfb-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/krfb-22.08.2.tar.xz";
+      sha256 = "0qkryb7n0k5dm22lqygk3nlkydvblvms80039v4im4ffjvbz9dna";
+      name = "krfb-22.08.2.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kross-interpreters-22.08.1.tar.xz";
-      sha256 = "0kkk9k8fxrxy8xh5pxh8zvn23b04vyml5w15x7hwx2g3w2gizn5r";
-      name = "kross-interpreters-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kross-interpreters-22.08.2.tar.xz";
+      sha256 = "0jdyvf4yfdkws9gpdgdfd87ghblq872jxqiqf5w2i778sxjxjiv6";
+      name = "kross-interpreters-22.08.2.tar.xz";
     };
   };
   kruler = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kruler-22.08.1.tar.xz";
-      sha256 = "02fi07ygl9i6r5r9xa8zknh2rd6d7mw4drayz8sw8bpdbg418lwf";
-      name = "kruler-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kruler-22.08.2.tar.xz";
+      sha256 = "05fxzya2dk2y8mxydw8xnabify8mvq6q7vpbb998fpwssiis9b1q";
+      name = "kruler-22.08.2.tar.xz";
     };
   };
   ksanecore = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ksanecore-22.08.1.tar.xz";
-      sha256 = "1rfj36d95g6yynr2f1jvdw50waliajzpj2ralvnn2afq6fk7mjzm";
-      name = "ksanecore-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ksanecore-22.08.2.tar.xz";
+      sha256 = "1vcywz0sz4znagxp3wcz98b5sqdmbk6fyy3bq7z3vz8yvbgy8cbv";
+      name = "ksanecore-22.08.2.tar.xz";
     };
   };
   kshisen = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kshisen-22.08.1.tar.xz";
-      sha256 = "0plhf018x1lzpgalkgbp4cc9ymgrhm1p9bx9ghrxq0nclyl4pg6d";
-      name = "kshisen-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kshisen-22.08.2.tar.xz";
+      sha256 = "16520gdkv65gbnnrdylbkr3ypvjirag29lhbkqks4laacvgfd4b8";
+      name = "kshisen-22.08.2.tar.xz";
     };
   };
   ksirk = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ksirk-22.08.1.tar.xz";
-      sha256 = "1rl1517jinnmbq1khjy2bvv6jd9llhfmaq7n91iq80ccg58hrncb";
-      name = "ksirk-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ksirk-22.08.2.tar.xz";
+      sha256 = "120r1c9kwhm9d5isc0kv8bwgi3gxiqcxs9psk8szk8wb0yycip61";
+      name = "ksirk-22.08.2.tar.xz";
     };
   };
   ksmtp = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ksmtp-22.08.1.tar.xz";
-      sha256 = "13ybnr39pim3r83p56wj98fwj0yk1rspd9g24a8d0qykmnbx57l3";
-      name = "ksmtp-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ksmtp-22.08.2.tar.xz";
+      sha256 = "15alzc5z054jcw2pkraj2vd29b2p0wwp4a90wr1fbvm1a10bp454";
+      name = "ksmtp-22.08.2.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ksnakeduel-22.08.1.tar.xz";
-      sha256 = "07qfrhxnsrv96x97lqbm0pm4wgvc0v3lrlgddaz7srk0b157yqrz";
-      name = "ksnakeduel-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ksnakeduel-22.08.2.tar.xz";
+      sha256 = "0s7qg05wr4zyyy8m76hmfc9q5kvk02c20ga890mq418qkxrhqycf";
+      name = "ksnakeduel-22.08.2.tar.xz";
     };
   };
   kspaceduel = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kspaceduel-22.08.1.tar.xz";
-      sha256 = "155syd31vmj6rjlhkpscy8fszinx5b5gv0vjlapg9l48cvv1hrwa";
-      name = "kspaceduel-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kspaceduel-22.08.2.tar.xz";
+      sha256 = "0p02j6hi5gvb36gxwvd8g7m8ajmmigwgfpx85jad01jnzrr8raci";
+      name = "kspaceduel-22.08.2.tar.xz";
     };
   };
   ksquares = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ksquares-22.08.1.tar.xz";
-      sha256 = "1xp7kc8x2624p67wl13s5sayw7xf0d44jzl6x03wd80lsckji9rm";
-      name = "ksquares-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ksquares-22.08.2.tar.xz";
+      sha256 = "1v7lfg3if1ksi6zjx9rkn8mbc9nnq1025s9zsc6x847lmnzc214v";
+      name = "ksquares-22.08.2.tar.xz";
     };
   };
   ksudoku = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ksudoku-22.08.1.tar.xz";
-      sha256 = "0afhffdly2233a3gzlslwybsyiww1zgx6gf94j43rl9jskwr2hn4";
-      name = "ksudoku-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ksudoku-22.08.2.tar.xz";
+      sha256 = "1qi75fbqqj3r8rchzpaf2sjxlib8gj44q8bbdqd4ba3p0y7qap77";
+      name = "ksudoku-22.08.2.tar.xz";
     };
   };
   ksystemlog = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ksystemlog-22.08.1.tar.xz";
-      sha256 = "0k1n5804j4bgh0bd87dcx3rbw328ih0dzzwjqk7c08vf5pwyibcy";
-      name = "ksystemlog-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ksystemlog-22.08.2.tar.xz";
+      sha256 = "0iil7mxn9g1v6p2vdriy7zfkml3znjaps27jzvpdwfna9wclbc2r";
+      name = "ksystemlog-22.08.2.tar.xz";
     };
   };
   kteatime = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kteatime-22.08.1.tar.xz";
-      sha256 = "0mgvncr9pvmgwkzn9vfi8zcf40bdncn2j781gfnsv2blpz96mahz";
-      name = "kteatime-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kteatime-22.08.2.tar.xz";
+      sha256 = "0zlj14glzbx3k4vrjjgk5xp7yzvvpsjafkm5h1470bvbrp8c6ird";
+      name = "kteatime-22.08.2.tar.xz";
     };
   };
   ktimer = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktimer-22.08.1.tar.xz";
-      sha256 = "0nplfpxws178r7lrvr24pf2gxw387h9s91gmqfbf8zrk4pcqsr22";
-      name = "ktimer-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktimer-22.08.2.tar.xz";
+      sha256 = "0nigdd98xdcyxjqbxbc37bqwkvv7qms3h6z03s9nv1h6cw45nsps";
+      name = "ktimer-22.08.2.tar.xz";
     };
   };
   ktnef = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktnef-22.08.1.tar.xz";
-      sha256 = "05rcs0m4dr4p4wxigcnhjmmp15nlf36ka85v8b8gd8630v61w6y6";
-      name = "ktnef-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktnef-22.08.2.tar.xz";
+      sha256 = "1k7vhmb3205ab626bjc0dm97c2cwcbfjzp2rc2dz4sgx0c090r6g";
+      name = "ktnef-22.08.2.tar.xz";
     };
   };
   ktorrent = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktorrent-22.08.1.tar.xz";
-      sha256 = "1din8qkjhq8nx20g1v2ib4zb7yj63qps3y18lbcdxqbdx6hx7pw2";
-      name = "ktorrent-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktorrent-22.08.2.tar.xz";
+      sha256 = "107x5y45x16z952kwgf3w0g6sv350snxbj46g4yziwsbhixmfzaw";
+      name = "ktorrent-22.08.2.tar.xz";
     };
   };
   ktouch = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktouch-22.08.1.tar.xz";
-      sha256 = "023vsrxz19z0jy04fnknp9mwqf06rcizn5vwdbl5lzicj5dkmwws";
-      name = "ktouch-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktouch-22.08.2.tar.xz";
+      sha256 = "1p5jzp2y8l70q7gjrq7fj2c0y3hydaan82c8v7h4nwgkji5p452c";
+      name = "ktouch-22.08.2.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-accounts-kcm-22.08.1.tar.xz";
-      sha256 = "0a6ij11wpz4j9g1sajxm6hrwyyzindkn23ri5qh1q7y2frml3c2l";
-      name = "ktp-accounts-kcm-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-accounts-kcm-22.08.2.tar.xz";
+      sha256 = "0dbv0qvj9lqqxm3app4856wvshrxdh42n6md83w4356fqgf4ihbf";
+      name = "ktp-accounts-kcm-22.08.2.tar.xz";
     };
   };
   ktp-approver = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-approver-22.08.1.tar.xz";
-      sha256 = "15m4y01vq3xkw9n1cww19p1ccqjaq4jsyxnkh7xmw7ivwjmqr96h";
-      name = "ktp-approver-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-approver-22.08.2.tar.xz";
+      sha256 = "0mnnpwx3khapz38agj1gw3fvpi8n3h3xdhx07i9kl2r0wpxhnrpi";
+      name = "ktp-approver-22.08.2.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-auth-handler-22.08.1.tar.xz";
-      sha256 = "1ssrpgx8lb1926l5a52y7gr8k5vndrjn89hmghqzhc5gs7f4blzp";
-      name = "ktp-auth-handler-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-auth-handler-22.08.2.tar.xz";
+      sha256 = "000rviz3mmdrmzy0nsjg4zbc1d1razkxw61rcnhg34xq2zjvp520";
+      name = "ktp-auth-handler-22.08.2.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-call-ui-22.08.1.tar.xz";
-      sha256 = "1k7jk9fcxl829d09lbri1filr9jk5fii5n53jc7sfmwyzksdi5s8";
-      name = "ktp-call-ui-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-call-ui-22.08.2.tar.xz";
+      sha256 = "0kadrba3kcj8vyskqd68msfg1l2s5v7bdkqdka4dmb5clhsycv19";
+      name = "ktp-call-ui-22.08.2.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-common-internals-22.08.1.tar.xz";
-      sha256 = "15hwf04bhay16zpfznylnvz36bfklq7aydpq1ss66cszgrnc82yk";
-      name = "ktp-common-internals-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-common-internals-22.08.2.tar.xz";
+      sha256 = "00xc8yjxc9bd5hmiwpphqz9bb1m77daqqp4hy6srpmnsmd5nvwa7";
+      name = "ktp-common-internals-22.08.2.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-contact-list-22.08.1.tar.xz";
-      sha256 = "1svbqqzxamv5zr9aal7556sfykvr898x9p1kyh6523dcbj360r3w";
-      name = "ktp-contact-list-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-contact-list-22.08.2.tar.xz";
+      sha256 = "0lx5cmsqk7xgffv1rfvqdbb02rhygc4grprg689g50c2b129rhcc";
+      name = "ktp-contact-list-22.08.2.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-contact-runner-22.08.1.tar.xz";
-      sha256 = "0fb36v47vh6gsk8zcmrk0qfzdxbdvd7pvh4zl6cbw16xrn5h7lsr";
-      name = "ktp-contact-runner-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-contact-runner-22.08.2.tar.xz";
+      sha256 = "1p9m36lpz4y7lsz5iidhsqi27nq9q8ldjasxb15m1b09rr8z95jp";
+      name = "ktp-contact-runner-22.08.2.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-desktop-applets-22.08.1.tar.xz";
-      sha256 = "179nb7b72nl6vxlqy2s3s06n0nlnhl0dn9java2kslf0197sy71y";
-      name = "ktp-desktop-applets-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-desktop-applets-22.08.2.tar.xz";
+      sha256 = "18ylsdkbvz6wfbnq5gjnzq3lpdx0v7hc531fs1p2p4p3ka0xfci5";
+      name = "ktp-desktop-applets-22.08.2.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-filetransfer-handler-22.08.1.tar.xz";
-      sha256 = "08bs3sarjbrx180vjjr2z0d5r95i2vdmnry65b84nnxykmclaspf";
-      name = "ktp-filetransfer-handler-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-filetransfer-handler-22.08.2.tar.xz";
+      sha256 = "0rxymb0jkdwmzq5l4q81bgajficaxm80wli8lld7kdwkh65mzjb8";
+      name = "ktp-filetransfer-handler-22.08.2.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-kded-module-22.08.1.tar.xz";
-      sha256 = "0yx1nr9lzijbiz47ni3livzazzapp9bxj14jnl9jczlgi4sq94q3";
-      name = "ktp-kded-module-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-kded-module-22.08.2.tar.xz";
+      sha256 = "10lq78rfrjr46v7fl55vki9hq6xsfsd48nbkp1ncxcdccd8a6j5g";
+      name = "ktp-kded-module-22.08.2.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-send-file-22.08.1.tar.xz";
-      sha256 = "19wdffn4ylf3sx0cl8sbccnmi78finms52ncjbkfb5akg6hl6sq4";
-      name = "ktp-send-file-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-send-file-22.08.2.tar.xz";
+      sha256 = "11pk0r82d0myskxdn90xq1fraiyyl1xzyrxx50j9imw1q6w8qv7f";
+      name = "ktp-send-file-22.08.2.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktp-text-ui-22.08.1.tar.xz";
-      sha256 = "1sh5b4vk4lwngka328651mqr19ypip6f0wnqc74ymcf6n62v6wsf";
-      name = "ktp-text-ui-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktp-text-ui-22.08.2.tar.xz";
+      sha256 = "1jk3f8x18c8zgax5v3jgn8vn091dg9xppi7h4851f1vm348ppfqx";
+      name = "ktp-text-ui-22.08.2.tar.xz";
     };
   };
   ktuberling = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/ktuberling-22.08.1.tar.xz";
-      sha256 = "1rgh0bkm6hm1wg2bsh6y59pbdwvlj8ps32hympazfav8njy3skqf";
-      name = "ktuberling-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/ktuberling-22.08.2.tar.xz";
+      sha256 = "06p8vakblj0la06ywi89zss9mcjpb018jhj3a105jj53gl1z8c73";
+      name = "ktuberling-22.08.2.tar.xz";
     };
   };
   kturtle = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kturtle-22.08.1.tar.xz";
-      sha256 = "0419wwrmlg2b7zrgkss1wv22q7wlbic0gx84iybzwhn62vfhggq6";
-      name = "kturtle-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kturtle-22.08.2.tar.xz";
+      sha256 = "17zg39377lwbnpf438b3jfj1ihrr9zlk4ibmgls7d4x8dqphg9hy";
+      name = "kturtle-22.08.2.tar.xz";
     };
   };
   kubrick = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kubrick-22.08.1.tar.xz";
-      sha256 = "14r7jznfgn9q71ldbf1nrdmy8l15lcclcvra7g515b94cxx7kbp9";
-      name = "kubrick-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kubrick-22.08.2.tar.xz";
+      sha256 = "1ld07pcpzj68p6pd4n7p9b1y8nflydraabqszc7sj88hkf601694";
+      name = "kubrick-22.08.2.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kwalletmanager-22.08.1.tar.xz";
-      sha256 = "1d07z1dmkz5h7amixp9d8cwpzgd3zm58gw8d9qax53zk0qh4a3n0";
-      name = "kwalletmanager-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kwalletmanager-22.08.2.tar.xz";
+      sha256 = "03a9brsck24z6ln6v86wbpj9flg7rpshjfsyr89xbkw6v61hjgaj";
+      name = "kwalletmanager-22.08.2.tar.xz";
     };
   };
   kwave = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kwave-22.08.1.tar.xz";
-      sha256 = "0a0cmpvp1s70c1fhrqhdzqhzdx2bsvgnkjdhyrggmj61iflkb5gh";
-      name = "kwave-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kwave-22.08.2.tar.xz";
+      sha256 = "0rwm080p56gnichjdaa9r8ki3ycb918c002k8pm8smwbsd7vkw5c";
+      name = "kwave-22.08.2.tar.xz";
     };
   };
   kwordquiz = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/kwordquiz-22.08.1.tar.xz";
-      sha256 = "0vv60gdy6l5ysaxf7qwacsbjv689g2qa414hfxn54zbrq5lgdah1";
-      name = "kwordquiz-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/kwordquiz-22.08.2.tar.xz";
+      sha256 = "1qy5micdpp0fa1zp15ck44i2afalqbliqnv25yi52aafabj05ixg";
+      name = "kwordquiz-22.08.2.tar.xz";
     };
   };
   libgravatar = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libgravatar-22.08.1.tar.xz";
-      sha256 = "1yhmxl2gqwrn5flr5qm56aqg6rgmqbgcr3pyb4d0vshdfksjr4rc";
-      name = "libgravatar-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libgravatar-22.08.2.tar.xz";
+      sha256 = "1rr6b1prdi2r1n3plg6jwjxm1kxp1azspcbwzs8igbyglmq2h5pq";
+      name = "libgravatar-22.08.2.tar.xz";
     };
   };
   libkcddb = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkcddb-22.08.1.tar.xz";
-      sha256 = "129qm4hz48fq7s573zgnm0zl9z887zc4lx1znqfbbpj53igd1xm0";
-      name = "libkcddb-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkcddb-22.08.2.tar.xz";
+      sha256 = "1nhfv9xrc3zxf6553h9sscalyzxw5wk2r9dkbaiv7fcczka7m5mg";
+      name = "libkcddb-22.08.2.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkcompactdisc-22.08.1.tar.xz";
-      sha256 = "12lw9dmp7sj3f6zdqw9hlxy7an4vj4lbli888456h8sfxq3ydd4z";
-      name = "libkcompactdisc-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkcompactdisc-22.08.2.tar.xz";
+      sha256 = "17rb5szf17xs6g1bn8wwsc7qxhjc996bfs14570xhyhhwil79z3v";
+      name = "libkcompactdisc-22.08.2.tar.xz";
     };
   };
   libkdcraw = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkdcraw-22.08.1.tar.xz";
-      sha256 = "12w48dz0s0k5qn029kzp8qbz06kqn9hpxsq00bj5q99ir1lzf3hf";
-      name = "libkdcraw-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkdcraw-22.08.2.tar.xz";
+      sha256 = "03rzd87gz2czq81y3mjbx0bgrnbipfkx9lnqrm5nj6mcagdir8di";
+      name = "libkdcraw-22.08.2.tar.xz";
     };
   };
   libkdegames = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkdegames-22.08.1.tar.xz";
-      sha256 = "1aihbha073fw2bxmdk4l768716kvrlyjd72x2nfx0vvr0ngc5wx9";
-      name = "libkdegames-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkdegames-22.08.2.tar.xz";
+      sha256 = "1gbdria8yk4j4bna8cs4mmzkgyainras59wrwn36v55c2cdx2jjj";
+      name = "libkdegames-22.08.2.tar.xz";
     };
   };
   libkdepim = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkdepim-22.08.1.tar.xz";
-      sha256 = "07ihnps983x3sp74yq5glsq3h3jw4k80mnc4xxzm6ps2vgswah12";
-      name = "libkdepim-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkdepim-22.08.2.tar.xz";
+      sha256 = "1vjc09l7lbhwqrggqihy05sdmffpqbipkxy6ykya7vf4dnm83ddw";
+      name = "libkdepim-22.08.2.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkeduvocdocument-22.08.1.tar.xz";
-      sha256 = "0f99xqhz1rk0m2mw7n2jxbx4iv2a9mlr87q9fj1b607i2sg119bz";
-      name = "libkeduvocdocument-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkeduvocdocument-22.08.2.tar.xz";
+      sha256 = "1n7km3xwgdv6mdk83nw16760nfzn7lfcs7mhfm4yay8x930mkhg8";
+      name = "libkeduvocdocument-22.08.2.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkexiv2-22.08.1.tar.xz";
-      sha256 = "0iwpy79ppv4bbsqrszp9kmghgjvkl13gdpnafsbikh4wy1ch4cv9";
-      name = "libkexiv2-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkexiv2-22.08.2.tar.xz";
+      sha256 = "17v90apzvw4rc7wrgla2j0gawvpn4h8m580zwpclh0mdgq7af0js";
+      name = "libkexiv2-22.08.2.tar.xz";
     };
   };
   libkgapi = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkgapi-22.08.1.tar.xz";
-      sha256 = "065441mbl67wyp4nz03jdygkn5wmnmkj4fiql4mnq99k2v80y0ka";
-      name = "libkgapi-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkgapi-22.08.2.tar.xz";
+      sha256 = "082bc6x4v9zjzxip9vdlhirnpjr3l1bayshwvzfx7m1f0l4l2ci6";
+      name = "libkgapi-22.08.2.tar.xz";
     };
   };
   libkipi = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkipi-22.08.1.tar.xz";
-      sha256 = "14pywsi08p94hkk48iynlk7g36lch6ljqq80xmi8rpdh8zsmsg86";
-      name = "libkipi-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkipi-22.08.2.tar.xz";
+      sha256 = "0g33hhy9b9xzis3kbxd25jg6d651n2cg3icblpf2nnfn6py8vsi6";
+      name = "libkipi-22.08.2.tar.xz";
     };
   };
   libkleo = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkleo-22.08.1.tar.xz";
-      sha256 = "05ypgrwynm1hr32hj35faj3sxabi46x8slnbs3pxwz2f2z2ry58a";
-      name = "libkleo-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkleo-22.08.2.tar.xz";
+      sha256 = "0lwknyq1342xlgq0lvbghqma92cpcdb04x20ihg8pv42sp1lhqav";
+      name = "libkleo-22.08.2.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkmahjongg-22.08.1.tar.xz";
-      sha256 = "0ilviq0lvnqf9fi32r3jqapf4zhciy4fb900005zs32vqpbk6v31";
-      name = "libkmahjongg-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkmahjongg-22.08.2.tar.xz";
+      sha256 = "0vl70bdgcwi7dvklb0sy67vjjjmp334biaczlzcq5pa7gkh3fqj5";
+      name = "libkmahjongg-22.08.2.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libkomparediff2-22.08.1.tar.xz";
-      sha256 = "0hjxxhfv0ds05l821avq787sfdy0afr595xx266c20x8fxgm6kv9";
-      name = "libkomparediff2-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libkomparediff2-22.08.2.tar.xz";
+      sha256 = "074dpggjcjjkhpdrxzybgnyxj0jp22g4d2p7h7shy2r4pmqdai0s";
+      name = "libkomparediff2-22.08.2.tar.xz";
     };
   };
   libksane = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libksane-22.08.1.tar.xz";
-      sha256 = "1m9jx3k2k0p7n4s4w1czlxhlxqsrsghk8da40arbkqmpal93j8yn";
-      name = "libksane-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libksane-22.08.2.tar.xz";
+      sha256 = "1yhxca4hqdfim6f2q8yay24mdwmcn082kddyddhpgdgl59rdrws6";
+      name = "libksane-22.08.2.tar.xz";
     };
   };
   libksieve = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libksieve-22.08.1.tar.xz";
-      sha256 = "1ia1gjx8x9ym3dml3y403kif50jhcsrqmhivn3j5yxf8abc3rnk6";
-      name = "libksieve-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libksieve-22.08.2.tar.xz";
+      sha256 = "1k0il3gi11xvd0zab7p09199ixh5hb3xdwqpijzsiwzgl27az46c";
+      name = "libksieve-22.08.2.tar.xz";
     };
   };
   libktorrent = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/libktorrent-22.08.1.tar.xz";
-      sha256 = "0gsmvblszsvwp6dpyax36ahd2n5bqbbv49zfnq8x8h5fpaf415db";
-      name = "libktorrent-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/libktorrent-22.08.2.tar.xz";
+      sha256 = "0vgq36hbypig2axb5wrn3y2mgm5r7dyrlfq1bj99dnrbrqivsrnd";
+      name = "libktorrent-22.08.2.tar.xz";
     };
   };
   lokalize = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/lokalize-22.08.1.tar.xz";
-      sha256 = "0gmnis0b1628b5429s8mgd8y9kxdxx466k5xpw2634phrgc0i19c";
-      name = "lokalize-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/lokalize-22.08.2.tar.xz";
+      sha256 = "0x1dxwjfbjqhb7dcz6rj74s505npdj2081zyd8sf0q8zjri3cpq6";
+      name = "lokalize-22.08.2.tar.xz";
     };
   };
   lskat = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/lskat-22.08.1.tar.xz";
-      sha256 = "08ijscnvm0dywnjahzrpnicjnh5gb1l8cwzac4qh42pj7hds1mzc";
-      name = "lskat-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/lskat-22.08.2.tar.xz";
+      sha256 = "0bw843l3fvwb4b0xg5jx9xyb9lmyq66gzbz3ahzixnw5wbj0c888";
+      name = "lskat-22.08.2.tar.xz";
     };
   };
   mailcommon = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/mailcommon-22.08.1.tar.xz";
-      sha256 = "1lpnfcj2p58lhgcjg6ray5b9ygz7gpb8xh8qkakn4m7cpjhgcj5j";
-      name = "mailcommon-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/mailcommon-22.08.2.tar.xz";
+      sha256 = "1l169cxizmms721wx7lag4i5fcsbplflfxkpglzh59pjqgfqv4kz";
+      name = "mailcommon-22.08.2.tar.xz";
     };
   };
   mailimporter = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/mailimporter-22.08.1.tar.xz";
-      sha256 = "1k7gwagcvhj733c48ayxwi1gf37y6w5g6n2b9fknhfs40kqpdri9";
-      name = "mailimporter-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/mailimporter-22.08.2.tar.xz";
+      sha256 = "1kcps0q857cy8bdssl8xmfphmlxqhp5i383khcqg42avgrqv3c2h";
+      name = "mailimporter-22.08.2.tar.xz";
     };
   };
   marble = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/marble-22.08.1.tar.xz";
-      sha256 = "1ry3svfbj2frbbfiix77p8822w48ayf5jkmrz8lagayqqvah7dlh";
-      name = "marble-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/marble-22.08.2.tar.xz";
+      sha256 = "1ys05l0sk4k3bibha23y6q38a9kwhg2rvafmafzg2l37krx0rn47";
+      name = "marble-22.08.2.tar.xz";
     };
   };
   markdownpart = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/markdownpart-22.08.1.tar.xz";
-      sha256 = "0v4lkzd7hmb7gzxscr02pcsd13bsnvyvd5k0l4s3lzyb0ik3ygb3";
-      name = "markdownpart-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/markdownpart-22.08.2.tar.xz";
+      sha256 = "0sgdkf85gmf1sg508bamll60vg0nanxjp2yccavdrq89snjg6c71";
+      name = "markdownpart-22.08.2.tar.xz";
     };
   };
   mbox-importer = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/mbox-importer-22.08.1.tar.xz";
-      sha256 = "1lcjybmjwkvfsldfrr6fqxc93plch65q3qsz8ccig0j3ar2msi66";
-      name = "mbox-importer-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/mbox-importer-22.08.2.tar.xz";
+      sha256 = "1msva2bs8558v0v1ad12fsppbkrrb9cn1kamyzq1hwzqd17dwkyg";
+      name = "mbox-importer-22.08.2.tar.xz";
     };
   };
   messagelib = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/messagelib-22.08.1.tar.xz";
-      sha256 = "0xq1a064g3h3igrqanfald9n21nnrsg16a4kmn9vn1k03qv1vlp2";
-      name = "messagelib-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/messagelib-22.08.2.tar.xz";
+      sha256 = "0mv7fn0q10hx60108y538apa2wcxc9fr9dm40ccpafx01za6099n";
+      name = "messagelib-22.08.2.tar.xz";
     };
   };
   minuet = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/minuet-22.08.1.tar.xz";
-      sha256 = "1r4c057d5pqmk5gzd2abpf15471vfx65m57ssjgi2pwbql95frkr";
-      name = "minuet-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/minuet-22.08.2.tar.xz";
+      sha256 = "07l79d8bn1d9jyv98hms3sgfhp0a2s386d9xj8slx8iwa9gh5bjv";
+      name = "minuet-22.08.2.tar.xz";
     };
   };
   okular = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/okular-22.08.1.tar.xz";
-      sha256 = "0f98kfsb6sirpym27j2wwz4qr4p5vl4pbnckxd3gmgyfpz8mszln";
-      name = "okular-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/okular-22.08.2.tar.xz";
+      sha256 = "1bcfdmrs7f3dxcrc73qyv8zswlf2pl4jk0qq5fmrh7dlazvsykp9";
+      name = "okular-22.08.2.tar.xz";
     };
   };
   palapeli = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/palapeli-22.08.1.tar.xz";
-      sha256 = "0gz3wsl0896wn5mfrm2dyvgxqsqkwbs28vgnf2lwndj8gljvkm9z";
-      name = "palapeli-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/palapeli-22.08.2.tar.xz";
+      sha256 = "0yjll4grrrwv538ikw1axm24bxqiik8hlny5ynm1sbrpbm3d273g";
+      name = "palapeli-22.08.2.tar.xz";
     };
   };
   parley = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/parley-22.08.1.tar.xz";
-      sha256 = "1ri4vz1a3v0baxdwg4krn5j9wmndjbxp33p7j2d9ksxiawipma99";
-      name = "parley-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/parley-22.08.2.tar.xz";
+      sha256 = "0w2dmdx1aanjs8fclxkssmz0kww5dbb5sbhk9a257p3ll6vwnh6l";
+      name = "parley-22.08.2.tar.xz";
     };
   };
   partitionmanager = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/partitionmanager-22.08.1.tar.xz";
-      sha256 = "0ggh3pmvqvi01shzkk4zir7kdh7cgksr41ywqr7mqn4b22v7kj2w";
-      name = "partitionmanager-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/partitionmanager-22.08.2.tar.xz";
+      sha256 = "05qjl82hb0n00p6gj3s6aq95nr4z40zk6znvzxjih24jycg938y4";
+      name = "partitionmanager-22.08.2.tar.xz";
     };
   };
   picmi = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/picmi-22.08.1.tar.xz";
-      sha256 = "0s7q020l1lb3jmvgrrw9gq9h78bb0n9n5hm2r8087fx75ncbnrjp";
-      name = "picmi-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/picmi-22.08.2.tar.xz";
+      sha256 = "1jrqply8cwm92rknshvlbp4lhn5afm61l4l7adsfh1lz6p4qq7i4";
+      name = "picmi-22.08.2.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/pim-data-exporter-22.08.1.tar.xz";
-      sha256 = "0lmmkmlhnc6v910r22dzip5vd53q63zjf6n538jvj6j1qsnm3fa7";
-      name = "pim-data-exporter-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/pim-data-exporter-22.08.2.tar.xz";
+      sha256 = "0rxvqpgykn22ylm467h00jf1mkd3qz5l0kc7zafqvamhafrqvqs1";
+      name = "pim-data-exporter-22.08.2.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/pim-sieve-editor-22.08.1.tar.xz";
-      sha256 = "0hdrp1nvxmmxybrm6m8qhklfp1w4ym4ck939cn47lhffdpr0i9vy";
-      name = "pim-sieve-editor-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/pim-sieve-editor-22.08.2.tar.xz";
+      sha256 = "0r58qlqrl0nv26jng80zm3wiy712idyg610gisq5pz5g8smngifc";
+      name = "pim-sieve-editor-22.08.2.tar.xz";
     };
   };
   pimcommon = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/pimcommon-22.08.1.tar.xz";
-      sha256 = "00gxv1028xdp7ag44z9h6cpmlw55f3rk7i6msymga3pdq639c19y";
-      name = "pimcommon-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/pimcommon-22.08.2.tar.xz";
+      sha256 = "1ah5w1zppamb8wii0qdwv0fhjq175kaql2h0h8gj8vlypwwsj458";
+      name = "pimcommon-22.08.2.tar.xz";
     };
   };
   poxml = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/poxml-22.08.1.tar.xz";
-      sha256 = "13jp5g5la3kq9i3qybdvwfl4vgqz3hxf64qzmh7kl71ykas7s5vi";
-      name = "poxml-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/poxml-22.08.2.tar.xz";
+      sha256 = "0pjmy83b2gkvdiq8l0xs4g5knh8i0gm024isxdvmj5drvzkwwdaz";
+      name = "poxml-22.08.2.tar.xz";
     };
   };
   print-manager = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/print-manager-22.08.1.tar.xz";
-      sha256 = "0rligj48l3wc6712wmbhy8h6xig34mjh2mpj39lxzvgsmpkqbb4h";
-      name = "print-manager-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/print-manager-22.08.2.tar.xz";
+      sha256 = "0f75ybcj5626kjwnd6njh2yxdsydz7ybmnia1vxiql6wn04h9ncz";
+      name = "print-manager-22.08.2.tar.xz";
     };
   };
   rocs = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/rocs-22.08.1.tar.xz";
-      sha256 = "1646w4a3y2gkl3a71mrxk5v9nw23sy5vdf54y0b476xgyiry5jqx";
-      name = "rocs-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/rocs-22.08.2.tar.xz";
+      sha256 = "0p30acx21ahvnxwfqvalhbsyz5131la6dpmcwrdazcgd05w9jj8b";
+      name = "rocs-22.08.2.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/signon-kwallet-extension-22.08.1.tar.xz";
-      sha256 = "0352qh3ck8rfz9s0iys9235m7z36jsz91hav0g4qzjx7bjq90aqy";
-      name = "signon-kwallet-extension-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/signon-kwallet-extension-22.08.2.tar.xz";
+      sha256 = "1sqnnli6p9krqam71nbgkqr0nr5d8j13328g70axi276sv94zc39";
+      name = "signon-kwallet-extension-22.08.2.tar.xz";
     };
   };
   skanlite = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/skanlite-22.08.1.tar.xz";
-      sha256 = "10h8ln3avdynjf1zanmrxrwwr72xa08s251jh2qhny2j8mlxqi9s";
-      name = "skanlite-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/skanlite-22.08.2.tar.xz";
+      sha256 = "14cj1zcqglg9sybv6qz55h2y1y17bs4yc565z72gxnp1lp6g0v51";
+      name = "skanlite-22.08.2.tar.xz";
     };
   };
   skanpage = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/skanpage-22.08.1.tar.xz";
-      sha256 = "1b9mfb9bdgdbsnzmisifp4cyrw3n9mbfjcrynd3w355x208bxqnh";
-      name = "skanpage-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/skanpage-22.08.2.tar.xz";
+      sha256 = "14bswzf4zb5ghnrb9mklswfd4faxar9qpbb27iwia0z5k7wm94xz";
+      name = "skanpage-22.08.2.tar.xz";
     };
   };
   spectacle = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/spectacle-22.08.1.tar.xz";
-      sha256 = "1248b8bm5c39xfssdcr4gc9id7hs1bkv7dy5bzqki6k850hvpzkc";
-      name = "spectacle-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/spectacle-22.08.2.tar.xz";
+      sha256 = "1bhyrhkkf6r49b152dgkjl34nx3w0rjraq7anbsnmapv3ny2qjnf";
+      name = "spectacle-22.08.2.tar.xz";
     };
   };
   step = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/step-22.08.1.tar.xz";
-      sha256 = "0mmgwi1pb8x73jmi8bd9v76z7a8mmvnb61xlpf2z1ixvqwd7m09k";
-      name = "step-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/step-22.08.2.tar.xz";
+      sha256 = "0n8b4vnmh2x7dq93rgs1rg45hbkpmkd31rghf5q096ln04p4yas0";
+      name = "step-22.08.2.tar.xz";
     };
   };
   svgpart = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/svgpart-22.08.1.tar.xz";
-      sha256 = "14g2k55sj53xcx8z7n4bjag266yjdqs1wn7nig9iwjrswwiq2yj4";
-      name = "svgpart-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/svgpart-22.08.2.tar.xz";
+      sha256 = "133ffawzv3r4ipgfagbc9bzjs1zfp2w4g8w8621wf0cwba6dgy0a";
+      name = "svgpart-22.08.2.tar.xz";
     };
   };
   sweeper = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/sweeper-22.08.1.tar.xz";
-      sha256 = "0sg8myfw8jn5iqqag3nddy5iab351d39j09nf0dk2pjs8jjs7bbw";
-      name = "sweeper-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/sweeper-22.08.2.tar.xz";
+      sha256 = "0bkfsl07s8lydjrvpnwqx68jig83fh4yi8vlmnsyw1qnxxi887dq";
+      name = "sweeper-22.08.2.tar.xz";
     };
   };
   umbrello = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/umbrello-22.08.1.tar.xz";
-      sha256 = "0qgl7n4g6h7bab9smjn0ay8ss31drsg0dgyv11l5m0r88q0vy9fx";
-      name = "umbrello-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/umbrello-22.08.2.tar.xz";
+      sha256 = "1ckq3nf230lvfrgnfnhf5sr9wrndn7jjpf9gbkfs2nd87r0wpldk";
+      name = "umbrello-22.08.2.tar.xz";
     };
   };
   yakuake = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/yakuake-22.08.1.tar.xz";
-      sha256 = "1q9a6zg4mmsyih8pyggfq6ln5mpcl5bh92z6pkx0l80zkj9hnfp3";
-      name = "yakuake-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/yakuake-22.08.2.tar.xz";
+      sha256 = "1yw7w0sqzwn8xqqif7zvpjaz6k3lc8wcb8k6dlcwp0awpxyb1c4p";
+      name = "yakuake-22.08.2.tar.xz";
     };
   };
   zanshin = {
-    version = "22.08.1";
+    version = "22.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/22.08.1/src/zanshin-22.08.1.tar.xz";
-      sha256 = "1fayh3f7kkwy16c9l07l0giwzzxxfmakj10w5hqmxmgambf3ml0x";
-      name = "zanshin-22.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/22.08.2/src/zanshin-22.08.2.tar.xz";
+      sha256 = "0wggr056kd8xigdf0ihra050j67sp54jly2drdwzipsn9jw4pss8";
+      name = "zanshin-22.08.2.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Description of changes

Bump KDE Gear / Applications to [22.08.2, released in 12/October/2022](https://kde.org/announcements/gear/22.08.2/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
