### PR TITLE
cargo-about: unbreak on darwin

### DIFF
--- a/pkgs/development/tools/rust/cargo-about/default.nix
+++ b/pkgs/development/tools/rust/cargo-about/default.nix
@@ -1,4 +1,11 @@
-{ lib, rustPlatform, fetchFromGitHub, pkg-config, zstd, stdenv }:
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, zstd
+, stdenv
+, darwin
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-about";
@@ -11,14 +18,21 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-T8Hhody0jMmZb6/xMkSvKCv4STZPbcrf/UB3APspYDM=";
   };
 
-  # enable pkg-config feature of zstd
-  cargoPatches = [ ./zstd-pkg-config.patch ];
+  cargoPatches = [
+    # update mimalloc to fix build with older apple sdks
+    ./update-mimalloc.patch
 
-  cargoSha256 = "sha256-x/HzDYNy0FDxJmhjSUUEiyahM7Sw27aC+ULP/Ii0X/8=";
+    # enable pkg-config feature of zstd
+    ./zstd-pkg-config.patch
+  ];
+
+  cargoSha256 = "sha256-2Reqj+WP6OoaB/3Z5llZP4c5ToVmMNX0Fe0IqDwcg2E=";
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ zstd ];
+  buildInputs = [ zstd ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
 
   meta = with lib; {
     description = "Cargo plugin to generate list of all licenses for a crate";
@@ -26,6 +40,5 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/EmbarkStudios/cargo-about/blob/${version}/CHANGELOG.md";
     license = with licenses; [ mit /* or */ asl20 ];
     maintainers = with maintainers; [ evanjs figsoda ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/tools/rust/cargo-about/update-mimalloc.patch
+++ b/pkgs/development/tools/rust/cargo-about/update-mimalloc.patch
@@ -1,0 +1,26 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -829,9 +829,9 @@ checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+ 
+ [[package]]
+ name = "libmimalloc-sys"
+-version = "0.1.24"
++version = "0.1.26"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7705fc40f6ed493f73584abbb324e74f96b358ff60dfe5659a0f8fc12c590a69"
++checksum = "8fc093ab289b0bfda3aa1bdfab9c9542be29c7ef385cfcbe77f8c9813588eb48"
+ dependencies = [
+  "cc",
+ ]
+@@ -884,9 +884,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "mimalloc"
+-version = "0.1.28"
++version = "0.1.30"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b0dfa131390c2f6bdb3242f65ff271fcdaca5ff7b6c08f28398be7f2280e3926"
++checksum = "76ce6a4b40d3bff9eb3ce9881ca0737a85072f9f975886082640cd46a75cdb35"
+ dependencies = [
+  "libmimalloc-sys",
+ ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
