### PR TITLE
paperless-ngx: remove unused build input

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -115,7 +115,6 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     inotifyrecursive
     joblib
     langdetect
-    pkgs.libmysqlclient
     lxml
     msgpack
     numpy


### PR DESCRIPTION
#### Copy of commit msg
Package `libmysqlclient` is required for MySQL support.

Because it is not a Python package, adding it to `propagatedBuildInputs` has no effects on the build output or service runtime behavior.

It could be added to `path` instead, but because we're only supporting and testing postgresql suppport in NixOS, we should leave it out.

#### Discussion
The pkg was added in https://github.com/NixOS/nixpkgs/commit/e79ac5627518c17a194e44f0a9452de4fbecce56