### PR TITLE
eva: 0.3.0 -> 0.3.0-2, add figsoda as a maintainer

### DIFF
--- a/pkgs/tools/misc/eva/default.nix
+++ b/pkgs/tools/misc/eva/default.nix
@@ -1,22 +1,21 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, rustPlatform, fetchCrate }:
 
 rustPlatform.buildRustPackage rec {
   pname = "eva";
-  version = "0.3.0";
+  version = "0.3.0-2";
 
-  src = fetchFromGitHub {
-    owner = "nerdypepper";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-INXKjjHW9HZ1NWx1CQOerTBUy0rYFLNJMuRgKQfQwdc=";
+  src = fetchCrate {
+    inherit pname;
+    version = "0.3.0";
+    sha256 = "sha256-oeNv4rKZAl/gQ8b8Yr7fgQeeszJjzMcf9q1KzYpVS1Y=";
   };
 
-  cargoSha256 = "sha256-4l9y2qmS7G1PvxF8/51F7fx/sDuYHWDkcyOin2sYHdk=";
+  cargoSha256 = "sha256-WBniKff9arVgNFBY2pwB0QgEBvzCL0Dls+6N49V86to=";
 
   meta = with lib; {
     description = "A calculator REPL, similar to bc";
     homepage = "https://github.com/NerdyPepper/eva";
     license = licenses.mit;
-    maintainers = with maintainers; [ nrdxp ma27 ];
+    maintainers = with maintainers; [ nrdxp ma27 figsoda ];
   };
 }


### PR DESCRIPTION
###### Description of changes

I'm not sure why the version didn't change, but this is a new version as both the github tag and crate version have recent updates

switched to fetchCrate because github version has outdated Cargo.lock

https://github.com/NerdyPepper/eva

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
