### PR TITLE
gnome.nixos-gsettings-overrides: Ensure the settings are not overwritten

### DIFF
--- a/pkgs/desktops/gnome/nixos/gsettings-overrides/default.nix
+++ b/pkgs/desktops/gnome/nixos/gsettings-overrides/default.nix
@@ -47,7 +47,7 @@ runCommand "gnome-gsettings-overrides" { preferLocalBuild = true; } ''
   ${concatMapStringsSep "\n" (pkg: "cp -rf \"${glib.getSchemaPath pkg}\"/*.xml \"${glib.getSchemaPath pkg}\"/*.gschema.override \"$schema_dir\"") gsettingsOverridePackages}
 
   chmod -R a+w "$data_dir"
-  cat - > "$schema_dir/nixos-defaults.gschema.override" <<- EOF
+  cat - > "$schema_dir/zz-nixos-defaults.gschema.override" <<- EOF
   ${gsettingsOverrides}
   EOF
 


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/commit/1d4bddaed58c23fbfb4df0bf80d5ffd6803a6a34 started copying override files from packages into the schema for compilation. `gsettings-desktop-schemas` package contains `remove-backgrounds.gschema.override` which is later in the alphabet than `nixos-defaults.gschema.override` so it would take precedence over the values from the GNOME NixOS module, causing the background to not be set, among other things.

Let’s rename the override file coming from the module to be applied last.

Noticed in #197029 

###### Things done

- [x] Verified it works in VM.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
