### PR TITLE
bottles: 2022.5.28-trento-3 -> 2022.10.14.1

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -1,10 +1,28 @@
-{ lib, fetchFromGitHub, gitUpdater
-, meson, ninja, pkg-config, wrapGAppsHook
-, desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy, webkitgtk
-, python3Packages, gettext
-, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3, gtksourceview4, gnome
-, steam, xdg-utils, pciutils, cabextract
-, freetype, p7zip, gamemode, mangohud
+{ lib
+, fetchFromGitHub
+, fetchFromGitLab
+, gitUpdater
+, python3Packages
+, blueprint-compiler
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook4
+, appstream-glib
+, desktop-file-utils
+, librsvg
+, gtk4
+, gtksourceview5
+, libadwaita
+, steam
+, cabextract
+, p7zip
+, xdpyinfo
+, imagemagick
+, procps
+, gamescope
+, mangohud
+, vmtouch
 , wine
 , bottlesExtraLibraries ? pkgs: [ ] # extra packages to add to steam.run multiPkgs
 , bottlesExtraPkgs ? pkgs: [ ] # extra packages to add to steam.run targetPkgs
@@ -21,75 +39,77 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2022.5.28-trento-3";
+  version = "2022.10.14.1";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-KIDLRqDLFTsVAczRpTchnUtKJfVHqbYzf8MhIR5UdYY=";
+    sha256 = "sha256-FO91GSGlc2f3TSLrlmRDPi5p933/Y16tdEpX4RcKhL0=";
   };
+
+  patches = [ ./vulkan_icd.patch ];
 
   postPatch = ''
     chmod +x build-aux/meson/postinstall.py
     patchShebangs build-aux/meson/postinstall.py
 
-    substituteInPlace src/backend/wine/winecommand.py \
+    substituteInPlace bottles/backend/wine/winecommand.py \
       --replace \
-        'self.__get_runner()' \
-        '(lambda r: (f"${steam-run}/bin/steam-run {r}", r)[r == "wine" or r == "wine64"])(self.__get_runner())'
-  '';
+        "command = f\"{runner} {command}\"" \
+        "command = f\"{''' if runner == 'wine' or runner == 'wine64' else '${steam-run}/bin/steam-run '}{runner} {command}\"" \
+      --replace \
+        "command = f\"{_picked['entry_point']} {command}\"" \
+        "command = f\"${steam-run}/bin/steam-run {_picked['entry_point']} {command}\""
+    '';
 
   nativeBuildInputs = [
+    blueprint-compiler
     meson
     ninja
     pkg-config
-    wrapGAppsHook
-    gettext
+    wrapGAppsHook4
+    gtk4 # gtk4-update-icon-cache
     appstream-glib
     desktop-file-utils
   ];
 
   buildInputs = [
-    gdk-pixbuf
-    glib
-    gobject-introspection
-    gsettings-desktop-schemas
-    gspell
-    gtk3
-    gtksourceview4
-    libhandy
-    libnotify
-    webkitgtk
-    gnome.adwaita-icon-theme
+    librsvg
+    gtk4
+    gtksourceview5
+    libadwaita
   ];
 
   propagatedBuildInputs = with python3Packages; [
     pyyaml
-    pytoml
     requests
-    pycairo
     pygobject3
-    lxml
-    dbus-python
-    gst-python
-    liblarch
     patool
     markdown
+    fvs
+    pefile
+    urllib3
+    chardet
+    certifi
+    idna
+    pillow
+    orjson
+    icoextract
   ] ++ [
-    steam-run
-    xdg-utils
-    pciutils
     cabextract
-    wine
-    freetype
     p7zip
-    gamemode # programs.gamemode.enable
+    xdpyinfo
+    imagemagick
+    procps
+
+    gamescope
     mangohud
+    vmtouch
+    wine
   ];
 
   format = "other";
-  strictDeps = false; # broken with gobject-introspection setup hook, see https://github.com/NixOS/nixpkgs/issues/56943
   dontWrapGApps = true; # prevent double wrapping
 
   preFixup = ''

--- a/pkgs/applications/misc/bottles/vulkan_icd.patch
+++ b/pkgs/applications/misc/bottles/vulkan_icd.patch
@@ -1,0 +1,13 @@
+diff --git a/bottles/backend/utils/vulkan.py b/bottles/backend/utils/vulkan.py
+index 6673493..07f70d1 100644
+--- a/bottles/backend/utils/vulkan.py
++++ b/bottles/backend/utils/vulkan.py
+@@ -29,6 +29,8 @@ class VulkanUtils:
+         "/etc/vulkan",
+         "/usr/local/share/vulkan",
+         "/usr/local/etc/vulkan"
++        "/run/opengl-driver/share/vulkan/",
++        "/run/opengl-driver-32/share/vulkan/",
+     ]
+     if "FLATPAK_ID" in os.environ:
+         __vk_icd_dirs += [

--- a/pkgs/development/python-modules/fvs/default.nix
+++ b/pkgs/development/python-modules/fvs/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, orjson}:
+
+buildPythonPackage rec {
+  pname = "fvs";
+  version = "0.3.4";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "FVS";
+    extension = "tar.gz";
+    sha256 = "sha256-yYd0HzdwbqB9kexJjBRRYmdsoWtZtcjCNRz0ZJVM5CI=";
+  };
+
+  propagatedBuildInputs = [
+    orjson
+  ];
+
+  # no tests in src
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "fvs"
+  ];
+
+  meta = with lib; {
+    description = "File Versioning System with hash comparison and data storage to create unlinked states that can be deleted";
+    homepage = "https://github.com/mirkobrombin/FVS";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/development/python-modules/icoextract/default.nix
+++ b/pkgs/development/python-modules/icoextract/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, pefile, pillow}:
+
+buildPythonPackage rec {
+  pname = "icoextract";
+  version = "0.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "tar.gz";
+    sha256 = "sha256-x0GEV0PUbkAzoUJgAqup9bHd7iYttGyzIZNdo8KsFyo=";
+  };
+
+  propagatedBuildInputs = [
+    pefile
+    pillow
+  ];
+
+  # tests expect mingw and multiarch
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "icoextract"
+  ];
+
+  meta = with lib; {
+    description = "Extract icons from Windows PE files";
+    homepage = "https://github.com/jlu5/icoextract";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27405,7 +27405,7 @@ with pkgs;
   bonzomatic = callPackage ../applications/editors/bonzomatic { };
 
   bottles = callPackage ../applications/misc/bottles {
-    wine = wineWowPackages.minimal;
+    wine = null;
   };
 
   brave = callPackage ../applications/networking/browsers/brave { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4369,6 +4369,8 @@ self: super: with self; {
 
   idasen = callPackage ../development/python-modules/idasen { };
 
+  icoextract = callPackage ../development/python-modules/icoextract { };
+
   icontract = callPackage ../development/python-modules/icontract { };
 
   identify = callPackage ../development/python-modules/identify { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3534,6 +3534,8 @@ self: super: with self; {
 
   fuzzywuzzy = callPackage ../development/python-modules/fuzzywuzzy { };
 
+  fvs = callPackage ../development/python-modules/fvs { };
+
   fx2 = callPackage ../development/python-modules/fx2 { };
 
   galario = toPythonModule (pkgs.galario.override {


### PR DESCRIPTION
###### Description of changes

Continuation of #181768 and #181819.
Closes #192292, closes #182539, closes #181501.

Fixing #182539 is a big deal (though it can technically be done in earlier versions as well).

Two of the problems of #181819 haven't been solved:
- The "Core" menu in the Preferences doesn't work (very small deal, also it doesn't even exist in the Flatpak version)
- The interface is slow when changing menus (not the biggest deal since applications launched through Bottles aren't affected, but not a small deal either)

I have no idea how to debug the slow interface issue. However, I noticed that a `nix-shell --pure` environment doesn't have the issue, for some reason.

I removed the system Wine dependency: in my opinion it has no place being installed by default, since Bottles incentives the user to use its own version of Wine, and system Wine works perfectly fine when in `environment.systemPackages` if the user wants that. EDIT: It is set to `null` now instead.

The new feature `vkBasalt` isn't supported here. EDIT: See one of the later comments for what needs to be solved. Blocker for 2022.11.14.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
