### PR TITLE
ddcutil: 1.3.0 -> 1.3.2

### DIFF
--- a/pkgs/tools/misc/ddcutil/default.nix
+++ b/pkgs/tools/misc/ddcutil/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchFromGitHub
+, fetchurl
 , autoreconfHook
 , pkg-config
 , glib
@@ -15,13 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ddcutil";
-  version = "1.3.0";
+  version = "1.3.2";
 
-  src = fetchFromGitHub {
-    owner = "rockowitz";
-    repo = "ddcutil";
-    rev = "v${version}";
-    sha256 = "sha256-Di/feEQOHNhU3y/HwXQoOnu+gPQYP2Oedf1CPt8gHJ0=";
+  src = fetchurl {
+    url = "http://www.ddcutil.com/tarballs/${pname}-${version}.tar.gz";
+    sha256 = "sha256-vZI7OquGjZ0koArdOWKkfFtfRzCvtXm8lGFCUklloEI=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];


### PR DESCRIPTION
###### Description of changes

Version bump with no functional changes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using (clight ddcui ddcutil enlightenment)
- [x] Tested basic functionality of all binary files
- [x] Tested with `ddcutil detect`
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
