### PR TITLE
nixos/nscd: add option to use nsncd, init nsncd

### DIFF
--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -51,7 +51,8 @@ in
 
       package = mkOption {
         type = types.package;
-        default = if pkgs.stdenv.hostPlatform.libc == "glibc"
+        default =
+          if pkgs.stdenv.hostPlatform.libc == "glibc"
           then pkgs.stdenv.cc.libc.bin
           else pkgs.glibc.bin;
         defaultText = lib.literalExpression ''
@@ -77,10 +78,11 @@ in
       group = cfg.group;
     };
 
-    users.groups.${cfg.group} = {};
+    users.groups.${cfg.group} = { };
 
     systemd.services.nscd =
-      { description = "Name Service Cache Daemon";
+      {
+        description = "Name Service Cache Daemon";
 
         before = [ "nss-lookup.target" "nss-user-lookup.target" ];
         wants = [ "nss-lookup.target" "nss-user-lookup.target" ];
@@ -106,7 +108,8 @@ in
         # sill want to read their configuration files after the privilege drop
         # and so users can set the owner of those files to the nscd user.
         serviceConfig =
-          { ExecStart = "!@${cfg.package}/bin/nscd nscd";
+          {
+            ExecStart = "!@${cfg.package}/bin/nscd nscd";
             Type = "forking";
             User = cfg.user;
             Group = cfg.group;
@@ -120,7 +123,8 @@ in
             PIDFile = "/run/nscd/nscd.pid";
             Restart = "always";
             ExecReload =
-              [ "${cfg.package}/bin/nscd --invalidate passwd"
+              [
+                "${cfg.package}/bin/nscd --invalidate passwd"
                 "${cfg.package}/bin/nscd --invalidate group"
                 "${cfg.package}/bin/nscd --invalidate hosts"
               ];

--- a/nixos/tests/nscd.nix
+++ b/nixos/tests/nscd.nix
@@ -40,9 +40,10 @@ in
                   "systemd-run --pty --property=Type=oneshot --property=DynamicUser=yes --property=User=iamatest whoami"
               )
 
-      # Test resolution of somehost.test with getent', to make sure we go via nscd
+      # Test resolution of somehost.test with getent', to make sure we go via
+      # nscd protocol
       def test_host_lookups():
-          with subtest("host lookups via nscd"):
+          with subtest("host lookups via nscd protocol"):
               # ahosts
               output = machine.succeed("${getent'} ahosts somehost.test")
               assert "192.0.2.1" in output

--- a/nixos/tests/nscd.nix
+++ b/nixos/tests/nscd.nix
@@ -43,6 +43,9 @@ in
       withUnscd.configuration = { ... }: {
         services.nscd.package = pkgs.unscd;
       };
+      withNsncd.configuration = { ... }: {
+        services.nscd.enableNsncd = true;
+      };
     };
   };
 
@@ -126,5 +129,13 @@ in
 
           # known to fail, unscd doesn't load external NSS modules
           # test_nss_myhostname()
+
+      with subtest("nsncd"):
+          machine.succeed('${specialisations}/withNsncd/bin/switch-to-configuration test')
+          machine.wait_for_unit("default.target")
+
+          test_dynamic_user()
+          test_host_lookups()
+          test_nss_myhostname()
     '';
 })

--- a/pkgs/os-specific/linux/nsncd/default.nix
+++ b/pkgs/os-specific/linux/nsncd/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, nix-gitignore
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nsncd";
+  version = "unstable-2021-10-20";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nsncd";
+    rev = "b9425070bb308565a6e4dc5aefd568952a07a4ed";
+    hash = "sha256-ZjInzPJo+PWAM2gAKhlasLXiqo+2Df4DIXpNwtqQVc8=";
+  };
+
+  cargoSha256 = "sha256-hxdI+HHB0PB/zDMI21Pg5Xr9mTDn4T+OcAAenUox4bs=";
+
+  meta = with lib; {
+    description = "the name service non-caching daemon";
+    longDescription = ''
+      nsncd is a nscd-compatible daemon that proxies lookups, without caching.
+    '';
+    homepage = "https://github.com/twosigma/nsncd";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ flokli ninjatrappeur ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36594,6 +36594,8 @@ with pkgs;
 
   nhentai = callPackage ../applications/misc/nhentai { };
 
+  nsncd = callPackage ../os-specific/linux/nsncd { };
+
   nvd = callPackage ../tools/package-management/nvd { };
 
   solfege = python3Packages.callPackage ../misc/solfege { };


### PR DESCRIPTION
###### Description of changes
This provides a `services.nscd.enableNsncd`, which will use `nsncd` instead of `nscd` to provide NSS lookups.

We use [nix-community/nsncd](https://github.com/nix-community/nsncd/tree/host-lookups-and-noops) due to https://github.com/twosigma/nsncd/discussions/44:

> We'd definitely like to collaborate with you and work to incorporate your changes in our project. But this is not the main day-to-day job for any of us, so if we're too slow to respond feel free to keep experimenting in your forks and we'll try to keep up with your pace.

The nscd test has been included, to ensure it works the way it's supposed to.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
