### PR TITLE
qt{5,6}: disable QML disk cache by default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -939,6 +939,19 @@
       </listitem>
       <listitem>
         <para>
+          The Qt QML disk cache is now disabled by default. This fixes a
+          long-standing issue where updating Qt/KDE apps would sometimes
+          cause them to crash or behave strangely without explanation.
+          Those concerned about the small (~10%) performance hit to
+          application startup can re-enable the cache (and expose
+          themselves to gremlins) by setting the envrionment variable
+          <literal>QML_FORCE_DISK_CACHE</literal> to
+          <literal>1</literal> using e.g. the
+          <literal>environment.sessionVariables</literal> NixOS option.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           systemd-oomd is enabled by default. Depending on which systemd
           units have <literal>ManagedOOMSwap=kill</literal> or
           <literal>ManagedOOMMemoryPressure=kill</literal>, systemd-oomd

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -298,6 +298,14 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - Add udev rules for the Teensy family of microcontrollers.
 
+- The Qt QML disk cache is now disabled by default. This fixes a 
+  long-standing issue where updating Qt/KDE apps would sometimes cause 
+  them to crash or behave strangely without explanation. Those concerned 
+  about the small (~10%) performance hit to application startup can 
+  re-enable the cache (and expose themselves to gremlins) by setting the 
+  envrionment variable `QML_FORCE_DISK_CACHE` to `1` using e.g. the 
+  `environment.sessionVariables` NixOS option.
+
 - systemd-oomd is enabled by default. Depending on which systemd units have
   `ManagedOOMSwap=kill` or `ManagedOOMMemoryPressure=kill`, systemd-oomd will
   SIGKILL all the processes under the appropriate descendant cgroups when the

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -269,20 +269,5 @@ in
     # To enable user switching, allow sddm to allocate TTYs/displays dynamically.
     services.xserver.tty = null;
     services.xserver.display = null;
-
-    systemd.tmpfiles.rules = [
-      # Prior to Qt 5.9.2, there is a QML cache invalidation bug which sometimes
-      # strikes new Plasma 5 releases. If the QML cache is not invalidated, SDDM
-      # will segfault without explanation. We really tore our hair out for awhile
-      # before finding the bug:
-      # https://bugreports.qt.io/browse/QTBUG-62302
-      # We work around the problem by deleting the QML cache before startup.
-      # This was supposedly fixed in Qt 5.9.2 however it has been reported with
-      # 5.10 and 5.11 as well. The initial workaround was to delete the directory
-      # in the Xsetup script but that doesn't do anything.
-      # Instead we use tmpfiles.d to ensure it gets wiped.
-      # This causes a small but perceptible delay when SDDM starts.
-      "e ${config.users.users.sddm.home}/.cache - - - 0"
-    ];
   };
 }

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -81,7 +81,11 @@ let
         sha256 = "0crkw3j1iwdc1pbf5dhar0b4q3h5gs2q1sika8m12y02yk3ns697";
       })
     ];
-    qtdeclarative = [ ./qtdeclarative.patch ];
+    qtdeclarative = [
+      ./qtdeclarative.patch
+      # prevent headaches from stale qmlcache data
+      ./qtdeclarative-default-disable-qmlcache.patch
+    ];
     qtlocation = [ ./qtlocation-gcc-9.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];

