### PR TITLE
dolbybcsoftwaredecode: init at april-2018

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8164,6 +8164,12 @@
       fingerprint = "5B93 9CFA E8FC 4D8F E07A  3AEA DFE1 D4A0 1733 7E2A";
     }];
   };
+  lorenz = {
+    name = "Lorenz Brun";
+    email = "lorenz@brun.one";
+    github = "lorenz";
+    githubId = 5228892;
+  };
   lorenzleutgeb = {
     email = "lorenz@leutgeb.xyz";
     github = "lorenzleutgeb";

--- a/pkgs/applications/audio/dolbybcsoftwaredecode/default.nix
+++ b/pkgs/applications/audio/dolbybcsoftwaredecode/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchurl, stdenv, unzip, fpc }:
+
+stdenv.mkDerivation rec {
+  pname = "dolbybcsoftwaredecode";
+  version = "april-2018";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/dolbybcsoftwaredecode/April-2018/SourceCode.zip";
+    sha256 = "sha256-uLcsRIpwmJlstlGV8I4+/30+D9GDpUt7DOIP/GkXWp4=";
+  };
+
+  nativeBuildInputs = [ unzip fpc ];
+  buildPhase = ''
+    fpc DolbyBi64.PP
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp DolbyBi64 $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "A Dolby B & C software decoder";
+    homepage = "https://sourceforge.net/projects/dolbybcsoftwaredecode/";
+    maintainers = with maintainers; [ lorenz ];
+
+    # Project is has source code available, but has no explicit license.
+    # I asked upstream to assign a license, so maybe this can be free
+    # in the future, but for now let's play it safe and make it unfree.
+    license = lib.licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1337,6 +1337,8 @@ with pkgs;
 
   davinci-resolve = callPackage ../applications/video/davinci-resolve { };
 
+  dolbybcsoftwaredecode = callPackage ../applications/audio/dolbybcsoftwaredecode { };
+
   dwarfs = callPackage ../tools/filesystems/dwarfs { };
 
   gamemode = callPackage ../tools/games/gamemode {


### PR DESCRIPTION
###### Description of changes

Adds a package for https://sourceforge.net/projects/dolbybcsoftwaredecode/ which is a DSP for decoding Dolby B & C as used in old compact cassettes.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
