### PR TITLE
python310Packages.dask-jobqueue: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/dask-jobqueue/default.nix
+++ b/pkgs/development/python-modules/dask-jobqueue/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , buildPythonPackage
+, cryptography
 , dask
 , distributed
 , docrep
@@ -12,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "dask-jobqueue";
-  version = "0.8.0";
+  version = "0.8.1";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-VCD6Oos9aSkbrzymQnqm2RV5uFzTj05VgPuhJ5PpyAk=";
+    hash = "sha256-Fv0bZGoHOtPedd3hKg3+UpuDbyGjvbzuKoi+8k6REqc=";
   };
 
   propagatedBuildInputs = [
@@ -29,18 +30,47 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    cryptography
     pytest-asyncio
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    # Do not run entire tests suite (requires slurm, sge, etc.)
-    "dask_jobqueue/tests/test_jobqueue_core.py"
-  ];
-
   disabledTests = [
+    # Tests have additional requirements (e.g., sge, etc.)
+    "test_adapt_parameters"
+    "test_adapt"
+    "test_adaptive_cores_mem"
+    "test_adaptive_grouped"
+    "test_adaptive"
+    "test_basic"
+    "test_basic_scale_edge_cases"
+    "test_cluster_error_scheduler_arguments_should_use_scheduler_options"
+    "test_cluster_has_cores_and_memory"
+    "test_cluster"
+    "test_command_template"
+    "test_complex_cancel_command"
+    "test_config"
+    "test_dashboard_link"
+    "test_default_number_of_worker_processes"
+    "test_deprecation_env_extra"
+    "test_deprecation_extra"
+    "test_deprecation_job_extra"
+    "test_different_interfaces_on_scheduler_and_workers"
+    "test_docstring_cluster"
+    "test_extra_args_broken_cancel"
+    "test_forward_ip"
     "test_import_scheduler_options_from_config"
+    "test_job"
+    "test_log_directory"
+    "test_scale_cores_memory"
+    "test_scale_grouped"
+    "test_scheduler_options_interface"
+    "test_scheduler_options"
     "test_security"
+    "test_shebang_settings"
+    "test_use_stdin"
+    "test_worker_name_uses_cluster_name"
+    "test_wrong_parameter_error"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 0.8.1

Fix build (https://hydra.nixos.org/build/195757574)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
