### PR TITLE
ocamlPackages.reason: 3.8.1 → 3.8.2

### DIFF
--- a/pkgs/development/compilers/reason/default.nix
+++ b/pkgs/development/compilers/reason/default.nix
@@ -1,15 +1,15 @@
-{ lib, callPackage, stdenv, makeWrapper, fetchurl, ocaml, findlib, dune_2
+{ lib, callPackage, stdenv, makeWrapper, fetchurl, ocaml, findlib, dune_3
 , ncurses
 , fix, menhir, menhirLib, menhirSdk, merlin-extend, ppxlib, utop, cppo, ppx_derivers
 }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-reason";
-  version = "3.8.1";
+  version = "3.8.2";
 
   src = fetchurl {
     url = "https://github.com/reasonml/reason/releases/download/${version}/reason-${version}.tbz";
-    sha256 = "sha256-v827CfYrTBCPJubcOAQxYT5N5LBl348UNk7+Ss6o5BQ=";
+    sha256 = "sha256-etzEXbILje+CrfJxIhH7jthEMoSJdS6O33QoG8HrLvI=";
   };
 
   nativeBuildInputs = [
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cppo
-    dune_2
+    dune_3
     findlib
     fix
     menhir

--- a/pkgs/development/ocaml-modules/graphql_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/graphql_ppx/default.nix
@@ -1,10 +1,13 @@
 { lib, buildDunePackage, fetchFromGitHub, alcotest, reason
+, result
 , ppxlib
 , yojson }:
 
 buildDunePackage rec {
   pname = "graphql_ppx";
   version = "1.2.2";
+
+  duneVersion = "3";
 
   minimalOCamlVersion = "4.08";
 
@@ -19,14 +22,13 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [
     reason
+    result
     yojson
   ];
 
   checkInputs = [ alcotest ];
 
   doCheck = true;
-
-  useDune2 = true;
 
   meta = {
     homepage = "https://github.com/reasonml-community/graphql_ppx";


### PR DESCRIPTION
###### Description of changes

Compatibility with future OCaml: https://github.com/reasonml/reason/blob/3.8.2/HISTORY.md#382

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
