### PR TITLE
ocamlPackages.zmq: 20180726 → 5.1.5

### DIFF
--- a/pkgs/development/ocaml-modules/zmq/default.nix
+++ b/pkgs/development/ocaml-modules/zmq/default.nix
@@ -1,17 +1,14 @@
-{ lib, fetchFromGitHub, buildDunePackage, dune-configurator, czmq, stdint }:
+{ lib, fetchurl, buildDunePackage, dune-configurator, czmq, stdint }:
 
 buildDunePackage rec {
-  minimumOCamlVersion = "4.03";
   pname = "zmq";
-  version = "20180726";
+  version = "5.1.5";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  src = fetchFromGitHub {
-    owner = "issuu";
-    repo = "ocaml-zmq";
-    rev = "d312a8458d6b688f75470248f11875fbbfa5bb1a";
-    sha256 = "1f5l4bw78y4drabhyvmpj3z8k30bill33ca7bzhr02m55yf6gqpf";
+  src = fetchurl {
+    url = "https://github.com/issuu/ocaml-zmq/releases/download/${version}/zmq-lwt-${version}.tbz";
+    sha256 = "sha256-mUfRPatLPFeSzWDwCIoFaVl85VkvDch4i6pOn3Kme1Y=";
   };
 
   buildInputs = [ czmq dune-configurator ];
@@ -22,6 +19,6 @@ buildDunePackage rec {
     description = "ZeroMQ bindings for OCaml";
     license     = lib.licenses.mit;
     maintainers = with lib.maintainers; [ akavel ];
-    inherit (src.meta) homepage;
+    homepage = "https://engineering.issuu.com/ocaml-zmq/";
   };
 }

--- a/pkgs/development/ocaml-modules/zmq/lwt.nix
+++ b/pkgs/development/ocaml-modules/zmq/lwt.nix
@@ -2,7 +2,8 @@
 
 buildDunePackage {
   pname = "zmq-lwt";
-  inherit (zmq) version src useDune2 meta;
+  inherit (zmq) version src meta;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ zmq ocaml_lwt ];
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/issuu/ocaml-zmq/blob/master/CHANGES.md#515

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
