### PR TITLE
hipcub: init at 2.12.0-5.3.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -256,6 +256,7 @@ in {
   hbase3 = handleTest ./hbase.nix { package=pkgs.hbase3; };
   hedgedoc = handleTest ./hedgedoc.nix {};
   herbstluftwm = handleTest ./herbstluftwm.nix {};
+  hipcub = handleTest ./hipcub.nix {};
   installed-tests = pkgs.recurseIntoAttrs (handleTest ./installed-tests {});
   invidious = handleTest ./invidious.nix {};
   oci-containers = handleTestOn ["aarch64-linux" "x86_64-linux"] ./oci-containers.nix {};

--- a/nixos/tests/hipcub.nix
+++ b/nixos/tests/hipcub.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+
+with lib;
+
+{
+  name = "hipcub";
+  meta.maintainers = with maintainers; [ Madouura ];
+  nodes.machine = { };
+
+  # This will likely always fail due to this being a virtual machine with no gpu
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.succeed("find ${(pkgs.hipcub.override { buildTests = true; }).test}/bin -maxdepth 1 -type f -executable -name 'test_*' > tests")
+
+    # We can do this directly with find, but can't get the command to fail
+    machine.succeed("for test in $(cat tests); do $test; done")
+  '';
+})

--- a/pkgs/development/libraries/hipcub/default.nix
+++ b/pkgs/development/libraries/hipcub/default.nix
@@ -1,0 +1,89 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, rocm-cmake
+, rocm-runtime
+, rocm-device-libs
+, rocm-comgr
+, rocprim
+, hip
+, gtest ? null
+, gbenchmark ? null
+, buildTests ? false
+, buildBenchmarks ? false
+}:
+
+assert buildTests -> gtest != null;
+assert buildBenchmarks -> gbenchmark != null;
+
+# CUB can also be used as a backend instead of rocPRIM.
+stdenv.mkDerivation rec {
+  pname = "hipcub";
+  rocmVersion = "5.3.1";
+  version = "2.12.0-${rocmVersion}";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "hipCUB";
+    rev = "rocm-${rocmVersion}";
+    hash = "sha256-/GMZKbMD1sZQCM2FulM9jiJQ8ByYZinn0C8d/deFh0g=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+  ];
+
+  buildInputs = [
+    rocm-runtime
+    rocm-device-libs
+    rocm-comgr
+    rocprim
+  ] ++ lib.optionals buildTests [
+    gtest
+  ] ++ lib.optionals buildBenchmarks [
+    gbenchmark
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    "-DHIP_ROOT_DIR=${hip}"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_TEST=ON"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DBUILD_BENCHMARK=ON"
+  ];
+
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv $out/bin/test_* $test/bin
+  '' + lib.optionalString buildBenchmarks ''
+    mkdir -p $benchmark/bin
+    mv $out/bin/benchmark_* $benchmark/bin
+  '' + lib.optionalString (buildTests || buildBenchmarks) ''
+    rmdir $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Thin wrapper library on top of rocPRIM or CUB";
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipCUB";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ Madouura ];
+    broken = rocmVersion != hip.version;
+  };
+}

--- a/pkgs/development/libraries/hipcub/default.nix
+++ b/pkgs/development/libraries/hipcub/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nixosTests
 , cmake
 , rocm-cmake
 , rocm-runtime
@@ -78,6 +79,10 @@ stdenv.mkDerivation rec {
   '' + lib.optionalString (buildTests || buildBenchmarks) ''
     rmdir $out/bin
   '';
+
+  passthru.tests = {
+    smoke-test = nixosTests.hipcub;
+  };
 
   meta = with lib; {
     description = "Thin wrapper library on top of rocPRIM or CUB";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14833,6 +14833,8 @@ with pkgs;
     inherit (llvmPackages_rocm) clang llvm;
   };
 
+  hipcub = callPackage ../development/libraries/hipcub { };
+
   rocm-cmake = callPackage ../development/tools/build-managers/rocm-cmake { };
 
   rocm-comgr = callPackage ../development/libraries/rocm-comgr {


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
Second part in a whole bunch of porting...
``hipcub.passthru.tests`` will likely always fail due to it being in a vm, but I have confirmed the tests generated do work on hardware.
Depends on #197838
Depends on #197337
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
