### PR TITLE
obsidian: enable wayland flag if NIXOS_OZONE_WL is set

### DIFF
--- a/pkgs/applications/misc/obsidian/default.nix
+++ b/pkgs/applications/misc/obsidian/default.nix
@@ -51,7 +51,8 @@ let
       runHook preInstall
       mkdir -p $out/bin
       makeWrapper ${electron_18}/bin/electron $out/bin/obsidian \
-        --add-flags $out/share/obsidian/app.asar
+        --add-flags $out/share/obsidian/app.asar \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}"
       install -m 444 -D resources/app.asar $out/share/obsidian/app.asar
       install -m 444 -D resources/obsidian.asar $out/share/obsidian/obsidian.asar
       install -m 444 -D "${desktopItem}/share/applications/"* \


### PR DESCRIPTION
###### Description of changes

Added conditional flag similar to other electron apps (*sigh*). Not sure if `--enable-features=WaylandWindowDecorations` is applicable to Obsidian, but it doesn't seem to have an effect on sway. Possibly it is desirable in Gnome or KDE, but I suspect obsidian doesn't need it since it has inline decorations.

Still not switching DPI correctly on mixed-DPI setups, but it's not worse than with X11

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
