### PR TITLE
touchosc: 1.1.5.145 → 1.1.6.150

### DIFF
--- a/pkgs/applications/audio/touchosc/default.nix
+++ b/pkgs/applications/audio/touchosc/default.nix
@@ -45,7 +45,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "touchosc";
-  version = "1.1.5.145";
+  version = "1.1.6.150";
 
   suffix = {
     aarch64-linux = "linux-arm64";
@@ -56,9 +56,9 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://hexler.net/pub/${pname}/${pname}-${version}-${suffix}.deb";
     hash = {
-      aarch64-linux = "sha256-3qbr9dveeDqP9psZNyN520B2JuG/R9yvpYX9CdqR7TI=";
-      armv7l-linux  = "sha256-wns0hb+5s7cEbV+4crUWRJ1yU3pl1N0NJ0GWmM4Uvos=";
-      x86_64-linux  = "sha256-LsrR46Epc8x0KTc2lbVN1rbb5KZXYTG8oygJ1BmsCC8=";
+      aarch64-linux = "sha256-sYkAFyXnmzgSzo68OF0oiv8tUvY+g1WCcY783OZO+RM=";
+      armv7l-linux  = "sha256-GWpYW1262plxIzPVzBEh4Z3fQIhSmy0N9xAgwnjXrQE=";
+      x86_64-linux  = "sha256-LUWlLEsTUqVoWAkjXC/zOziPqO85H8iIlwJU7eqLRcY=";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 

--- a/pkgs/applications/audio/touchosc/default.nix
+++ b/pkgs/applications/audio/touchosc/default.nix
@@ -96,6 +96,8 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://hexler.net/touchosc";
     description = "Next generation modular control surface";

--- a/pkgs/applications/audio/touchosc/update.sh
+++ b/pkgs/applications/audio/touchosc/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix curl libxml2 jq common-updater-scripts
+
+set -euo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel || (printf 'Could not find root of nixpkgs repo\nAre we running from within the nixpkgs git repo?\n' >&2; exit 1))"
+
+attr="${UPDATE_NIX_ATTR_PATH:-touchosc}"
+version="$(curl -sSL https://hexler.net/touchosc/appcast/linux | xmllint --xpath '/rss/channel/item/enclosure/@*[local-name()="version"]' - | cut -d= -f2- | tr -d '"' | head -n1)"
+
+findpath() {
+    path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+
+    if [ -n "$outpath" ]; then
+        path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"
+    fi
+
+    echo "$path"
+}
+
+pkgpath="$(findpath "$attr")"
+
+sed -i -e "/version\s*=/ s|\"$UPDATE_NIX_OLD_VERSION\"|\"$version\"|" "$pkgpath"
+
+for system in aarch64-linux armv7l-linux x86_64-linux; do
+    url="$(nix --extra-experimental-features nix-command eval --json --impure --argstr system "$system" -f "$nixpkgs" "$attr".src.url | jq -r .)"
+
+    curhash="$(nix --extra-experimental-features nix-command eval --json --impure --argstr system "$system" -f "$nixpkgs" "$attr".src.outputHash | jq -r .)"
+    newhash="$(nix --extra-experimental-features nix-command store prefetch-file --json "$url" | jq -r .hash)"
+
+    sed -i -e "s|\"$curhash\"|\"$newhash\"|" "$pkgpath"
+done


### PR DESCRIPTION
###### Description of changes

Add an `updateScript` for touchosc and bump to [1.1.6.150](https://hexler.net/touchosc/releases#1.1.6.150)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).