### PR TITLE
utm: 3.2.4 → 4.0.8

### DIFF
--- a/pkgs/os-specific/darwin/utm/default.nix
+++ b/pkgs/os-specific/darwin/utm/default.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "utm";
-  version = "3.2.4";
+  version = "4.0.8";
 
   src = fetchurl {
     url = "https://github.com/utmapp/UTM/releases/download/v${version}/UTM.dmg";
-    sha256 = "sha256-ejUfL6UHqMusVfaglGlODKtFfKbNwzZ1LmRkcSzieso=";
+    sha256 = "sha256-a6GQyiW8pqw6fN3WVuTVUfnsl/qPtmzDxUvWNElli5k=";
   };
 
   nativeBuildInputs = [ undmg ];
@@ -41,12 +41,14 @@ stdenvNoCC.mkDerivation rec {
         - Hardware accelerated virtualization using Hypervisor.framework and
           QEMU
         - Boot macOS guests with Virtualization.framework on macOS 12+
+
+      See https://docs.getutm.app/ for more information.
     '';
     homepage = "https://mac.getutm.app/";
     changelog = "https://github.com/utmapp/${pname}/releases/tag/v${version}";
     mainProgram = "UTM";
     license = licenses.apsl20;
-    platforms = platforms.darwin;
+    platforms = platforms.darwin; # 11.3 is the minimum supported version as of UTM 4.
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ rrbutani ];
   };


### PR DESCRIPTION
###### Description of changes

This is the first stable `4.0.x` release; the full changelog is [here](https://github.com/utmapp/UTM/releases/tag/v4.0.8).

UTM 4 bumps the minimum supported macOS version from 11.0 to 11.3. Unfortunately I do not think there is any way to encode this in `meta.platforms`.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).