### PR TITLE
python310Packages.minimock: 1.2.8 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/minimock/default.nix
+++ b/pkgs/development/python-modules/minimock/default.nix
@@ -1,28 +1,39 @@
 { lib
 , buildPythonPackage
-, fetchurl
-, nose
+, fetchFromGitHub
+, pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
-  version = "1.2.8";
   pname = "minimock";
+  version = "1.3.0";
+  format = "pyproject";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/jab/minimock/get/${version}.zip";
-    sha256 = "c88fa8a7120623f23990a7f086a9657f6ced09025a55e3be8649a30b4945441a";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "lowks";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Ut3iKc7Sr28uGgWCV3K3CS+gBta2icvbUPMjjo4fflU=";
   };
 
-  checkInputs = [ nose ];
+  nativeBuildInputs = [
+    setuptools
+  ];
 
-  checkPhase = ''
-    ./test
-  '';
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "minimock"
+  ];
 
   meta = with lib; {
-    description = "A minimalistic mocking library for python";
+    description = "A minimalistic mocking library";
     homepage = "https://pypi.python.org/pypi/MiniMock";
     license = licenses.mit;
+    maintainers = with maintainers; [ drewrisinger ];
   };
-
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/lowks/minimock/blob/master/CHANGELOG.txt
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
