### PR TITLE
dub: enable aarch64-linux

### DIFF
--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -150,6 +150,6 @@ stdenv.mkDerivation rec {
     homepage = "https://code.dlang.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ ThomasMader ];
-    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Enable `dub` on `aarch64-linux`. This allows `btdu` to build on `aarch64-linux`.

```shell
$ nix-build -A btdu
/nix/store/pib9m0gs7i2q9pa7rsf13ksz2gsbhzsr-btdu-0.4.1

$ file /nix/store/pib9m0gs7i2q9pa7rsf13ksz2gsbhzsr-btdu-0.4.1/bin/btdu 
/nix/store/pib9m0gs7i2q9pa7rsf13ksz2gsbhzsr-btdu-0.4.1/bin/btdu: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/za07fznxcl4wm116xn1ba3fx9wsyyraj-glibc-2.35-163/lib/ld-linux-aarch64.so.1, for GNU/Linux 2.6.32, not stripped

$ /nix/store/pib9m0gs7i2q9pa7rsf13ksz2gsbhzsr-btdu-0.4.1/bin/btdu 
btdu v0.4.1
Usage: btdu [OPTION]... PATH

Sampling disk usage profiler for btrfs.

Options:
      PATH                   Path to the root of the filesystem to analyze
  -j, --procs=N              Number of sampling subprocesses
                              (default is number of logical CPUs for this
                              system)
      --seed=N               Random seed used to choose samples
      --expert               Expert mode: collect and show additional metrics.
                             Uses more memory.
      --headless             Run without launching the result browser UI.
  -n, --max-samples=N        Stop after collecting N samples.
      --max-time=DURATION    Stop after running for this duration.
      --min-resolution=SIZE  Stop after achieving this resolution.
  -o, --export=PATH          On exit, export the collected results to the given
                              file.
      --du                   On exit, export represented size estimates in 'du'
                              format to standard output.
  -f, --import               Instead of analyzing a btrfs filesystem, read
                              previously collected results saved with --export from PATH.

Fatal error: No path specified.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
