### PR TITLE
ocamlPackages: add update script to some packages I maintain

### DIFF
--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, ocaml-syntax-shims, alcotest, result, bigstringaf, ppx_let }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, ocaml-syntax-shims, alcotest, result, bigstringaf, ppx_let, gitUpdater }:
 
 buildDunePackage rec {
   pname = "angstrom";
@@ -18,6 +18,8 @@ buildDunePackage rec {
   buildInputs = [ ocaml-syntax-shims ];
   propagatedBuildInputs = [ bigstringaf result ];
   doCheck = lib.versionAtLeast ocaml.version "4.08";
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://github.com/inhabitedtype/angstrom";

--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -1,5 +1,6 @@
 { lib, fetchFromGitHub, ocaml, buildDunePackage
 , cmdliner, dap, fmt, iter, logs, lru, lwt_ppx, lwt_react, menhir, menhirLib, path_glob, ppx_deriving_yojson
+, gitUpdater
 }:
 
 if lib.versionAtLeast ocaml.version "4.13"
@@ -22,6 +23,8 @@ buildDunePackage rec {
   };
 
   buildInputs = [ cmdliner dap fmt iter logs lru lwt_ppx lwt_react menhir menhirLib path_glob ppx_deriving_yojson ];
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://github.com/hackwaly/ocamlearlybird";

--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, ocaml, buildDunePackage
+{ lib, fetchFromGitHub, ocaml, buildDunePackage
 , cmdliner, dap, fmt, iter, logs, lru, lwt_ppx, lwt_react, menhir, menhirLib, path_glob, ppx_deriving_yojson
 }:
 
@@ -14,9 +14,11 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.11";
 
-  src = fetchurl {
-    url = "https://github.com/hackwaly/ocamlearlybird/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "1pwzhcr3pw24ra4j4d23vz71h0psz4xkyp7b12l2wl1slxzjbrxa";
+  src = fetchFromGitHub {
+    owner = "hackwaly";
+    repo = "ocamlearlybird";
+    rev = version;
+    hash = "sha256-8JHZWsgpz2pzpDxST3bkMSmPHtj7MDzD5G3ujqMW+MU=";
   };
 
   buildInputs = [ cmdliner dap fmt iter logs lru lwt_ppx lwt_react menhir menhirLib path_glob ppx_deriving_yojson ];

--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, ocaml
+{ lib, fetchFromGitHub, buildDunePackage, ocaml
 , alcotest
 , astring, cmdliner, cppo, fmt, logs, ocaml-version, odoc-parser, ocaml_lwt, re, result, csexp
 , pandoc}:
@@ -9,9 +9,11 @@ buildDunePackage rec {
 
   minimalOCamlVersion = "4.08";
 
-  src = fetchurl {
-    url = "https://github.com/realworldocaml/mdx/releases/download/${version}/mdx-${version}.tbz";
-    sha256 = "sha256-ol1zy8LODDYdcnv/jByE0pnqJ5ujQuMALq3v9y7td/o=";
+  src = fetchFromGitHub {
+    owner = "realworldocaml";
+    repo = pname;
+    rev = version;
+    hash = "sha256-p7jmksltgfLFTSkPxMuJWJexLq2VvPWT/DJtDveOL/A=";
   };
 
   nativeBuildInputs = [ cppo ];

--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -1,7 +1,9 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml
 , alcotest
 , astring, cmdliner, cppo, fmt, logs, ocaml-version, odoc-parser, ocaml_lwt, re, result, csexp
-, pandoc}:
+, pandoc
+, gitUpdater
+}:
 
 buildDunePackage rec {
   pname = "mdx";
@@ -31,6 +33,8 @@ buildDunePackage rec {
     dune install --prefix=$bin --libdir=$lib/lib/ocaml/${ocaml.version}/site-lib ${pname}
     runHook postInstall
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Executable OCaml code blocks inside markdown files";

--- a/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
@@ -5,6 +5,7 @@
 , cmdliner
 , ppx_deriving
 , ppxlib
+, gitUpdater
 }:
 
 buildDunePackage rec {
@@ -31,6 +32,8 @@ buildDunePackage rec {
   checkInputs = [
     alcotest
   ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = with lib; {
     description = "Ppx_deriving plugin for generating command line interfaces from types for OCaml";

--- a/pkgs/development/ocaml-modules/printbox/default.nix
+++ b/pkgs/development/ocaml-modules/printbox/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, mdx }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, mdx, gitUpdater }:
 
 buildDunePackage rec {
   pname = "printbox";
@@ -19,6 +19,8 @@ buildDunePackage rec {
 
   # mdx is not available for OCaml < 4.08
   doCheck = lib.versionAtLeast ocaml.version "4.08";
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = {
     homepage = "https://github.com/c-cube/printbox/";

--- a/pkgs/development/ocaml-modules/xml-light/default.nix
+++ b/pkgs/development/ocaml-modules/xml-light/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, gitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-xml-light";
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
     cp -vai doc $out/share/
     runHook postInstall
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Minimal Xml parser and printer for OCaml";


### PR DESCRIPTION
###### Description of changes

- ocamlPackages.angstrom: add update script
- ocamlPackages.earlybird: use fetchFromGitHub
- ocamlPackages.earlybird: add update script
- ocamlPackages.mdx: use fetchFromGitHub
- ocamlPackages.mdx: add update script
- ocamlPackages.ppx_deriving_cmdliner: add update script
- ocamlPackages.printbox: add update script
- ocamlPackages.xml-light: add update script


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
