### PR TITLE
calibre-web: don't use the flask_login alias

### DIFF
--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -21,7 +21,7 @@ python3.pkgs.buildPythonApplication rec {
     backports_abc
     chardet
     flask-babel
-    flask_login
+    flask-login
     flask_principal
     flask-wtf
     iso-639


### PR DESCRIPTION
This was somehow forgotten in a11a2a6d18 (PR #196488).

https://hydra.nixos.org/build/195985112
- - -
The usual checklist doesn't apply here.  I checked:
- [x] `git grep flask_login`
- [x] `nix build -f pkgs/top-level/release.nix tarball`