### PR TITLE
[staging-next] stdenvBootstrapTools: fix cycle on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
-  ] ++ lib.optionals (haveLibc && !isMusl) [
+  ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
     "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"

--- a/pkgs/development/compilers/llvm/11/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
-  ] ++ lib.optionals (haveLibc && !isMusl) [
+  ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
     "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl || isNewDarwinBootstrap) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"

--- a/pkgs/development/compilers/llvm/12/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/12/compiler-rt/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
-  ] ++ lib.optionals (haveLibc && !isMusl) [
+  ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
     "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"

--- a/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/13/compiler-rt/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
-  ] ++ lib.optionals (haveLibc && !isMusl) [
+  ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
     "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl || isAarch64) [
     "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF"

--- a/pkgs/development/compilers/llvm/14/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/14/compiler-rt/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
     "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
-  ] ++ lib.optionals (haveLibc && !isMusl) [
+  ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.isGnu) [
     "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
   ] ++ lib.optionals (useLLVM || bareMetal || isMusl) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -1,6 +1,5 @@
-{ lib, stdenv, makeWrapper, writeText, writeShellScriptBin, runCommand
+{ lib, stdenv, makeWrapper, writeText, writeTextFile, runCommand, callPackage
 , CoreServices, ImageIO, CoreGraphics
-, runtimeShell, callPackage
 , xcodePlatform ? stdenv.targetPlatform.xcodePlatform or "MacOSX"
 , xcodeVer ? stdenv.targetPlatform.xcodeVer or "9.4.1"
 , sdkVer ? stdenv.targetPlatform.darwinSdkVersion or "10.12" }:
@@ -37,7 +36,7 @@ let
   '';
 
   xcode-select = writeText "xcode-select" ''
-#!${runtimeShell}
+#!${stdenv.shell}
 while [ $# -gt 0 ]; do
    case "$1" in
          -h | --help) ;; # noop
@@ -51,7 +50,12 @@ while [ $# -gt 0 ]; do
 done
   '';
 
-  xcrun = writeShellScriptBin "xcrun" ''
+  xcrun = writeTextFile {
+    name = "xcrun";
+    executable = true;
+    destination = "/bin/xcrun";
+    text = ''
+#!${stdenv.shell}
 args=( "$@" )
 
 # If an SDK was requested, check that it matches.
@@ -94,7 +98,11 @@ done
 if ! [[ -z "$@" ]]; then
    exec "$@"
 fi
-  '';
+    '';
+    checkPhase = ''
+      ${stdenv.shellDryRun} "$target"
+    '';
+  };
 
 in
 


### PR DESCRIPTION
###### Description of changes

This fixes the issue highlighted in: https://github.com/NixOS/nixpkgs/pull/186575#issuecomment-1285162963

There were actually two culprits:

- #186575 uses helpers from `trivial-builders.nix` to write shell scripts for `xcbuild.xcrun`, but those rely on `runtimeShell` which is apparently not possible at this stage. (I guess they create a dependency on the final stdenv, instead of whatever stdenv stage is part of bootstrap-tools?)
- #181764 adds a dependency on libxcrypt to LLVM compiler-rt, but I believe this should be glibc specific. I changed the conditions to reflect this.

I only tested evaluation of `{aarch64,x86_64}-darwin`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).