### PR TITLE
tauray: init at 1.0.1

### DIFF
--- a/pkgs/applications/graphics/tauray/default.nix
+++ b/pkgs/applications/graphics/tauray/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, graphviz
+, doxygen
+, pkg-config
+, python3
+, libcbor
+, czmq
+, glm
+, nng
+, mbedtls
+, openxr-loader
+, SDL2
+, shaderc
+, spirv-headers
+, vulkan-headers
+, vulkan-loader
+, wayland
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tauray";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "vga-group";
+    repo = "tauray";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-Q3Dv96iptDvmBp9mIVSYzb7EnIzD1kFejwrFuc1HqdU=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    czmq
+    glm
+    libcbor
+    nng
+    mbedtls
+    openxr-loader
+    (SDL2.override { withStatic = true; })
+    vulkan-loader
+    wayland
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    graphviz
+    doxygen
+    pkg-config
+    python3
+    shaderc
+    vulkan-headers
+  ];
+
+  meta = with lib; {
+    description = "A real-time rendering framework, with a focus on distributed computing, scalability, portability and low latency";
+    homepage = "https://github.com/vga-group/tauray";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ jansol ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+})
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1405,6 +1405,8 @@ with pkgs;
 
   tauon = callPackage ../applications/audio/tauon { };
 
+  tauray = callPackage ../applications/graphics/tauray { };
+
   tere = callPackage ../tools/misc/tere { };
 
   termusic = callPackage ../applications/audio/termusic { };


### PR DESCRIPTION
###### Description of changes
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Real-time path tracer based on vulkan and its hardware-accelerated ray tracing extensions: https://github.com/vga-group/tauray

Draft until #196854 is merged since this won't build without it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
