### PR TITLE
sorted-grep: init at 1.0

### DIFF
--- a/pkgs/tools/text/sorted-grep/default.nix
+++ b/pkgs/tools/text/sorted-grep/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchurl, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "sorted-grep";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/sgrep/sgrep-${version}.tgz";
+    hash = "sha256-3F7cXrZnB38YwE1sHYm/CIGKmG+1c0QU+Pk3Y53a0T4=";
+  };
+
+  postPatch = ''
+    # Its Makefile is missing compiler flags and an install step
+    rm -f Makefile
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    ${stdenv.cc.targetPrefix}cc -Wall -O2 -o sgrep sgrep.c
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D sgrep "$out/bin/sgrep"
+
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    set +o pipefail
+    $out/bin/sgrep 2>&1 | grep ^Usage:
+
+    runHook postInstallCheck
+  '';
+
+  doInstallCheck = true;
+
+  meta = with lib; {
+    homepage = "https://sgrep.sourceforge.net/";
+    description = "Sgrep (sorted grep) searches sorted input files for lines that match a search key";
+    longDescription = ''
+      Sgrep (sorted grep) searches sorted input files for lines that match a search
+      key and outputs the matching lines. When searching large files sgrep is much
+      faster than traditional Unix grep, but with significant restrictions.
+    '';
+    platforms = platforms.unix;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ivan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1395,6 +1395,8 @@ with pkgs;
 
   sgrep = callPackage ../tools/text/sgrep { };
 
+  sorted-grep = callPackage ../tools/text/sorted-grep { };
+
   smbscan = callPackage ../tools/security/smbscan { };
 
   spectre-cli = callPackage ../tools/security/spectre-cli { };


### PR DESCRIPTION
###### Description of changes

This is https://sgrep.sourceforge.net/, which is quite useful for finding lines in very large sorted files.

I renamed the package in nixpkgs from `sgrep` to `sorted-grep` because nixpkgs `sgrep` is already https://www.cs.helsinki.fi/u/jjaakkol/sgrep.html

It is old, but I don't know of an equivalent replacement. If something better exists, I would be happy to know about it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).