### PR TITLE
caerbannog: fix launching

### DIFF
--- a/pkgs/applications/misc/caerbannog/default.nix
+++ b/pkgs/applications/misc/caerbannog/default.nix
@@ -7,6 +7,7 @@
 , ninja
 , pkg-config
 , wrapGAppsHook
+, gtk3
 , atk
 , libhandy
 , libnotify
@@ -35,6 +36,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   buildInputs = [
+    gtk3
     atk
     gobject-introspection
     libhandy


### PR DESCRIPTION
###### Description of changes

Fixes the following error on launching:

```
Traceback (most recent call last):
  File "/nix/store/4mxc21f2xfjh9m0calq82qkfil6wwh5q-caerbannog-0.3/bin/..caerbannog-wrapped-wrapped", line 23, in <module>
    from caerbannog import main
  File "/nix/store/4mxc21f2xfjh9m0calq82qkfil6wwh5q-caerbannog-0.3/share/caerbannog/caerbannog/main.py", line 7, in <module>
    from .window import MainWindow
  File "/nix/store/4mxc21f2xfjh9m0calq82qkfil6wwh5q-caerbannog-0.3/share/caerbannog/caerbannog/window.py", line 4, in <module>
    from .passlist import PassList
  File "/nix/store/4mxc21f2xfjh9m0calq82qkfil6wwh5q-caerbannog-0.3/share/caerbannog/caerbannog/passlist.py", line 10, in <module>
    gi.require_version('Gdk', '3.0')
  File "/nix/store/0r0x4g07zd3nrrrlla8hfzsg88sfp0as-python3.10-pygobject-3.42.2/lib/python3.10/site-packages/gi/__init__.py", line 126, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Gdk not available
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
