### PR TITLE
webp-pixbuf-loader: Adopt by GNOME

### DIFF
--- a/nixos/modules/services/x11/gdk-pixbuf.nix
+++ b/nixos/modules/services/x11/gdk-pixbuf.nix
@@ -1,34 +1,17 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.services.xserver.gdk-pixbuf;
 
-  # Get packages to generate the cache for. We always include gdk-pixbuf.
-  effectivePackages = unique ([pkgs.gdk-pixbuf] ++ cfg.modulePackages);
-
-  # Generate the cache file by running gdk-pixbuf-query-loaders for each
-  # package and concatenating the results.
-  loadersCache = pkgs.runCommand "gdk-pixbuf-loaders.cache" { preferLocalBuild = true; } ''
-    (
-      for package in ${concatStringsSep " " effectivePackages}; do
-        module_dir="$package/${pkgs.gdk-pixbuf.moduleDir}"
-        if [[ ! -d $module_dir ]]; then
-          echo "Warning (services.xserver.gdk-pixbuf): missing module directory $module_dir" 1>&2
-          continue
-        fi
-        GDK_PIXBUF_MODULEDIR="$module_dir" \
-          ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} ${pkgs.gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders
-      done
-    ) > "$out"
-  '';
+  loadersCache = pkgs.gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
+    extraLoaders = lib.unique (cfg.modulePackages);
+  };
 in
 
 {
   options = {
-    services.xserver.gdk-pixbuf.modulePackages = mkOption {
-      type = types.listOf types.package;
+    services.xserver.gdk-pixbuf.modulePackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
       default = [ ];
       description = lib.mdDoc "Packages providing GDK-Pixbuf modules, for cache generation.";
     };
@@ -37,7 +20,7 @@ in
   # If there is any package configured in modulePackages, we generate the
   # loaders.cache based on that and set the environment variable
   # GDK_PIXBUF_MODULE_FILE to point to it.
-  config = mkIf (cfg.modulePackages != []) {
+  config = lib.mkIf (cfg.modulePackages != []) {
     environment.variables = {
       GDK_PIXBUF_MODULE_FILE = "${loadersCache}";
     };

--- a/pkgs/desktops/gnome/core/eog/default.nix
+++ b/pkgs/desktops/gnome/core/eog/default.nix
@@ -22,6 +22,7 @@
 , shared-mime-info
 , wrapGAppsHook
 , librsvg
+, webp-pixbuf-loader
 , libexif
 , gobject-introspection
 , gi-docgen
@@ -77,6 +78,17 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dgtk_doc=true"
   ];
+
+  postInstall = ''
+    # Pull in WebP support for gnome-backgrounds.
+    # In postInstall to run before gappsWrapperArgsHook.
+    export GDK_PIXBUF_MODULE_FILE="${gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
+      extraLoaders = [
+        librsvg
+        webp-pixbuf-loader
+      ];
+    }}"
+  '';
 
   preFixup = ''
     gappsWrapperArgs+=(

--- a/pkgs/desktops/gnome/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-control-center/default.nix
@@ -33,6 +33,7 @@
 , libpulseaudio
 , libpwquality
 , librsvg
+, webp-pixbuf-loader
 , libsecret
 , libwacom
 , libxml2
@@ -137,6 +138,17 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     # For ITS rules
     addToSearchPath "XDG_DATA_DIRS" "${polkit.out}/share"
+  '';
+
+  postInstall = ''
+    # Pull in WebP support for gnome-backgrounds.
+    # In postInstall to run before gappsWrapperArgsHook.
+    export GDK_PIXBUF_MODULE_FILE="${gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
+      extraLoaders = [
+        librsvg
+        webp-pixbuf-loader
+      ];
+    }}"
   '';
 
   preFixup = ''

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -20,6 +20,7 @@
 , shared-mime-info
 , libgweather
 , librsvg
+, webp-pixbuf-loader
 , geoclue2
 , perl
 , docbook_xml_dtd_45
@@ -185,6 +186,17 @@ stdenv.mkDerivation rec {
     # We can generate it ourselves.
     rm -f man/gnome-shell.1
     rm data/theme/gnome-shell.css
+  '';
+
+  postInstall = ''
+    # Pull in WebP support for gnome-backgrounds.
+    # In postInstall to run before gappsWrapperArgsHook.
+    export GDK_PIXBUF_MODULE_FILE="${gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
+      extraLoaders = [
+        librsvg
+        webp-pixbuf-loader
+      ];
+    }}"
   '';
 
   preFixup = ''

