### PR TITLE
ocamlPackages.carton: Tests require getconf

### DIFF
--- a/pkgs/development/ocaml-modules/carton/carton-find-getconf.patch
+++ b/pkgs/development/ocaml-modules/carton/carton-find-getconf.patch
@@ -1,0 +1,13 @@
+diff --git a/bin/fiber/fiber.ml b/bin/fiber/fiber.ml
+index 188a92cc9..6087a8687 100644
+--- a/bin/fiber/fiber.ml
++++ b/bin/fiber/fiber.ml
+@@ -129,7 +129,7 @@ let worker pool =
+ 
+ let get_concurrency () =
+   try
+-    let ic = Unix.open_process_in "getconf _NPROCESSORS_ONLN" in
++    let ic = Unix.open_process_in "@getconf@/bin/getconf _NPROCESSORS_ONLN" in
+     let close () = ignore (Unix.close_process_in ic) in
+     let sc = Scanf.Scanning.from_channel ic in
+     try

--- a/pkgs/development/ocaml-modules/carton/default.nix
+++ b/pkgs/development/ocaml-modules/carton/default.nix
@@ -3,6 +3,7 @@
 , checkseum, logs, psq, fmt
 , result, rresult, fpath, base64, bos, digestif, alcotest
 , crowbar, alcotest-lwt, lwt, findlib, mirage-flow, cmdliner, hxd
+, getconf, substituteAll
 }:
 
 buildDunePackage rec {
@@ -15,6 +16,13 @@ buildDunePackage rec {
     url = "https://github.com/mirage/ocaml-git/releases/download/${pname}-v${version}/git-${pname}-v${version}.tbz";
     sha256 = "sha256-7mgCgu87Cn4XhjEhonlz9lhgTw0Cu5hnxNJ1wXr+Qhw=";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./carton-find-getconf.patch;
+      getconf = "${getconf}";
+    })
+  ];
 
   # remove changelogs for mimic and the git* packages
   postPatch = ''


### PR DESCRIPTION
catched while reviewing another PR https://github.com/NixOS/nixpkgs/pull/196958#pullrequestreview-1150201632

getconf is used here https://github.com/mirage/ocaml-git/blob/471406dde6c3056ea49547de379fef12871da48b/bin/fiber/fiber.ml#L132 since it is a runtime dips I patched the source.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
