### PR TITLE
xdg-utils,nixos/xdg/portal: implement workaround for opening programs from FHS envs or wrappers reliably

### DIFF
--- a/nixos/modules/config/xdg/portal.nix
+++ b/nixos/modules/config/xdg/portal.nix
@@ -61,6 +61,17 @@ in
         Defaults to `false` to respect its opt-in nature.
       '';
     };
+
+    xdgOpenUsePortal = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Sets environment variable `NIXOS_XDG_OPEN_USE_PORTAL` to `1`
+        This will make `xdg-open` use the portal to open programs, which resolves bugs involving
+        programs opening inside FHS envs or with unexpected env vars set from wrappers.
+        See [#160923](https://github.com/NixOS/nixpkgs/issues/160923) for more info.
+      '';
+    };
   };
 
   config =
@@ -95,6 +106,7 @@ in
 
         sessionVariables = {
           GTK_USE_PORTAL = mkIf cfg.gtkUsePortal "1";
+          NIXOS_XDG_OPEN_USE_PORTAL = mkIf cfg.xdgOpenUsePortal "1";
           XDG_DESKTOP_PORTAL_DIR = "${joinedPortals}/share/xdg-desktop-portal/portals";
         };
       };

--- a/pkgs/tools/X11/xdg-utils/allow-forcing-portal-use.patch
+++ b/pkgs/tools/X11/xdg-utils/allow-forcing-portal-use.patch
@@ -1,0 +1,29 @@
+From 835eed6a2b975fba40c3ac18b4cf5429ba9d2836 Mon Sep 17 00:00:00 2001
+From: Luna Nova <git@lunnova.dev>
+Date: Wed, 7 Sep 2022 08:45:56 -0700
+Subject: [PATCH] xdg-open: add $XDG_OPEN_USE_PORTAL env var
+
+When set, the same mechanism that is used in a flatpak is used,
+a dbus call to the portal. This is useful for distros with non-flatpak
+wrapper or sandboxing features which require the same treatment, eg NixOS.
+
+See https://github.com/NixOS/nixpkgs/issues/160923
+---
+ scripts/xdg-open.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scripts/xdg-open.in b/scripts/xdg-open.in
+index 8de839a..80d8fb3 100644
+--- a/scripts/xdg-open.in
++++ b/scripts/xdg-open.in
+@@ -508,6 +508,10 @@ if [ x"$DE" = x"" ]; then
+     DE=generic
+ fi
+ 
++if [ -n "$NIXOS_XDG_OPEN_USE_PORTAL"  ]; then
++    DE=flatpak
++fi
++
+ DEBUG 2 "Selected DE $DE"
+ 
+ # sanitize BROWSER (avoid calling ourselves in particular)

--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -2,6 +2,7 @@
 , file, libxslt, docbook_xml_dtd_412, docbook_xsl, xmlto
 , w3m, gnugrep, gnused, coreutils, xset, perlPackages
 , mimiSupport ? false, gawk
+, glib
 , withXdgOpenUsePortalPatch ? true }:
 
 let
@@ -56,13 +57,15 @@ stdenv.mkDerivation rec {
     &#' -i "$out"/bin/*
 
     substituteInPlace $out/bin/xdg-open \
-      --replace "/usr/bin/printf" "${coreutils}/bin/printf"
+      --replace "/usr/bin/printf" "${coreutils}/bin/printf" \
+      --replace "gdbus" "${glib}/bin/gdbus"
 
     substituteInPlace $out/bin/xdg-mime \
       --replace "/usr/bin/file" "${file}/bin/file"
 
     substituteInPlace $out/bin/xdg-email \
-      --replace "/bin/echo" "${coreutils}/bin/echo"
+      --replace "/bin/echo" "${coreutils}/bin/echo" \
+      --replace "gdbus" "${glib}/bin/gdbus"
 
     sed 's|\bwhich\b|type -P|g' -i "$out"/bin/*
   '';

--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchFromGitLab, fetchFromGitHub
 , file, libxslt, docbook_xml_dtd_412, docbook_xsl, xmlto
 , w3m, gnugrep, gnused, coreutils, xset, perlPackages
-, mimiSupport ? false, gawk }:
+, mimiSupport ? false, gawk
+, withXdgOpenUsePortalPatch ? true }:
 
 let
   # A much better xdg-open
@@ -29,6 +30,12 @@ stdenv.mkDerivation rec {
     rev = "d11b33ec7f24cfb1546f6b459611d440013bdc72";
     sha256 = "sha256-8PtXfI8hRneEpnUvIV3M+6ACjlkx0w/NEiJFdGbbHnQ=";
   };
+
+  patches = lib.optionals withXdgOpenUsePortalPatch [
+    # Allow forcing the use of XDG portals using NIXOS_XDG_OPEN_USE_PORTAL environment variable.
+    # Upstream PR: https://github.com/freedesktop/xdg-utils/pull/12
+    ./allow-forcing-portal-use.patch
+  ];
 
   # just needed when built from git
   nativeBuildInputs = [ libxslt docbook_xml_dtd_412 docbook_xsl xmlto w3m ];


### PR DESCRIPTION
###### Description of changes

Works around #160923, does not enable the fix by default. Requires `xdg.portal = { enable = true; xdgOpenUsePortal = true; }` to activate it, which depends on a running portal.

Alternative approach to #187293 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
