### PR TITLE
nixos/manticore: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -104,6 +104,8 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
 
 - [dnsproxy](https://github.com/AdguardTeam/dnsproxy), a simple DNS proxy with DoH, DoT, DoQ and DNSCrypt support. Available as [services.dnsproxy](#opt-services.dnsproxy.enable).
 
+- [manticoresearch](https://manticoresearch.com), easy to use open source fast database for search. Available as [services.manticore](#opt-services.manticore.enable).
+
 - [rspamd-trainer](https://gitlab.com/onlime/rspamd-trainer), script triggered by a helper which reads mails from a specific mail inbox and feeds them into rspamd for spam/ham training.
 
 - [ollama](https://ollama.ai), server for running large language models locally.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1219,6 +1219,7 @@
   ./services/search/elasticsearch-curator.nix
   ./services/search/elasticsearch.nix
   ./services/search/hound.nix
+  ./services/search/manticore.nix
   ./services/search/meilisearch.nix
   ./services/search/opensearch.nix
   ./services/search/qdrant.nix

--- a/nixos/modules/services/search/manticore.nix
+++ b/nixos/modules/services/search/manticore.nix
@@ -1,0 +1,131 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.manticore;
+  format = pkgs.formats.json { };
+
+  toSphinx = {
+    mkKeyValue    ? mkKeyValueDefault {} "=",
+    listsAsDuplicateKeys ? true
+  }: attrsOfAttrs:
+    let
+        # map function to string for each key val
+        mapAttrsToStringsSep = sep: mapFn: attrs:
+          concatStringsSep sep
+            (mapAttrsToList mapFn attrs);
+        mkSection = sectName: sectValues: ''
+          ${sectName} {
+        '' + lib.generators.toKeyValue { inherit mkKeyValue listsAsDuplicateKeys; } sectValues + ''}'';
+    in
+      # map input to ini sections
+      mapAttrsToStringsSep "\n" mkSection attrsOfAttrs;
+
+  configFile = pkgs.writeText "manticore.conf" (
+    toSphinx {
+        mkKeyValue = k: v: "  ${k} = ${v}";
+    } cfg.settings
+  );
+
+in {
+
+  options = {
+    services.manticore = {
+
+      enable = mkEnableOption "Manticoresearch";
+
+      settings = mkOption {
+        default = {
+          searchd = {
+            listen = [
+              "127.0.0.1:9312"
+              "127.0.0.1:9306:mysql"
+              "127.0.0.1:9308:http"
+            ];
+            log = "/var/log/manticore/searchd.log";
+            query_log = "/var/log/manticore/query.log";
+            pid_file = "/run/manticore/searchd.pid";
+            data_dir = "/var/lib/manticore";
+          };
+        };
+        description = ''
+          Configuration for Manticoresearch. See
+          <https://manual.manticoresearch.com/Server%20settings>
+          for more information.
+        '';
+        type = types.submodule {
+          freeformType = format.type;
+        };
+        example = literalExpression ''
+          {
+            searchd = {
+                listen = [
+                  "127.0.0.1:9312"
+                  "127.0.0.1:9306:mysql"
+                  "127.0.0.1:9308:http"
+                ];
+                log = "/var/log/manticore/searchd.log";
+                query_log = "/var/log/manticore/query.log";
+                pid_file = "/run/manticore/searchd.pid";
+                data_dir = "/var/lib/manticore";
+            };
+          }
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd = {
+      packages = [ pkgs.manticoresearch ];
+      services.manticore = {
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          ExecStart = [
+            ""
+            "${pkgs.manticoresearch}/bin/searchd --config ${configFile}"
+          ];
+          ExecStop = [
+            ""
+            "${pkgs.manticoresearch}/bin/searchd --config ${configFile} --stopwait"
+          ];
+          ExecStartPre = [ "" ];
+          DynamicUser = true;
+          LogsDirectory = "manticore";
+          RuntimeDirectory = "manticore";
+          StateDirectory = "manticore";
+          ReadWritePaths = "";
+          CapabilityBoundingSet = "";
+          RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+          RestrictNamespaces = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "@system-service" "~@privileged" ];
+          RestrictRealtime = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          UMask = "0066";
+          ProtectHostname = true;
+        } // lib.optionalAttrs (cfg.settings.searchd.pid_file != null) {
+          PIDFile = cfg.settings.searchd.pid_file;
+        };
+      };
+    };
+
+  };
+
+  meta.maintainers = with lib.maintainers; [ onny ];
+
+}


### PR DESCRIPTION
###### Description of changes

Simple module for the open-source Elasticsearch alternative [manticore](https://manticoresearch.com/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
