### PR TITLE
nodejs-19_x: init at 19.0.0

### DIFF
--- a/pkgs/development/web/nodejs/disable-darwin-v8-system-instrumentation-node19.patch
+++ b/pkgs/development/web/nodejs/disable-darwin-v8-system-instrumentation-node19.patch
@@ -1,0 +1,16 @@
+Disable v8 system instrumentation on Darwin
+
+On Darwin, the v8 system instrumentation requires the header "os/signpost.h"
+which is available since apple_sdk 11+. See: https://github.com/nodejs/node/issues/39584
+
+--- old/tools/v8_gypfiles/features.gypi
++++ new/tools/v8_gypfiles/features.gypi
+@@ -62,7 +62,7 @@
+       }, {
+         'is_component_build': 0,
+       }],
+-      ['OS == "win" or OS == "mac"', {
++      ['OS == "win"', {
+         # Sets -DENABLE_SYSTEM_INSTRUMENTATION. Enables OS-dependent event tracing
+         'v8_enable_system_instrumentation': 1,
+       }, {

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -67,7 +67,7 @@ let
     configureFlags = let
       isCross = stdenv.hostPlatform != stdenv.buildPlatform;
       inherit (stdenv.hostPlatform) gcc isAarch32;
-    in sharedConfigureFlags ++ [
+    in sharedConfigureFlags ++ optionals (versionOlder version "19") [
       "--without-dtrace"
     ] ++ (optionals isCross [
       "--cross-compiling"

--- a/pkgs/development/web/nodejs/v19.nix
+++ b/pkgs/development/web/nodejs/v19.nix
@@ -1,0 +1,25 @@
+{ callPackage, openssl, fetchpatch, python3, enableNpm ? true }:
+
+let
+  buildNodejs = callPackage ./nodejs.nix {
+    inherit openssl;
+    python = python3;
+  };
+in
+buildNodejs {
+  inherit enableNpm;
+  version = "19.0.0";
+  sha256 = "sha256-C3LSB6WBXxznskezPL+aLIb20BJT+jmQyXROJdl1BQ0=";
+  patches = [
+    (fetchpatch {
+      # Fixes cross compilation to aarch64-linux by reverting https://github.com/nodejs/node/pull/43200
+      name = "revert-arm64-pointer-auth.patch";
+      url = "https://github.com/nodejs/node/pull/43200/commits/d42c42cc8ac652ab387aa93205aed6ece8a5040a.patch";
+      sha256 = "sha256-ipGzg4lEoftTJbt6sW+0QJO/AZqHvUkFKe0qlum+iLY=";
+      revert = true;
+    })
+
+    ./disable-darwin-v8-system-instrumentation-node19.patch
+    ./bypass-darwin-xcrun-node16.patch
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8691,9 +8691,13 @@ with pkgs;
   nodejs-slim-18_x = callPackage ../development/web/nodejs/v18.nix {
     enableNpm = false;
   };
+  nodejs-19_x = callPackage ../development/web/nodejs/v19.nix { };
+  nodejs-slim-19_x = callPackage ../development/web/nodejs/v19.nix {
+    enableNpm = false;
+  };
   # Update this when adding the newest nodejs major version!
-  nodejs_latest = nodejs-18_x;
-  nodejs-slim_latest = nodejs-slim-18_x;
+  nodejs_latest = nodejs-19_x;
+  nodejs-slim_latest = nodejs-slim-19_x;
 
   nodePackages_latest = dontRecurseIntoAttrs nodejs_latest.pkgs;
 


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/nodejs/node/releases/tag/v19.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