--- a/pkgs/desktops/gnome/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome/core/nautilus/default.nix
@@ -21,6 +21,7 @@
 , libexif
 , libseccomp
 , librsvg
+, webp-pixbuf-loader
 , tracker
 , tracker-miners
 , gexiv2
@@ -106,6 +107,7 @@ stdenv.mkDerivation rec {
       # Thumbnailers
       --prefix XDG_DATA_DIRS : "${gdk-pixbuf}/share"
       --prefix XDG_DATA_DIRS : "${librsvg}/share"
+      --prefix XDG_DATA_DIRS : "${webp-pixbuf-loader}/share"
       --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
     )
   '';

--- a/pkgs/desktops/gnome/default.nix
+++ b/pkgs/desktops/gnome/default.nix
@@ -3,6 +3,10 @@
 lib.makeScope pkgs.newScope (self: with self; {
   updateScript = callPackage ./update.nix { };
 
+  # Temporary helper until gdk-pixbuf supports multiple cache files.
+  # This will go away, do not use outside Nixpkgs.
+  _gdkPixbufCacheBuilder_DO_NOT_USE = callPackage ./gdk-pixbuf-cache-builder.nix { };
+
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
 

--- a/pkgs/desktops/gnome/gdk-pixbuf-cache-builder.nix
+++ b/pkgs/desktops/gnome/gdk-pixbuf-cache-builder.nix
@@ -1,0 +1,37 @@
+{
+  runCommand,
+  pkg-config,
+  gdk-pixbuf,
+  lib,
+  stdenv,
+  buildPackages,
+}:
+
+{
+  extraLoaders,
+}:
+
+let
+  # Get packages to generate the cache for. We always include gdk-pixbuf.
+  loaderPackages = [
+    gdk-pixbuf
+  ] ++ extraLoaders;
+in
+
+# Generate the cache file by running gdk-pixbuf-query-loaders for each
+# package and concatenating the results.
+runCommand "gdk-pixbuf-loaders.cache" {
+  preferLocalBuild = true;
+} ''
+  (
+    for package in ${lib.escapeShellArgs loaderPackages}; do
+      module_dir="$package/${gdk-pixbuf.moduleDir}"
+      if [[ ! -d "$module_dir" ]]; then
+        echo "Error: gdkPixbufCacheBuilder: Passed package “''${package}” does not contain GdkPixbuf loaders in “${gdk-pixbuf.moduleDir}”." 1>&2
+        exit 1
+      fi
+      GDK_PIXBUF_MODULEDIR="$module_dir" \
+        ${stdenv.hostPlatform.emulator buildPackages} ${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders
+    done
+  ) > "$out"
+''

--- a/pkgs/development/libraries/webp-pixbuf-loader/default.nix
+++ b/pkgs/development/libraries/webp-pixbuf-loader/default.nix
@@ -1,9 +1,16 @@
-{ lib, stdenv, fetchFromGitHub
-, meson, ninja, pkg-config, makeWrapper
-, gdk-pixbuf, libwebp
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, makeWrapper
+, gdk-pixbuf
+, libwebp
 }:
+
 let
-  moduleDir = gdk-pixbuf.moduleDir;
+  inherit (gdk-pixbuf) moduleDir;
 
   # turning lib/gdk-pixbuf-#.#/#.#.#/loaders into lib/gdk-pixbuf-#.#/#.#.#/loaders.cache
   # removeSuffix is just in case moduleDir gets a trailing slash
@@ -15,36 +22,47 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "aruiz";
-    repo = pname;
+    repo = "webp-pixbuf-loader";
     rev = version;
     sha256 = "sha256-dcdydWYrXZJjo4FxJtvzGzrQLOs87/BmxshFZwsT2ws=";
   };
 
-  # It looks for gdk-pixbuf-thumbnailer in this package's bin rather than the gdk-pixbuf bin. We need to patch that.
-  postPatch = ''
-    substituteInPlace webp-pixbuf.thumbnailer.in --replace @bindir@/gdk-pixbuf-thumbnailer $out/bin/webp-thumbnailer
-  '';
+  nativeBuildInputs = [
+    gdk-pixbuf
+    meson
+    ninja
+    pkg-config
+    makeWrapper
+  ];
 
-  nativeBuildInputs = [ gdk-pixbuf meson ninja pkg-config makeWrapper ];
-  buildInputs = [ gdk-pixbuf libwebp ];
+  buildInputs = [
+    gdk-pixbuf
+    libwebp
+  ];
 
   mesonFlags = [
     "-Dgdk_pixbuf_query_loaders_path=${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders"
     "-Dgdk_pixbuf_moduledir=${placeholder "out"}/${moduleDir}"
   ];
 
-  # It assumes gdk-pixbuf-thumbnailer can find the webp loader in the loaders.cache referenced by environment variable, breaking containment.
-  # So we replace it with a wrapped executable.
-  postInstall = ''
-    mkdir -p $out/bin
-    makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer $out/bin/webp-thumbnailer \
-      --set GDK_PIXBUF_MODULE_FILE $out/${loadersPath}
+  postPatch = ''
+    # It looks for gdk-pixbuf-thumbnailer in this package's bin rather than the gdk-pixbuf bin. We need to patch that.
+    substituteInPlace webp-pixbuf.thumbnailer.in \
+      --replace "@bindir@/gdk-pixbuf-thumbnailer" "$out/bin/webp-thumbnailer"
   '';
 
-  # environment variables controlling loaders.cache generation by gdk-pixbuf-query-loaders
   preInstall = ''
-    export GDK_PIXBUF_MODULE_FILE=$out/${loadersPath}
-    export GDK_PIXBUF_MODULEDIR=$out/${moduleDir}
+    # environment variables controlling loaders.cache generation by gdk-pixbuf-query-loaders
+    export GDK_PIXBUF_MODULE_FILE="$out/${loadersPath}"
+    export GDK_PIXBUF_MODULEDIR="$out/${moduleDir}"
+  '';
+
+  postInstall = ''
+    # It assumes gdk-pixbuf-thumbnailer can find the webp loader in the loaders.cache referenced by environment variable, breaking containment.
+    # So we replace it with a wrapped executable.
+    mkdir -p "$out/bin"
+    makeWrapper "${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer" "$out/bin/webp-thumbnailer" \
+      --set GDK_PIXBUF_MODULE_FILE "$out/${loadersPath}"
   '';
 
   meta = with lib; {
@@ -52,7 +70,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/aruiz/webp-pixbuf-loader";
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;
-    maintainers = [ maintainers.cwyc ];
+    maintainers = teams.gnome.members ++ [ maintainers.cwyc ];
     # meson.build:16:0: ERROR: Program or command 'gcc' not found or not executable
     broken = stdenv.isDarwin;
   };

--- a/pkgs/development/libraries/xdg-desktop-portal-gnome/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-gnome/default.nix
@@ -14,6 +14,8 @@
 , xdg-desktop-portal
 , wayland
 , gnome
+, librsvg
+, webp-pixbuf-loader
 }:
 
 stdenv.mkDerivation rec {
@@ -46,6 +48,17 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
   ];
+
+  postInstall = ''
+    # Pull in WebP support for gnome-backgrounds.
+    # In postInstall to run before gappsWrapperArgsHook.
+    export GDK_PIXBUF_MODULE_FILE="${gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
+      extraLoaders = [
+        librsvg
+        webp-pixbuf-loader
+      ];
+    }}"
+  '';
 
   passthru = {
     updateScript = gnome.updateScript {


### PR DESCRIPTION
###### Description of changes

GNOME uses this for backgrounds so let’s add GNOME team to maintainers and adopt GNOME coding style aimed at cleaner git diffs.

Also add into GNOME packages so that gnome-backgrounds 43 work.

Fixes: https://github.com/NixOS/nixpkgs/issues/196428

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] gnome-control-center displays WebP backgrounds
  - [x] GNOME Shell displays WebP backgrounds
  - [x] Nautilus thumbnails WebP images
  - [x] eog can view WebP files
  - [x] Nautilus “set background” dialogue (GNOME portal) previews WebP files
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
