### PR TITLE
influxdb: 1.8.10 -> 1.10.0

### DIFF
--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -1,17 +1,76 @@
-{ lib, buildGoModule, fetchFromGitHub, stdenv }:
+{ lib, buildGoModule, fetchFromGitHub, stdenv, pkg-config, rustPlatform, llvmPackages, libiconv, fetchpatch }:
 
+let
+  libflux_version = "0.170.1";
+
+  # This is copied from influxdb2 with flux version matching the needed by thi
+  flux = rustPlatform.buildRustPackage {
+    pname = "libflux";
+    version = "v${libflux_version}";
+    src = fetchFromGitHub {
+      owner = "influxdata";
+      repo = "flux";
+      rev = "v${libflux_version}";
+      sha256 = "sha256-P3SpleOVbL+nGWdscwjj9yWqRdck/9JsAwuJtGOO7N8=";
+    };
+    patches = [
+      # https://github.com/influxdata/flux/pull/5273
+      # fix compile error with Rust 1.64
+      (fetchpatch {
+        url = "https://github.com/influxdata/flux/commit/20ca62138a0669f2760dd469ca41fc333e04b8f2.patch";
+        stripLen = 2;
+        extraPrefix = "";
+        sha256 = "sha256-Fb4CuH9ZvrPha249dmLLI8MqSNQRKqKPxPbw2pjqwfY=";
+      })
+    ];
+    sourceRoot = "source/libflux";
+    cargoSha256 = "sha256-kYiZ5ZRiFHRf1RQeeUGjIhnEkTvhNSZ0t4tidpRIDyk=";
+    nativeBuildInputs = [ llvmPackages.libclang ];
+    buildInputs = lib.optional stdenv.isDarwin libiconv;
+    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+    pkgcfg = ''
+      Name: flux
+      Version: ${libflux_version}
+      Description: Library for the InfluxData Flux engine
+      Cflags: -I/out/include
+      Libs: -L/out/lib -lflux -ldl -lpthread
+    '';
+    passAsFile = [ "pkgcfg" ];
+    postInstall = ''
+      mkdir -p $out/include $out/pkgconfig
+      cp -r $NIX_BUILD_TOP/source/libflux/include/influxdata $out/include
+      substitute $pkgcfgPath $out/pkgconfig/flux.pc \
+        --replace /out $out
+    '' + lib.optionalString stdenv.isDarwin ''
+      install_name_tool -id $out/lib/libflux.dylib $out/lib/libflux.dylib
+    '';
+  };
+in
 buildGoModule rec {
   pname = "influxdb";
-  version = "1.8.10";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "influxdata";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-PErAxRpSi1Kk6IpEAhsUSxCGYeY4p6bbhwLdbRB0M00=";
+    sha256 = "sha256-BMHR9EdYC+8oA0he7emzBRmNnHn15nO/5NqsLcr+R0k=";
   };
 
-  vendorSha256 = "sha256-jgAbEWXL1LYRN7ud9ij0Z1KBGHPZ0sRq78tsK92ob8k=";
+  vendorSha256 = "sha256-AY04cmfg7vbrWR4+LBuCFYqBgQJBXlPpO+2oj0qqjM4=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  PKG_CONFIG_PATH = "${flux}/pkgconfig";
+
+  # Check that libflux is at the right version
+  preBuild = ''
+    flux_ver=$(grep github.com/influxdata/flux go.mod | awk '{print $2}')
+    if [ "$flux_ver" != "v${libflux_version}" ]; then
+      echo "go.mod wants libflux $flux_ver, but nix derivation provides ${libflux_version}"
+      exit 1
+    fi
+  '';
 
   doCheck = false;
 
@@ -24,6 +83,5 @@ buildGoModule rec {
     license = licenses.mit;
     homepage = "https://influxdata.com/";
     maintainers = with maintainers; [ offline zimbatm ];
-    broken = stdenv.isDarwin; # build fails with go > 1.17
   };
 }

--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, stdenv, pkg-config, rustPlatform, llvmPackages, libiconv, fetchpatch }:
+{ lib, buildGoModule, fetchFromGitHub, stdenv, pkg-config, rustPlatform, llvmPackages, libiconv, fetchpatch, nixosTests }:
 
 let
   libflux_version = "0.170.1";
@@ -77,6 +77,8 @@ buildGoModule rec {
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
 
   excludedPackages = "test";
+
+  passthru.tests = { inherit (nixosTests) influxdb; };
 
   meta = with lib; {
     description = "An open-source distributed time series database";


### PR DESCRIPTION
###### Description of changes

This change updates the version of influxdb and also makes it compile on darwin. The issue with darwin was that 1.8 couldn't be compiled using go 1.18. 1.10 can be compiled using the recent go.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
