### PR TITLE
hypr: init at unstable-2022-05-25

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -23,6 +23,7 @@ in
     ./fvwm3.nix
     ./hackedbox.nix
     ./herbstluftwm.nix
+    ./hypr.nix
     ./i3.nix
     ./jwm.nix
     ./leftwm.nix

--- a/nixos/modules/services/x11/window-managers/hypr.nix
+++ b/nixos/modules/services/x11/window-managers/hypr.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.hypr;
+in
+{
+  ###### interface
+  options = {
+    services.xserver.windowManager.hypr.enable = mkEnableOption (lib.mdDoc "hypr");
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "hypr";
+      start = ''
+        ${pkgs.hypr}/bin/Hypr &
+        waitPID=$!
+      '';
+    };
+    environment.systemPackages = [ pkgs.hypr ];
+  };
+}

--- a/pkgs/applications/window-managers/hyprwm/hypr/000-dont-set-compiler.diff
+++ b/pkgs/applications/window-managers/hyprwm/hypr/000-dont-set-compiler.diff
@@ -1,0 +1,18 @@
+diff -Naur source-old/CMakeLists.txt source/CMakeLists.txt
+--- source-old/CMakeLists.txt	2022-10-19 00:55:52.766480588 -0300
++++ source/CMakeLists.txt	2022-10-19 00:56:08.368515654 -0300
+@@ -1,7 +1,5 @@
+ cmake_minimum_required(VERSION 3.4)
+ 
+-set(CMAKE_CXX_COMPILER "/bin/g++")
+-
+ project(Hypr 
+     VERSION 0.1
+     DESCRIPTION "A Modern OOP C++ Window Manager"
+@@ -54,4 +52,4 @@
+     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg -no-pie -fno-builtin")
+     SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg -no-pie -fno-builtin")
+     SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pg -no-pie -fno-builtin")
+-ENDIF(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
+\ No newline at end of file
++ENDIF(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)

--- a/pkgs/applications/window-managers/hyprwm/hypr/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hypr/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cairo
+, cmake
+, glib
+, gtkmm3
+, harfbuzz
+, libX11
+, libXdmcp
+, libxcb
+, makeWrapper
+, pcre2
+, pkg-config
+, xcbutilcursor
+, xcbutilkeysyms
+, xcbutilwm
+, xmodmap
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hypr";
+  version = "unstable-2022-05-25";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "Hypr";
+    rev = "3e3d943c446ae77c289611a1a875c8dff8883c1e";
+    hash = "sha256-lyaGGm53qxg7WVoFxZ7kerLe12P1N3JbN8nut6oZS50=";
+  };
+
+  patches = [
+    ./000-dont-set-compiler.diff
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    glib
+    gtkmm3
+    harfbuzz
+    libX11
+    libXdmcp
+    libxcb
+    pcre2
+    xcbutilcursor
+    xcbutilkeysyms
+    xcbutilwm
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 Hypr -t $out/bin
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/Hypr --prefix PATH : ${lib.makeBinPath [ xmodmap ]}
+  '';
+
+  meta = with lib; {
+    inherit (finalAttrs.src.meta) homepage;
+    description = "A tiling X11 window manager written in modern C++";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ AndersonTorres ];
+    inherit (libX11.meta) platforms;
+    broken = stdenv.isDarwin; # xcb/xcb_atom.h not found
+    mainProgram = "Hypr";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4230,6 +4230,8 @@ with pkgs;
 
   hunt = callPackage ../tools/misc/hunt { };
 
+  hypr = callPackage ../applications/window-managers/hyprwm/hypr { };
+
   hyprland = callPackage ../applications/window-managers/hyprwm/hyprland { };
 
   hyprpaper = callPackage ../applications/window-managers/hyprwm/hyprpaper { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
