### PR TITLE
[staging-next] rustc: don't strip bootstrap on darwin

### DIFF
--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -52,6 +52,12 @@ rec {
       # https://github.com/rust-lang/rust/issues/34722#issuecomment-232164943
     '';
 
+    # The strip tool in cctools 973.0.1 and up appears to break rlibs in the
+    # binaries. The lib.rmeta object inside the ar archive should contain an
+    # .rmeta section, but it is removed. Luckily, this doesn't appear to be an
+    # issue for Rust builds produced by Nix.
+    dontStrip = stdenv.isDarwin;
+
     setupHooks = ./setup-hook.sh;
   };
 


### PR DESCRIPTION
###### Description of changes

Fixes the issue seen in https://github.com/NixOS/nixpkgs/pull/185656#issuecomment-1282822825

I verified up to ripgrep locally.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
