### PR TITLE
go-font: 2017-03-30 -> 2.010

### DIFF
--- a/pkgs/data/fonts/go-font/default.nix
+++ b/pkgs/data/fonts/go-font/default.nix
@@ -1,11 +1,11 @@
 { lib, fetchgit }:
 
 let
-  version = "2017-03-30";
+  version = "2.010";
 in (fetchgit {
   name = "go-font-${version}";
   url = "https://go.googlesource.com/image";
-  rev = "f03a046406d4d7fbfd4ed29f554da8f6114049fc";
+  rev = "41969df76e82aeec85fa3821b1e24955ea993001";
 
   postFetch = ''
     mv $out/* .
@@ -15,11 +15,12 @@ in (fetchgit {
     mv $out/share/fonts/truetype/README $out/share/doc/go-font/LICENSE
   '';
 
-  sha256 = "1488426ya2nzmwjas947fx9h5wzxrp9wasn8nkjqf0y0mpd4f1xz";
+  sha256 = "dteUL/4ZUq3ybL6HaLYqu2Tslx3q8VvELIY3tVC+ODo=";
 }) // {
   meta = with lib; {
     homepage = "https://blog.golang.org/go-fonts";
     description = "The Go font family";
+    changelog = "https://go.googlesource.com/image/+log/refs/heads/master/font/gofont";
     license = licenses.bsd3;
     maintainers = with maintainers; [ sternenseemann ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
