### PR TITLE
python3Packages.mip: init at 1.14.1

### DIFF
--- a/pkgs/development/python-modules/mip/default.nix
+++ b/pkgs/development/python-modules/mip/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, buildPythonPackage
+, cffi
+, dos2unix
+, fetchPypi
+, matplotlib
+, networkx
+, numpy
+, pytestCheckHook
+, pythonOlder
+, gurobi
+, gurobipy
+# Enable support for the commercial Gurobi solver (requires a license)
+, gurobiSupport ? false
+# If Gurobi has already been installed outside of the Nix store, specify its
+# installation directory here
+, gurobiHome ? null
+}:
+
+buildPythonPackage rec {
+  pname = "mip";
+  version = "1.14.1";
+
+  disabled = pythonOlder "3.7";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-bvpm5vUp15fbv/Sw1Lx70ihA7VHsSUzwFzoFDG+Ow1M=";
+  };
+
+  checkInputs = [ matplotlib networkx numpy pytestCheckHook ];
+  nativeBuildInputs = [ dos2unix ];
+  propagatedBuildInputs = [
+    cffi
+  ] ++ lib.optionals gurobiSupport ([
+    gurobipy
+  ] ++ lib.optional (builtins.isNull gurobiHome) gurobi);
+
+  # Source files have CRLF terminators, which make patch error out when supplied
+  # with diffs made on *nix machines
+  prePatch = ''
+    find . -type f -exec ${dos2unix}/bin/dos2unix {} \;
+  '';
+
+  patches = [
+    # Some tests try to be smart and dynamically construct a path to their test
+    # inputs. Unfortunately, since the test phase is run after installation,
+    # those paths point to the Nix store, which no longer contains the test
+    # data. This patch hardcodes the data path to point to the source directory.
+    ./test-data-path.patch
+  ];
+
+  postPatch = ''
+    # Allow cffi versions with a different patch level to be used
+    substituteInPlace pyproject.toml --replace "cffi==1.15.0" "cffi==1.15.*"
+  '';
+
+  # Make MIP use the Gurobi solver, if configured to do so
+  makeWrapperArgs = lib.optional gurobiSupport
+    "--set GUROBI_HOME ${if builtins.isNull gurobiHome then gurobi.outPath else gurobiHome}";
+
+  # Tests that rely on Gurobi are activated only when Gurobi support is enabled
+  disabledTests = lib.optional (!gurobiSupport) "gurobi";
+
+  passthru.optional-dependencies = {
+    inherit gurobipy numpy;
+  };
+
+  meta = with lib; {
+    homepage = "http://python-mip.com/";
+    description = "A collection of Python tools for the modeling and solution of Mixed-Integer Linear programs (MIPs)";
+    downloadPage = "https://github.com/coin-or/python-mip/releases";
+    changelog = "https://github.com/coin-or/python-mip/releases/tag/${version}";
+    license = licenses.epl20;
+    maintainers = with maintainers; [ nessdoor ];
+  };
+}

--- a/pkgs/development/python-modules/mip/test-data-path.patch
+++ b/pkgs/development/python-modules/mip/test-data-path.patch
@@ -1,0 +1,30 @@
+diff --git a/examples/extract_features_mip.py b/examples/extract_features_mip.py
+index cdc109f..90e79fa 100644
+--- a/examples/extract_features_mip.py
++++ b/examples/extract_features_mip.py
+@@ -9,9 +9,7 @@ import mip
+ lp_path = ""
+ 
+ #  using test data, replace with your instance
+-lp_path = mip.__file__.replace("mip/__init__.py", "test/data/1443_0-9.lp").replace(
+-    "mip\\__init__.py", "test\\data\\1443_0-9.lp"
+-)
++lp_path = "test/data/1443_0-9.lp"
+ 
+ m = Model()
+ if m.solver_name.upper() in ["GRB", "GUROBI"]:
+diff --git a/examples/gen_cuts_mip.py b/examples/gen_cuts_mip.py
+index f71edae..2799734 100644
+--- a/examples/gen_cuts_mip.py
++++ b/examples/gen_cuts_mip.py
+@@ -11,9 +11,7 @@ import mip
+ lp_path = ""
+ 
+ #  using test data
+-lp_path = mip.__file__.replace("mip/__init__.py", "test/data/1443_0-9.lp").replace(
+-    "mip\\__init__.py", "test\\data\\1443_0-9.lp"
+-)
++lp_path = "test/data/1443_0-9.lp"
+ 
+ m = Model()
+ if m.solver_name.upper() in ["GRB", "GUROBI"]:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5827,6 +5827,8 @@ in {
     inherit (pkgs.darwin) cctools;
   };
 
+  mip = callPackage ../development/python-modules/mip { };
+
   misaka = callPackage ../development/python-modules/misaka { };
 
   mistletoe = callPackage ../development/python-modules/mistletoe { };


### PR DESCRIPTION
###### Description of changes

[Python MIP](https://www.python-mip.com/) is a toolset for the modeling and solution of mixed-integer linear programs, at the heart of many real-world mathematical optimization problems.

Not only useful to engineers operating on the field, Python MIP is also used for teaching linear programming in university courses.

Contributes to the closure of #112353.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
