### PR TITLE
openai: 0.23.1 -> 0.24.0

### DIFF
--- a/pkgs/applications/science/math/readstat/default.nix
+++ b/pkgs/applications/science/math/readstat/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "readstat";
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
+
+  buildInputs = lib.optionals (stdenv.isDarwin && stdenv.isx86_64)  [ libiconv ];
 
   meta = {
     homepage = "https://github.com/WizardMac/ReadStat";

--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "openai";
-  version = "0.23.1";
+  version = "0.24.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7.1";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "openai";
     repo = "openai-python";
     rev = "v${version}";
-    hash = "sha256-4RdER6ecvHGXTLZ1GnBNI1hIETI8O/t+kuOXiQhMigs=";
+    hash = "sha256-0bXJoEq8FHRNaFMjncIwDbJROtFz/IJ4gD+LfvmtFUg=";
   };
 
   propagatedBuildInputs = [
@@ -72,7 +72,9 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Requires a real API key
     "openai/tests/test_endpoints.py"
+    # openai: command not found
     "openai/tests/test_file_cli.py"
+    "openai/tests/test_long_examples_validator.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , jinja2
@@ -101,6 +102,8 @@ buildPythonPackage rec {
     "test_dummies"
     "test_from_dummies_args"
     "test_rolling_step_method"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "test_plotting" # Fatal Python error: Illegal instruction
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pyreadstat/default.nix
+++ b/pkgs/development/python-modules/pyreadstat/default.nix
@@ -1,7 +1,9 @@
 { lib
+, stdenv
 , buildPythonPackage
 , cython
 , fetchFromGitHub
+, libiconv
 , pandas
 , python
 , pythonOlder
@@ -29,6 +31,8 @@ buildPythonPackage rec {
 
   buildInputs = [
     zlib
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10744,7 +10744,9 @@ with pkgs;
 
   read-edid = callPackage ../os-specific/linux/read-edid { };
 
-  readstat = callPackage ../applications/science/math/readstat { };
+  readstat = callPackage ../applications/science/math/readstat {
+    inherit (pkgs.darwin) libiconv;
+  };
 
   redir = callPackage ../tools/networking/redir { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8493,7 +8493,9 @@ in {
 
   pyramid_multiauth = callPackage ../development/python-modules/pyramid_multiauth { };
 
-  pyreadstat = callPackage ../development/python-modules/pyreadstat { };
+  pyreadstat = callPackage ../development/python-modules/pyreadstat {
+    inherit (pkgs.darwin) libiconv;
+  };
 
   pyrealsense2 = toPythonModule (pkgs.librealsense.override {
     enablePython = true;


### PR DESCRIPTION
###### Description of changes

Updated to latest version. 

Changes: https://github.com/openai/openai-python/compare/v0.23.1...v0.24.0

Also updated dependencies that wouldn't build on Darwin systems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
