### PR TITLE
lib/modules: `prepareImport`, nixos: import the flake default module

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -348,6 +348,10 @@ checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survive
 # because of an `extendModules` bug, issue 168767.
 checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-imports.nix
 
+# specialArgs.prepareImport
+checkConfigOutput 'ok' config.result ./prepareImport.nix
+
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/prepareImport.nix
+++ b/lib/tests/modules/prepareImport.nix
@@ -1,0 +1,24 @@
+{ config, lib, ... }: {
+  options.result = lib.mkOption { };
+  config.result = (lib.evalModules {
+    specialArgs.prepareImport = x: x.testModules.default or x;
+    modules = [
+      {
+        testModules.default = {
+          config = {
+            v = "ok";
+          };
+        };
+      }
+      {
+        imports = [
+          {
+            testModules.default = {
+              options.v = lib.mkOption { };
+            };
+          }
+        ];
+      }
+    ];
+  }).config.v;
+}

--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -40,6 +40,12 @@ let
     inherit prefix modules;
     specialArgs = {
       modulesPath = builtins.toString ../modules;
+      prepareImport = x:
+        # TODO https://github.com/NixOS/nix/issues/7186
+        #      x._type or null == "flake"
+        if x?sourceInfo && x?inputs && x?nixosModules.default
+        then x.nixosModules.default
+        else x;
     } // specialArgs;
   };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Also motivated by
 - https://github.com/hercules-ci/flake-parts/pull/61


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
