### PR TITLE
treewide: Remove optional adminAddr setting

### DIFF
--- a/nixos/doc/manual/from_md/administration/imperative-containers.section.xml
+++ b/nixos/doc/manual/from_md/administration/imperative-containers.section.xml
@@ -101,7 +101,6 @@ Linux foo 3.4.82 #1-NixOS SMP Thu Mar 20 14:44:05 UTC 2014 x86_64 GNU/Linux
   <programlisting>
 # nixos-container update foo --config '
   services.httpd.enable = true;
-  services.httpd.adminAddr = &quot;foo@example.org&quot;;
   networking.firewall.allowedTCPPorts = [ 80 ];
 '
 

--- a/nixos/doc/manual/from_md/configuration/abstractions.section.xml
+++ b/nixos/doc/manual/from_md/configuration/abstractions.section.xml
@@ -9,14 +9,12 @@
   services.httpd.virtualHosts =
     { &quot;blog.example.org&quot; = {
         documentRoot = &quot;/webroot/blog.example.org&quot;;
-        adminAddr = &quot;alice@example.org&quot;;
         forceSSL = true;
         enableACME = true;
         enablePHP = true;
       };
       &quot;wiki.example.org&quot; = {
         documentRoot = &quot;/webroot/wiki.example.org&quot;;
-        adminAddr = &quot;alice@example.org&quot;;
         forceSSL = true;
         enableACME = true;
         enablePHP = true;
@@ -32,8 +30,7 @@
   <programlisting language="bash">
 let
   commonConfig =
-    { adminAddr = &quot;alice@example.org&quot;;
-      forceSSL = true;
+    { forceSSL = true;
       enableACME = true;
     };
 in
@@ -80,7 +77,6 @@ in
     let
       makeVirtualHost = webroot:
         { documentRoot = webroot;
-          adminAddr = &quot;alice@example.org&quot;;
           forceSSL = true;
           enableACME = true;
         };

--- a/nixos/doc/manual/from_md/configuration/config-file.section.xml
+++ b/nixos/doc/manual/from_md/configuration/config-file.section.xml
@@ -25,7 +25,6 @@
 { config, pkgs, ... }:
 
 { services.httpd.enable = true;
-  services.httpd.adminAddr = &quot;alice@example.org&quot;;
   services.httpd.virtualHosts.localhost.documentRoot = &quot;/webroot&quot;;
 }
 </programlisting>
@@ -50,7 +49,6 @@
 { services = {
     httpd = {
       enable = true;
-      adminAddr = &quot;alice@example.org&quot;;
       virtualHosts = {
         localhost = {
           documentRoot = &quot;/webroot&quot;;

--- a/nixos/modules/services/monitoring/nagios.nix
+++ b/nixos/modules/services/monitoring/nagios.nix
@@ -158,7 +158,6 @@ in
         type = types.submodule (import ../web-servers/apache-httpd/vhost-options.nix);
         example = literalExpression ''
           { hostName = "example.org";
-            adminAddr = "webmaster@example.org";
             enableSSL = true;
             sslServerCert = "/var/lib/acme/example.org/full.pem";
             sslServerKey = "/var/lib/acme/example.org/key.pem";

--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -104,7 +104,6 @@ in
       example = literalExpression ''
         {
           hostName = "survey.example.org";
-          adminAddr = "webmaster@example.org";
           forceSSL = true;
           enableACME = true;
         }
@@ -209,7 +208,6 @@ in
 
     services.httpd = {
       enable = true;
-      adminAddr = mkDefault cfg.virtualHost.adminAddr;
       extraModules = [ "proxy_fcgi" ];
       virtualHosts.${cfg.virtualHost.hostName} = mkMerge [ cfg.virtualHost {
         documentRoot = mkForce "${pkg}/share/limesurvey";

--- a/nixos/modules/services/web-apps/mediawiki.nix
+++ b/nixos/modules/services/web-apps/mediawiki.nix
@@ -307,7 +307,6 @@ in
         example = literalExpression ''
           {
             hostName = "mediawiki.example.org";
-            adminAddr = "webmaster@example.org";
             forceSSL = true;
             enableACME = true;
           }

--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -149,7 +149,6 @@ in
       example = literalExpression ''
         {
           hostName = "moodle.example.org";
-          adminAddr = "webmaster@example.org";
           forceSSL = true;
           enableACME = true;
         }
@@ -242,7 +241,6 @@ in
 
     services.httpd = {
       enable = true;
-      adminAddr = mkDefault cfg.virtualHost.adminAddr;
       extraModules = [ "proxy_fcgi" ];
       virtualHosts.${cfg.virtualHost.hostName} = mkMerge [ cfg.virtualHost {
         documentRoot = mkForce "${cfg.package}/share/moodle";

--- a/nixos/modules/services/web-apps/nextcloud.xml
+++ b/nixos/modules/services/web-apps/nextcloud.xml
@@ -198,7 +198,6 @@
   };
   services.httpd = {
     <link linkend="opt-services.httpd.enable">enable</link> = true;
-    <link linkend="opt-services.httpd.adminAddr">adminAddr</link> = "webmaster@localhost";
     <link linkend="opt-services.httpd.extraModules">extraModules</link> = [ "proxy_fcgi" ];
     virtualHosts."localhost" = {
       <link linkend="opt-services.httpd.virtualHosts._name_.documentRoot">documentRoot</link> = config.services.nextcloud.package;

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -257,7 +257,6 @@ let
           type = types.submodule (import ../web-servers/apache-httpd/vhost-options.nix);
           example = literalExpression ''
             {
-              adminAddr = "webmaster@example.org";
               forceSSL = true;
               enableACME = true;
             }

--- a/nixos/modules/services/web-apps/zabbix.nix
+++ b/nixos/modules/services/web-apps/zabbix.nix
@@ -126,7 +126,6 @@ in
         example = literalExpression ''
           {
             hostName = "zabbix.example.org";
-            adminAddr = "webmaster@example.org";
             forceSSL = true;
             enableACME = true;
           }
@@ -205,7 +204,6 @@ in
 
     services.httpd = {
       enable = true;
-      adminAddr = mkDefault cfg.virtualHost.adminAddr;
       extraModules = [ "proxy_fcgi" ];
       virtualHosts.${cfg.virtualHost.hostName} = mkMerge [ cfg.virtualHost {
         documentRoot = mkForce "${cfg.package}/share/zabbix";

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -393,7 +393,6 @@ in rec {
     # Linux/Apache/PostgreSQL/PHP stack.
     lapp = makeClosure ({ pkgs, ... }:
       { services.httpd.enable = true;
-        services.httpd.adminAddr = "foo@example.org";
         services.httpd.enablePHP = true;
         services.postgresql.enable = true;
         services.postgresql.package = pkgs.postgresql;

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -328,9 +328,6 @@ in {
           server = "httpd";
           group = "wwwrun";
           vhostBaseData = vhostBaseHttpd;
-          extraConfig = {
-            services.httpd.adminAddr = config.security.acme.defaults.email;
-          };
         });
     };
 

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -52,12 +52,7 @@ in
       # We need Apache on the tracker to serve the torrents.
       services.httpd = {
         enable = true;
-        virtualHosts = {
-          "torrentserver.org" = {
-            adminAddr = "foo@example.org";
-            documentRoot = "/tmp";
-          };
-        };
+        virtualHosts."torrentserver.org".documentRoot = "/tmp";
       };
       services.opentracker.enable = true;
     };

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -31,7 +31,6 @@ import ./make-test-python.nix ({ pkgs, ...} : {
           services.cjdns.ETHInterface.bind = "eth1";
 
           services.httpd.enable = true;
-          services.httpd.adminAddr = "foo@example.org";
           networking.firewall.allowedTCPPorts = [ 80 ];
         };
 

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -37,7 +37,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
           localAddress6 = containerIp6;
           config =
             { services.httpd.enable = true;
-              services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
             };
         };
@@ -49,7 +48,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
           hostBridge = "br0";
           config =
             { services.httpd.enable = true;
-              services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
             };
         };

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -3,10 +3,7 @@ let
     inherit hostAddress localAddress;
     privateNetwork = true;
     config = {
-      services.httpd = {
-        enable = true;
-        adminAddr = "foo@example.org";
-      };
+      services.httpd.enable = true;
       networking.firewall.allowedTCPPorts = [ 80 ];
     };
   };

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -23,7 +23,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
           forwardPorts = [ { protocol = "tcp"; hostPort = hostPort; containerPort = containerPort; } ];
           config =
             { services.httpd.enable = true;
-              services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
             };
         };

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -30,7 +30,6 @@ in {
       containers.test1.config = {
         environment.etc.check.text = lib.mkForce "client_c1";
         services.httpd.enable = true;
-        services.httpd.adminAddr = "nixos@example.com";
       };
     };
     client_c2 = { lib, ... }: {

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -135,7 +135,6 @@ in {
 
         services.httpd = {
           enable = true;
-          adminAddr = "test@example.org";
           virtualHosts.localhost.documentRoot = "''${pkgs.valgrind.doc}/share/doc/valgrind/html";
         };
         networking.firewall.allowedTCPPorts = [ 80 ];

--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -12,7 +12,6 @@ import ./make-test-python.nix ( { pkgs, ... } : {
         { networking.firewall.enable = true;
           networking.firewall.logRefusedPackets = true;
           services.httpd.enable = true;
-          services.httpd.adminAddr = "foo@example.org";
         };
 
       # Dummy configuration to check whether firewall.service will be honored
@@ -28,7 +27,6 @@ import ./make-test-python.nix ( { pkgs, ... } : {
       attacker =
         { ... }:
         { services.httpd.enable = true;
-          services.httpd.adminAddr = "foo@example.org";
           networking.firewall.enable = false;
         };
     };

--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -24,7 +24,6 @@ import ./make-test-python.nix ({ pkgs, ...}: {
         enable = true;
         virtualHosts.localhost = {
           documentRoot = pkgs.writeTextDir "index.txt" "We are all good!";
-          adminAddr = "notme@yourhost.local";
           listen = [{
             ip = "::1";
             port = 8000;

--- a/nixos/tests/hitch/default.nix
+++ b/nixos/tests/hitch/default.nix
@@ -17,7 +17,6 @@ import ../make-test-python.nix ({ pkgs, ... }:
     services.httpd = {
       enable = true;
       virtualHosts.localhost.documentRoot = ./example;
-      adminAddr = "noone@testing.nowhere";
     };
   };
 

--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -37,7 +37,6 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
 
       server =
         { services.httpd.enable = true;
-          services.httpd.adminAddr = "foo@example.org";
           networking.firewall.allowedTCPPorts = [ 80 ];
         };
 

--- a/nixos/tests/limesurvey.nix
+++ b/nixos/tests/limesurvey.nix
@@ -5,10 +5,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   nodes.machine = { ... }: {
     services.limesurvey = {
       enable = true;
-      virtualHost = {
-        hostName = "example.local";
-        adminAddr = "root@example.local";
-      };
+      virtualHost.hostName = "example.local";
     };
 
     # limesurvey won't work without a dot in the hostname

--- a/nixos/tests/mediawiki.nix
+++ b/nixos/tests/mediawiki.nix
@@ -6,7 +6,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     { ... }:
     { services.mediawiki.enable = true;
       services.mediawiki.virtualHost.hostName = "localhost";
-      services.mediawiki.virtualHost.adminAddr = "root@example.com";
       services.mediawiki.passwordFile = pkgs.writeText "password" "correcthorsebatterystaple";
       services.mediawiki.extensions = {
         Matomo = pkgs.fetchzip {

--- a/nixos/tests/mod_perl.nix
+++ b/nixos/tests/mod_perl.nix
@@ -8,7 +8,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   nodes.machine = { config, lib, pkgs, ... }: {
     services.httpd = {
       enable = true;
-      adminAddr = "admin@localhost";
       virtualHosts."modperl" =
         let
           inc = pkgs.writeTextDir "ModPerlTest.pm" ''

--- a/nixos/tests/moodle.nix
+++ b/nixos/tests/moodle.nix
@@ -6,7 +6,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     { ... }:
     { services.moodle.enable = true;
       services.moodle.virtualHost.hostName = "localhost";
-      services.moodle.virtualHost.adminAddr = "root@example.com";
       services.moodle.initialPassword = "correcthorsebatterystaple";
 
       # Ensure the virtual machine has enough memory to avoid errors like:

--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -58,7 +58,6 @@ import ./make-test-python.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ?
           { virtualisation.vlans = [ 2 ];
             networking.firewall.enable = false;
             services.httpd.enable = true;
-            services.httpd.adminAddr = "foo@example.org";
             services.vsftpd.enable = true;
             services.vsftpd.anonymousUser = true;
           };

--- a/nixos/tests/php/httpd.nix
+++ b/nixos/tests/php/httpd.nix
@@ -5,7 +5,6 @@ import ../make-test-python.nix ({ pkgs, lib, php, ... }: {
   nodes.machine = { config, lib, pkgs, ... }: {
     services.httpd = {
       enable = true;
-      adminAddr = "admin@phpfpm";
       virtualHosts."phpfpm" =
         let
           testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";

--- a/nixos/tests/php/pcre.nix
+++ b/nixos/tests/php/pcre.nix
@@ -9,7 +9,6 @@ import ../make-test-python.nix ({ lib, php, ... }: {
     time.timeZone = "UTC";
     services.httpd = {
       enable = true;
-      adminAddr = "please@dont.contact";
       phpPackage = php;
       enablePHP = true;
       phpOptions = "pcre.jit = true";

--- a/nixos/tests/proxy.nix
+++ b/nixos/tests/proxy.nix
@@ -4,7 +4,6 @@ let
   backend = { pkgs, ... }: {
     services.httpd = {
       enable = true;
-      adminAddr = "foo@example.org";
       virtualHosts.localhost.documentRoot = "${pkgs.valgrind.doc}/share/doc/valgrind/html";
     };
     networking.firewall.allowedTCPPorts = [ 80 ];
@@ -19,7 +18,6 @@ in {
     proxy = { nodes, ... }: {
       services.httpd = {
         enable = true;
-        adminAddr = "bar@example.org";
         extraModules = [ "proxy_balancer" "lbmethod_byrequests" ];
         extraConfig = ''
           ExtendedStatus on

--- a/nixos/tests/upnp.nix
+++ b/nixos/tests/upnp.nix
@@ -58,7 +58,6 @@ in
           services.httpd.enable = true;
           services.httpd.virtualHosts.localhost = {
             listen = [{ ip = "*"; port = 9000; }];
-            adminAddr = "foo@example.org";
             documentRoot = "/tmp";
           };
         };

--- a/nixos/tests/v2ray.nix
+++ b/nixos/tests/v2ray.nix
@@ -71,10 +71,7 @@ in {
       enable = true;
       config = v2rayConfig;
     };
-    services.httpd = {
-      enable = true;
-      adminAddr = "foo@example.org";
-    };
+    services.httpd.enable = true;
   };
 
   testScript = ''

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -12,7 +12,6 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
   nodes = {
     wp_httpd = { ... }: {
-      services.httpd.adminAddr = "webmaster@site.local";
       services.httpd.logPerVirtualHost = true;
 
       services.wordpress.sites = {

--- a/nixos/tests/yggdrasil.nix
+++ b/nixos/tests/yggdrasil.nix
@@ -38,7 +38,6 @@ in import ./make-test-python.nix ({ pkgs, ...} : {
           firewall.allowedTCPPorts = [ 80 12345 ];
         };
         services.httpd.enable = true;
-        services.httpd.adminAddr = "foo@example.org";
 
         services.yggdrasil = {
           enable = true;
@@ -98,7 +97,6 @@ in import ./make-test-python.nix ({ pkgs, ...} : {
               }];
             };
             services.httpd.enable = true;
-            services.httpd.adminAddr = "foo@example.org";
             networking.firewall.allowedTCPPorts = [ 80 ];
           };
         };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
