### PR TITLE
jitsi: fix update scripts

### DIFF
--- a/pkgs/misc/jitsi-meet-prosody/update.sh
+++ b/pkgs/misc/jitsi-meet-prosody/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 version="$(curl https://download.jitsi.org/stable/ | \
     pup 'a[href] text{}' | \
     awk -F'[_-]' '/jitsi-meet-prosody/ {printf $4"\n"}' | \
-    sort -u | \
+    sort -Vu | \
     tail -n 1)"
 
 update-source-version jitsi-meet-prosody "$version"

--- a/pkgs/servers/jibri/update.sh
+++ b/pkgs/servers/jibri/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 version="$(curl https://download.jitsi.org/stable/ | \
     pup 'a[href] text{}' | \
     awk -F'[_-]' '/jibri/ {printf $2"-"$3"-"$4"\n"}' | \
-    sort -u | \
+    sort -Vu | \
     tail -n 1)"
 
 update-source-version jibri "$version"

--- a/pkgs/servers/jicofo/update.sh
+++ b/pkgs/servers/jicofo/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 version="$(curl https://download.jitsi.org/stable/ | \
     pup 'a[href] text{}' | \
     awk -F'[_-]' '/jicofo/ {printf $2"-"$3"\n"}' | \
-    sort -u | \
+    sort -Vu | \
     tail -n 1)"
 
 update-source-version jicofo "$version"

--- a/pkgs/servers/web-apps/jitsi-meet/update.sh
+++ b/pkgs/servers/web-apps/jitsi-meet/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 version="$(curl https://download.jitsi.org/stable/ | \
     pup 'a[href] text{}' | \
     awk -F'[_-]' '/jitsi-meet-web_/ {printf $4"\n"}' | \
-    sort -u | \
+    sort -Vu | \
     tail -n 1)"
 
 update-source-version jitsi-meet "$version"


### PR DESCRIPTION
To consistently return the latest version number even when it is no longer at the bottom of the alphanumeric list on the Jitsi stable download page. Based on fix by @sbruder in 13760b87d2067dec6afa76859f3e69027bc2e139

This fixes the underlying bug that resulted in an accidental downgrade of jibri earlier this year: https://github.com/NixOS/nixpkgs/pull/158911

The underlying bug is triggered when there is a base-10 turnover adding an additional digit to the version number of a package so that the first sort-relevant digit changes from 9 (lower on list) to 1 (higher on the list), such as jibri_8.0-93 -> jibri_8.0-104. This already happened in 2021 for Jibri, and could happen soon  for jicofo (currently on version jicofo_1.0-940). It will not likely happen soon for the jitsi-meet and jitsi-meet-prosody packages (both currently on version 1.0.6644) but this commit fixes their update scripts anyways. 

I have manually run the fixed curl commands from all four of these scripts and confirmed that they returned the latest package version. 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (curl scripts run)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
