### PR TITLE
ncnn: fix build

### DIFF
--- a/pkgs/development/libraries/ncnn/cmakelists.patch
+++ b/pkgs/development/libraries/ncnn/cmakelists.patch
@@ -1,13 +1,26 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 98611276..989350bb 100644
+index c453d23e..66b4aa24 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -260,6 +260,8 @@ if(NCNN_VULKAN)
-                 include("${GLSLANG_TARGET_DIR}/HLSLTargets.cmake")
-             endif()
-             include("${GLSLANG_TARGET_DIR}/glslangTargets.cmake")
+@@ -478,6 +478,8 @@ if(NCNN_VULKAN)
+ 
+             find_package(Threads)
+ 
 +            include("${GLSLANG_TARGET_DIR}/SPIRV-Tools/SPIRV-ToolsTarget.cmake")
 +            include("${GLSLANG_TARGET_DIR}/SPIRV-Tools-opt/SPIRV-Tools-optTargets.cmake")
-             include("${GLSLANG_TARGET_DIR}/SPIRVTargets.cmake")
+             include("${GLSLANG_TARGET_DIR}/OSDependentTargets.cmake")
+             include("${GLSLANG_TARGET_DIR}/OGLCompilerTargets.cmake")
+             if(EXISTS "${GLSLANG_TARGET_DIR}/HLSLTargets.cmake")
+diff --git a/src/ncnn.pc.in b/src/ncnn.pc.in
+index b580fcee..be2becd0 100644
+--- a/src/ncnn.pc.in
++++ b/src/ncnn.pc.in
+@@ -1,6 +1,6 @@
+ prefix=${pcfiledir}/../..
+-librarydir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++librarydir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
  
-             if (NOT TARGET glslang OR NOT TARGET SPIRV)
+ Name: @CMAKE_PROJECT_NAME@
+ Description: high-performance neural network inference framework optimized for the mobile platform

--- a/pkgs/development/libraries/ncnn/default.nix
+++ b/pkgs/development/libraries/ncnn/default.nix
@@ -45,6 +45,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Tencent/ncnn";
     license = licenses.bsd3;
     maintainers = with maintainers; [ tilcreator ];
-    broken = true; # at 2022-11-23
   };
 }

--- a/pkgs/tools/graphics/realesrgan-ncnn-vulkan/cmakelists.patch
+++ b/pkgs/tools/graphics/realesrgan-ncnn-vulkan/cmakelists.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a234caa..cd9d2c5 100644
+index a234caa..d94388a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -114,6 +114,8 @@ if(USE_SYSTEM_NCNN)
-             include("${GLSLANG_TARGET_DIR}/HLSLTargets.cmake")
-         endif()
-         include("${GLSLANG_TARGET_DIR}/glslangTargets.cmake")
+@@ -107,6 +107,8 @@ if(USE_SYSTEM_NCNN)
+ 
+         find_package(Threads)
+ 
 +        include("${GLSLANG_TARGET_DIR}/SPIRV-Tools/SPIRV-ToolsTarget.cmake")
 +        include("${GLSLANG_TARGET_DIR}/SPIRV-Tools-opt/SPIRV-Tools-optTargets.cmake")
-         include("${GLSLANG_TARGET_DIR}/SPIRVTargets.cmake")
- 
-         if (NOT TARGET glslang OR NOT TARGET SPIRV)
+         include("${GLSLANG_TARGET_DIR}/OSDependentTargets.cmake")
+         include("${GLSLANG_TARGET_DIR}/OGLCompilerTargets.cmake")
+         if(EXISTS "${GLSLANG_TARGET_DIR}/HLSLTargets.cmake")


### PR DESCRIPTION
###### Description of changes

Fixes #192617. The breakage is introduced by a glslang update. Now `${glslang}/lib/cmake/OSDependentTargets.cmake` points to `${glslang}/share/glslang/glslang-targets.cmake`. The latter requires the `SPIRV-Tools-opt` target. So the two lines in patch should be moved before `OSDependentTargets.cmake`.

This also fixes a breakage introduced by cmake described in #144170.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
