### PR TITLE
graudit: init at 3.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6118,6 +6118,12 @@
     githubId = 488556;
     name = "Javier Aguirre";
   };
+  jaybosamiya = {
+    name = "Jay Bosamiya";
+    email = "nixpkgs@jaybosamiya.com";
+    github = "jaybosamiya";
+    githubId = 5683582;
+  };
   jayesh-bhoot = {
     name = "Jayesh Bhoot";
     email = "jayesh@bhoot.sh";

--- a/pkgs/development/tools/analysis/graudit/default.nix
+++ b/pkgs/development/tools/analysis/graudit/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, groff
+, which
+, zip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "graudit";
+  version = "3.4";
+
+  src = fetchFromGitHub {
+    owner = "wireghoul";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-VgXlOVACvIOQJSXKsR27yL6R3QWoaKZc/t+bt+gP4gk=";
+  };
+
+  buildInputs = [ groff which zip ];
+
+  patches = [
+    ./fix-lib-path.patch
+    ./remove-fixed-prefix.patch
+    ./remove-git-test.patch
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    description = "grep rough audit - source code auditing tool";
+    longDescription = ''
+      A simple script and signature sets that allows you to
+      find potential security flaws in source code using the GNU
+      utility grep.
+    '';
+    homepage = "https://github.com/wireghoul/graudit";
+    changelog = "https://github.com/wireghoul/graudit/releases/tag/v${version}";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.jaybosamiya ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/analysis/graudit/fix-lib-path.patch
+++ b/pkgs/development/tools/analysis/graudit/fix-lib-path.patch
@@ -1,0 +1,23 @@
+diff --git a/graudit b/graudit
+index 70626e6..0e458b0 100755
+--- a/graudit
++++ b/graudit
+@@ -94,6 +94,9 @@ listdb () {
+     if [ -d "$basedir"/signatures/ ]; then
+         ls -1 "$basedir"/signatures/*.db 2>/dev/null
+     fi
++    if [ -d "$basedir"/../share/graudit/ ]; then
++        ls -1 "$basedir"/../share/graudit/*.db 2>/dev/null
++    fi
+     if [ -d "$basedir"/misc/ ]; then
+         ls -1 "$basedir"/misc/*.db 2>/dev/null
+     fi
+@@ -175,6 +178,8 @@ elif [ -f "$HOME/.graudit/$sigdb.db" ]; then
+     database="$HOME/.graudit/$sigdb.db"
+ elif [ -f "$basedir/signatures/$sigdb.db" ]; then
+     database="$basedir/signatures/$sigdb.db"
++elif [ -f "$basedir/../share/graudit/$sigdb.db" ]; then
++    database="$basedir/../share/graudit/$sigdb.db"
+ elif [ -f "$basedir/misc/$sigdb.db" ]; then
+     database="$basedir/misc/$sigdb.db"
+ elif [ -f "$HOME/graudit/signatures/$sigdb.db" ]; then

--- a/pkgs/development/tools/analysis/graudit/remove-fixed-prefix.patch
+++ b/pkgs/development/tools/analysis/graudit/remove-fixed-prefix.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index b685fae..d1b7073 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,7 +2,6 @@
+ # graudit makefile
+ ###
+ 
+-prefix = /usr
+ dataroot = $(prefix)/share
+ datadir = $(dataroot)/graudit
+ bindir = $(prefix)/bin

--- a/pkgs/development/tools/analysis/graudit/remove-git-test.patch
+++ b/pkgs/development/tools/analysis/graudit/remove-git-test.patch
@@ -1,0 +1,11 @@
+diff --git a/t/git-test.sh b/t/git-test.sh
+index b5acd87..3ae7fd3 100755
+--- a/t/git-test.sh
++++ b/t/git-test.sh
+@@ -6,6 +6,4 @@ test_description='graudit repo tests'
+ . ./test-lib.sh
+ 
+ # TESTS
+-test_expect_success 'No outstanding commits' 'git status|grep "working tree clean"'
+-test_expect_code 1 'No outstanding push/pulls' 'git status|grep "# Your branch is"'
+ test_done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16864,6 +16864,8 @@ with pkgs;
   gradle_7 = callPackage gradle-packages.gradle_7 { };
   gradle = gradle_7;
 
+  graudit = callPackage ../development/tools/analysis/graudit { };
+
   grcov = callPackage ../development/tools/misc/grcov { };
 
   gperf = callPackage ../development/tools/misc/gperf { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> graudit is a simple script and signature sets that allows you to find potential security flaws in source code using the GNU utility grep.

https://github.com/wireghoul/graudit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
