### PR TITLE
nvitop: init at 0.10.0

### DIFF
--- a/pkgs/tools/system/nvitop/default.nix
+++ b/pkgs/tools/system/nvitop/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, python3Packages
+, fetchFromGitHub
+, makeWrapper
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "nvitop";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "XuehaiPan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-nGdEMLxpw2Ts0dypkoZg3r2NF4IeT1ykbRmrmf9qxrA=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    cachetools
+    psutil
+    termcolor
+    nvidia-ml-py
+  ];
+
+  checkPhase = ''
+    $out/bin/nvitop --help
+  '';
+
+  meta = with lib; {
+    description = "An interactive NVIDIA-GPU process viewer, the one-stop solution for GPU process management";
+    homepage = "https://github.com/XuehaiPan/nvitop";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ GaetanLepage ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21230,6 +21230,8 @@ with pkgs;
 
   nvidia-optical-flow-sdk = callPackage ../development/libraries/nvidia-optical-flow-sdk { };
 
+  nvitop = callPackage ../tools/system/nvitop { };
+
   nvtop = callPackage ../tools/system/nvtop { };
   nvtop-nvidia = callPackage ../tools/system/nvtop { amd = false; };
   nvtop-amd = callPackage ../tools/system/nvtop { nvidia = false; };


### PR DESCRIPTION
###### Description of changes

nvitop is an interactive NVIDIA-GPU process viewer.

Project homepage: https://github.com/XuehaiPan/nvitop

For now, I encounter a problem when trying to use it on a non-nixos computer.
The problem happens within this dependency which I recently packages: [`nvidia-ml-py`](https://github.com/NixOS/nixpkgs/pull/189028).
Indeed, the NixOS provided `python` is not able to find the `libnvidia-ml.so.1` library on the system.
More info about this bug here: https://discourse.nixos.org/t/python-dll-import/22594

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
