### PR TITLE
spirv-llvm-translator_14: init at 14.0.0

### DIFF
--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -3,31 +3,40 @@
 , cmake
 , pkg-config
 , lit
-, llvm_11
+, llvm
 , spirv-headers
 , spirv-tools
 }:
 
+let
+  llvmMajor = lib.versions.major llvm.version;
+
+  branch =
+    if llvmMajor == "11" then {
+      version = "unstable-2022-05-04";
+      rev = "99420daab98998a7e36858befac9c5ed109d4920"; # 265 commits ahead of v11.0.0
+      hash = "sha256-/vUyL6Wh8hykoGz1QmT1F7lfGDEmG4U3iqmqrJxizOg=";
+    } else throw "Incompatible LLVM version.";
+in
 stdenv.mkDerivation rec {
   pname = "SPIRV-LLVM-Translator";
-  version = "unstable-2022-05-04";
+  inherit (branch) version;
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-LLVM-Translator";
-    rev = "99420daab98998a7e36858befac9c5ed109d4920";
-    sha256 = "sha256-/vUyL6Wh8hykoGz1QmT1F7lfGDEmG4U3iqmqrJxizOg=";
+    inherit (branch) rev hash;
   };
 
-  nativeBuildInputs = [ pkg-config cmake llvm_11.dev spirv-tools ];
+  nativeBuildInputs = [ pkg-config cmake llvm.dev spirv-tools ];
 
-  buildInputs = [ spirv-headers llvm_11 ];
+  buildInputs = [ spirv-headers llvm ];
 
   checkInputs = [ lit ];
 
   cmakeFlags = [
     "-DLLVM_INCLUDE_TESTS=ON"
-    "-DLLVM_DIR=${llvm_11.dev}"
+    "-DLLVM_DIR=${llvm.dev}"
     "-DBUILD_SHARED_LIBS=YES"
     "-DLLVM_SPIRV_BUILD_EXTERNAL=YES"
     # RPATH of binary /nix/store/.../bin/llvm-spirv contains a forbidden reference to /build/

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -12,7 +12,15 @@ let
   llvmMajor = lib.versions.major llvm.version;
 
   branch =
-    if llvmMajor == "11" then {
+    if llvmMajor == "15" then rec {
+      version = "15.0.0";
+      rev = "v${version}";
+      hash = "sha256-111yL6Wh8hykoGz1QmT1F7lfGDEmG4U3iqmqrJxizOg=";
+    } else if llvmMajor == "14" then rec{
+      version = "14.0.0";
+      rev = "v${version}";
+      hash = "sha256-BhNAApgZ/w/92XjpoDY6ZEIhSTwgJ4D3/EfNvPmNM2o=";
+    } else if llvmMajor == "11" then {
       version = "unstable-2022-05-04";
       rev = "99420daab98998a7e36858befac9c5ed109d4920"; # 265 commits ahead of v11.0.0
       hash = "sha256-/vUyL6Wh8hykoGz1QmT1F7lfGDEmG4U3iqmqrJxizOg=";
@@ -41,7 +49,7 @@ stdenv.mkDerivation rec {
     "-DLLVM_SPIRV_BUILD_EXTERNAL=YES"
     # RPATH of binary /nix/store/.../bin/llvm-spirv contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
-  ];
+  ] ++ lib.optionals (llvmMajor != "11") [ "-DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${spirv-headers.src}" ];
 
   # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
   doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15134,6 +15134,8 @@ with pkgs;
 
   spirv-llvm-translator = callPackage ../development/compilers/spirv-llvm-translator { };
 
+  spirv-llvm-translator_14 = callPackage ../development/compilers/spirv-llvm-translator { llvm = llvm_14; };
+
   sqldeveloper = callPackage ../development/tools/database/sqldeveloper {
     jdk = oraclejdk;
   };


### PR DESCRIPTION
###### Description of changes

This newer version will be needed to build Mesa 22.3 with Rusticl.

Apparently, LLVM API is not stable, and we should depend on the toolchain version here (according to Bas and Tatsuyuki).

Closes #130127. Republishes #197231 (with much smaller eval diff).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
