### PR TITLE
cargo-ui: unbreak on darwin

### DIFF
--- a/pkgs/development/tools/rust/cargo-ui/default.nix
+++ b/pkgs/development/tools/rust/cargo-ui/default.nix
@@ -1,14 +1,16 @@
 { lib
 , rustPlatform
 , fetchCrate
-, cmake
 , pkg-config
 , makeWrapper
+, libgit2
 , openssl
 , stdenv
+, expat
 , fontconfig
 , libGL
 , xorg
+, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -20,13 +22,23 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-IL7BxiJg6eTuFM0pJ3qLxYCVofE/RjmgQjvOW96QF9A=";
   };
 
-  cargoSha256 = "sha256-16mgp7GsjbizzCWN3MDpl6ps9CK1zdIpLiyNiKYjDI4=";
+  # update dependencies so it is compatible with libgit2 1.5
+  # libgit2-sys 0.14.3 is only compatible with libgit2 1.4
+  cargoPatches = [ ./update-git2.patch ];
 
-  nativeBuildInputs = [ cmake pkg-config ] ++ lib.optionals stdenv.isLinux [
+  cargoSha256 = "sha256-i/ERVPzAWtN4884051VoA/ItypyURpHb/Py6w3KDOAo=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ lib.optionals stdenv.isLinux [
     makeWrapper
   ];
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.isLinux [
+  buildInputs = [
+    libgit2
+    openssl
+  ] ++ lib.optionals stdenv.isLinux [
+    expat
     fontconfig
     libGL
     xorg.libX11
@@ -34,6 +46,10 @@ rustPlatform.buildRustPackage rec {
     xorg.libXi
     xorg.libXrandr
     xorg.libxcb
+  ] ++ lib.optionals stdenv.isDarwin [
+    # dark-light doesn't build on apple sdk < 10.14
+    # see https://github.com/frewsxcv/rust-dark-light/issues/14
+    darwin.apple_sdk_11_0.frameworks.AppKit
   ];
 
   postInstall = lib.optionalString stdenv.isLinux ''
@@ -47,7 +63,5 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/slint-ui/cargo-ui/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ mit asl20 gpl3Only ];
     maintainers = with maintainers; [ figsoda ];
-    # figsoda: I can't figure how to make it build on darwin
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/tools/rust/cargo-ui/update-git2.patch
+++ b/pkgs/development/tools/rust/cargo-ui/update-git2.patch
@@ -1,0 +1,94 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -720,9 +720,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "crates-index"
+-version = "0.18.7"
++version = "0.18.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0044896374c388ccbf1497dad6384bf6111dbcad9d7069506df7450ce9b62ea3"
++checksum = "3447ec855b0c44cad8eedb3d32b53837f233894d5f4584a2648a7ebc5d3feef4"
+ dependencies = [
+  "git2",
+  "hex",
+@@ -1387,9 +1387,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "git2"
+-version = "0.14.3"
++version = "0.15.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5e77a14ffc6ba4ad5188d6cf428894c4fcfda725326b37558f35bb677e712cec"
++checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+ dependencies = [
+  "bitflags",
+  "libc",
+@@ -1884,9 +1884,9 @@ checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+ 
+ [[package]]
+ name = "libgit2-sys"
+-version = "0.13.3+1.4.2"
++version = "0.14.0+1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c24d36c3ac9b9996a2418d6bf428cc0bc5d1a814a84303fc60986088c5ed60de"
++checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -2712,9 +2712,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rayon"
+-version = "1.5.2"
++version = "1.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
++checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+ dependencies = [
+  "autocfg",
+  "crossbeam-deque",
+diff --git a/Cargo.toml b/Cargo.toml
+index ca5269d..6fa4ec2 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -33,7 +33,7 @@ version = "1.0.53"
+ version = "0.14"
+ 
+ [dependencies.crates-index]
+-version = "0.18.0"
++version = "0.18.10"
+ 
+ [dependencies.dunce]
+ version = "1.0.2"
+@@ -42,7 +42,7 @@ version = "1.0.2"
+ version = "0.3"
+ 
+ [dependencies.git2]
+-version = "0.14.3"
++version = "0.15.0"
+ 
+ [dependencies.itertools]
+ version = "0.10"
+diff --git a/Cargo.toml.orig b/Cargo.toml.orig
+index 52eadbd..ef8aa7c 100644
+--- a/Cargo.toml.orig
++++ b/Cargo.toml.orig
+@@ -22,7 +22,7 @@ default = ["slint-backend-qt", "slint-backend-gl-all"]
+ [dependencies]
+ anyhow = "1.0.53"
+ cargo_metadata = "0.14"
+-crates-index = { version = "0.18.0" }
++crates-index = { version = "0.18.10" }
+ dunce = "1.0.2"
+ futures = "0.3"
+ itertools = "0.10"
+@@ -34,7 +34,7 @@ shlex = "1.1"
+ slint = { version = "0.2.4", default-features = false, features = [ "compat-0-2-0" ] }
+ tokio = { version = "1.16.1", features= ["full"] }
+ toml_edit = "0.14.3"
+-git2 = "0.14.3"
++git2 = "0.15.0"
+ 
+ [build-dependencies]
+ slint-build = { version = "0.2.4" }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14915,9 +14915,7 @@ with pkgs;
   cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
   };
-  cargo-ui = callPackage ../development/tools/rust/cargo-ui {
-    inherit (darwin.apple_sdk.frameworks);
-  };
+  cargo-ui = darwin.apple_sdk_11_0.callPackage ../development/tools/rust/cargo-ui { };
 
   cargo-tauri = callPackage ../development/tools/rust/cargo-tauri { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

had to add a patch so we can use libgit2 from nixpkgs since building libgit2 from source wasn't working with apple_sdk_11_0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
