### PR TITLE
tctl: init at 1.16.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6869,6 +6869,12 @@
     githubId = 7183441;
     name = "Justin Lovinger";
   };
+  justinmir = {
+    email = "justinmiron@protonmail.com";
+    github = "justinmir";
+    githubId = 8886628;
+    name = "Justin Miron";
+  };
   justinwoo = {
     email = "moomoowoo@gmail.com";
     github = "justinwoo";

--- a/pkgs/tools/admin/tctl/default.nix
+++ b/pkgs/tools/admin/tctl/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-tctl";
+  version = "1.16.3";
+
+  src = fetchFromGitHub {
+    owner = "temporalio";
+    repo = "tctl";
+    rev = "v${version}";
+    sha256 = "sha256-GZTCxHs2/HeQIYRkhGzNYYyCd/vcGRey2lsFU7fV4gM=";
+  };
+
+  vendorSha256 = "sha256-9bgovXVj+qddfDSI4DTaNYH4H8Uc4DZqeVYG5TWXTNw=";
+
+  subPackages = [ "cmd/tctl" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/temporalio/tctl";
+    description = "Temporal CLI to perform various tasks on a Temporal Server";
+    maintainers = with maintainers; [ justinmir ];
+    license = licenses.mit;
+    mainProgram = "tctl";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36979,6 +36979,8 @@ with pkgs;
 
   tcat = callPackage ../tools/misc/tcat { };
 
+  tctl = callPackage ../tools/admin/tctl { };
+
   tellico = libsForQt5.callPackage ../applications/misc/tellico { };
 
   termpdfpy = python3Packages.callPackage ../applications/misc/termpdf.py {};


### PR DESCRIPTION
###### Description of changes
tctl: [https://github.com/temporalio/tctl](https://github.com/temporalio/tctl)
Command line tool for operating [Temporal](https://temporal.io/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).