### PR TITLE
tdlib: 1.8.3 -> 1.8.7

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/tdlib-purple/default.nix
@@ -37,5 +37,9 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;
+
+    # tdlib-purple is not actively maintained and currently not
+    # compatible with recent versions of tdlib
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/tdlib/default.nix
+++ b/pkgs/development/libraries/tdlib/default.nix
@@ -2,14 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "tdlib";
-  version = "1.8.3";
+  version = "1.8.7";
 
   src = fetchFromGitHub {
     owner = "tdlib";
     repo = "td";
-    # https://github.com/tdlib/td/issues/1790
-    rev = "054a823c1a812ee3e038f702c6d8ba3e6974be9c";
-    sha256 = "sha256-YlvIGR3Axej0nfcGBQ5lwwYVWsLgqFrYgOxoNubYMPM=";
+
+    # The tdlib authors do not set tags for minor versions, but
+    # external programs depending on tdlib constrain the minor
+    # version, hence we set a specific commit with a known version.
+    rev = "a7a17b34b3c8fd3f7f6295f152746beb68f34d83";
+    sha256 = "sha256:0a5609knn7rmiiblz315yrvc9f2r207l2nl6brjy5bnhjdspmzs6";
   };
 
   buildInputs = [ gperf openssl readline zlib ];


### PR DESCRIPTION
Added a comment explaining why we use commit hashes directly instead of tags.

###### Description of changes

* bumped tdlib to version 1.8.7, which is past the 1.8.4 required by Emacs' `telega` now

Note that this breaks `tdlib-purple`, an unmaintained library that we have in nixpkgs. tdlib itself, as well as other software depending on it (like telega) are maintained.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