--- a/pkgs/development/libraries/qt-5/5.12/qtdeclarative-default-disable-qmlcache.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtdeclarative-default-disable-qmlcache.patch
@@ -1,0 +1,40 @@
+diff --git a/src/qml/qml/qqmltypeloader.cpp b/src/qml/qml/qqmltypeloader.cpp
+index 9e5bc0b0..9219def6 100644
+--- a/src/qml/qml/qqmltypeloader.cpp
++++ b/src/qml/qml/qqmltypeloader.cpp
+@@ -2151,7 +2151,7 @@ void QQmlTypeData::unregisterCallback(TypeDataCallback *callback)
+ 
+ bool QQmlTypeData::tryLoadFromDiskCache()
+ {
+-    if (disableDiskCache() && !forceDiskCache())
++    if (!forceDiskCache())
+         return false;
+ 
+     if (isDebugging())
+@@ -2658,7 +2658,7 @@ void QQmlTypeData::compile(const QQmlRefPointer<QQmlTypeNameCache> &typeNameCach
+         return;
+     }
+ 
+-    const bool trySaveToDisk = (!disableDiskCache() || forceDiskCache()) && !m_document->jsModule.debugMode && !typeRecompilation;
++    const bool trySaveToDisk = (forceDiskCache()) && !m_document->jsModule.debugMode && !typeRecompilation;
+     if (trySaveToDisk) {
+         QString errorString;
+         if (m_compiledData->saveToDisk(url(), &errorString)) {
+@@ -3014,7 +3014,7 @@ QQmlRefPointer<QQmlScriptData> QQmlScriptBlob::scriptData() const
+ 
+ void QQmlScriptBlob::dataReceived(const SourceCodeData &data)
+ {
+-    if (!disableDiskCache() || forceDiskCache()) {
++    if (forceDiskCache()) {
+         QQmlRefPointer<QV4::CompiledData::CompilationUnit> unit = QV4::Compiler::Codegen::createUnitForLoading();
+         QString error;
+         if (unit->loadFromDisk(url(), data.sourceTimeStamp(), &error)) {
+@@ -3077,7 +3077,7 @@ void QQmlScriptBlob::dataReceived(const SourceCodeData &data)
+         qmlGenerator.generate(irUnit);
+     }
+ 
+-    if ((!disableDiskCache() || forceDiskCache()) && !isDebugging()) {
++    if ((forceDiskCache()) && !isDebugging()) {
+         QString errorString;
+         if (unit->saveToDisk(url(), &errorString)) {
+             QString error;

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -68,7 +68,11 @@ let
       ./qtbase.patch.d/0010-qtbase-assert.patch
       ./qtbase.patch.d/0011-fix-header_module.patch
     ];
-    qtdeclarative = [ ./qtdeclarative.patch ];
+    qtdeclarative = [
+      ./qtdeclarative.patch
+      # prevent headaches from stale qmlcache data
+      ./qtdeclarative-default-disable-qmlcache.patch
+    ];
     qtlocation = [ ./qtlocation-gcc-9.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];

--- a/pkgs/development/libraries/qt-5/5.14/qtdeclarative-default-disable-qmlcache.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtdeclarative-default-disable-qmlcache.patch
@@ -1,0 +1,13 @@
+diff --git a/src/qml/qml/qqmltypeloader.cpp b/src/qml/qml/qqmltypeloader.cpp
+index 6c12de92..fc67dc07 100644
+--- a/src/qml/qml/qqmltypeloader.cpp
++++ b/src/qml/qml/qqmltypeloader.cpp
+@@ -705,7 +705,7 @@ bool QQmlTypeLoader::Blob::isDebugging() const
+ 
+ bool QQmlTypeLoader::Blob::diskCacheEnabled() const
+ {
+-    return (!disableDiskCache() || forceDiskCache()) && !isDebugging();
++    return (forceDiskCache()) && !isDebugging();
+ }
+ 
+ bool QQmlTypeLoader::Blob::qmldirDataAvailable(const QQmlRefPointer<QQmlQmldirData> &data, QList<QQmlError> *errors)

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -56,7 +56,11 @@ let
       ./qtbase.patch.d/0010-qtbase-assert.patch
       ./qtbase.patch.d/0011-fix-header_module.patch
     ];
-    qtdeclarative = [ ./qtdeclarative.patch ];
+    qtdeclarative = [
+      ./qtdeclarative.patch
+      # prevent headaches from stale qmlcache data
+      ./qtdeclarative-default-disable-qmlcache.patch
+    ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qtwebengine = lib.optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/qt-5/5.15/qtdeclarative-default-disable-qmlcache.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtdeclarative-default-disable-qmlcache.patch
@@ -1,0 +1,13 @@
+diff --git a/src/qml/qml/qqmltypeloader.cpp b/src/qml/qml/qqmltypeloader.cpp
+index 1d66e75..827567a 100644
+--- a/src/qml/qml/qqmltypeloader.cpp
++++ b/src/qml/qml/qqmltypeloader.cpp
+@@ -727,7 +727,7 @@ bool QQmlTypeLoader::Blob::isDebugging() const
+ 
+ bool QQmlTypeLoader::Blob::diskCacheEnabled() const
+ {
+-    return (!disableDiskCache() && !isDebugging()) || forceDiskCache();
++    return forceDiskCache();
+ }
+ 
+ bool QQmlTypeLoader::Blob::qmldirDataAvailable(const QQmlRefPointer<QQmlQmldirData> &data, QList<QQmlError> *errors)

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative.nix
@@ -16,6 +16,10 @@ qtModule {
     "-DQT6_INSTALL_PREFIX=${placeholder "out"}"
     "-DQT_INSTALL_PREFIX=${placeholder "out"}"
   ];
+  patches = [
+    # prevent headaches from stale qmlcache data
+    ../patches/qtdeclarative-default-disable-qmlcache.patch
+  ];
   postInstall = ''
     substituteInPlace "$out/lib/cmake/Qt6Qml/Qt6QmlMacros.cmake" \
       --replace ''\'''${QT6_INSTALL_PREFIX}' "$dev"

--- a/pkgs/development/libraries/qt-6/patches/qtdeclarative-default-disable-qmlcache.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtdeclarative-default-disable-qmlcache.patch
@@ -1,0 +1,13 @@
+diff --git a/src/qml/jsruntime/qv4engine.cpp b/src/qml/jsruntime/qv4engine.cpp
+index 852cde9e..165f1b57 100644
+--- a/src/qml/jsruntime/qv4engine.cpp
++++ b/src/qml/jsruntime/qv4engine.cpp
+@@ -2093,7 +2093,7 @@ void ExecutionEngine::registerModule(const QString &_name, const QJSValue &modul
+ 
+ bool ExecutionEngine::diskCacheEnabled() const
+ {
+-    return (!disableDiskCache() && !debugger()) || forceDiskCache();
++    return forceDiskCache();
+ }
+ 
+ void ExecutionEngine::callInContext(QV4::Function *function, QObject *self,


### PR DESCRIPTION
###### Description of changes

Some context (including benchmark data): #177720 
Please see the commit messages for details.

I have verified that `qtdeclarative` still builds for all supported Qt versions and that `cool-retro-term` exhibits a disabled cache and that the cache can be re-enabled when built against all supported Qt 5 versions. I don't know of a suitable app to test Qt 6 but I don't really have a reason to believe it won't work.

It would be great to get this in for 22.11 to finally put this issue to bed, at least until someone can come up with a better cache key.

cc: @NixOS/qt-kde 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
