### PR TITLE
wordpressPackages.plugins.wordpress-seo: init at 19.8

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/languages.json
+++ b/pkgs/servers/web-apps/wordpress/packages/languages.json
@@ -1,14 +1,14 @@
 {
   "de_DE": {
     "path": "de_DE",
-    "rev": "963451",
-    "sha256": "0zp1sz9f5vwz3ywj746la799nlaqxigja34qb83qqrsgkgaliff2",
+    "rev": "970135",
+    "sha256": "1kd05aihdcf8bqrci50wg4i61mqrjhd6z5d5yb05p4ivaiirak6x",
     "version": "5.8"
   },
   "fr_FR": {
     "path": "fr_FR",
-    "rev": "967096",
-    "sha256": "0r40kkmm7an6zdqszqcgr07ffkfif5c9446fjxba20vslhgkj9mg",
+    "rev": "968330",
+    "sha256": "12mzr1i2dl1hh7p93zda6af0xi49mw31v79gg0qgqsnhd5adrlgm",
     "version": "5.8"
   }
 }

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -18,10 +18,10 @@
     "version": "2.21.08.31"
   },
   "breeze": {
-    "path": "breeze/tags/2.0.9",
-    "rev": "2786857",
-    "sha256": "0nn3kalwb50kyd563jiixc134hiygkbzs8zkxgsbgmsi511vfzkz",
-    "version": "2.0.9"
+    "path": "breeze/tags/2.0.10",
+    "rev": "2799885",
+    "sha256": "00d36s6ws8bd8qj33nq090lplw2fqj9zz1yzfky4w74lyabih0hw",
+    "version": "2.0.10"
   },
   "co-authors-plus": {
     "path": "co-authors-plus/tags/3.5.2",
@@ -72,10 +72,10 @@
     "version": "5.0.18"
   },
   "mailpoet": {
-    "path": "mailpoet/tags/3.100.2",
-    "rev": "2797181",
-    "sha256": "04vxwxdvpp80hh381xb88g81i9ps1imvvax5nljjx7nywwc5p9ci",
-    "version": "3.100.2"
+    "path": "mailpoet/tags/3.101.0",
+    "rev": "2800580",
+    "sha256": "050ip4vd514nlfw69ax9x8acszlcsqzd7zw5bdvy1xk3dlva6fkb",
+    "version": "3.101.0"
   },
   "opengraph": {
     "path": "opengraph/tags/1.11.0",
@@ -100,6 +100,12 @@
     "rev": "2798010",
     "sha256": "1flggxd6hw0ps3b0y32a2aj9g3zfpzbaiwzx1zn2s7zpxn508y1b",
     "version": "5.3.1"
+  },
+  "wordpress-seo": {
+    "path": "wordpress-seo/tags/19.8",
+    "rev": "2796969",
+    "sha256": "0vnj7b37s9rra2m957baz8ki4z6x6acl76wgx8yj2063823q0pl2",
+    "version": "19.8"
   },
   "worker": {
     "path": "worker/tags/4.9.14",

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -16,6 +16,7 @@
 , "simple-login-captcha"
 , "static-mail-sender-configurator"
 , "webp-converter-for-media"
+, "wordpress-seo"
 , "worker"
 , "wp-mail-smtp"
 , "wp-gdpr-compliance"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
