### PR TITLE
qudida: init at 0.0.4

### DIFF
--- a/pkgs/development/python-modules/qudida/default.nix
+++ b/pkgs/development/python-modules/qudida/default.nix
@@ -1,0 +1,47 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, numpy
+, opencv4
+, scikit-learn
+, typing-extensions
+, pythonOlder
+, pythonRelaxDepsHook
+}:
+
+buildPythonPackage rec {
+  pname = "qudida";
+  version = "0.0.4";
+  format = "setuptools";
+
+
+  src = fetchFromGitHub {
+    owner = "arsenyinfo";
+    repo = "qudida";
+    rev = version;
+    sha256 = "sha256-4XQAdbqV6vRdwUDDdrilV9D8mGTUXUzPBWcX9LMwlvQ=";
+  };
+
+  disabled = pythonOlder "3.5.0";
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRemoveDeps = [ "opencv-python-headless" ];
+
+  propagatedBuildInputs =
+    [ numpy scikit-learn typing-extensions opencv4 ];
+
+  doCheck = false; #tests seem to burn cpu endlessly without progress
+
+  pythonImportsCheck = [
+    "qudida"
+  ];
+
+  meta = with lib; {
+    description = "QUick and DIrty Domain Adaptation";
+    homepage = "https://github.com/arsenyinfo/qudida";
+    maintainers = with maintainers; [ gbtb ];
+    licence = licenses.mit;
+    platforms = opencv4.meta.platforms;
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9552,6 +9552,8 @@ in {
 
   quantum-gateway = callPackage ../development/python-modules/quantum-gateway { };
 
+  qudida = callPackage ../development/python-modules/qudida { };
+
   querystring_parser = callPackage ../development/python-modules/querystring-parser { };
 
   questionary = callPackage ../development/python-modules/questionary { };


### PR DESCRIPTION
###### Description of changes

First small package required for running Stable Diffusion on NixOS without external dependencies. 
Issue: https://github.com/NixOS/nixpkgs/issues/195412

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
