### PR TITLE
pythonPackages.passlib: disable native support test on darwin

### DIFF
--- a/pkgs/development/python-modules/passlib/default.nix
+++ b/pkgs/development/python-modules/passlib/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     # timming sensitive
     "test_dummy_verify"
   ]
-  # These tests fail because they don't expect native support for these algorithms
+  # These tests fail because they don't expect support for algorithms provided through libxcrypt
   ++ lib.optionals stdenv.isDarwin [
     "test_82_crypt_support"
   ];

--- a/pkgs/development/python-modules/passlib/default.nix
+++ b/pkgs/development/python-modules/passlib/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , argon2-cffi
@@ -25,12 +26,16 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
   ] ++ passthru.optional-dependencies.argon2
-    ++ passthru.optional-dependencies.bcrypt
-    ++ passthru.optional-dependencies.totp;
+  ++ passthru.optional-dependencies.bcrypt
+  ++ passthru.optional-dependencies.totp;
 
   disabledTests = [
     # timming sensitive
     "test_dummy_verify"
+  ]
+  # These tests fail because they don't expect native support for these algorithms
+  ++ lib.optionals stdenv.isDarwin [
+    "test_82_crypt_support"
   ];
 
   meta = with lib; {


### PR DESCRIPTION

###### Description of changes

Several instances of this test fail with error like:

```
AssertionError: did not expect 'darwin' platform would have native support for '...'
```

It looks like passlib's tests erroneously assume that some methods should not have native support on Darwin while modern systems have such support.

This gates building of a bunch of Python packages on Darwin, including Ansible.

Found while looking through errors for staging-next PR https://github.com/NixOS/nixpkgs/pull/195862

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
