### PR TITLE
sftpgo: init at 2.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13538,6 +13538,12 @@
     githubId = 3105057;
     name = "Jan Beinke";
   };
+  thenonameguy = {
+    email = "thenonameguy24@gmail.com";
+    name = "Krisztian Szabo";
+    github = "thenonameguy";
+    githubId = 2217181;
+  };
   therealansh = {
     email = "tyagiansh23@gmail.com";
     github = "therealansh";

--- a/pkgs/servers/sftpgo/default.nix
+++ b/pkgs/servers/sftpgo/default.nix
@@ -1,0 +1,52 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "sftpgo";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "drakkan";
+    repo = "sftpgo";
+    rev = "v${version}";
+    sha256 = "sha256-A4+YmChUPn+6P0rBuzYcABXyjXRZWY5KS1YcFZHCrYo=";
+  };
+
+  vendorHash = "sha256-kwluXCkbclrfRsrdqSxb5+TCBpVPZmDmrbpzR+yuQdQ=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/drakkan/sftpgo/v2/internal/version.commit=${src.rev}"
+    "-X github.com/drakkan/sftpgo/v2/internal/version.date=1970-01-01T00:00:00Z"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  doCheck = false;
+
+  subPackages = [ "." ];
+
+  postInstall = ''
+    $out/bin/sftpgo gen man
+    installManPage man/*.1
+
+    installShellCompletion --cmd sftpgo \
+      --bash <($out/bin/sftpgo gen completion bash) \
+      --zsh <($out/bin/sftpgo gen completion zsh) \
+      --fish <($out/bin/sftpgo gen completion fish)
+  '';
+
+  meta = {
+    homepage = "https://github.com/drakkan/sftpgo";
+    description = "Fully featured and highly configurable SFTP server";
+    longDescription = ''
+      Fully featured and highly configurable SFTP server
+      with optional HTTP/S, FTP/S and WebDAV support.
+      Several storage backends are supported:
+      local filesystem, encrypted local filesystem, S3 (compatible) Object Storage,
+      Google Cloud Storage, Azure Blob Storage, SFTP.
+    '';
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ thenonameguy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11241,6 +11241,10 @@ with pkgs;
 
   sftpman = callPackage ../tools/filesystems/sftpman { };
 
+  sftpgo = callPackage ../servers/sftpgo {
+    buildGoModule = buildGo119Module;
+  };
+
   screenfetch = callPackage ../tools/misc/screenfetch { };
 
   sg3_utils = callPackage ../tools/system/sg3_utils { };


### PR DESCRIPTION
###### Description of changes

New package added, this adds capability to nixpkgs to run rootless SFTP servers easily.

https://github.com/drakkan/sftpgo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
