### PR TITLE
python310Packages.virtualenv: disable on older Python releases

### DIFF
--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -1,9 +1,8 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , buildPythonPackage
 , pythonOlder
 , isPy27
-, backports-entry-points-selectable
 , cython
 , distlib
 , fetchPypi
@@ -18,13 +17,14 @@
 , pytest-timeout
 , pytestCheckHook
 , setuptools-scm
-, six
 }:
 
 buildPythonPackage rec {
   pname = "virtualenv";
   version = "20.17.1";
   format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -36,13 +36,9 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    backports-entry-points-selectable
     distlib
     filelock
     platformdirs
-    six
-  ] ++ lib.optionals (pythonOlder "3.4" && !stdenv.hostPlatform.isWindows) [
-    pathlib2
   ] ++ lib.optionals (pythonOlder "3.7") [
     importlib-resources
   ] ++ lib.optionals (pythonOlder "3.8") [
@@ -66,8 +62,8 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  # Ignore tests which require network access
   disabledTestPaths = [
+    # Ignore tests which require network access
     "tests/unit/create/test_creator.py"
     "tests/unit/seed/embed/test_bootstrap_link_via_app_data.py"
   ];
@@ -78,16 +74,16 @@ buildPythonPackage rec {
     "test_seed_link_via_app_data"
     # Permission Error
     "test_bad_exe_py_info_no_raise"
-  ] ++ lib.optionals isPy27 [
-    "test_python_via_env_var"
-    "test_python_multi_value_prefer_newline_via_env_var"
   ];
 
-  pythonImportsCheck = [ "virtualenv" ];
+  pythonImportsCheck = [
+    "virtualenv"
+  ];
 
   meta = with lib; {
     description = "A tool to create isolated Python environments";
     homepage = "http://www.virtualenv.org";
+    changelog = "https://github.com/pypa/virtualenv/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ goibhniu ];
   };


### PR DESCRIPTION
###### Description of changes
Only Python > 3.6 is [supported](https://github.com/pypa/virtualenv/blob/main/setup.cfg#L41).

Fixes #196784
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
