### PR TITLE
gitlab: 15.4.2 -> 15.4.4

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "15.4.2",
-  "repo_hash": "sha256-KGVZrfrzfIn2ZQJ42FisLvjIGg0+QOnzfjCR6mQHjlM=",
+  "version": "15.4.4",
+  "repo_hash": "sha256-iIgN1j02Lr/RtNeopqs6ndFqw8YIU2F6c49RGWvpmgc=",
   "yarn_hash": "1r33qrvwf2wmq5c1d2awk9qhk9nzvafqn3drdvnczfv43sda4lg8",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v15.4.2-ee",
+  "rev": "v15.4.4-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "15.4.2",
+    "GITALY_SERVER_VERSION": "15.4.4",
     "GITLAB_PAGES_VERSION": "1.62.0",
     "GITLAB_SHELL_VERSION": "14.10.0",
-    "GITLAB_WORKHORSE_VERSION": "15.4.2"
+    "GITLAB_WORKHORSE_VERSION": "15.4.4"
   },
   "vendored_gems": [
     "bundler-checksum",

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "15.4.2";
+  version = "15.4.4";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -22,7 +22,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      sha256 = "sha256-DBAQ1dJLQ+Xno4e/n1jvgKiHAol/uTMjx6RtZIBwM3w=";
+      sha256 = "sha256-b8ChQYaj+7snlrLP4P9FIUSIq/SNMh9hFlFajOPcBEU=";
     };
 
     vendorSha256 = "sha256-CUFYHjmOfosM3mfw0qEY+AQcR8U3J/1lU2Ml6wSZ/QM=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "15.4.2";
+  version = "15.4.4";
 
   src = fetchFromGitLab {
     owner = data.owner;


### PR DESCRIPTION
###### Description of changes
https://about.gitlab.com/releases/2022/11/02/security-release-gitlab-15-5-2-released/

Fixes [CVE-2022-3767](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3767)
Fixes [CVE-2022-3265](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3265)
Fixes [CVE-2022-3483](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3483)
Fixes [CVE-2022-3818](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3818)
Fixes [CVE-2022-3726](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3726)
Fixes [CVE-2022-2251](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2251)
Fixes [CVE-2022-3486](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3486)
Fixes [CVE-2022-3793](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3793)
Fixes [CVE-2022-3413](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3413)
Fixes [CVE-2022-2761](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2761)
Fixes [CVE-2022-3819](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3819)
Fixes [CVE-2022-3280](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3280)
Fixes [CVE-2022-3706](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3706)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

