### PR TITLE
faad2: add some key reverse-dependencies to `passthru.tests`

### DIFF
--- a/pkgs/development/libraries/faad2/default.nix
+++ b/pkgs/development/libraries/faad2/default.nix
@@ -1,5 +1,14 @@
-{lib, stdenv, fetchFromGitHub, autoreconfHook
+{lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
 , drmSupport ? false # Digital Radio Mondiale
+
+# for passthru.tests
+, gst_all_1
+, mpd
+, ocamlPackages
+, vlc
 }:
 
 with lib;
@@ -18,6 +27,12 @@ stdenv.mkDerivation rec {
     ++ optional drmSupport "--with-drm";
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  passthru.tests = {
+    inherit mpd vlc;
+    inherit (gst_all_1) gst-plugins-bad;
+    ocaml-faad = ocamlPackages.faad;
+  };
 
   meta = {
     description = "An open source MPEG-4 and MPEG-2 AAC decoder";


### PR DESCRIPTION
###### Description of changes

This is helpful for packages which trigger a huge number of rebuilds because it's impractical to do a full `nixpkgs-review`.

These are the packages I tested in #197192.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
