### PR TITLE
cargo-lambda: init at 0.11.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13305,6 +13305,12 @@
     githubId = 102685;
     name = "Thomas Friese";
   };
+  taylor1791 = {
+    email = "nixpkgs@tayloreverding.com";
+    github = "taylor1791";
+    githubId = 555003;
+    name = "Taylor Everding";
+  };
   tazjin = {
     email = "mail@tazj.in";
     github = "tazjin";

--- a/pkgs/development/tools/rust/cargo-lambda/default.nix
+++ b/pkgs/development/tools/rust/cargo-lambda/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub, makeWrapper, cargo-watch, zig, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-lambda";
+  version = "0.11.2";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-IK4HVj8Y8Vz+mza8G9C+m5JRfNT3BWWdlbQQkJPu6RI=";
+  };
+
+  cargoSha256 = "sha256-oSqoSvv8IiChtduQQA31wItHcsnRBAQgOCrQN4sjcx8=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/cargo-lambda --prefix PATH : ${lib.makeBinPath [ cargo-watch zig ]}
+  '';
+
+  checkFlags = [
+    # Disabled because it accesses the network.
+    "--skip test_download_example"
+    # Disabled because it makes assumptions about the file system.
+    "--skip test_target_dir_from_env"
+  ];
+
+  meta = with lib; {
+    description = "A Cargo subcommand to help you work with AWS Lambda";
+    homepage = "https://cargo-lambda.info";
+    license = licenses.mit;
+    maintainers = with maintainers; [ taylor1791 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14974,6 +14974,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
   cargo-insta = callPackage ../development/tools/rust/cargo-insta { };
+  cargo-lambda = callPackage ../development/tools/rust/cargo-lambda {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-limit = callPackage ../development/tools/rust/cargo-limit { };
   cargo-make = callPackage ../development/tools/rust/cargo-make {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;


### PR DESCRIPTION
###### Description of changes

This adds [cargo-lambda](https://www.cargo-lambda.info/) to nixpkgs. A Cargo subcommand to help you work with AWS Lambda.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable: 
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
