### PR TITLE
mkvtoolnix updates

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , pkg-config
 , autoreconfHook
 , rake
@@ -46,13 +47,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mkvtoolnix";
-  version = "70.0.0";
+  version = "71.1.0";
 
   src = fetchFromGitLab {
     owner = "mbunkus";
     repo = "mkvtoolnix";
     rev = "release-${version}";
-    sha256 = "sha256-7ryLf/SKM5m7MdOd2K2XhJEdLF2H8xjV1aZMKUjm+Ok=";
+    sha256 = "sha256-JHbnjcXOctB6HQeHXykWbykdn35S2fCYegMkc3GLmAI=";
   };
 
   nativeBuildInputs = [
@@ -102,7 +103,7 @@ stdenv.mkDerivation rec {
     "--disable-profiling"
     "--disable-static-qt"
     "--enable-optimization"
-    "--with-boost-libdir=${boost.out}/lib"
+    "--with-boost-libdir=${lib.getLib boost}/lib"
     "--with-docbook-xsl-root=${docbook_xsl}/share/xml/docbook-xsl"
     "--with-gettext"
     (enableFeature withGUI "gui")

--- a/pkgs/development/libraries/libebml/default.nix
+++ b/pkgs/development/libraries/libebml/default.nix
@@ -1,30 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "libebml";
-  version = "1.4.2";
+  version = "1.4.4";
 
   src = fetchFromGitHub {
     owner  = "Matroska-Org";
     repo   = "libebml";
     rev    = "release-${version}";
-    sha256 = "1hiilnabar826lfxsaflqjhgsdli6hzzhjv8q2nmw36fvvlyks25";
+    sha256 = "sha256-36SfZUHJ2sIvrrHox583cQqfWWcrL2zW1IHzgDchC9g=";
   };
-
-  patches = [
-    # Upstream fix for gcc-11
-    (fetchpatch {
-      url = "https://github.com/Matroska-Org/libebml/commit/f0bfd53647961e799a43d918c46cf3b6bff89806.patch";
-      sha256 = "1yd6rsds03kwx5jki4hihd2bpfh26g5l1pi82qzaqzarixdxwzvl";
-      excludes = [ "ChangeLog" ];
-    })
-    # in master post 1.4.2, see https://github.com/Matroska-Org/libebml/issues/97
-    (fetchpatch {
-      name = "fix-pkg-config.patch";
-      url = "https://github.com/Matroska-Org/libebml/commit/42fbae35d291b737f2bb4ad5d643fd0d48537a88.patch";
-      sha256 = "020qp4a3l60mcm4n310ynxbbv5qlpmybb9xy10pjvx4brp83pmy3";
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 

--- a/pkgs/development/libraries/libmatroska/default.nix
+++ b/pkgs/development/libraries/libmatroska/default.nix
@@ -1,25 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config
-, libebml }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libebml }:
 
 stdenv.mkDerivation rec {
   pname = "libmatroska";
-  version = "1.6.3";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner  = "Matroska-Org";
     repo   = "libmatroska";
     rev    = "release-${version}";
-    sha256 = "01dg12ndxfdqgjx5v2qy4mff6xjdxglywyg82sr3if5aw6rp3dji";
+    sha256 = "sha256-hfu3Q1lIyMlWFWUM2Pu70Hie0rlQmua7Kq8kSIWnfHE=";
   };
-
-  # in master post 1.6.3, see https://github.com/Matroska-Org/libmatroska/issues/62
-  patches = [
-    (fetchpatch {
-      name = "fix-pkg-config.patch";
-      url = "https://github.com/Matroska-Org/libmatroska/commit/53f6ea573878621871bca5f089220229fcb33a3b.patch";
-      sha256 = "1lcxl3n32kk5x4aa4ja7p68km7qb2bwscavpv7qdmbhp3w5ia0mk";
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 


### PR DESCRIPTION
###### Description of changes

Version bump mkvtoolnix and its dependencies

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using
- [x] Tested basic functionality of all binary files
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
