### PR TITLE
rocprim: init at 2.11.0-5.3.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -546,6 +546,7 @@ in {
   restic = handleTest ./restic.nix {};
   retroarch = handleTest ./retroarch.nix {};
   robustirc-bridge = handleTest ./robustirc-bridge.nix {};
+  rocprim = handleTest ./rocprim.nix {};
   roundcube = handleTest ./roundcube.nix {};
   rspamd = handleTest ./rspamd.nix {};
   rss2email = handleTest ./rss2email.nix {};

--- a/nixos/tests/rocprim.nix
+++ b/nixos/tests/rocprim.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+
+with lib;
+
+{
+  name = "rocprim";
+  meta.maintainers = with maintainers; [ Madouura ];
+  nodes.machine = { };
+
+  # This will likely always fail due to this being a virtual machine with no gpu
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.succeed("find ${(pkgs.rocprim.override { buildTests = true; }).test}/bin -maxdepth 1 -type f -executable -name 'test_*' > tests")
+
+    # We can do this directly with find, but can't get the command to fail
+    machine.succeed("for test in $(cat tests); do $test; done")
+  '';
+})

--- a/pkgs/development/libraries/rocprim/default.nix
+++ b/pkgs/development/libraries/rocprim/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, rocm-cmake
+, rocm-runtime
+, rocm-device-libs
+, rocm-comgr
+, hip
+, gtest ? null
+, gbenchmark ? null
+, buildTests ? false
+, buildBenchmarks ? false
+}:
+
+assert buildTests -> gtest != null;
+assert buildBenchmarks -> gbenchmark != null;
+
+stdenv.mkDerivation rec {
+  pname = "rocprim";
+  rocmVersion = "5.3.1";
+  version = "2.11.0-${rocmVersion}";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "rocPRIM";
+    rev = "rocm-${rocmVersion}";
+    hash = "sha256-aapvj9bwwlg7VJfnH1PVR8DulMcJh1xR6B4rPPGU6Q4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+  ];
+
+  buildInputs = [
+    rocm-runtime
+    rocm-device-libs
+    rocm-comgr
+  ] ++ lib.optionals buildTests [
+    gtest
+  ] ++ lib.optionals buildBenchmarks [
+    gbenchmark
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_TEST=ON"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DBUILD_BENCHMARK=ON"
+  ];
+
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv $out/bin/test_* $test/bin
+  '' + lib.optionalString buildBenchmarks ''
+    mkdir -p $benchmark/bin
+    mv $out/bin/benchmark_* $benchmark/bin
+  '' + lib.optionalString (buildTests || buildBenchmarks) ''
+    rmdir $out/bin
+  '';
+
+  meta = with lib; {
+    description = "ROCm parallel primitives";
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocPRIM";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ Madouura ];
+    broken = rocmVersion != hip.version;
+  };
+}

--- a/pkgs/development/libraries/rocprim/default.nix
+++ b/pkgs/development/libraries/rocprim/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nixosTests
 , cmake
 , rocm-cmake
 , rocm-runtime
@@ -74,6 +75,10 @@ stdenv.mkDerivation rec {
   '' + lib.optionalString (buildTests || buildBenchmarks) ''
     rmdir $out/bin
   '';
+
+  passthru.tests = {
+    smoke-test = nixosTests.rocprim;
+  };
 
   meta = with lib; {
     description = "ROCm parallel primitives";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14859,6 +14859,8 @@ with pkgs;
 
   rocminfo = callPackage ../development/tools/rocminfo { };
 
+  rocprim = callPackage ../development/libraries/rocprim { };
+
   rtags = callPackage ../development/tools/rtags {
     inherit (darwin) apple_sdk;
   };


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
First part in a whole bunch of porting...
``rocprim.passthru.tests`` will likely always fail due to it being in a vm, but I have confirmed the tests generated do work on hardware.
Depends on  #197838
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
