### PR TITLE
hackgen-font: init at 2.7.1

### DIFF
--- a/pkgs/data/fonts/hackgen/default.nix
+++ b/pkgs/data/fonts/hackgen/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, fetchzip
+}:
+
+fetchzip rec {
+  pname = "hackgen-font";
+  version = "2.7.1";
+
+  url = "https://github.com/yuru7/HackGen/releases/download/v${version}/HackGen_v${version}.zip";
+  sha256 = "sha256-UL6U/q2u1UUP31lp0tEnFjzkn6dn8AY6hk5hJhPsOAE=";
+  postFetch = ''
+    install -Dm644 $out/*.ttf -t $out/share/fonts/hackgen
+    shopt -s extglob dotglob
+    rm -rf $out/!(share)
+    shopt -u extglob dotglob
+  '';
+
+  meta = with lib; {
+    description = "A composite font of Hack and GenJyuu-Goghic";
+    homepage = "https://github.com/yuru7/HackGen";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/data/fonts/hackgen/nerdfont.nix
+++ b/pkgs/data/fonts/hackgen/nerdfont.nix
@@ -1,0 +1,25 @@
+{ lib
+, fetchzip
+}:
+
+fetchzip rec {
+  pname = "hackgen-nf-font";
+  version = "2.7.1";
+
+  url = "https://github.com/yuru7/HackGen/releases/download/v${version}/HackGen_NF_v${version}.zip";
+  sha256 = "sha256-9sylGr37kKIGWgThZFqL2y6oI3t2z4kbXYk5DBMIb/g=";
+  postFetch = ''
+    install -Dm644 $out/*.ttf -t $out/share/fonts/hackgen-nf
+    shopt -s extglob dotglob
+    rm -rf $out/!(share)
+    shopt -u extglob dotglob
+  '';
+
+  meta = with lib; {
+    description = "A composite font of Hack, GenJyuu-Gothic and nerd-fonts";
+    homepage = "https://github.com/yuru7/HackGen";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26054,6 +26054,8 @@ with pkgs;
 
   hackgen-font = callPackage ../data/fonts/hackgen { };
 
+  hackgen-nf-font = callPackage ../data/fonts/hackgen/nerdfont.nix { };
+
   helvetica-neue-lt-std = callPackage ../data/fonts/helvetica-neue-lt-std { };
 
   helvum = callPackage ../applications/audio/helvum { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26052,6 +26052,8 @@ with pkgs;
 
   hack-font = callPackage ../data/fonts/hack { };
 
+  hackgen-font = callPackage ../data/fonts/hackgen { };
+
   helvetica-neue-lt-std = callPackage ../data/fonts/helvetica-neue-lt-std { };
 
   helvum = callPackage ../applications/audio/helvum { };


### PR DESCRIPTION
###### Description of changes

HackGen is a Japanese composite font of Hack and GenJyuu-Gothic.
https://github.com/yuru7/HackGen

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
