### PR TITLE
arcanPackages.cat9: init at unstable-2018-09-13

### DIFF
--- a/pkgs/desktops/arcan/cat9/default.nix
+++ b/pkgs/desktops/arcan/cat9/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation (finalPackages: {
+  pname = "cat9";
+  version = "unstable-2018-09-13";
+
+  src = fetchFromGitHub {
+    owner = "letoram";
+    repo = finalPackages.pname;
+    rev = "754d9d2900d647a0fa264720528117471a32f295";
+    hash = "sha256-UmbynVOJYvHz+deA99lj/BBFOauZzwSNs+qR28pASPY=";
+  };
+
+  dontConfigure = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p ${placeholder "out"}/share/arcan/appl/cat9
+    cp -a ./* ${placeholder "out"}/share/arcan/appl/cat9
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/letoram/cat9";
+    description = "A User shell for LASH";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/desktops/arcan/default.nix
+++ b/pkgs/desktops/arcan/default.nix
@@ -15,6 +15,12 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   # Appls
 
+  cat9 = callPackage ./cat9 { };
+  cat9-wrapped = callPackage ./wrapper.nix {
+    name = "cat9-wrapped";
+    appls = [ cat9 ];
+  };
+
   durden = callPackage ./durden { };
   durden-wrapped = callPackage ./wrapper.nix {
     name = "durden-wrapped";
@@ -38,6 +44,6 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   all-wrapped = callPackage ./wrapper.nix {
     name = "all-wrapped";
-    appls = [ durden pipeworld ];
+    appls = [ durden cat9 pipeworld ];
   };
 })


### PR DESCRIPTION
###### Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/196825

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
