### PR TITLE
discord: add a script to disable breaking updates

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
+++ b/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
@@ -1,0 +1,42 @@
+#!@pythonInterpreter@
+# slightly tweaked from the script created by @lionirdeadman
+# https://github.com/flathub/com.discordapp.Discord/blob/master/disable-breaking-updates.py
+"""
+Disable breaking updates which will prompt users to download a deb or tar file
+and lock them out of Discord making the program unusable.
+
+This will dramatically improve the experience :
+
+ 1) The maintainer doesn't need to be worried at all times of an update which will break Discord.
+ 2) People will not be locked out of the program while the maintainer runs to update it.
+
+"""
+
+import json
+import os
+from pathlib import Path
+
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+    os.path.expanduser("~"), ".config"
+)
+
+settings_path = Path(f"{XDG_CONFIG_HOME}/@configDirName@/settings.json")
+settings_path_temp = Path(f"{XDG_CONFIG_HOME}/@configDirName@/settings.json.tmp")
+try:
+    with settings_path.open(encoding="utf-8") as settings_file:
+        settings = json.load(settings_file)
+
+        if settings.get("SKIP_HOST_UPDATE"):
+            print("[Nix] Disabling updates already done")
+        else:
+            skip_host_update = {"SKIP_HOST_UPDATE": True}
+            settings.update(skip_host_update)
+
+            with settings_path_temp.open("w", encoding="utf-8") as settings_file_temp:
+                json.dump(settings, settings_file_temp, indent=2)
+
+            settings_path_temp.rename(settings_path)
+            print("[Nix] Disabled updates")
+
+except IOError:
+    print("[Nix] settings.json doesn't yet exist, can't disable it yet")

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -4,8 +4,21 @@
 , glib, gtk3, libcxx, libdrm, libnotify, libpulseaudio, libuuid, libX11
 , libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext, libXfixes
 , libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence, mesa, nspr, nss
-, pango, systemd, libappindicator-gtk3, libdbusmenu, writeScript
+, pango, systemd, libappindicator-gtk3, libdbusmenu, writeScript, python3, runCommand
 , common-updater-scripts, withOpenASAR ? false }:
+
+let
+  disableBreakingUpdates = runCommand "disable-breaking-updates.py"
+    {
+      pythonInterpreter = "${python3.interpreter}";
+      configDirName = lib.toLower binaryName;
+    } ''
+    mkdir -p $out/bin
+    cp ${./disable-breaking-updates.py} $out/bin/disable-breaking-updates.py
+    substituteAllInPlace $out/bin/disable-breaking-updates.py
+    chmod +x $out/bin/disable-breaking-updates.py
+  '';
+in
 
 stdenv.mkDerivation rec {
   inherit pname version src meta;
@@ -85,7 +98,8 @@ stdenv.mkDerivation rec {
         "''${gappsWrapperArgs[@]}" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
         --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-        --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/${binaryName}
+        --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/${binaryName} \
+        --run "${lib.getExe disableBreakingUpdates}"
 
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
     # Without || true the install would fail on case-insensitive filesystems
@@ -115,15 +129,19 @@ stdenv.mkDerivation rec {
     mimeTypes = [ "x-scheme-handler/discord" ];
   };
 
-  passthru.updateScript = writeScript "discord-update-script" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl gnugrep common-updater-scripts
-    set -eou pipefail;
-    url=$(curl -sI "https://discordapp.com/api/download/${
-      builtins.replaceStrings [ "discord-" "discord" ] [ "" "stable" ] pname
-    }?platform=linux&format=tar.gz" | grep -oP 'location: \K\S+')
-    version=''${url##https://dl*.discordapp.net/apps/linux/}
-    version=''${version%%/*.tar.gz}
-    update-source-version ${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix
-  '';
+  passthru = {
+    # make it possible to run disableBreakingUpdates standalone
+    inherit disableBreakingUpdates;
+    updateScript = writeScript "discord-update-script" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl gnugrep common-updater-scripts
+      set -eou pipefail;
+      url=$(curl -sI "https://discordapp.com/api/download/${
+        builtins.replaceStrings [ "discord-" "discord" ] [ "" "stable" ] pname
+      }?platform=linux&format=tar.gz" | grep -oP 'location: \K\S+')
+      version=''${url##https://dl*.discordapp.net/apps/linux/}
+      version=''${version%%/*.tar.gz}
+      update-source-version ${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix
+    '';
+  };
 }


### PR DESCRIPTION
Check the docstring

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
