### PR TITLE
kiln: 0.3.2 → 0.4.0

### DIFF
--- a/pkgs/applications/misc/kiln/default.nix
+++ b/pkgs/applications/misc/kiln/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "kiln";
-  version = "0.3.2";
+  version = "0.4.0";
 
   src = fetchFromSourcehut {
     owner = "~adnano";
-    repo = pname;
+    repo = "kiln";
     rev = version;
-    hash = "sha256-PI80td/GV92Msdtive+f+H6FWo7wdaPmPCpwrX3iLlo=";
+    hash = "sha256-BMYySYbV4Exl0gCUt+95FnOoIhKM1UO4cw8gCw3Zf9M=";
   };
 
   nativeBuildInputs = [ scdoc installShellFiles ];


### PR DESCRIPTION
###### Description of changes
[kiln 0.4.0](https://lists.sr.ht/~adnano/kiln-announce/%3CCNSKQ9D3K2R5.8HCJK5RFDBM5%40nitro%3E)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
