### PR TITLE
thunderbird-{,bin-}unwrapped: 102.3.3 -> 102.4.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "102.3.3";
+  version = "102.4.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/af/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/af/thunderbird-102.4.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2117862d27cc35495f89ce0f013cf7afa64af058528ed9d85033f0da6513d9a8";
+      sha256 = "93c9dccd3f4a81610d91f4388d0f84d91cd9e8c55458dc2992f510ed07744780";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ar/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ar/thunderbird-102.4.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "6d21c2ac3b202720d9c512aa24d2365508c8b887e37e08cb130128186a6dc575";
+      sha256 = "f3693cbc8d7c8eaec41a6498660686a94b7c7ac541cf65193385bbc090b080c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ast/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ast/thunderbird-102.4.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "edf2fd51ed6525c3695ba2a73a333f80e71db56ed3465e95545cc11817db5ff7";
+      sha256 = "324d925d6c6b5a0e46123b0a4bfee932dc01a1e91df0b0f0d88a5159c87909ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/be/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/be/thunderbird-102.4.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "7c151e8aa9fc9a625df19578756bea5895c9c32ec521f662f5d4c007718a6175";
+      sha256 = "e89053d47291e001b60e76f01ce56c01e180a7785b3e8a80b30e85eddfcabddc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/bg/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/bg/thunderbird-102.4.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "5b0300f866c0d4f5d82dac26a49ad57a6acbc1761eff5b9a05beecebfb41827e";
+      sha256 = "ebd61de1626f18fb3c4296f4a3e546064e280cffd1290fe95049adaa942453e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/br/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/br/thunderbird-102.4.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "9ff4ea160821ff92451a644d1b9adb11a931af0d2799bfd62efc4babcdda6c52";
+      sha256 = "50c6ed53eb3e8db065562b4ec3d2e780385364426133fa5204141a93d7d6c400";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ca/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ca/thunderbird-102.4.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "55209f52c756351f175583d30976d0aff65e6434a53fab26a579fe576104bc08";
+      sha256 = "9c500fae332cfd1140547da498d8d5c5798a00e9fbf8036da1cc69f8f30974d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/cak/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/cak/thunderbird-102.4.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "76b8051c060f1ba667215ad3a9f7dd86674bf1644af2121f2397ad8f248fd8de";
+      sha256 = "cb21ff9e839c092bf7b15dc033af66d7e0817ebccb54a93ad20a485cf2ef017d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/cs/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/cs/thunderbird-102.4.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "0d346c3116243125a63e2a3be2dbe99def481fa1be5b3013fe50354940daccea";
+      sha256 = "82718115f0cbf0f609c465a9399a5947292a0ae81234802b163ec362c3d1b7b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/cy/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/cy/thunderbird-102.4.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "1e2782ddd0716094f5ea4a79221ace671c7edd3acf87c4a5f88b2fff768c5a8a";
+      sha256 = "25e7f01c83e17b7181776430308fe39bf914d0da2d8a2e8351a8a2f45c791b50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/da/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/da/thunderbird-102.4.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "da350c192ad5cb9084a9fd0544600b7c518d4f68b1f097a8c7a756ca5697235a";
+      sha256 = "0f7c6940092081ed29ca4ed1f3b83a8dcab040e08a09822f079a7273f04494f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/de/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/de/thunderbird-102.4.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "a4218fbe3e1c791bb408bf0e9ad330c3c5b8cd4a080a2f7040889b055d0c2f14";
+      sha256 = "3e1c3235af50d99f6de0815a10465e57377fc51de0ab76b923c9a9b804c3a94e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/dsb/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/dsb/thunderbird-102.4.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "46fa8c1559d2de3ddc7728c20efa40e917240ad49385a636cb7d1a1dea83370a";
+      sha256 = "bc7d3206e6b1fe2ccf151fad27c7b34f42a2d2b3cc36c1505ee3f47bf94de247";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/el/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/el/thunderbird-102.4.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "1de3a316c05fd321d9cdb2c7c8d810ed0f23b9551e2cfafff5b72281cf7c309e";
+      sha256 = "70abfc1e011a2901e7639e7ebfb01ac06f18732b10f2e640e5c1dbbcef3e0e6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/en-CA/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/en-CA/thunderbird-102.4.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "994b2ac276c1526f76f3cf5a50401413ac00f4238703b5c853d5b5cebd2511a3";
+      sha256 = "82e8043502072528c4bdd5e267cd6d581fbeaaa125cd74977461eae1bf1da861";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/en-GB/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/en-GB/thunderbird-102.4.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "3eae960037dd0d3d2b7fc902355a832cb739bd014c5ef075e63a3ecdaf53c75a";
+      sha256 = "707608d9c55c073522071732cd0541a04bb7b7b0d3bff6fa35fd2307e0320ae1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/en-US/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/en-US/thunderbird-102.4.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "d6c475666c7bca01ed05926cda69ffc58135f223e7ae72df24d5714f3e1580ea";
+      sha256 = "52c80623976ea2e62a52b5b62f741450e684c07e0fce72fbb5218dcadce9b4da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/es-AR/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/es-AR/thunderbird-102.4.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "5d48de31d823b1995b10a64ab809a85c1ef0f907efd30595d22d0231d73507ca";
+      sha256 = "09ca8111a3c0792591515f4e7abc090148b28e2bef7e0c591c3f0eb15fa0b8d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/es-ES/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/es-ES/thunderbird-102.4.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "8816039b4a8466de5777649d740ca7e30c9902d9f0bb372742fd649fc7f9d8fc";
+      sha256 = "923d07aeb9bccf7ae42baca048bd8222cccc31ffde1f090675df8df715aed21e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/es-MX/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/es-MX/thunderbird-102.4.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "f9a9ca30c9d28a5f3b0f9d160cc2b8676a5f8e74036ce7e479e23dec775ddf4b";
+      sha256 = "6f03c99fbfab67d593c94f9d12f104385208040229eb403eb51472df1442aa8c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/et/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/et/thunderbird-102.4.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "951bccc704cda03d34657fe61917a2e0aa11fdfe3238575dacc888ef4f012754";
+      sha256 = "db864bbb22fadcdb7419565523318f97e4e57a25fe11429e27fffaf353df4a36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/eu/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/eu/thunderbird-102.4.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "70835c9c3af0e6479cad0e01b20c183cff62f8d1569d049147a0777806e83ee6";
+      sha256 = "e25a04af4f402075575e1ebbc5f9a74a9de008ff303fdc13fd916c55349a83ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/fi/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/fi/thunderbird-102.4.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "70b2c3a8b7cabdd053c314167109d300b3f391f256f401f56a645eb2f7e3871c";
+      sha256 = "73b8cf72eb9a34149eaf0961ce1fd7a29f46c65f5a806c451f0736c2d2b2dec2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/fr/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/fr/thunderbird-102.4.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "1f53f5cc1be471d59527e58dcce58c27567e7a93af4726d9868ee79a0e2c01ff";
+      sha256 = "6bcc2d614ed0b83a8b015e3c39412d4df8de2e862d0615d6093aa826fafe0773";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/fy-NL/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/fy-NL/thunderbird-102.4.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "b41d18c1e425422a234b99e6ed8aff7e7c73fa1cb6285ea5f0e2e32932cc7b01";
+      sha256 = "abbf802853ee2035d886971d3cad73124a79e78f1aa543db9ab8602a41144bb9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ga-IE/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ga-IE/thunderbird-102.4.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "09063d0879797fca3c2e2f589251744ba8c52029a9ec86a3f13ffe8f6eb7321e";
+      sha256 = "e4d9452a2c59c7f06b6851c2549b9f65a41d7ea4f059c05c793fb163ef5bb8ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/gd/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/gd/thunderbird-102.4.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "b410065a55c62671bb35eb954c573f2cf97fbbeec379faae4c4c6ed77aba5b8e";
+      sha256 = "b08c04011f0de20025632e4a29a13b0d5f6296ec46e35c02e37a74ab4abfb8e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/gl/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/gl/thunderbird-102.4.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "50840082735b56d52bc2f271175f4abca337303a74a311ec5021a24ab3fe3ccf";
+      sha256 = "f9d326962e33c93d351392d88897aa2f1e4c3a545c9b8e646e931fe950872cbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/he/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/he/thunderbird-102.4.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "4f507ce715c3512a23713d245304a045d07169610035b568452b2d4a702874ed";
+      sha256 = "8bd8e26d383aadc97dbb4485a8644b3f49068f3772a669c2ec3c0df87f2ebcdf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/hr/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/hr/thunderbird-102.4.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "216ed2cfd39dafd483943ef2d1ba3984058329cca6e2c1706d93a7f4b34bb1cc";
+      sha256 = "c234210e83dccc3562ffd3cb50b37d8924a1145d5dff1db4a6a404f67da0b656";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/hsb/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/hsb/thunderbird-102.4.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "c062e346aca53f4b3b323f95220f497787161a6839f38fb10774936807b4bf81";
+      sha256 = "ed513858dae38683768b0a3839b20f800011fc8817b28e09f31301f614b4f2cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/hu/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/hu/thunderbird-102.4.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "a5cf3e6c746edd752a67e3db5df82db5c2f87cd72b92880dca4ef7c2a0c5e032";
+      sha256 = "5c7b48aee0a7b843b709bc614f83d814cafaebe343dececbcf7f66c858df47f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/hy-AM/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/hy-AM/thunderbird-102.4.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "af862f50f4f56668ef9f3301d67707cb0193fc4df04bf542691b4e0a0d35b283";
+      sha256 = "84fcbc6317d1fd543283528d5bfd899bdfe8a7d54cc3ccde12fbf36054976808";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/id/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/id/thunderbird-102.4.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "06e4a66c9553a607c7b96a7622594a0e79c93894b71eabdfd85cc0b689571bda";
+      sha256 = "53d7c3aa54a0a53eba05ad0281bbf48a05747699e8d5c874e0a31fe7e34d53aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/is/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/is/thunderbird-102.4.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "b348937b74d997f8ba09f0f285df29159bacdebbf711c0648b58558ee9e63d92";
+      sha256 = "b9f313d350c687c04c74d0fce3ec898553a1c91650668a7d7dbf02e53b27847b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/it/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/it/thunderbird-102.4.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "e8bc3d399b2a8d52b0d67063dc293981acf6574d3dd3a961986ccd7fcb3cd1d2";
+      sha256 = "637b1c3a60cbf3edaa65e29b602067b0ca37a4da6434c266ed2a60eae239a6be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ja/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ja/thunderbird-102.4.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "3ec22d6fe5202f9c9ad2c6a56f8daedf424c2d7ba2de5a89882e0735ce3e9fc8";
+      sha256 = "b42908e1920cdac0fc5e1e3645f4e92e2ae891ce0ffb117d2e0db502f1ba10cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ka/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ka/thunderbird-102.4.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "7e23cfdbbf7d168c39ac76992a9fbe021d92cde57b19b58ddb80a0aab9a90ccb";
+      sha256 = "622fcb7991199de7de373b894622290e4e7f2245ab6f8869d23512c02c3c9949";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/kab/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/kab/thunderbird-102.4.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "c53bc2049d5a538c3a703aef0b02f5a64b126b84aeb9920855cb4614e96c9da5";
+      sha256 = "fd3f03b334466df26e24d390027ab215e46d45bfe8cf6b1b87c6025b55426364";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/kk/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/kk/thunderbird-102.4.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "7a3dcbfeca9245b5a72d043331e4f98dbbf7bc3d66dddaa16b4309e96a67dd0b";
+      sha256 = "9aa0af8d48eaf1c2f0111f2d4a57b46c8fd4b365f307b30cf6f0865440fde217";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ko/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ko/thunderbird-102.4.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "515825543b2660c1a6da2bd8825e64c5334ae0b07831f4af5b87100b025a4c68";
+      sha256 = "da990d20167bcacc2e8ed9083f905c9b0b6cde1a7994f557865304a322be1dae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/lt/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/lt/thunderbird-102.4.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "28139cd4d56189ff3d16b2a135fb29a9d541ccd33cb7dc62f176015b9e73b8dc";
+      sha256 = "468590ba13345d76ad511122a423080c789c39b8993a613be0706678d1174d70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/lv/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/lv/thunderbird-102.4.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "0a4a7d6af0b4ad933745793f85b6c504b7468cb1796728cb5b19f5be0e23813c";
+      sha256 = "66ee93518731d5364ed70a49688b672b485cc77e0b2111f18905a21425ee319b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ms/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ms/thunderbird-102.4.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "4e6642a75afd4344a9b4ecd02f62e5ab31bbdf2c08026305a19994e13d0925be";
+      sha256 = "ceed80f3eed734a3e7af87bff1f03862d7ded388484ea8cecf2873c91dcee225";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/nb-NO/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/nb-NO/thunderbird-102.4.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "e93a5f0cb40f8d6940e337987519913390408ebb11dda1fb0a53fb4e6a920c60";
+      sha256 = "01ba526dfb5d82cd6b51a30b06f47a85b81589aa3ba8e6d9d318603b083f1195";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/nl/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/nl/thunderbird-102.4.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "8e2a3f87eae178b3f8335f1f99d0fcf8104d386552948841874716cd86981d4d";
+      sha256 = "d6f315e1168d6a5433a724e6bf3160e0089ce26abb929187b122f44e46c84652";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/nn-NO/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/nn-NO/thunderbird-102.4.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "5036f50250fc42aecf2ece02e8e2901e86626add5643b5794103086e33760c4e";
+      sha256 = "f9a3195807f753f8cb7bfaffc2e1d647f79dd7afa31fe85f94d2438c08e93ffe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/pa-IN/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/pa-IN/thunderbird-102.4.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "4dd0956b509692034e5f517e57ef1ddecc00ee15aed40680bfa8f2fed56912e7";
+      sha256 = "f68b60dc2d946bcff7a03ce781c77c17e68aff2e376bc6e9c84ed2be14e17b33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/pl/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/pl/thunderbird-102.4.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "7330ccffc01b6357c0bc7c4781a931ef807a20052b2ee7a962d781cd75ed15b9";
+      sha256 = "94d24fd3d184cb8d46e584599b8cf43462c38a2113a24921c03bdec391b74ccd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/pt-BR/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/pt-BR/thunderbird-102.4.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "6ac7c34d3b89e5c18170256d6e038064d98fedc070526da226c34f55068ced1e";
+      sha256 = "93f73967bd35eef0ad9bc820e07d8f8eb458ffa9415bc9f1e08c9ac9e3de876e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/pt-PT/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/pt-PT/thunderbird-102.4.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "37807584c2536d06f00a7e042f74c1a481c3d1a9570cb16f0f57d8df5b3b8d3b";
+      sha256 = "e08033d393fd804504b41fbcf9e902dd3ea262a3c9346bfb89e101a7acdb1478";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/rm/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/rm/thunderbird-102.4.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "0f72208d14efd2d375f0911da4cefdff93770a89335d1d07ae8e9c93b79e68c3";
+      sha256 = "04b46b74a949e5803e68dd243c16e77d6fad91997c105d1b670f553c3eff66aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ro/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ro/thunderbird-102.4.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "f9d3cc56bc986bf7a33920bec19c4dabb4885f5c30f95c69e964d175c1a99931";
+      sha256 = "d9d8556c0c330cefda91804fc534a5443e2fc787c83d58fcf9455f6215608c0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/ru/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/ru/thunderbird-102.4.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "5d8550088ac2fcbbd0008dedcfd916f11c7c838062c50c96af8b0ff604611603";
+      sha256 = "606ddd0868b3b61cf8dd87db75da52559d6e66a9cff5fb62e521a64afccbe7b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/sk/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/sk/thunderbird-102.4.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "e5ac6a6981b7dfc4c7d49119abdbe4f2beef9641c89ba0b38a0e60275ad3c525";
+      sha256 = "ef94704bf009e178ffed2032cb7dbbbf5476e03cf41536796fa65e40b495f557";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/sl/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/sl/thunderbird-102.4.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "a7f228c2a74b2cfd45b4ad48a1f230741628a158f172076896fcc68588a175c6";
+      sha256 = "6ffac67a7fa242565946a9939faaa70ae652ee70b441e71a4768316affbe80fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/sq/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/sq/thunderbird-102.4.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "e977dc827518893f426f3177cb97eb5265aa358e1921f07d8b6843192d6a9f54";
+      sha256 = "9ebe4616896df6e437ca6e639ab273c6098266b72fe7946b4f1aa28f002d5198";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/sr/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/sr/thunderbird-102.4.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "0f185c385bcc6882cbd0654d4ebf5cef8c1ed8e104877886a812cbffce86a6e4";
+      sha256 = "9a8979b83e7d7e129cddd7812fef4803782aa951b190c20aa50919423a0b7127";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/sv-SE/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/sv-SE/thunderbird-102.4.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "a43fd70f46b059bdbc64a19cdbd72209f6f0939815c878d198ba41c22a7b1de4";
+      sha256 = "1724ae0e9fe2d92afb21d8e7440a219822920e569aec801d6b1167b51862796a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/th/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/th/thunderbird-102.4.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "02f75552404ed0068dbc51c3dd6005a91d6c638fd2236d67d8a48d11c94e7274";
+      sha256 = "e767d6c6dda151370c2a04c850b8f55eec4b2326be493d16af219a9737535a9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/tr/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/tr/thunderbird-102.4.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "28b97981fc225eb3e534a923bc6df3ffc4afa5043224ffe415847cf0d9ecabef";
+      sha256 = "1d1bae1f7e76a0acd5f4d51a68d9805f34b2397005234ce33ecf2b9668c1caf9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/uk/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/uk/thunderbird-102.4.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "082f50dee3a7e41802541c197126ab2331da9d83e391eecc251113c0cc0f9fdc";
+      sha256 = "2602294d73ee0dce17960c453b0b7f188566a4b09af5c593aae4f57c13c6c6bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/uz/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/uz/thunderbird-102.4.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "0ce85eda10854f979e0c8667653126e03c268ccc4d078bc58e39fbf6ffd46fd9";
+      sha256 = "57e424a2d1b3d58aa23b87d85cfcd6af7030ef9b539ad74beed6284051142fbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/vi/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/vi/thunderbird-102.4.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "f42d2f507647ca7f8ca8ce7aa377528c27ac4e2b4bfcd395eb424a71356b0a73";
+      sha256 = "d4f19ac4584c5523009a660f819d43e3244d552bd0b2890fa8e52fc5cf48d9de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/zh-CN/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/zh-CN/thunderbird-102.4.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "0362aff801bcb734003607e265961932efd2059ab3bf6a967662368522eb49e9";
+      sha256 = "204f5faee35bece1bd444d4d0a18973b13f2e05e481d77b25acd201fb8b5e2e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-x86_64/zh-TW/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-x86_64/zh-TW/thunderbird-102.4.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "2c14d717bdc4ef8f031e71811092550c429b86306e9964020c3ab4cdd73cc011";
+      sha256 = "8aac9a823ef4df7678e93316b9e312dc84fe589de520740ed2b018d9976b823d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/af/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/af/thunderbird-102.4.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "b1ba07c2903e30e52263887ae23e96ca506f33feeefb6d665968ae73b4618241";
+      sha256 = "5da88620d3676d21e2dd98d514f073535e6b84e9156c5c4766de7b41aba148fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ar/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ar/thunderbird-102.4.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "a34beacb63b18f88f817e2190826f1859bdcc1c7ef84fb4a4a8b7ea2f2ff7eb5";
+      sha256 = "3d50816819f2d0a3db242f83dab9cf269f2db5b8b74efc460976070413cfa568";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ast/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ast/thunderbird-102.4.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "adf85142f454a44f3acb54a83a2e2117457314046f0ce22c6ba0638a737c547c";
+      sha256 = "fc5508c42732b470edcf1dbd6fd9e03d66f11f5976a1dc433283b19e0657e54b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/be/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/be/thunderbird-102.4.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "6bd7732095177c6702c3af380e686f14c31114d2987d6e5e564f0181533a6978";
+      sha256 = "4b68c8b1e7f0493ba3fcec4041bb86b88f770530b5842f1954ed65c2bff6ef91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/bg/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/bg/thunderbird-102.4.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "f3af40e4576f224f2d2c8f11858446c13832008daad462a25e4d35bcc0be5556";
+      sha256 = "08e8518a774d8ff6dd7fc944ef9cae66d565c3ecbea4e71cbb670575c8abf84f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/br/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/br/thunderbird-102.4.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "3d41a4a15b0de37d4fa10aab086247b737bcada395bda86e4e681772125e7ccf";
+      sha256 = "9df36d6165b4ff71383cf922e49dfe93e13add7426b43be79e72596517d01b64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ca/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ca/thunderbird-102.4.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "1ed85a0b6c04cc181dba423ef848aa57db22cfb8526c3ec4465dfc9a664d1cf8";
+      sha256 = "7caa728b60f16660d40b3c714ccca559c9998268e71a3602b64319f28908f384";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/cak/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/cak/thunderbird-102.4.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "458395aeb8e92dea90cd4dfebd2c1b5ac4549e6683af9343de3d0e8022397c14";
+      sha256 = "f85fd60655fe7e09736c31c2451d78110fcfb329cac4c2550cda2119c48da11e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/cs/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/cs/thunderbird-102.4.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "eb8f9c5a5a78520a6fe9d7e33a6a3de26e2623e15be219396cc1ec6d3fef1a90";
+      sha256 = "14c6b188ccb93367a3ba411b3e383d3816d6b0bcf1fa1bb48025fda30f7adf4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/cy/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/cy/thunderbird-102.4.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "d298941a3f856ff534705fef9ae6c7b3979e53ea08a2ad392db34fa8713d0dd0";
+      sha256 = "d82b7a995b1f92170ed6ee0a2b7056aeb69922523aaf9c66ff24f435d38b45e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/da/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/da/thunderbird-102.4.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "9ed3cd6d123169145246cc752202fffee6db55de2c2923b5bdb394f0bc441ffb";
+      sha256 = "bb6967140ecb94cea0f48f4a0f937bd6734a901d5c3f947585391908dacaf05d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/de/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/de/thunderbird-102.4.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "2991288757087526928ad8c61c3bb8ecb2398bf34948036608647fe2c00be1e6";
+      sha256 = "4411fe74340c1c62b6845cd70e60c133130f4e780916f998cae5a7b103dbd1f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/dsb/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/dsb/thunderbird-102.4.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "acc46f046e543cf1dd88d506de7d3ec0d67ce1fd3be0669c6b301803e80c47ac";
+      sha256 = "9badc6942ad260da94230f9b223d63cceb94cb4689090dfc8d3c6df372d70692";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/el/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/el/thunderbird-102.4.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "4a5fa9516fb3e171c0b74a694d9bc29cd68b259e1bed9f45303b211b6aba45a0";
+      sha256 = "c26dfdc2b5f2da4917dc18bdc92739962e2a2931cb2886c8f2f395a66c8bd841";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/en-CA/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/en-CA/thunderbird-102.4.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "ae438cac6628024660cec15d5ce6c2e746b63c484cfcac69b3e4be733e1f50f1";
+      sha256 = "f8f1801eb8676a095efa20e410121ebe2eaef1517d0b549bca27b435bcaf097e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/en-GB/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/en-GB/thunderbird-102.4.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "1eaf7fc696aa584632845aa2ef93fe346c889131fb2e5f85c09ca91550616b00";
+      sha256 = "57d3cc43fb1b6012d5fa91f3ed5a55fccf162137ee00e186ee1954b50f445759";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/en-US/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/en-US/thunderbird-102.4.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "d90faab60b4641d509be7f1c20b7102e8bd469a9528b11604adbfec359f07cb3";
+      sha256 = "e21b148eab4e643c5a66b61b892775c9761efe38db9a41e0d9d6ad63fdb9fa03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/es-AR/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/es-AR/thunderbird-102.4.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "73cd1b6aead028e22eb6a0b09076d604128b8779b4519b2b33e417eefc51277e";
+      sha256 = "dd3e4356aaac24bc1be1a2a7f9e662d9d97e77971de961816f2e6cb0f46175cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/es-ES/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/es-ES/thunderbird-102.4.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "46bd4345b717bba7236829696325e00db4b6d2bfd7e3f31aba1d619615ffc0d4";
+      sha256 = "70600cde32452b505fe76352f8a53f124169b20ec75c6089d45e0b3e0709aa74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/es-MX/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/es-MX/thunderbird-102.4.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "ab5ec4347cd85d4f93658b48a687d0bead8dccbdafd766b754068649772f67e1";
+      sha256 = "c07ff511260781cca4e2f4ac82d7c1aa76e990fe7a0770fb9bd5551766838fcc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/et/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/et/thunderbird-102.4.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "6f2a7a2db746e068a903a266dee042353f8723be448b28b0199931cf024ab30b";
+      sha256 = "156d75d2638a2e44d345ca2bd2374f321193227089827b4d2d69feb89a4dd6c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/eu/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/eu/thunderbird-102.4.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "08581d2ef770abd5fa70e6f2418633b111e316c5aa95bcb9c7c31a62d76d9591";
+      sha256 = "8af2a6e5bb6e2bf2d03c97e90ce0115faf8c40121e7210c20be88b16fb2e0feb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/fi/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/fi/thunderbird-102.4.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "850a64dbf7b3a4f612d3c2c29ab7d6960c7e553ee395305e70161eff81533396";
+      sha256 = "ca98fe916aa005b60511ae7c1274e64726a5f35d567ac7407a80cb0438878fe4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/fr/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/fr/thunderbird-102.4.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "c5bda9bd4909adaeec36d5bb2a17b867f9cc34a31f3ddb97ab42c91ccfb4d1f2";
+      sha256 = "6c9fc2454dfd286a8efc3b8de6377044f2ccabc6e0379b9e1cc2cd16653a7840";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/fy-NL/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/fy-NL/thunderbird-102.4.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "fba378198ddab043493677225373cfdda0edeb9f5130d6a1a6141fd232ceaca7";
+      sha256 = "0822c65394cda172ee1f66688db6d86c7426df44a80770a0d22d824ffacf7f7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ga-IE/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ga-IE/thunderbird-102.4.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a594af3d31419ebaedcdae09ab3b519d1a2096df398e42b76fc09d76a401f6b7";
+      sha256 = "70d56fd565b1ab65946819347a5b2394d179358e3eb8d1e87b24056d87a516e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/gd/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/gd/thunderbird-102.4.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "54b6921f8a3be97b81b4f769141d84fb11845b971e77fa82f383f3bc0e50d338";
+      sha256 = "bb156b134b3e43b015de264e6852f9cec656dab4c395efecf6035cd937187d0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/gl/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/gl/thunderbird-102.4.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "4598af27e3aedf8af67d76874baa4f7cbddc1a7fd53be7d3c334eea075d06991";
+      sha256 = "5ed959f3ea9f0961948b525bb51126a7d1786c5468868586267ff46c1b7dd121";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/he/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/he/thunderbird-102.4.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "648cc4a3e295303cfa49fc9e766848c3aa4b78d65f70ba743724a3964c4110bd";
+      sha256 = "fdd0cbf39f8f0f982ec034627d68661d3392aa2657353941c4664f610497ea00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/hr/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/hr/thunderbird-102.4.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "e5ee4e3d15620e78075631656704d4051d76cd04095e8737709ec5d487f9cc4f";
+      sha256 = "aecf6bf555c84b6cae28cf4514efee9c6334fd1c69e3afbf045842748645f2ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/hsb/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/hsb/thunderbird-102.4.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "ed50bc3e2695e2061e31ae2721ee76e13051ca85399cb493aeafb1230a1888bc";
+      sha256 = "8381a36906102e17e165f8d383d0f8bba7dde4a39264e14b66bca5313a9da077";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/hu/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/hu/thunderbird-102.4.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "97494393ccc4c02f253210d9f3a7249a5bd1a8dbfba5f3bca94fd99c5a30e763";
+      sha256 = "3193566d29f0407b9ba5cbde1f470d7a5fa4d501eab23d3709246a082d96ab33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/hy-AM/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/hy-AM/thunderbird-102.4.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "0d42530f12a2891caaab06eae16cf605e1272d8cbda24a595c162aae07ea7ab1";
+      sha256 = "284a4cd9731abddf68e8cdd5c2c52cdfb0da22732f5d2f6b782f3311d9c297f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/id/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/id/thunderbird-102.4.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "8be0c411f75f14402cb1b34dce65848073987901fd7ef1eb5d123e3062ea90c2";
+      sha256 = "cc61630f7ab5261d42bec691625bbdaaa9a1788b99807b06f3d5c34961d67432";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/is/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/is/thunderbird-102.4.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "031f157a8291b6a149d28971f3c6befdef22db81877c1ec32a6eda2d2c9497ae";
+      sha256 = "2852c2c6fe22756e83d27b3718d8913cd0618b2491e1b327251fe94f081c30de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/it/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/it/thunderbird-102.4.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "73abba45b37787e534499be37ed6ee0b71eb61b9b812c4a87b41ce9492171aec";
+      sha256 = "85e81bb62a94205d3886d335cc70ad2024bd66658d2b0037cf2ef72118955ec9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ja/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ja/thunderbird-102.4.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "91be0ddcc4f16d47348c5f62693c22a9af944bbeac12f3dbbab54da756819c8d";
+      sha256 = "e5de175ef6e96d34da21ff9c82059f37867ca279c07f2aee748c21ad9fcc9133";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ka/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ka/thunderbird-102.4.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "347e1ad3223fcd7288a048bea5cbb3508ef9f0377091ac8654eba3f62737baf4";
+      sha256 = "b32652acce69f60795ab6e8a942b15ab394cda4a2d8ada37f8f1436628e6cc18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/kab/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/kab/thunderbird-102.4.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "c140e63f750c0c8ffd368b4a79831b4aea4f283db05bffdad58371cb052ed5e0";
+      sha256 = "ffd8fda6889463a558c1354af2fdb30680c564c7650c0d70e9a12bc02f71ea45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/kk/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/kk/thunderbird-102.4.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "4441479e9bc91c7f2fde53904ef5dce34b8c81ad74a7a6483775644a4416b49b";
+      sha256 = "c664d38e01e27b2869848d4a12bc703bb61fb60369b56dd0fba8d5225bd45069";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ko/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ko/thunderbird-102.4.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "84731cd21a44a556fca01fb5d72ecbcf0aa11320928b28240a49dc51849a0975";
+      sha256 = "d1e116857ce58acab34af920f767d7eba9d9080a2135aa2651a0b398860b199d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/lt/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/lt/thunderbird-102.4.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a50ffdacfc5a4e0f69f4dfc8b4aee8c00a1ea8dc3e58e022ccd432d09cc5f42f";
+      sha256 = "2df015a969cc5bd0571051bcac8c73e8164519bcb395dbab290a8b31e0da6eed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/lv/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/lv/thunderbird-102.4.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "5e39e7ad880674948715dbd275a9410688a153e6f822b1063710b5520604ed35";
+      sha256 = "1926845d7d6c73950faa160a2e06eb530ed250e45ca1c6ca2b3dce1744d36494";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ms/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ms/thunderbird-102.4.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "087680b99f9ad0030a379aeeec6665a5066106a5fc1a816b9d4d56623b557194";
+      sha256 = "8d029da2bc3b1dbeac391c8cf089cc24ccf7c090b7636308b5778f8f563d84fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/nb-NO/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/nb-NO/thunderbird-102.4.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "6ca2c6dae3c87cb5f66dc48da1049039629c653fd144f675d86c40b2b9a6e92d";
+      sha256 = "9bfce479878b1431cde83522b3a13bb85e962699ef49860be39dcf98fd4ab2ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/nl/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/nl/thunderbird-102.4.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "1d81fa00b001fa19f78897a23e5f5972673bcc8a0ca6f58172d7720ae9636d3a";
+      sha256 = "b94854a1e278514930f4d6f405c99c2674a6a0d6bbd2a606e8e2931d20d64c27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/nn-NO/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/nn-NO/thunderbird-102.4.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "400d959701e7a867637cd32a8c69f53bacc69c5d082e391e0e6690ada9b921da";
+      sha256 = "a3b6ea808b6b190ff60c17a173132180d07bddc0683ac12e6bf5537660aee957";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/pa-IN/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/pa-IN/thunderbird-102.4.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "e664dc2fac39de71cca8a9d7307880409af0664753a91c591befd2752bf768a9";
+      sha256 = "9681f45460a6583a26e9580784f27ba565184391de142d1d23cf75e4ace0a102";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/pl/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/pl/thunderbird-102.4.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "ad83ff34ab55271f328961392d4b02679882defac3a1864a4da9145e40e87d4d";
+      sha256 = "56359ce8ff9a1904954ef4c8c04d3ddeba4dfcf60e14fe3be8864c43f38023d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/pt-BR/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/pt-BR/thunderbird-102.4.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "f1f07563a9bda75ea311600f0e45286e081b2d039c54a19b8c570272727635b4";
+      sha256 = "cf46c656f7ef37737dec931beb88c03ee79cb90e0cca429e22cf8d311b1b2aac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/pt-PT/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/pt-PT/thunderbird-102.4.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "33507adcfadf1db7967b0a40532f311610420798394bc6df450076407f4bb687";
+      sha256 = "30a03b9bdc9e0fb3272d283f44b446011c1801608f4cdca730848598b7671dce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/rm/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/rm/thunderbird-102.4.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "7c56f1d9cd3d5d313c6acb7915911c443bbf1073b16fe406a225b5a2c45cc858";
+      sha256 = "87db729d6fe4f93dfefd009d49e631b9a0540927e854d5a908951708e06ee902";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ro/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ro/thunderbird-102.4.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "078fa1d28e5370cad25a7f4c8e7162dbeda17b19e9ffdccf4b504222d7f8a208";
+      sha256 = "dfb295a1dd9c0fcc5e2d2a2645d9b6a7a9404f0c278404501b407963a7fd7adf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/ru/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/ru/thunderbird-102.4.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "29f842188f0fcab4d1dc0b80f8af422e4445ac3958426949b5cb32921a62c856";
+      sha256 = "72416015e3a56f05e31cc90970903e16d756a219c63a776177431b0688f23a56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/sk/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/sk/thunderbird-102.4.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "46fc3d121a9559573fab59165a4ef26f764b451e9d9ebd07b63cbaeb38759de1";
+      sha256 = "2ff17c8a109e1031032f9deae6997b2d7a70658e89af39436618904020162afa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/sl/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/sl/thunderbird-102.4.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "5252c6c511150af4aff9a0922ed5435ee235dd10cf7bda0d5f7b9b45fab390e7";
+      sha256 = "fa907a23de32b00eda97533345a8e77ba3badb4b6fb4660b5b9616fc1ecaf796";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/sq/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/sq/thunderbird-102.4.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "5ef982ce3d31ded7fa5ebe617d4be7fa4808a43dbbdd16c13983eb2a7f009bd8";
+      sha256 = "60fc9e217138531ae014348f793bf8b159c85c253069f1e3881357f63c047946";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/sr/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/sr/thunderbird-102.4.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "104ce567e97504648656e33f180e2168be9e94c52ee9107e3a19e0bb2d521671";
+      sha256 = "f6eccd0e094adec5eb092c926a59a5a162dd38c3f0919f1dca057203d3daa6cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/sv-SE/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/sv-SE/thunderbird-102.4.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "862d41270c85a7444e3a99514cadc4df79ba104b764891e3e62d2f39a0cfb65c";
+      sha256 = "029918b677978a74fc5c896d529d07201e38e283256cc83aa065b721f6570b51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/th/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/th/thunderbird-102.4.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "7cb5c0a5c165455e82d9e013f865c88ae9e6782981a86164a684efef09a3238d";
+      sha256 = "ca3f0bbf8e077f1521d949171353e9404939cacadefe96fb1ee6d9b86237bcd8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/tr/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/tr/thunderbird-102.4.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "543d63317a0e42d7bba23cf964e816d9aa30de44eab7f7d81ac5ba178d4975e8";
+      sha256 = "d09d7fedce1a467ce32948332e9b7695d8113c3ee3078c9771cdd4a87168d164";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/uk/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/uk/thunderbird-102.4.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "87eb738708454a7082836df803d400cb6f2d7c7dd836890a26681f3c5f06d38a";
+      sha256 = "834914fa4b058721d7f3d43e3fd9b0f509d4284315780999057f8960feb87fe0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/uz/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/uz/thunderbird-102.4.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "a11e52fccb2cf0e96be69c59e74d3766c71b895d41a13971de369abacae5044d";
+      sha256 = "d4e9309eef2f58271097e750fc46988200526ef6971f2bce7487305dfc1f8d37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/vi/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/vi/thunderbird-102.4.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "34cca2f1cda994a41a3ab772fb987f494159473f361da0835291b979dc8b0134";
+      sha256 = "ef1d679ae415ebc51353f2ca475dd9c968a308150387f33c85cc1fb5fb7d3d0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/zh-CN/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/zh-CN/thunderbird-102.4.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "6fb4c51c37fe78fd6430f82869317a9b1580f042cde00ef5d0aae99b91fc7264";
+      sha256 = "61e247c35e102c836c68083ecae7ab8268dcc7d4a6fa15cd81dcf2e9a9ae7053";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.3.3/linux-i686/zh-TW/thunderbird-102.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/102.4.0/linux-i686/zh-TW/thunderbird-102.4.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0271acf95abad4ef6957108e18f5d4149d7a6829b7ae96ccb600c1c210c24669";
+      sha256 = "b464abc16f43d675a70d0b05491fbca28b8c3c9e5a6e684b2d442081b8538a2b";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -5,13 +5,13 @@ rec {
 
   thunderbird-102 = (buildMozillaMach rec {
     pname = "thunderbird";
-    version = "102.3.3";
+    version = "102.4.0";
     application = "comm/mail";
     applicationName = "Mozilla Thunderbird";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "37027f251513885d1432ee8cbe0fb2b4cb3c95b0ce88bd35f207cd7a4552d6700a63d13e0542712f796d46be6cfc165d6d1c224b30a445be7f5058fc396655fe";
+      sha512 = "e2ce59eefb0c4df3eb20af01af2b7ad78a09e0fbac7bcc8800538d6655ca63a5d132c0700e2465654cc707a50aee01c62df0532f2c53b5f11c2d3a7ca881d8f0";
     };
     extraPatches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.


### PR DESCRIPTION
###### Description of changes

https://www.thunderbird.net/en-US/thunderbird/102.4.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
  <details>
    <summary>5 packages built:</summary>
    <ul>
      <li>thunderbird</li>
      <li>thunderbird-bin</li>
      <li>thunderbird-bin-unwrapped</li>
      <li>thunderbird-unwrapped</li>
      <li>thunderbird-wayland</li>
    </ul>
  </details>
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - only `${thunderbird-102}/bin/thunderbird`
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
