### PR TITLE
nixos/doc: rewrite customizing-packages section

### DIFF
--- a/nixos/doc/manual/configuration/customizing-packages.section.md
+++ b/nixos/doc/manual/configuration/customizing-packages.section.md
@@ -1,74 +1,203 @@
 # Customising Packages {#sec-customising-packages}
 
-Some packages in Nixpkgs have options to enable or disable optional
-functionality or change other aspects of the package. For instance, the
-Firefox wrapper package (which provides Firefox with a set of plugins
-such as the Adobe Flash player) has an option to enable the Google Talk
-plugin. It can be set in `configuration.nix` as follows:
-`nixpkgs.config.firefox.enableGoogleTalkPlugin = true;`
+In Nix, packages are usually referred to as `pkgs.git`. This expression can be extended to allow modification of the package. For example, instead of `pkgs.git` you can also use `(pkgs.git.override { guiSupport = true; })`. This results in a new package where support for Git GUI is enabled. When using this expression, a package is built that includes the `git-gui` binary.
 
-::: {.warning}
-Unfortunately, Nixpkgs currently lacks a way to query available
-configuration options.
-:::
+The Nixpkgs manual has information about modifying existing packages by overriding. See [the chapter on overriding](https://nixos.org/manual/nixpkgs/stable/#chap-overrides) to know more.
 
-Apart from high-level options, it's possible to tweak a package in
-almost arbitrary ways, such as changing or disabling dependencies of a
-package. For instance, the Emacs package in Nixpkgs by default has a
-dependency on GTK 2. If you want to build it against GTK 3, you can
-specify that as follows:
+Here we will focus on the ways to use those modified packages in NixOS. We describe 3 methods:
+
+* [System environment](#system-environment) for executable packages available system-wide
+* [package options in NixOS modules](#package-options-in-nix-os-modules) for background services and programs
+* [Nixpkgs overlays](#nixpkgs-overlays) for in-place package replacements and additions
+
+## System environment (#system-environment)
+
+Using a custom package in `environment.systemPackages` will only change the system environment. Basically, it'll allow you to change the packages that you'd use in your terminal, but not anything else.
+
+Changing:
 
 ```nix
-environment.systemPackages = [ (pkgs.emacs.override { gtk = pkgs.gtk3; }) ];
+{
+  environment.systemPackages = [
+    pkgs.git
+  ];
+}
 ```
 
-The function `override` performs the call to the Nix function that
-produces Emacs, with the original arguments amended by the set of
-arguments specified by you. So here the function argument `gtk` gets the
-value `pkgs.gtk3`, causing Emacs to depend on GTK 3. (The parentheses
-are necessary because in Nix, function application binds more weakly
-than list construction, so without them,
-[](#opt-environment.systemPackages)
-would be a list with two elements.)
-
-Even greater customisation is possible using the function
-`overrideAttrs`. While the `override` mechanism above overrides the
-arguments of a package function, `overrideAttrs` allows changing the
-*attributes* passed to `mkDerivation`. This permits changing any aspect
-of the package, such as the source code. For instance, if you want to
-override the source code of Emacs, you can say:
+To:
 
 ```nix
-environment.systemPackages = [
-  (pkgs.emacs.overrideAttrs (oldAttrs: {
-    name = "emacs-25.0-pre";
-    src = /path/to/my/emacs/tree;
-  }))
-];
+{
+  environment.systemPackages = [
+    (pkgs.git.override { guiSupport = true; })
+  ];
+}
 ```
 
-Here, `overrideAttrs` takes the Nix derivation specified by `pkgs.emacs`
-and produces a new derivation in which the original's `name` and `src`
-attribute have been replaced by the given values by re-calling
-`stdenv.mkDerivation`. The original attributes are accessible via the
-function argument, which is conventionally named `oldAttrs`.
+will allow you to use the Git GUI tools (`git-gui`) in your terminal. It _doesn't_ alter packages or NixOS modules that _depend_ on Git. This is an important distinction, as it only affects the environment (applications available in `PATH`) and doesn't rebuild any other packages.
 
-The overrides shown above are not global. They do not affect the
-original package; other packages in Nixpkgs continue to depend on the
-original rather than the customised package. This means that if another
-package in your system depends on the original package, you end up with
-two instances of the package. If you want to have everything depend on
-your customised instance, you can apply a *global* override as follows:
+## Package options in NixOS modules (#package-options-in-nix-os-modules)
+
+Some packages are only used in background services, so you won't interact with them directly. In NixOS these are often configured with `services.*.enable` options.
+
+These options usually also have an option to change the package for the service, named `services.*.package`.
+
+For example, pipewire is a service to handle audio and video streams on a system. It is enabled on NixOS using:
 
 ```nix
-nixpkgs.config.packageOverrides = pkgs:
-  { emacs = pkgs.emacs.override { gtk = pkgs.gtk3; };
-  };
+{
+  services.pipewire.enable = true;
+}
 ```
 
-The effect of this definition is essentially equivalent to modifying the
-`emacs` attribute in the Nixpkgs source tree. Any package in Nixpkgs
-that depends on `emacs` will be passed your customised instance.
-(However, the value `pkgs.emacs` in `nixpkgs.config.packageOverrides`
-refers to the original rather than overridden instance, to prevent an
-infinite recursion.)
+To override the pipewire package being used, the following option can be added:
+
+```nix
+{
+  services.pipewire.package = pkgs.pipewire.override { x11Support = false; };
+}
+```
+
+In this case `pipewire` is compiled without x11 support. The resulting package is used as the pipewire background service, which will be configured by NixOS in systemd.
+
+Just like with `systemPackages`, the altered package is only used in the NixOS system and packages that depend on pipewire will still refer to the original pipewire package.
+
+## Nixpkgs overlays (#nixpkgs-overlays)
+
+Overlays in Nix allow extending Nixpkgs. Like the name suggests, it overlays your package definitions on top of Nixpkgs. Usually this means that you can alter what packages are available in the `pkgs` variable, allowing you to add or overwrite packages.
+
+With overlays you can replace an existing package system-wide. That means overwriting an existing package with your own will not only change your system, but can also change all packages that depend on the original package.
+
+This can be useful when you want to for instance patch a library that is used by other software. It does however require all depending packages to be rebuild. Nix does these rebuilds seamlessly and automatically, but it does cost time.
+
+Also a word of warning: overlays can become confusing. You generally want to be aware of overwritten packages in overlays. It is not obvious when referring to a package `pkgs.git` that it is different from what is in Nixpkgs. This can become especially confusing when overwriting packages like `openssl`, which `git` and many other packages depends on. With great power comes great responsibility!
+
+On NixOS you can use [the `nixpkgs.overlays` option](https://search.nixos.org/options?show=nixpkgs.overlays&query=nixpkgs.overlays):
+
+```nix
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      pipewire = prev.pipewire.override { x11Support = false; };
+    })
+  ];
+}
+```
+
+When creating such an overlay, it is not needed anymore to specify the override in `systemPackages` nor `services.*.package`, as `pkgs.pipewire` will only refer to this overridden package.
+
+Note that the overlay is defined as a function with the arguments `final` and `prev`.
+
+`prev` refers to the previous layer, the underlying one. In this case that is `nixpkgs`. We take the original package from `nixpkgs` using `prev.pipewire` and alter that package. With `pipewire = ...;` we overwrite the orignal pipewire package in succeeding layers, which eventually results in the change in `pkgs`.
+
+`final` refers to the top-level overlay, which includes our overwritten packages. If we want to refer to a another package that we have overridden, then we can refer to `final`.
+
+More information about overlays can be found in [the Nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#chap-overlays).
+
+It is also possible to introduce a new attribute for custom packages, so that you can refer to this attribute in other parts of your configuration. For instance:
+
+```nix
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      git-with-gui = prev.git.override { guiSupport = true; };
+    })
+  ];
+}
+```
+
+will allow referring to `pkgs.git-with-gui` where-ever you have access to pkgs. For instance in NixOS:
+
+```nix
+{
+  environment.systemPackages = [ pkgs.git-with-gui ];
+}
+```
+
+Or even in Nix CLI:
+
+```sh
+nix-env -iA git-with-gui
+```
+
+Note that even though we have a new attribute name in the above example, the _name of the package_ didn't change. The name is part of the derivation. The package is called `git`, so the Nix store path is still `/nix/store/*-git`. When using `.override` this part of the derivation would not change. The name can only be changed using `.overrideAttrs`.
+
+## Common use-cases (#use-cases)
+
+With the above knowledge we can tackle a number of common use-cases.
+
+### Use different version of a package in NixOS
+
+```nix
+{
+  services.xserver.windowManager.i3.package = pkgs.i3.overrideAttrs (previousAttrs: {
+    name = "i3-next";
+    src = pkgs.fetchFromGitHub {
+      owner = "i3";
+      repo = "i3";
+      rev = "81287743869a5bdec4ffc0c1e6d1f8fd33920bcb";
+      hash = pkgs.lib.fakeHash;
+    };
+  });
+}
+```
+
+This overrides the `i3` package with a version based on https://github.com/i3/i3/commit/81287743869a5bdec4ffc0c1e6d1f8fd33920bcb. `pkgs.lib.fakeHash` is a placeholder for the actual hash of the retrieved directory. Upon building Nix will ask to replace it with the actual hash that Nix calculated.
+
+The `name = "i3-next"` is also set. This is to make sure the new package name doesn't equal the original package name (`i3-X.X.X`).
+
+### Use local source code for a package
+
+```nix
+{
+  environment.systemPackages = [ pkgs.myfortune ];
+
+  nixpkgs.overlays = [
+    (final: prev: {
+      myfortune = prev.fortune.overrideAttrs (previousAttrs: {
+        src = ./fortune-src;
+      });
+    })
+  ];
+}
+```
+
+This creates a new attribute `myfortune` that uses the build steps from `fortune` to build source code from a local directory `./fortune-src` into a package. It makes the package available through `environment.systemPackages`, so that it is available in the terminal.
+
+### Use a different dependency for a single package
+
+```nix
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      maven-jdk8 = prev.maven.override {
+        jdk = final.jdk8;
+      };
+    })
+  ];
+}
+```
+
+This creates a new attribute `maven-jdk8` that builds and runs maven explicitly under `jdk8`. Notice that `final.jdk8` is used, so that other overlays may potentially overwrite `jdk8`. Also note that `final.maven` is _not_ used, because that would refer to this package, causing an infinite loop during Nix evaluation.
+
+### Apply a security patch system-wide
+
+```nix
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      openssl = prev.openssl.overrideAttrs (previousAttrs: {
+        patches = previousAttrs.patches ++ [
+          (fetchpatch {
+            name = "CVE-2021-4044.patch";
+            url = "https://git.openssl.org/gitweb/?p=openssl.git;a=patch;h=758754966791c537ea95241438454aa86f91f256";
+            hash = pkgs.lib.fakeHash;
+          })
+        ];
+      });
+    })
+  ];
+}
+```
+
+This overwrites `openssl` with a patched version. The patch itself is fetched from OpenSSL's own git repository. Overwriting `openssl` in an overlay will rebuild and test all packages that depend on OpenSSL as well, so in this case can lead to high build times.

--- a/nixos/doc/manual/from_md/configuration/customizing-packages.section.xml
+++ b/nixos/doc/manual/from_md/configuration/customizing-packages.section.xml
@@ -1,90 +1,350 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-customising-packages">
   <title>Customising Packages</title>
   <para>
-    Some packages in Nixpkgs have options to enable or disable optional
-    functionality or change other aspects of the package. For instance,
-    the Firefox wrapper package (which provides Firefox with a set of
-    plugins such as the Adobe Flash player) has an option to enable the
-    Google Talk plugin. It can be set in
-    <literal>configuration.nix</literal> as follows:
-    <literal>nixpkgs.config.firefox.enableGoogleTalkPlugin = true;</literal>
+    In Nix, packages are usually referred to as
+    <literal>pkgs.git</literal>. This expression can be extended to
+    allow modification of the package. For example, instead of
+    <literal>pkgs.git</literal> you can also use
+    <literal>(pkgs.git.override { guiSupport = true; })</literal>. This
+    results in a new package where support for Git GUI is enabled. When
+    using this expression, a package is built that includes the
+    <literal>git-gui</literal> binary.
   </para>
-  <warning>
+  <para>
+    The Nixpkgs manual has information about modifying existing packages
+    by overriding. See
+    <link xlink:href="https://nixos.org/manual/nixpkgs/stable/#chap-overrides">the
+    chapter on overriding</link> to know more.
+  </para>
+  <para>
+    Here we will focus on the ways to use those modified packages in
+    NixOS. We describe 3 methods:
+  </para>
+  <itemizedlist spacing="compact">
+    <listitem>
+      <para>
+        <link linkend="system-environment">System environment</link> for
+        executable packages available system-wide
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link linkend="package-options-in-nix-os-modules">package
+        options in NixOS modules</link> for background services and
+        programs
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link linkend="nixpkgs-overlays">Nixpkgs overlays</link> for
+        in-place package replacements and additions
+      </para>
+    </listitem>
+  </itemizedlist>
+  <section>
+    <title>System environment (#system-environment)</title>
     <para>
-      Unfortunately, Nixpkgs currently lacks a way to query available
-      configuration options.
+      Using a custom package in
+      <literal>environment.systemPackages</literal> will only change the
+      system environment. Basically, it’ll allow you to change the
+      packages that you’d use in your terminal, but not anything else.
     </para>
-  </warning>
-  <para>
-    Apart from high-level options, it’s possible to tweak a package in
-    almost arbitrary ways, such as changing or disabling dependencies of
-    a package. For instance, the Emacs package in Nixpkgs by default has
-    a dependency on GTK 2. If you want to build it against GTK 3, you
-    can specify that as follows:
-  </para>
-  <programlisting language="bash">
-environment.systemPackages = [ (pkgs.emacs.override { gtk = pkgs.gtk3; }) ];
+    <para>
+      Changing:
+    </para>
+    <programlisting language="bash">
+{
+  environment.systemPackages = [
+    pkgs.git
+  ];
+}
 </programlisting>
-  <para>
-    The function <literal>override</literal> performs the call to the
-    Nix function that produces Emacs, with the original arguments
-    amended by the set of arguments specified by you. So here the
-    function argument <literal>gtk</literal> gets the value
-    <literal>pkgs.gtk3</literal>, causing Emacs to depend on GTK 3. (The
-    parentheses are necessary because in Nix, function application binds
-    more weakly than list construction, so without them,
-    <xref linkend="opt-environment.systemPackages" /> would be a list
-    with two elements.)
-  </para>
-  <para>
-    Even greater customisation is possible using the function
-    <literal>overrideAttrs</literal>. While the
-    <literal>override</literal> mechanism above overrides the arguments
-    of a package function, <literal>overrideAttrs</literal> allows
-    changing the <emphasis>attributes</emphasis> passed to
-    <literal>mkDerivation</literal>. This permits changing any aspect of
-    the package, such as the source code. For instance, if you want to
-    override the source code of Emacs, you can say:
-  </para>
-  <programlisting language="bash">
-environment.systemPackages = [
-  (pkgs.emacs.overrideAttrs (oldAttrs: {
-    name = &quot;emacs-25.0-pre&quot;;
-    src = /path/to/my/emacs/tree;
-  }))
-];
+    <para>
+      To:
+    </para>
+    <programlisting language="bash">
+{
+  environment.systemPackages = [
+    (pkgs.git.override { guiSupport = true; })
+  ];
+}
 </programlisting>
-  <para>
-    Here, <literal>overrideAttrs</literal> takes the Nix derivation
-    specified by <literal>pkgs.emacs</literal> and produces a new
-    derivation in which the original’s <literal>name</literal> and
-    <literal>src</literal> attribute have been replaced by the given
-    values by re-calling <literal>stdenv.mkDerivation</literal>. The
-    original attributes are accessible via the function argument, which
-    is conventionally named <literal>oldAttrs</literal>.
-  </para>
-  <para>
-    The overrides shown above are not global. They do not affect the
-    original package; other packages in Nixpkgs continue to depend on
-    the original rather than the customised package. This means that if
-    another package in your system depends on the original package, you
-    end up with two instances of the package. If you want to have
-    everything depend on your customised instance, you can apply a
-    <emphasis>global</emphasis> override as follows:
-  </para>
-  <programlisting language="bash">
-nixpkgs.config.packageOverrides = pkgs:
-  { emacs = pkgs.emacs.override { gtk = pkgs.gtk3; };
-  };
+    <para>
+      will allow you to use the Git GUI tools
+      (<literal>git-gui</literal>) in your terminal. It
+      <emphasis>doesn’t</emphasis> alter packages or NixOS modules that
+      <emphasis>depend</emphasis> on Git. This is an important
+      distinction, as it only affects the environment (applications
+      available in <literal>PATH</literal>) and doesn’t rebuild any
+      other packages.
+    </para>
+  </section>
+  <section>
+    <title>Package options in NixOS modules
+    (#package-options-in-nix-os-modules)</title>
+    <para>
+      Some packages are only used in background services, so you won’t
+      interact with them directly. In NixOS these are often configured
+      with <literal>services.*.enable</literal> options.
+    </para>
+    <para>
+      These options usually also have an option to change the package
+      for the service, named <literal>services.*.package</literal>.
+    </para>
+    <para>
+      For example, pipewire is a service to handle audio and video
+      streams on a system. It is enabled on NixOS using:
+    </para>
+    <programlisting language="bash">
+{
+  services.pipewire.enable = true;
+}
 </programlisting>
-  <para>
-    The effect of this definition is essentially equivalent to modifying
-    the <literal>emacs</literal> attribute in the Nixpkgs source tree.
-    Any package in Nixpkgs that depends on <literal>emacs</literal> will
-    be passed your customised instance. (However, the value
-    <literal>pkgs.emacs</literal> in
-    <literal>nixpkgs.config.packageOverrides</literal> refers to the
-    original rather than overridden instance, to prevent an infinite
-    recursion.)
-  </para>
+    <para>
+      To override the pipewire package being used, the following option
+      can be added:
+    </para>
+    <programlisting language="bash">
+{
+  services.pipewire.package = pkgs.pipewire.override { x11Support = false; };
+}
+</programlisting>
+    <para>
+      In this case <literal>pipewire</literal> is compiled without x11
+      support. The resulting package is used as the pipewire background
+      service, which will be configured by NixOS in systemd.
+    </para>
+    <para>
+      Just like with <literal>systemPackages</literal>, the altered
+      package is only used in the NixOS system and packages that depend
+      on pipewire will still refer to the original pipewire package.
+    </para>
+  </section>
+  <section>
+    <title>Nixpkgs overlays (#nixpkgs-overlays)</title>
+    <para>
+      Overlays in Nix allow extending Nixpkgs. Like the name suggests,
+      it overlays your package definitions on top of Nixpkgs. Usually
+      this means that you can alter what packages are available in the
+      <literal>pkgs</literal> variable, allowing you to add or overwrite
+      packages.
+    </para>
+    <para>
+      With overlays you can replace an existing package system-wide.
+      That means overwriting an existing package with your own will not
+      only change your system, but can also change all packages that
+      depend on the original package.
+    </para>
+    <para>
+      This can be useful when you want to for instance patch a library
+      that is used by other software. It does however require all
+      depending packages to be rebuild. Nix does these rebuilds
+      seamlessly and automatically, but it does cost time.
+    </para>
+    <para>
+      Also a word of warning: overlays can become confusing. You
+      generally want to be aware of overwritten packages in overlays. It
+      is not obvious when referring to a package
+      <literal>pkgs.git</literal> that it is different from what is in
+      Nixpkgs. This can become especially confusing when overwriting
+      packages like <literal>openssl</literal>, which
+      <literal>git</literal> and many other packages depends on. With
+      great power comes great responsibility!
+    </para>
+    <para>
+      On NixOS you can use
+      <link xlink:href="https://search.nixos.org/options?show=nixpkgs.overlays&amp;query=nixpkgs.overlays">the
+      <literal>nixpkgs.overlays</literal> option</link>:
+    </para>
+    <programlisting language="bash">
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      pipewire = prev.pipewire.override { x11Support = false; };
+    })
+  ];
+}
+</programlisting>
+    <para>
+      When creating such an overlay, it is not needed anymore to specify
+      the override in <literal>systemPackages</literal> nor
+      <literal>services.*.package</literal>, as
+      <literal>pkgs.pipewire</literal> will only refer to this
+      overridden package.
+    </para>
+    <para>
+      Note that the overlay is defined as a function with the arguments
+      <literal>final</literal> and <literal>prev</literal>.
+    </para>
+    <para>
+      <literal>prev</literal> refers to the previous layer, the
+      underlying one. In this case that is <literal>nixpkgs</literal>.
+      We take the original package from <literal>nixpkgs</literal> using
+      <literal>prev.pipewire</literal> and alter that package. With
+      <literal>pipewire = ...;</literal> we overwrite the orignal
+      pipewire package in succeeding layers, which eventually results in
+      the change in <literal>pkgs</literal>.
+    </para>
+    <para>
+      <literal>final</literal> refers to the top-level overlay, which
+      includes our overwritten packages. If we want to refer to a
+      another package that we have overridden, then we can refer to
+      <literal>final</literal>.
+    </para>
+    <para>
+      More information about overlays can be found in
+      <link xlink:href="https://nixos.org/manual/nixpkgs/stable/#chap-overlays">the
+      Nixpkgs manual</link>.
+    </para>
+    <para>
+      It is also possible to introduce a new attribute for custom
+      packages, so that you can refer to this attribute in other parts
+      of your configuration. For instance:
+    </para>
+    <programlisting language="bash">
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      git-with-gui = prev.git.override { guiSupport = true; };
+    })
+  ];
+}
+</programlisting>
+    <para>
+      will allow referring to <literal>pkgs.git-with-gui</literal>
+      where-ever you have access to pkgs. For instance in NixOS:
+    </para>
+    <programlisting language="bash">
+{
+  environment.systemPackages = [ pkgs.git-with-gui ];
+}
+</programlisting>
+    <para>
+      Or even in Nix CLI:
+    </para>
+    <programlisting language="bash">
+nix-env -iA git-with-gui
+</programlisting>
+    <para>
+      Note that even though we have a new attribute name in the above
+      example, the <emphasis>name of the package</emphasis> didn’t
+      change. The name is part of the derivation. The package is called
+      <literal>git</literal>, so the Nix store path is still
+      <literal>/nix/store/*-git</literal>. When using
+      <literal>.override</literal> this part of the derivation would not
+      change. The name can only be changed using
+      <literal>.overrideAttrs</literal>.
+    </para>
+  </section>
+  <section>
+    <title>Common use-cases (#use-cases)</title>
+    <para>
+      With the above knowledge we can tackle a number of common
+      use-cases.
+    </para>
+    <section>
+      <title>Use different version of a package in NixOS</title>
+      <programlisting language="bash">
+{
+  services.xserver.windowManager.i3.package = pkgs.i3.overrideAttrs (previousAttrs: {
+    name = &quot;i3-next&quot;;
+    src = pkgs.fetchFromGitHub {
+      owner = &quot;i3&quot;;
+      repo = &quot;i3&quot;;
+      rev = &quot;81287743869a5bdec4ffc0c1e6d1f8fd33920bcb&quot;;
+      hash = pkgs.lib.fakeHash;
+    };
+  });
+}
+</programlisting>
+      <para>
+        This overrides the <literal>i3</literal> package with a version
+        based on
+        https://github.com/i3/i3/commit/81287743869a5bdec4ffc0c1e6d1f8fd33920bcb.
+        <literal>pkgs.lib.fakeHash</literal> is a placeholder for the
+        actual hash of the retrieved directory. Upon building Nix will
+        ask to replace it with the actual hash that Nix calculated.
+      </para>
+      <para>
+        The <literal>name = &quot;i3-next&quot;</literal> is also set.
+        This is to make sure the new package name doesn’t equal the
+        original package name (<literal>i3-X.X.X</literal>).
+      </para>
+    </section>
+    <section>
+      <title>Use local source code for a package</title>
+      <programlisting language="bash">
+{
+  environment.systemPackages = [ pkgs.myfortune ];
+
+  nixpkgs.overlays = [
+    (final: prev: {
+      myfortune = prev.fortune.overrideAttrs (previousAttrs: {
+        src = ./fortune-src;
+      });
+    })
+  ];
+}
+</programlisting>
+      <para>
+        This creates a new attribute <literal>myfortune</literal> that
+        uses the build steps from <literal>fortune</literal> to build
+        source code from a local directory
+        <literal>./fortune-src</literal> into a package. It makes the
+        package available through
+        <literal>environment.systemPackages</literal>, so that it is
+        available in the terminal.
+      </para>
+    </section>
+    <section>
+      <title>Use a different dependency for a single package</title>
+      <programlisting language="bash">
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      maven-jdk8 = prev.maven.override {
+        jdk = final.jdk8;
+      };
+    })
+  ];
+}
+</programlisting>
+      <para>
+        This creates a new attribute <literal>maven-jdk8</literal> that
+        builds and runs maven explicitly under <literal>jdk8</literal>.
+        Notice that <literal>final.jdk8</literal> is used, so that other
+        overlays may potentially overwrite <literal>jdk8</literal>. Also
+        note that <literal>final.maven</literal> is
+        <emphasis>not</emphasis> used, because that would refer to this
+        package, causing an infinite loop during Nix evaluation.
+      </para>
+    </section>
+    <section>
+      <title>Apply a security patch system-wide</title>
+      <programlisting language="bash">
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      openssl = prev.openssl.overrideAttrs (previousAttrs: {
+        patches = previousAttrs.patches ++ [
+          (fetchpatch {
+            name = &quot;CVE-2021-4044.patch&quot;;
+            url = &quot;https://git.openssl.org/gitweb/?p=openssl.git;a=patch;h=758754966791c537ea95241438454aa86f91f256&quot;;
+            hash = pkgs.lib.fakeHash;
+          })
+        ];
+      });
+    })
+  ];
+}
+</programlisting>
+      <para>
+        This overwrites <literal>openssl</literal> with a patched
+        version. The patch itself is fetched from OpenSSL’s own git
+        repository. Overwriting <literal>openssl</literal> in an overlay
+        will rebuild and test all packages that depend on OpenSSL as
+        well, so in this case can lead to high build times.
+      </para>
+    </section>
+  </section>
 </section>


### PR DESCRIPTION
###### Description of changes

Follow-up from https://github.com/NixOS/nixpkgs/pull/196274

Currently the section about customizing packages contains a number of problems:

* Refer to global nixpkgs options, like `nixpkgs.config.firefox.enableGoogleTalkPlugin`, which do not exist anymore.
* Refer to `packageOverrides`, for which [overlays is a better alternative](https://github.com/NixOS/nixpkgs/issues/43266).
* Did not refer to NixOS modules that provide `.package` options, which is a safer alternative than `overlays` or `packageOverrides`.
* Did not contain practical use-cases that most users would want to use the section for.

Because I was a bit hesitant to make a lot of small changes to the section, I wanted to start from scratch. I wrote a blog post about this topic instead: https://bobvanderlinden.me/customizing-packages-in-nix/

It was read quite a bit and I got feedback from different sources:

* https://discourse.nixos.org/t/customizing-packages-in-nix/22523
* https://www.reddit.com/r/NixOS/comments/y6hwwb/customizing_packages_in_nix/
* https://www.reddit.com/r/Nix/comments/y6hj48/customizing_packages_in_nix/
* https://lobste.rs/s/qgvgxv/customizing_packages_nix

The goal always was to improve the documentation of Nix itself instead making the information scattered across blogs. This PR is the result. I changed the post a bit in this PR so that it fits in the manual better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
