### PR TITLE
EasyOCR: init at 1.6.2

### DIFF
--- a/pkgs/development/python-modules/easyocr/default.nix
+++ b/pkgs/development/python-modules/easyocr/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hdf5
+, numpy
+, opencv3
+, pillow
+, pyaml
+, pyclipper
+, python-bidi
+, torch
+, scikitimage
+, scipy
+, shapely
+, torchvision
+, onnx
+}:
+
+buildPythonPackage rec {
+  pname = "easyocr";
+  version = "1.6.2";
+
+  src = fetchFromGitHub {
+    owner = "JaidedAI";
+    repo = "EasyOCR";
+    rev = "v${version}";
+    sha256 = "sha256-f+JBSnFMRvVlhRRiL1rJb7a0CNjZPuh6r8r3K1meQCk=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "opencv-python-headless<=4.5.4.60" "" \
+      --replace "ninja" ""
+  '';
+
+  propagatedBuildInputs = [
+    scikitimage
+    hdf5
+    python-bidi
+    numpy
+    opencv3
+    torchvision
+    pillow
+    pyaml
+    pyclipper
+    torch
+    scipy
+    shapely
+  ];
+
+  checkInputs = [ onnx ];
+
+  pythonImportsCheck = [ "easyocr" ];
+
+  meta = with lib; {
+    description = "Ready-to-use OCR with 80+ supported languages and all popular writing scripts";
+    homepage = "https://github.com/JaidedAI/EasyOCR";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3927,6 +3927,8 @@ with pkgs;
 
   easycrypt-runtest = callPackage ../applications/science/logic/easycrypt/runtest.nix { };
 
+  easyocr = with python3.pkgs; toPythonApplication easyocr;
+
   EBTKS = callPackage ../development/libraries/science/biology/EBTKS { };
 
   ecasound = callPackage ../applications/audio/ecasound { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2834,6 +2834,8 @@ self: super: with self; {
 
   easygui = callPackage ../development/python-modules/easygui { };
 
+  easyocr = callPackage ../development/python-modules/easyocr { };
+
   EasyProcess = callPackage ../development/python-modules/easyprocess { };
 
   easysnmp = callPackage ../development/python-modules/easysnmp { };


### PR DESCRIPTION
###### Description of changes

Resolves #195340

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
