### PR TITLE
cmucl_binary: 21b -> 21d

### DIFF
--- a/pkgs/development/compilers/cmucl/binary.nix
+++ b/pkgs/development/compilers/cmucl/binary.nix
@@ -1,44 +1,62 @@
-{lib, stdenv, fetchurl}:
+{ lib
+, stdenv
+, fetchurl
+, installShellFiles
+}:
 
-let
-  inherit (stdenv.hostPlatform) system;
-  version = "21b";
-  downloadUrl = arch:
-    "http://common-lisp.net/project/cmucl/downloads/release/" +
-    "${version}/cmucl-${version}-${arch}.tar.bz2";
-  fetchDist = {arch, sha256}: fetchurl {
-    url = downloadUrl arch;
-    inherit sha256;
-  };
-  dist =
-    if system == "i686-linux" then fetchDist {
-        arch = "x86-linux";
-        sha256 = "13k3b5ygnbsq6n2i3r5i4ljw3r1qlskn2p5f4x9hrx6vfvbb3k7a";
-      }
-    else throw "Unsupported platform for cmucl.";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cmucl-binary";
-  inherit version;
+  version = "21d";
 
-  buildCommand = ''
-    mkdir -p $out
-    tar -C $out -xjf ${dist}
+  srcs = [
+    (fetchurl {
+      url = "http://common-lisp.net/project/cmucl/downloads/release/"
+            + finalAttrs.version + "/cmucl-${finalAttrs.version}-x86-linux.tar.bz2";
+      hash = "sha256-RdctcqPTtQh1Yb3BrpQ8jtRFQn85OcwOt1l90H6xDZs=";
+    })
+    (fetchurl {
+      url = "http://common-lisp.net/project/cmucl/downloads/release/"
+            + finalAttrs.version + "/cmucl-${finalAttrs.version}-x86-linux.extra.tar.bz2";
+      hash = "sha256-zEmiW3m5VPpFgPxV1WJNCqgYRlHMovtaMXcgXyNukls=";
+    })];
+
+  sourceRoot = ".";
+
+  outputs = [ "out" "doc" "man" ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -pv $out $doc/share $man
+    mv bin lib -t $out
+    mv -v doc -t $doc/share
+    installManPage man/man1/*
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       $out/bin/lisp
   '';
 
-  meta = {
+  meta = with lib; {
+    homepage = "http://www.cons.org/cmucl/";
     description = "The CMU implementation of Common Lisp";
     longDescription = ''
       CMUCL is a free implementation of the Common Lisp programming language
       which runs on most major Unix platforms.  It mainly conforms to the
       ANSI Common Lisp standard.
     '';
-    license = lib.licenses.free;		# public domain
-    homepage = "http://www.cons.org/cmucl/";
+    license = licenses.publicDomain;
     maintainers = [ ];
-    platforms = lib.platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
-}
+})


### PR DESCRIPTION
And a complete rewite of this somewhat old expression.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
