### PR TITLE
ocamlPackages.faraday: 0.8.1 → 0.8.2

### DIFF
--- a/pkgs/development/ocaml-modules/faraday/async.nix
+++ b/pkgs/development/ocaml-modules/faraday/async.nix
@@ -1,17 +1,12 @@
-{ buildDunePackage, lib, fetchpatch, faraday, core, async }:
+{ buildDunePackage, lib, faraday, core_unix, async }:
 
 buildDunePackage rec {
   pname = "faraday-async";
   inherit (faraday) version src;
 
-  patches = lib.optional (lib.versionAtLeast async.version "0.15") (fetchpatch {
-    url = "https://github.com/inhabitedtype/faraday/commit/31c3fc7f91ecca0f1deea10b40fd5e33bcd35f75.patch";
-    sha256 = "05z5gk7hxq7qvwg6f73hdhfcnx19p1dq6wqh8prx667y8zsaq2zj";
-  });
-
   minimalOCamlVersion = "4.08";
 
-  propagatedBuildInputs = [ faraday core async ];
+  propagatedBuildInputs = [ faraday core_unix async ];
 
   meta = faraday.meta // {
     description = "Async support for Faraday";

--- a/pkgs/development/ocaml-modules/faraday/default.nix
+++ b/pkgs/development/ocaml-modules/faraday/default.nix
@@ -2,22 +2,20 @@
 
 buildDunePackage rec {
   pname = "faraday";
-  version = "0.8.1";
+  version = "0.8.2";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
     repo = pname;
     rev = version;
-    sha256 = "sha256-eeR+nst/r2iFxCDmRS+LGr3yl/o27DcsS30YAu1GJmc=";
+    sha256 = "sha256-wR4kDocR1t3OLRuudXH8IccYde552O6Gvo5BHNxRbAI=";
   };
 
   checkInputs = [ alcotest ];
   propagatedBuildInputs = [ bigstringaf ];
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
   meta = {
     description = "Serialization library built for speed and memory efficiency";

--- a/pkgs/development/ocaml-modules/faraday/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/faraday/lwt-unix.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "faraday-lwt-unix";
-  inherit (faraday) version src useDune2 minimumOCamlVersion;
+  inherit (faraday) version src;
 
   propagatedBuildInputs = [ lwt faraday-lwt ];
 

--- a/pkgs/development/ocaml-modules/faraday/lwt.nix
+++ b/pkgs/development/ocaml-modules/faraday/lwt.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "faraday-lwt";
-  inherit (faraday) version src useDune2 minimumOCamlVersion;
+  inherit (faraday) version src;
 
   propagatedBuildInputs = [ faraday lwt ];
 


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
