### PR TITLE
nixos/steam: add package option

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -4,16 +4,30 @@ with lib;
 
 let
   cfg = config.programs.steam;
-
-  steam = pkgs.steam.override {
-    extraLibraries = pkgs: with config.hardware.opengl;
-      if pkgs.hostPlatform.is64bit
-      then [ package ] ++ extraPackages
-      else [ package32 ] ++ extraPackages32;
-  };
 in {
   options.programs.steam = {
     enable = mkEnableOption (lib.mdDoc "steam");
+
+    package = mkOption {
+      type        = types.package;
+      default     = pkgs.steam.override {
+        extraLibraries = pkgs: with config.hardware.opengl;
+          if pkgs.hostPlatform.is64bit
+          then [ package ] ++ extraPackages
+          else [ package32 ] ++ extraPackages32;
+      };
+      defaultText = literalExpression ''
+        pkgs.steam.override {
+          extraLibraries = pkgs: with config.hardware.opengl;
+            if pkgs.hostPlatform.is64bit
+            then [ package ] ++ extraPackages
+            else [ package32 ] ++ extraPackages32;
+        }
+      '';
+      description = lib.mdDoc ''
+        steam package to use.
+      '';
+    };
 
     remotePlay.openFirewall = mkOption {
       type = types.bool;
@@ -44,7 +58,10 @@ in {
 
     hardware.steam-hardware.enable = true;
 
-    environment.systemPackages = [ steam steam.run ];
+    environment.systemPackages = [
+      cfg.package
+      cfg.package.run
+    ];
 
     networking.firewall = lib.mkMerge [
       (mkIf cfg.remotePlay.openFirewall {


### PR DESCRIPTION
###### Description of changes

Currently whenever modifications of the Steam package are needed, overlays are required to be used. Overlays can become unwieldy and NixOS options are a good alternative for that.

Most NixOS modules have a separate package option to make such alterations. So, this PR introduces `programs.steam.package`.

For the steam module, steam package is already being modified by adding opengl libraries to the package. I have made this the default value of the package option. It allows people to override this as well when needed. I have set this as the defaultText in documentation as well, so that people using the steam module know that the opengl libraries are being added.

One specific use-case that was mentioned online is to always add some envvars to the steam binary, regardless of whether it was started thought a .desktop or through a terminal without polluting the users profile. In this case the envvars are for Nvidia offloading when using steam, but not with anything else. See https://www.reddit.com/r/NixOS/comments/y6hwwb/comment/iste6v2/?utm_source=share&utm_medium=web2x&context=3

###### Things done

I used the following for testing in a VM:

```
{ pkgs, ... }:
{
  documentation.man.enable = false;
  documentation.info.enable = false;
  programs.steam.enable = true;
  programs.steam.package = pkgs.steam.overrideAttrs (oldAttrs: {
    name = "mysteam";
  });

  # root
  users.users.root.initialHashedPassword = "$6$P9z8rUfd1oBKaOPW$uCS4zF1ZQUdK9ADmAW7LIEoq.nLdssrL7mBudTc6lIw0zsZfpoc9XX6fAbGwF9DOFfYKgRg8GThuirkiTsB4V1";
  system.stateVersion = "22.11";
}
```

```sh
NIXPKGS_ALLOW_UNFREE=1 NIX_PATH=nixpkgs=$PWD NIXOS_CONFIG=$PWD/configuration.nix nixos-rebuild build-vm && result/bin/run-nixos-vm
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
