### PR TITLE
libcurl for unixODBC and MSSQL ODBC update

### DIFF
--- a/pkgs/development/libraries/unixODBC/default.nix
+++ b/pkgs/development/libraries/unixODBC/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "unixODBC";
-  version = "2.3.9";
+  version = "2.3.11";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.unixodbc.org/pub/unixODBC/${pname}-${version}.tar.gz"
       "http://www.unixodbc.org/${pname}-${version}.tar.gz"
     ];
-    sha256 = "sha256-UoM+rD1oHIsMmlpl8uvXRbOpZPII/HSPl35EAVoxsgc=";
+    sha256 = "sha256-2eVcjnEYNH48ZshzOIVtrRUWtJD7fHVsFWKiwmfHO1w=";
   };
 
   configureFlags = [ "--disable-gui" "--sysconfdir=/etc" ];

--- a/pkgs/development/libraries/unixODBC/default.nix
+++ b/pkgs/development/libraries/unixODBC/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, curlFull }:
 
 stdenv.mkDerivation rec {
   pname = "unixODBC";
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     ];
     sha256 = "sha256-2eVcjnEYNH48ZshzOIVtrRUWtJD7fHVsFWKiwmfHO1w=";
   };
+
+  postFixup = "cp ${curlFull.out}/lib/libcurl.so $out/lib";
 
   configureFlags = [ "--disable-gui" "--sysconfdir=/etc" ];
 

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -140,12 +140,12 @@
     version = "${versionMajor}.${versionMinor}.${versionAdditional}-1";
 
     versionMajor = "17";
-    versionMinor = "7";
+    versionMinor = "10";
     versionAdditional = "1.1";
 
     src = fetchurl {
-      url = "https://packages.microsoft.com/debian/10/prod/pool/main/m/msodbcsql17/msodbcsql${versionMajor}_${version}_amd64.deb";
-      sha256 = "0vwirnp56jibm3qf0kmi4jnz1w7xfhnsfr8imr0c9hg6av4sk3a6";
+      url = "https://packages.microsoft.com/debian/10/prod/pool/main/m/msodbcsql${versionMajor}/msodbcsql${versionMajor}_${version}_amd64.deb";
+      sha256 = "PFDQX0OlqbtVi+qSNMm7tfLVi9RrGm8L3tW1mAZV+qY=";
     };
 
     nativeBuildInputs = [ dpkg patchelf ];

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -180,6 +180,51 @@
     };
   };
 
+  msodbcsql18 = stdenv.mkDerivation rec {
+    pname = "msodbcsql18";
+    version = "${versionMajor}.${versionMinor}.${versionAdditional}-1";
+
+    versionMajor = "18";
+    versionMinor = "1";
+    versionAdditional = "1.1";
+
+    src = fetchurl {
+      url = "https://packages.microsoft.com/debian/10/prod/pool/main/m/msodbcsql${versionMajor}/msodbcsql${versionMajor}_${version}_amd64.deb";
+      sha256 = "otC4+e23RnN/OJ/nHh3wS5bPBfR6USYr1sFZrwKsGbg=";
+    };
+
+    nativeBuildInputs = [ dpkg patchelf ];
+
+    unpackPhase = "dpkg -x $src ./";
+    buildPhase = "";
+
+    installPhase = ''
+      mkdir -p $out
+      mkdir -p $out/lib
+      cp -r opt/microsoft/msodbcsql${versionMajor}/lib64 opt/microsoft/msodbcsql${versionMajor}/share $out/
+    '';
+
+    postFixup = ''
+      patchelf --set-rpath ${lib.makeLibraryPath [ unixODBC openssl libkrb5 libuuid stdenv.cc.cc ]} \
+        $out/lib/libmsodbcsql-${versionMajor}.${versionMinor}.so.${versionAdditional}
+    '';
+
+    passthru = {
+      fancyName = "ODBC Driver 18 for SQL Server";
+      driver = "lib/libmsodbcsql-${versionMajor}.${versionMinor}.so.${versionAdditional}";
+    };
+
+    meta = with lib; {
+      broken = stdenv.isDarwin;
+      description = "ODBC Driver 18 for SQL Server";
+      homepage = "https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-2018";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ spencerjanssen ];
+    };
+  };
+
   redshift = stdenv.mkDerivation rec {
     pname = "redshift-odbc";
     version = "1.4.49.1000";


### PR DESCRIPTION

- Add libcurl to unixODBC because it is need by MSSQL driver
- update MSSQL driver version
