### PR TITLE
mprocs: 0.4.0 -> 0.6.3

### DIFF
--- a/pkgs/tools/misc/mprocs/default.nix
+++ b/pkgs/tools/misc/mprocs/default.nix
@@ -2,16 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mprocs";
-  version = "0.4.0";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "pvolok";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-IzaXcEm4eUpLWsn59ZSiIJ0mCegLhBiA3ONKI1Djemk=";
+    sha256 = "sha256-CEvQq5tBVRvjgb/yReuGkPk8Uq1oZbrsGilV4ulOPEk=";
   };
 
-  cargoSha256 = "sha256-nTFCFmmS3IIm+D2PjvDxUKQGTn2h0ajXtxLuosa9rRY=";
+  cargoSha256 = "sha256-RK8VmEajfqYXGS8VMCRxhENLbe40CdaC+vS4EKeW958=";
+
+  # Package tests are currently failing (even upstream) but the package seems to work fine.
+  # Relevant issues:
+  # https://github.com/pvolok/mprocs/issues/50
+  # https://github.com/pvolok/mprocs/issues/61
+  doCheck = false;
 
   meta = with lib; {
     description = "A TUI tool to run multiple commands in parallel and show the output of each command separately";


### PR DESCRIPTION
###### Description of changes

Update to version 0.6.3.
A [PR](https://github.com/NixOS/nixpkgs/pull/183550) was previously automatically generated to update to 0.6.1 but as tests were failing, it never got merged.
In this PR, I update to the latest release (0.6.3) and **I disabled the tests**.
Indeed, the latter are failing, but [the package maintainer says that the app works fine nonetheless](https://github.com/pvolok/mprocs/issues/61#issuecomment-1286159079).

Hence I suggest we perform the update and re-enable the tests once they get fixed upstream.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@theHedgehog0 