### PR TITLE
[Backport release-22.05] maintainers: add Scrumplex and minion3665, tomlplusplus: init at 3.2.0, prismlauncher: init at 5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8473,6 +8473,17 @@
       fingerprint = "3196 83D3 9A1B 4DE1 3DC2  51FD FEA8 88C9 F5D6 4F62";
     }];
   };
+  minion3665 = {
+    name = "Skyler Grey";
+    email = "skyler3665@gmail.com";
+    matrix = "@minion3665:matrix.org";
+    github = "Minion3665";
+    githubId = 34243578;
+    keys = [{
+      longkeyid = "rsa4096/0x1AFD10256B3C714D";
+      fingerprint = "D520 AC8D 7C96 9212 5B2B  BD3A 1AFD 1025 6B3C 714D";
+    }];
+  };
   mir06 = {
     email = "armin.leuprecht@uni-graz.at";
     github = "mir06";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11466,6 +11466,17 @@
     githubId = 3598650;
     name = "Fritz Otlinghaus";
   };
+  Scrumplex = {
+    name = "Sefa Eyeoglu";
+    email = "contact@scrumplex.net";
+    matrix = "@Scrumplex:duckhub.io";
+    github = "Scrumplex";
+    githubId = 11587657;
+    keys = [{
+      longkeyid = "rsa2048/0xC10411294912A422";
+      fingerprint = "AF1F B107 E188 CB97 9A94  FD7F C104 1129 4912 A422";
+    }];
+  };
   scubed2 = {
     email = "scubed2@gmail.com";
     github = "scubed2";

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1524,18 +1524,18 @@
       </listitem>
       <listitem>
         <para>
-          MultiMC has been replaced with the fork PolyMC due to upstream
-          developers being hostile to 3rd party package maintainers.
-          PolyMC removes all MultiMC branding and is aimed at providing
-          proper 3rd party packages like the one contained in Nixpkgs.
-          This change affects the data folder where game instances and
-          other save and configuration files are stored. Users with
-          existing installations should rename
+          MultiMC has been replaced with the fork PrismLauncher due to
+          upstream developers being hostile to 3rd party package
+          maintainers. PrismLauncher removes all MultiMC branding and is
+          aimed at providing proper 3rd party packages like the one
+          contained in Nixpkgs. This change affects the data folder
+          where game instances and other save and configuration files
+          are stored. Users with existing installations should rename
           <literal>~/.local/share/multimc</literal> to
-          <literal>~/.local/share/polymc</literal>. The main config
-          file’s path has also moved from
+          <literal>~/.local/share/PrismLauncher</literal>. The main
+          config file’s path has also moved from
           <literal>~/.local/share/multimc/multimc.cfg</literal> to
-          <literal>~/.local/share/polymc/polymc.cfg</literal>.
+          <literal>~/.local/share/PrismLauncher/prismlauncher.cfg</literal>.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -587,7 +587,15 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `miller` package has been upgraded from 5.10.3 to [6.2.0](https://github.com/johnkerl/miller/releases/tag/v6.2.0). See [What's new in Miller 6](https://miller.readthedocs.io/en/latest/new-in-miller-6).
 
-- MultiMC has been replaced with the fork PolyMC due to upstream developers being hostile to 3rd party package maintainers. PolyMC removes all MultiMC branding and is aimed at providing proper 3rd party packages like the one contained in Nixpkgs. This change affects the data folder where game instances and other save and configuration files are stored. Users with existing installations should rename `~/.local/share/multimc` to `~/.local/share/polymc`. The main config file's path has also moved from `~/.local/share/multimc/multimc.cfg` to `~/.local/share/polymc/polymc.cfg`.
+- MultiMC has been replaced with the fork PrismLauncher due to upstream
+  developers being hostile to 3rd party package maintainers. PrismLauncher
+  removes all MultiMC branding and is aimed at providing proper 3rd party
+  packages like the one contained in Nixpkgs. This change affects the data
+  folder where game instances and other save and configuration files are stored.
+  Users with existing installations should rename `~/.local/share/multimc` to
+  `~/.local/share/PrismLauncher`. The main config file's path has also moved
+  from `~/.local/share/multimc/multimc.cfg` to
+  `~/.local/share/PrismLauncher/prismlauncher.cfg`.
 
 - `systemd-nspawn@.service` settings have been reverted to the default systemd behaviour. User namespaces are now activated by default. If you want to keep running nspawn containers without user namespaces you need to set `systemd.nspawn.<name>.execConfig.PrivateUsers = false`
 

--- a/pkgs/development/libraries/tomlplusplus/default.nix
+++ b/pkgs/development/libraries/tomlplusplus/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, stdenv
+, meson
+, ninja
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tomlplusplus";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "marzer";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-nohO4eySs73BSgjvq+uzybiE5lw2rFY5YqGbl/oqGek=";
+  };
+
+  nativeBuildInputs = [ meson ninja ];
+
+  meta = with lib;{
+    homepage = "https://github.com/marzer/tomlplusplus";
+    description = "Header-only TOML config file parser and serializer for C++17";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Scrumplex ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, jdk8
+, jdk
+, zlib
+, file
+, wrapQtAppsHook
+, xorg
+, libpulseaudio
+, qtbase
+, libGL
+, quazip
+, glfw
+, openal
+, extra-cmake-modules
+, tomlplusplus
+, ghc_filesystem
+, msaClientID ? ""
+, jdks ? [ jdk jdk8 ]
+,
+}:
+let
+  libnbtplusplus = fetchFromGitHub {
+    owner = "PrismLauncher";
+    repo = "libnbtplusplus";
+    rev = "2203af7eeb48c45398139b583615134efd8d407f";
+    sha256 = "sha256-TvVOjkUobYJD9itQYueELJX3wmecvEdCbJ0FinW2mL4=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "prismlauncher";
+  version = "5.0";
+
+  src = fetchFromGitHub {
+    owner = "PrismLauncher";
+    repo = "PrismLauncher";
+    rev = version;
+    sha256 = "sha256-oN+DpJ08N/ar5wLAahgpBV9DeHtMTwSrE7uOwT3A+Yo=";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules ghc_filesystem cmake file jdk wrapQtAppsHook ];
+  buildInputs = [ qtbase zlib quazip tomlplusplus ];
+
+  cmakeFlags = lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ];
+  dontWrapQtApps = true;
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    mkdir source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus}/* source/libraries/libnbtplusplus
+    chmod -R +r+w source/libraries/libnbtplusplus
+    chown -R $USER: source/libraries/libnbtplusplus
+  '';
+
+  postInstall =
+    let
+      libpath = with xorg;
+        lib.makeLibraryPath [
+          libX11
+          libXext
+          libXcursor
+          libXrandr
+          libXxf86vm
+          libpulseaudio
+          libGL
+          glfw
+          openal
+          stdenv.cc.cc.lib
+        ];
+    in
+    ''
+      # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      wrapQtApp $out/bin/prismlauncher \
+        --set LD_LIBRARY_PATH /run/opengl-driver/lib:${libpath} \
+        --prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks} \
+        --prefix PATH : ${lib.makeBinPath [xorg.xrandr]}
+    '';
+
+  meta = with lib; {
+    homepage = "https://prismlauncher.org/";
+    description = "A free, open source launcher for Minecraft";
+    longDescription = ''
+      Allows you to have multiple, separate instances of Minecraft (each with
+      their own mods, texture packs, saves, etc) and helps you manage them and
+      their associated options with a simple interface.
+    '';
+    platforms = platforms.linux;
+    changelog = "https://github.com/PrismLauncher/PrismLauncher/releases/tag/${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ minion3665 Scrumplex ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -858,7 +858,7 @@ mapAliases ({
   mpd_clientlib = libmpdclient; # Added 2021-02-11
   mpich2 = throw "'mpich2' has been renamed to/replaced by 'mpich'"; # Converted to throw 2022-02-22
   msf = throw "'msf' has been renamed to/replaced by 'metasploit'"; # Converted to throw 2022-02-22
-  multimc = throw "multimc was removed from nixpkgs; use polymc instead (see https://github.com/NixOS/nixpkgs/pull/154051 for more information)"; # Added 2022-01-08
+  multimc = throw "multimc was removed from nixpkgs; use prismlauncher instead (see https://github.com/NixOS/nixpkgs/pull/154051 for more information)"; # Added 2022-01-08
   mumble_git = pkgs.mumble; # Added 2019-08-01
   murmur_git = pkgs.murmur; # Added 2019-08-01
   mysql-client = hiPrio mariadb.client;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32212,6 +32212,8 @@ with pkgs;
 
   polymc = libsForQt5.callPackage ../games/polymc { };
 
+  prismlauncher = libsForQt5.callPackage ../games/prismlauncher { };
+
   pong3d = callPackage ../games/pong3d { };
 
   pokerth = libsForQt5.callPackage ../games/pokerth {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21009,6 +21009,8 @@ with pkgs;
 
   tomlcpp = callPackage ../development/libraries/tomlcpp { };
 
+  tomlplusplus = callPackage ../development/libraries/tomlplusplus { };
+
   tokyocabinet = callPackage ../development/libraries/tokyo-cabinet { };
 
   tokyotyrant = callPackage ../development/libraries/tokyo-tyrant { };


### PR DESCRIPTION
###### Description of changes

- Add myself to maintainers as in #174095 (although do not backport the package)
- Backport all commits from #193038
- Add the long key ID to the Scrumplex key, as this appears to be required in 22.05
- Init prism launcher at 5.0

This is a manual backport of #196624, as well as all its dependencies

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).