### PR TITLE
nixos/github-runner: support fine-grained personal access tokens

### DIFF
--- a/nixos/modules/services/continuous-integration/github-runner/options.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/options.nix
@@ -42,13 +42,14 @@ with lib;
     type = types.path;
     description = lib.mdDoc ''
       The full path to a file which contains either a runner registration token or a
-      personal access token (PAT).
+      (fine-grained) personal access token (PAT).
       The file should contain exactly one line with the token without any newline.
       If a registration token is given, it can be used to re-register a runner of the same
       name but is time-limited. If the file contains a PAT, the service creates a new
       registration token on startup as needed. Make sure the PAT has a scope of
       `admin:org` for organization-wide registrations or a scope of
-      `repo` for a single repository.
+      `repo` for a single repository. Fine-grained PATs need read and write permission
+      to the "Adminstration" resources.
 
       Changing this option or the file's content triggers a new runner registration.
     '';

--- a/nixos/modules/services/continuous-integration/github-runner/service.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/service.nix
@@ -134,10 +134,10 @@ with lib;
               ${optionalString (cfg.runnerGroup != null) "--runnergroup ${escapeShellArg cfg.runnerGroup}"}
               ${optionalString cfg.ephemeral "--ephemeral"}
             )
-            # If the token file contains a PAT (i.e., it starts with "ghp_"), we have to use the --pat option,
+            # If the token file contains a PAT (i.e., it starts with "ghp_" or "github_pat_"), we have to use the --pat option,
             # if it is not a PAT, we assume it contains a registration token and use the --token option
             token=$(<"${newConfigTokenPath}")
-            if [[ "$token" =~ ^ghp_* ]]; then
+            if [[ "$token" =~ ^ghp_* ]] || [[ "$token" =~ ^github_pat_* ]]; then
               args+=(--pat "$token")
             else
               args+=(--token "$token")


### PR DESCRIPTION
###### Description of changes

Add support for GitHub's new fine-grained personal access tokens [1]. As
opposed to the classic PATs, those start with `github_pat_` instead of
`ghp_`.

Make sure to use a token which has read and write access to the
"Administration" resource group [2] to allow for registrations of new
runners.

[1] https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/

[2] https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#administration

Tested using a minimally scoped (i.e., "Administration" access only) fine-grained PAT.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
