### PR TITLE
libsoup_3: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -10,9 +10,7 @@
 , sqlite
 , glib-networking
 , gobject-introspection
-, withIntrospection ? stdenv.buildPlatform == stdenv.hostPlatform
 , vala
-, withVala ? stdenv.buildPlatform == stdenv.hostPlatform
 , libpsl
 , python3
 , gi-docgen
@@ -31,6 +29,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ses9LDvkn7vQUacfZTLJYmvOzqaXgxkGkM1+Tf3yjyk=";
   };
 
+  depsBuildBuild = [
+    pkg-config
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -38,9 +40,7 @@ stdenv.mkDerivation rec {
     glib
     python3
     gi-docgen
-  ] ++ lib.optionals withIntrospection [
     gobject-introspection
-  ] ++ lib.optionals withVala [
     vala
   ];
 
@@ -61,8 +61,8 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dtls_check=false" # glib-networking is a runtime dependency, not a compile-time dependency
     "-Dgssapi=disabled"
-    "-Dvapi=${if withVala then "enabled" else "disabled"}"
-    "-Dintrospection=${if withIntrospection then "enabled" else "disabled"}"
+    "-Dvapi=enabled"
+    "-Dintrospection=enabled"
     "-Dntlm=disabled"
     # Requires wstest from autobahn-testsuite.
     "-Dautobahn=disabled"


### PR DESCRIPTION
###### Description of changes

Update to latest state of affairs, now gobject can be used for cross we can enable it. pkg-config in depsBuildBuild is required for meson to pick up dependencies only used on build platform.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
