### PR TITLE
ghc: allow extra configuration flags to be sent to configure script

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -41,6 +41,9 @@
   ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
+, # Extra flags that should be sent to ghc's ./configure script
+  extraConfigureFlags ? ""
+
 , #  Whether to build sphinx documentation.
   enableDocs ? (
     # Docs disabled for musl and cross because it's a large task to keep
@@ -320,7 +323,7 @@ stdenv.mkDerivation (rec {
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
-  ];
+  ] ++ extraConfigureFlags;
 
   # Make sure we never relax`$PATH` and hooks support for compatibility.
   strictDeps = true;

--- a/pkgs/development/compilers/ghc/9.0.2.nix
+++ b/pkgs/development/compilers/ghc/9.0.2.nix
@@ -44,6 +44,9 @@
   ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
+, # Extra flags that should be sent to ghc's ./configure script
+  extraConfigureFlags ? ""
+
 , #  Whether to build sphinx documentation.
   enableDocs ? (
     # Docs disabled for musl and cross because it's a large task to keep
@@ -302,7 +305,7 @@ stdenv.mkDerivation (rec {
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
-  ];
+  ] ++ extraConfigureFlags;
 
   # Make sure we never relax`$PATH` and hooks support for compatibility.
   strictDeps = true;

--- a/pkgs/development/compilers/ghc/9.2.4.nix
+++ b/pkgs/development/compilers/ghc/9.2.4.nix
@@ -44,6 +44,9 @@
   ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
+, # Extra flags that should be sent to ghc's ./configure script
+  extraConfigureFlags ? ""
+
 , #  Whether to build sphinx documentation.
   enableDocs ? (
     # Docs disabled for musl and cross because it's a large task to keep
@@ -285,7 +288,7 @@ stdenv.mkDerivation (rec {
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
-  ];
+  ] ++ extraConfigureFlags;
 
   # Make sure we never relax`$PATH` and hooks support for compatibility.
   strictDeps = true;

--- a/pkgs/development/compilers/ghc/9.4.2.nix
+++ b/pkgs/development/compilers/ghc/9.4.2.nix
@@ -46,6 +46,9 @@
   ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
     (if useLLVM then "perf-cross" else "perf-cross-ncg")
 
+, # Extra flags that should be sent to ghc's ./configure script
+  extraConfigureFlags ? ""
+
 , #  Whether to build sphinx documentation.
   enableDocs ? (
     # Docs disabled for musl and cross because it's a large task to keep
@@ -288,7 +291,7 @@ stdenv.mkDerivation (rec {
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
-  ];
+  ] ++ extraConfigureFlags;
 
   # Make sure we never relax`$PATH` and hooks support for compatibility.
   strictDeps = true;


### PR DESCRIPTION
This can be useful for when one wishes to compile GHC with the dwarf flavour. It is currently recommended to use the --enable-dwarf-unwind flag for best performance when it comes to [unwinding support](https://downloads.haskell.org/ghc/latest/docs/users_guide/debug-info.html#ghc-flag--g%E2%9F%A8n%E2%9F%A9)

###### Description of changes
Allow extra configuration flags to be sent to configure script.

This can be useful for when one whishes to compile GHC with the dwarf flavour. It is currently recommended to use the --enable-dwarf-unwind flag for best performance when it comes to unwiding support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
