### PR TITLE
nextcloudPackages: init

### DIFF
--- a/pkgs/development/tools/nc4nix/default.nix
+++ b/pkgs/development/tools/nc4nix/default.nix
@@ -1,21 +1,33 @@
 { lib
 , buildGoModule
 , fetchFromGitLab
+, nix
+, makeWrapper
 }:
 
 buildGoModule rec {
   pname = "nc4nix";
-  version = "unstable-2022-11-12";
+  version = "unstable-2022-11-13";
 
   src = fetchFromGitLab {
     domain = "git.project-insanity.org";
     owner = "onny";
     repo = "nc4nix";
-    rev = "d7f55a42b5ca0d02382349c6ec776eefe6079703";
-    sha256 = "sha256-MfMW2B+udXV/lQPGUBFuAE7jwmy4D1M+CYkCuJ088aM=";
+    rev = "857e789287692e42f3fcaae039d6f323b383543b";
+    sha256 = "sha256-ekuvqTyoaYiNju4yiQLPmxaXaGD4T3Wv9A8CHY1MZOI=";
   };
 
   vendorSha256 = "sha256-uhINWxFny/OY7M2vV3ehFzP90J6Z8cn5IZHWOuEg91M=";
+
+ nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postInstall = ''
+    # Depends on nix-prefetch-url
+    wrapProgram $out/bin/nc4nix \
+      --prefix PATH : ${lib.makeBinPath [ nix ]}
+  '';
 
   meta = with lib; {
     description = "Packaging helper for Nextcloud apps";

--- a/pkgs/servers/nextcloud/packages/23.json
+++ b/pkgs/servers/nextcloud/packages/23.json
@@ -1,0 +1,122 @@
+{
+  "bookmarks": {
+    "sha256": "511aadcda0b1f051191c20cfd7048150536cfb1e748deb11b568bec4e535a173",
+    "url": "https://github.com/nextcloud/bookmarks/releases/download/v11.0.4/bookmarks-11.0.4.tar.gz",
+    "version": "11.0.4",
+    "description": "- 📂 Sort bookmarks into folders\n- 🏷 Add tags and personal notes\n- 🔍 Full-text search\n- 📲 Synchronize with all your browsers and devices\n- 👪 Share bookmarks with other users and publicly\n- ☠ Find broken links\n- ⚛ Generate RSS feeds of your collections\n- 📔 Read archived versions of your links in case they are depublished\n- 💬 Create new bookmarks directly from within Nextcloud Talk\n- 💼 Built-in Dashboard widgets for frequent and recent links\n\nRequirements:\n - PHP v7.4+\n - PHP extensions:\n   - intl: *\n   - mbstring: *\n - when using MySQL, use at least v8.0",
+    "homepage": "https://github.com/nextcloud/bookmarks",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "calendar": {
+    "sha256": "d6edc166d63204e39135c0e9f00c0f7a6875db89d34a936e16b513c749ac8b8d",
+    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v3.5.2/calendar-v3.5.2.tar.gz",
+    "version": "3.5.2",
+    "description": "The Calendar app is a user interface for Nextcloud's CalDAV server. Easily sync events from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Contacts - more to come.\n* 🌐 **WebCal Support!** Want to see your favorite team’s matchdays in your calendar? No problem!\n* 🙋 **Attendees!** Invite people to your events\n* ⌚️ **Free/Busy!** See when your attendees are available to meet\n* ⏰ **Reminders!** Get alarms for events inside your browser and via email\n* 🔍 Search! Find your events at ease\n* ☑️ Tasks! See tasks with a due date directly in the calendar\n* 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.",
+    "homepage": "https://github.com/nextcloud/calendar/",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "contacts": {
+    "sha256": "1938b266c5070573e0435ec31c08a19add96fd99c08c3c1f8309ee8e447093a0",
+    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v4.2.2/contacts-v4.2.2.tar.gz",
+    "version": "4.2.2",
+    "description": "The Nextcloud contacts app is a user interface for Nextcloud's CardDAV server. Easily sync contacts from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.\n* 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.\n* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!\n* 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.",
+    "homepage": "https://github.com/nextcloud/contacts#readme",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "deck": {
+    "sha256": "fd9ea1ce98c531c7442a784f693cb047d90fbaee313a820ee648f690697f5e13",
+    "url": "https://github.com/nextcloud-releases/deck/releases/download/v1.6.4/deck-v1.6.4.tar.gz",
+    "version": "1.6.4",
+    "description": "Deck is a kanban style organization tool aimed at personal planning and project organization for teams integrated with Nextcloud.\n\n\n- 📥 Add your tasks to cards and put them in order\n- 📄 Write down additional notes in markdown\n- 🔖 Assign labels for even better organization\n- 👥 Share with your team, friends or family\n- 📎 Attach files and embed them in your markdown description\n- 💬 Discuss with your team using comments\n- ⚡ Keep track of changes in the activity stream\n- 🚀 Get your project organized",
+    "homepage": "https://github.com/nextcloud/deck",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "keeweb": {
+    "sha256": "a3281fcfdb4058971a3b5c838870a8d5b533445c999b8e921fb8758b216dadbc",
+    "url": "https://github.com/jhass/nextcloud-keeweb/releases/download/v0.6.10/keeweb-0.6.10.tar.gz",
+    "version": "0.6.10",
+    "description": "Open Keepass stores inside Nextcloud with Keeweb just by clicking on an *.kdbx file in your Nextcloud.",
+    "homepage": "https://github.com/jhass/nextcloud-keeweb",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "mail": {
+    "sha256": "0e2c5465436b894ac916222391d94d364592c18b4258fd3aa4b760afa8fa6ad7",
+    "url": "https://github.com/nextcloud-releases/mail/releases/download/v1.14.3.alpha.1/mail-v1.14.3.alpha.1.tar.gz",
+    "version": "1.14.3-alpha.1",
+    "description": "**💌 A mail app for Nextcloud**\n\n- **🚀 Integration with other Nextcloud apps!** Currently Contacts, Calendar & Files – more to come.\n- **📥 Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox. Connect any IMAP account.\n- **🔒 Send & receive encrypted mails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.\n- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.\n- **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!",
+    "homepage": "https://github.com/nextcloud/mail#readme",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "news": {
+    "sha256": "9551781fdbfb6d2c3cd77ee57eae0fb1583c7b54e9720bc955053f51541f4a86",
+    "url": "https://github.com/nextcloud/news/releases/download/19.0.0/news.tar.gz",
+    "version": "19.0.0",
+    "description": "📰 A RSS/Atom Feed reader App for Nextcloud\n\n- 📲 Synchronize your feeds with multiple mobile or desktop [clients](https://nextcloud.github.io/news/clients/)\n- 🔄 Automatic updates of your news feeds\n- 🆓 Free and open source under AGPLv3, no ads or premium functions\n\n**System Cron is currently required for this app to work**\n\nRequirements can be found [here](https://nextcloud.github.io/news/install/#dependencies)\n\nThe Changelog is available [here](https://github.com/nextcloud/news/blob/master/CHANGELOG.md)\n\nCreate a [bug report](https://github.com/nextcloud/news/issues/new/choose)\n\nCreate a [feature request](https://github.com/nextcloud/news/discussions/new)\n\nReport a [feed issue](https://github.com/nextcloud/news/discussions/new)",
+    "homepage": "https://github.com/nextcloud/news",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "notes": {
+    "sha256": "adddee56456d0115f87a74405a6d62bd5e3af256e86199d87bbff3b2a6876299",
+    "url": "https://github.com/nextcloud/notes/releases/download/v4.5.1/notes.tar.gz",
+    "version": "4.5.1",
+    "description": "The Notes app is a distraction free notes taking app for [Nextcloud](https://www.nextcloud.com/). It provides categories for better organization and supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [REST API](https://github.com/nextcloud/notes/blob/master/docs/api/README.md) allows for an easy integration into third-party apps (currently, there are notes apps for [Android](https://github.com/stefan-niedermann/nextcloud-notes), [iOS](https://github.com/owncloud/notes-iOS-App) and the [console](https://git.danielmoch.com/nncli/about) which allow convenient access to your Nextcloud notes). Further features include marking notes as favorites.",
+    "homepage": "https://github.com/nextcloud/notes",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "onlyoffice": {
+    "sha256": "e7170f7cffb50547d51a17f0ad38dfab83040a25ebd80146a840d233093a27f0",
+    "url": "https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v7.4.8/onlyoffice.tar.gz",
+    "version": "7.4.8",
+    "description": "ONLYOFFICE connector allows you to view, edit and collaborate on text documents, spreadsheets and presentations within Nextcloud using ONLYOFFICE Docs. This will create a new Edit in ONLYOFFICE action within the document library for Office documents. This allows multiple users to co-author documents in real time from the familiar web interface and save the changes back to your file storage.",
+    "homepage": "https://www.onlyoffice.com",
+    "licenses": [
+      "apache"
+    ]
+  },
+  "polls": {
+    "sha256": "b6ef0e8b34cdb5169341e30340bc9cefaa1254a1a6020e951f86e828f8591a11",
+    "url": "https://github.com/nextcloud/polls/releases/download/v3.8.3/polls.tar.gz",
+    "version": "3.8.3",
+    "description": "A polls app, similar to Doodle/Dudle with the possibility to restrict access (members, certain groups/users, hidden and public).",
+    "homepage": "https://github.com/nextcloud/polls",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "tasks": {
+    "sha256": "fdfa3168ac80eaef3e2de5009eee02a369acc8d35dfd8283d1f25423bdf3c532",
+    "url": "https://github.com/nextcloud/tasks/releases/download/v0.14.5/tasks.tar.gz",
+    "version": "0.14.5",
+    "description": "Once enabled, a new Tasks menu will appear in your Nextcloud apps menu. From there you can add and delete tasks, edit their title, description, start and due dates and mark them as important. Tasks can be shared between users. Tasks can be synchronized using CalDav (each task list is linked to an Nextcloud calendar, to sync it to your local client: Thunderbird, Evolution, KDE Kontact, iCal … - just add the calendar as a remote calendar in your client). You can download your tasks as ICS files using the download button for each calendar.",
+    "homepage": "https://github.com/nextcloud/tasks/",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "twofactor_webauthn": {
+    "sha256": "291c20032cfc1f2fb081cc8721e272bc503d103987c6abb7ce442e497d278d0a",
+    "url": "https://github.com/nextcloud-releases/twofactor_webauthn/releases/download/v0.3.3/twofactor_webauthn-v0.3.3.tar.gz",
+    "version": "0.3.3",
+    "description": "A two-factor provider for WebAuthn devices",
+    "homepage": "https://github.com/nextcloud/twofactor_webauthn#readme",
+    "licenses": [
+      "agpl"
+    ]
+  }
+}

--- a/pkgs/servers/nextcloud/packages/24.json
+++ b/pkgs/servers/nextcloud/packages/24.json
@@ -1,0 +1,122 @@
+{
+  "bookmarks": {
+    "sha256": "511aadcda0b1f051191c20cfd7048150536cfb1e748deb11b568bec4e535a173",
+    "url": "https://github.com/nextcloud/bookmarks/releases/download/v11.0.4/bookmarks-11.0.4.tar.gz",
+    "version": "11.0.4",
+    "description": "- 📂 Sort bookmarks into folders\n- 🏷 Add tags and personal notes\n- 🔍 Full-text search\n- 📲 Synchronize with all your browsers and devices\n- 👪 Share bookmarks with other users and publicly\n- ☠ Find broken links\n- ⚛ Generate RSS feeds of your collections\n- 📔 Read archived versions of your links in case they are depublished\n- 💬 Create new bookmarks directly from within Nextcloud Talk\n- 💼 Built-in Dashboard widgets for frequent and recent links\n\nRequirements:\n - PHP v7.4+\n - PHP extensions:\n   - intl: *\n   - mbstring: *\n - when using MySQL, use at least v8.0",
+    "homepage": "https://github.com/nextcloud/bookmarks",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "calendar": {
+    "sha256": "d6edc166d63204e39135c0e9f00c0f7a6875db89d34a936e16b513c749ac8b8d",
+    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v3.5.2/calendar-v3.5.2.tar.gz",
+    "version": "3.5.2",
+    "description": "The Calendar app is a user interface for Nextcloud's CalDAV server. Easily sync events from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Contacts - more to come.\n* 🌐 **WebCal Support!** Want to see your favorite team’s matchdays in your calendar? No problem!\n* 🙋 **Attendees!** Invite people to your events\n* ⌚️ **Free/Busy!** See when your attendees are available to meet\n* ⏰ **Reminders!** Get alarms for events inside your browser and via email\n* 🔍 Search! Find your events at ease\n* ☑️ Tasks! See tasks with a due date directly in the calendar\n* 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.",
+    "homepage": "https://github.com/nextcloud/calendar/",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "contacts": {
+    "sha256": "1938b266c5070573e0435ec31c08a19add96fd99c08c3c1f8309ee8e447093a0",
+    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v4.2.2/contacts-v4.2.2.tar.gz",
+    "version": "4.2.2",
+    "description": "The Nextcloud contacts app is a user interface for Nextcloud's CardDAV server. Easily sync contacts from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.\n* 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.\n* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!\n* 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.",
+    "homepage": "https://github.com/nextcloud/contacts#readme",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "deck": {
+    "sha256": "82d8816595a89e3d11be3e076d6d26ad75f0c9e31d91b89df5fb34acdc111aab",
+    "url": "https://github.com/nextcloud-releases/deck/releases/download/v1.7.2/deck-v1.7.2.tar.gz",
+    "version": "1.7.2",
+    "description": "Deck is a kanban style organization tool aimed at personal planning and project organization for teams integrated with Nextcloud.\n\n\n- 📥 Add your tasks to cards and put them in order\n- 📄 Write down additional notes in markdown\n- 🔖 Assign labels for even better organization\n- 👥 Share with your team, friends or family\n- 📎 Attach files and embed them in your markdown description\n- 💬 Discuss with your team using comments\n- ⚡ Keep track of changes in the activity stream\n- 🚀 Get your project organized",
+    "homepage": "https://github.com/nextcloud/deck",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "keeweb": {
+    "sha256": "a3281fcfdb4058971a3b5c838870a8d5b533445c999b8e921fb8758b216dadbc",
+    "url": "https://github.com/jhass/nextcloud-keeweb/releases/download/v0.6.10/keeweb-0.6.10.tar.gz",
+    "version": "0.6.10",
+    "description": "Open Keepass stores inside Nextcloud with Keeweb just by clicking on an *.kdbx file in your Nextcloud.",
+    "homepage": "https://github.com/jhass/nextcloud-keeweb",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "mail": {
+    "sha256": "0e2c5465436b894ac916222391d94d364592c18b4258fd3aa4b760afa8fa6ad7",
+    "url": "https://github.com/nextcloud-releases/mail/releases/download/v1.14.3.alpha.1/mail-v1.14.3.alpha.1.tar.gz",
+    "version": "1.14.3-alpha.1",
+    "description": "**💌 A mail app for Nextcloud**\n\n- **🚀 Integration with other Nextcloud apps!** Currently Contacts, Calendar & Files – more to come.\n- **📥 Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox. Connect any IMAP account.\n- **🔒 Send & receive encrypted mails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.\n- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.\n- **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!",
+    "homepage": "https://github.com/nextcloud/mail#readme",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "news": {
+    "sha256": "9551781fdbfb6d2c3cd77ee57eae0fb1583c7b54e9720bc955053f51541f4a86",
+    "url": "https://github.com/nextcloud/news/releases/download/19.0.0/news.tar.gz",
+    "version": "19.0.0",
+    "description": "📰 A RSS/Atom Feed reader App for Nextcloud\n\n- 📲 Synchronize your feeds with multiple mobile or desktop [clients](https://nextcloud.github.io/news/clients/)\n- 🔄 Automatic updates of your news feeds\n- 🆓 Free and open source under AGPLv3, no ads or premium functions\n\n**System Cron is currently required for this app to work**\n\nRequirements can be found [here](https://nextcloud.github.io/news/install/#dependencies)\n\nThe Changelog is available [here](https://github.com/nextcloud/news/blob/master/CHANGELOG.md)\n\nCreate a [bug report](https://github.com/nextcloud/news/issues/new/choose)\n\nCreate a [feature request](https://github.com/nextcloud/news/discussions/new)\n\nReport a [feed issue](https://github.com/nextcloud/news/discussions/new)",
+    "homepage": "https://github.com/nextcloud/news",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "notes": {
+    "sha256": "adddee56456d0115f87a74405a6d62bd5e3af256e86199d87bbff3b2a6876299",
+    "url": "https://github.com/nextcloud/notes/releases/download/v4.5.1/notes.tar.gz",
+    "version": "4.5.1",
+    "description": "The Notes app is a distraction free notes taking app for [Nextcloud](https://www.nextcloud.com/). It provides categories for better organization and supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [REST API](https://github.com/nextcloud/notes/blob/master/docs/api/README.md) allows for an easy integration into third-party apps (currently, there are notes apps for [Android](https://github.com/stefan-niedermann/nextcloud-notes), [iOS](https://github.com/owncloud/notes-iOS-App) and the [console](https://git.danielmoch.com/nncli/about) which allow convenient access to your Nextcloud notes). Further features include marking notes as favorites.",
+    "homepage": "https://github.com/nextcloud/notes",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "onlyoffice": {
+    "sha256": "6117b7b8c5c7133975e4ebf482814cdcd3f94a1b3c76ea1b5eed47bdd1fbfcbb",
+    "url": "https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v7.5.8/onlyoffice.tar.gz",
+    "version": "7.5.8",
+    "description": "ONLYOFFICE connector allows you to view, edit and collaborate on text documents, spreadsheets and presentations within Nextcloud using ONLYOFFICE Docs. This will create a new Edit in ONLYOFFICE action within the document library for Office documents. This allows multiple users to co-author documents in real time from the familiar web interface and save the changes back to your file storage.",
+    "homepage": "https://www.onlyoffice.com",
+    "licenses": [
+      "apache"
+    ]
+  },
+  "polls": {
+    "sha256": "b6ef0e8b34cdb5169341e30340bc9cefaa1254a1a6020e951f86e828f8591a11",
+    "url": "https://github.com/nextcloud/polls/releases/download/v3.8.3/polls.tar.gz",
+    "version": "3.8.3",
+    "description": "A polls app, similar to Doodle/Dudle with the possibility to restrict access (members, certain groups/users, hidden and public).",
+    "homepage": "https://github.com/nextcloud/polls",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "tasks": {
+    "sha256": "fdfa3168ac80eaef3e2de5009eee02a369acc8d35dfd8283d1f25423bdf3c532",
+    "url": "https://github.com/nextcloud/tasks/releases/download/v0.14.5/tasks.tar.gz",
+    "version": "0.14.5",
+    "description": "Once enabled, a new Tasks menu will appear in your Nextcloud apps menu. From there you can add and delete tasks, edit their title, description, start and due dates and mark them as important. Tasks can be shared between users. Tasks can be synchronized using CalDav (each task list is linked to an Nextcloud calendar, to sync it to your local client: Thunderbird, Evolution, KDE Kontact, iCal … - just add the calendar as a remote calendar in your client). You can download your tasks as ICS files using the download button for each calendar.",
+    "homepage": "https://github.com/nextcloud/tasks/",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "twofactor_webauthn": {
+    "sha256": "291c20032cfc1f2fb081cc8721e272bc503d103987c6abb7ce442e497d278d0a",
+    "url": "https://github.com/nextcloud-releases/twofactor_webauthn/releases/download/v0.3.3/twofactor_webauthn-v0.3.3.tar.gz",
+    "version": "0.3.3",
+    "description": "A two-factor provider for WebAuthn devices",
+    "homepage": "https://github.com/nextcloud/twofactor_webauthn#readme",
+    "licenses": [
+      "agpl"
+    ]
+  }
+}

--- a/pkgs/servers/nextcloud/packages/25.json
+++ b/pkgs/servers/nextcloud/packages/25.json
@@ -1,0 +1,122 @@
+{
+  "bookmarks": {
+    "sha256": "1jkbwzig4xd042jcbdbdh4whkpxb87f7ba0c89c78bdgcqzjv1a3",
+    "url": "https://github.com/nextcloud/bookmarks/releases/download/v11.0.4/bookmarks-11.0.4.tar.gz",
+    "version": "11.0.4",
+    "description": "- 📂 Sort bookmarks into folders\n- 🏷 Add tags and personal notes\n- 🔍 Full-text search\n- 📲 Synchronize with all your browsers and devices\n- 👪 Share bookmarks with other users and publicly\n- ☠ Find broken links\n- ⚛ Generate RSS feeds of your collections\n- 📔 Read archived versions of your links in case they are depublished\n- 💬 Create new bookmarks directly from within Nextcloud Talk\n- 💼 Built-in Dashboard widgets for frequent and recent links\n\nRequirements:\n - PHP v7.4+\n - PHP extensions:\n   - intl: *\n   - mbstring: *\n - when using MySQL, use at least v8.0",
+    "homepage": "https://github.com/nextcloud/bookmarks",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "calendar": {
+    "sha256": "00rw09g2az0vly1lf1p67yl72cniigydwvvv698g38b34f2ca0i8",
+    "url": "https://github.com/nextcloud-releases/calendar/releases/download/v4.1.0/calendar-v4.1.0.tar.gz",
+    "version": "4.1.0",
+    "description": "The Calendar app is a user interface for Nextcloud's CalDAV server. Easily sync events from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Contacts - more to come.\n* 🌐 **WebCal Support!** Want to see your favorite team’s matchdays in your calendar? No problem!\n* 🙋 **Attendees!** Invite people to your events\n* ⌚️ **Free/Busy!** See when your attendees are available to meet\n* ⏰ **Reminders!** Get alarms for events inside your browser and via email\n* 🔍 Search! Find your events at ease\n* ☑️ Tasks! See tasks with a due date directly in the calendar\n* 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.",
+    "homepage": "https://github.com/nextcloud/calendar/",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "contacts": {
+    "sha256": "1mg714j8fjrgp80xzdygh313kvsag47ihckzrz95vzqkiq32la3b",
+    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v5.0.1/contacts-v5.0.1.tar.gz",
+    "version": "5.0.1",
+    "description": "The Nextcloud contacts app is a user interface for Nextcloud's CardDAV server. Easily sync contacts from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.\n* 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.\n* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!\n* 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.",
+    "homepage": "https://github.com/nextcloud/contacts#readme",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "deck": {
+    "sha256": "0lgbi8ha31zrc2sjqd3yrb9ms1jlmkcvrkvgapw4n932m4mvsrvs",
+    "url": "https://github.com/nextcloud-releases/deck/releases/download/v1.8.1/deck-v1.8.1.tar.gz",
+    "version": "1.8.1",
+    "description": "Deck is a kanban style organization tool aimed at personal planning and project organization for teams integrated with Nextcloud.\n\n\n- 📥 Add your tasks to cards and put them in order\n- 📄 Write down additional notes in markdown\n- 🔖 Assign labels for even better organization\n- 👥 Share with your team, friends or family\n- 📎 Attach files and embed them in your markdown description\n- 💬 Discuss with your team using comments\n- ⚡ Keep track of changes in the activity stream\n- 🚀 Get your project organized",
+    "homepage": "https://github.com/nextcloud/deck",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "keeweb": {
+    "sha256": "1g6bjbzk7rf9x7cblwsc7cmd3fx5zrkib5ra5xzsmqc9aqpy22zh",
+    "url": "https://github.com/jhass/nextcloud-keeweb/releases/download/v0.6.10/keeweb-0.6.10.tar.gz",
+    "version": "0.6.10",
+    "description": "Open Keepass stores inside Nextcloud with Keeweb just by clicking on an *.kdbx file in your Nextcloud.",
+    "homepage": "https://github.com/jhass/nextcloud-keeweb",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "mail": {
+    "sha256": "1c2ddi49p4wni51sp6n9wb7jh42glgjbhsiabqbk2c0krpwwrcbh",
+    "url": "https://github.com/nextcloud-releases/mail/releases/download/v2.1.0/mail-v2.1.0.tar.gz",
+    "version": "2.1.0",
+    "description": "**💌 A mail app for Nextcloud**\n\n- **🚀 Integration with other Nextcloud apps!** Currently Contacts, Calendar & Files – more to come.\n- **📥 Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox. Connect any IMAP account.\n- **🔒 Send & receive encrypted mails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.\n- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.\n- **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!",
+    "homepage": "https://github.com/nextcloud/mail#readme",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "news": {
+    "sha256": "1afpszalvrqkaij6yp45y6a2skbhvqlp50fsb9f0ha6l3wli07qp",
+    "url": "https://github.com/nextcloud/news/releases/download/19.0.0/news.tar.gz",
+    "version": "19.0.0",
+    "description": "📰 A RSS/Atom Feed reader App for Nextcloud\n\n- 📲 Synchronize your feeds with multiple mobile or desktop [clients](https://nextcloud.github.io/news/clients/)\n- 🔄 Automatic updates of your news feeds\n- 🆓 Free and open source under AGPLv3, no ads or premium functions\n\n**System Cron is currently required for this app to work**\n\nRequirements can be found [here](https://nextcloud.github.io/news/install/#dependencies)\n\nThe Changelog is available [here](https://github.com/nextcloud/news/blob/master/CHANGELOG.md)\n\nCreate a [bug report](https://github.com/nextcloud/news/issues/new/choose)\n\nCreate a [feature request](https://github.com/nextcloud/news/discussions/new)\n\nReport a [feed issue](https://github.com/nextcloud/news/discussions/new)",
+    "homepage": "https://github.com/nextcloud/news",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "notes": {
+    "sha256": "1jcgv3awr45jq3n3qv851qlpbdl2plixba0iq2s54dmhciypdckl",
+    "url": "https://github.com/nextcloud/notes/releases/download/v4.6.0/notes.tar.gz",
+    "version": "4.6.0",
+    "description": "The Notes app is a distraction free notes taking app for [Nextcloud](https://www.nextcloud.com/). It provides categories for better organization and supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [REST API](https://github.com/nextcloud/notes/blob/master/docs/api/README.md) allows for an easy integration into third-party apps (currently, there are notes apps for [Android](https://github.com/stefan-niedermann/nextcloud-notes), [iOS](https://github.com/owncloud/notes-iOS-App) and the [console](https://git.danielmoch.com/nncli/about) which allow convenient access to your Nextcloud notes). Further features include marking notes as favorites.",
+    "homepage": "https://github.com/nextcloud/notes",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "onlyoffice": {
+    "sha256": "0gy4n86q7b5qmy609ncibp94v1b3z9msc0129572qz2zyxfqxq3i",
+    "url": "https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v7.6.8/onlyoffice.tar.gz",
+    "version": "7.6.8",
+    "description": "ONLYOFFICE connector allows you to view, edit and collaborate on text documents, spreadsheets and presentations within Nextcloud using ONLYOFFICE Docs. This will create a new Edit in ONLYOFFICE action within the document library for Office documents. This allows multiple users to co-author documents in real time from the familiar web interface and save the changes back to your file storage.",
+    "homepage": "https://www.onlyoffice.com",
+    "licenses": [
+      "apache"
+    ]
+  },
+  "polls": {
+    "sha256": "07jcw9hzn4b1h35d1yk2dvvsva8xw9cbl12g0n2frjmpzkiayc1r",
+    "url": "https://github.com/nextcloud/polls/releases/download/v4.0.0/polls.tar.gz",
+    "version": "4.0.0",
+    "description": "A polls app, similar to Doodle/Dudle with the possibility to restrict access (members, certain groups/users, hidden and public).",
+    "homepage": "https://github.com/nextcloud/polls",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "tasks": {
+    "sha256": "0jm13d6nm7cfsw27yfiq1il9xjlh0qrq8xby2yz9dmggn7lk1dx5",
+    "url": "https://github.com/nextcloud/tasks/releases/download/v0.14.5/tasks.tar.gz",
+    "version": "0.14.5",
+    "description": "Once enabled, a new Tasks menu will appear in your Nextcloud apps menu. From there you can add and delete tasks, edit their title, description, start and due dates and mark them as important. Tasks can be shared between users. Tasks can be synchronized using CalDav (each task list is linked to an Nextcloud calendar, to sync it to your local client: Thunderbird, Evolution, KDE Kontact, iCal … - just add the calendar as a remote calendar in your client). You can download your tasks as ICS files using the download button for each calendar.",
+    "homepage": "https://github.com/nextcloud/tasks/",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "twofactor_webauthn": {
+    "sha256": "06ip0ks2ngpxirfybkc6j7nlnwsx2kf7f0rl855j648zf1y369hp",
+    "url": "https://github.com/nextcloud-releases/twofactor_webauthn/releases/download/v1.0.0/twofactor_webauthn-v1.0.0.tar.gz",
+    "version": "1.0.0",
+    "description": "A two-factor provider for WebAuthn devices",
+    "homepage": "https://github.com/nextcloud/twofactor_webauthn#readme",
+    "licenses": [
+      "agpl"
+    ]
+  }
+}

--- a/pkgs/servers/nextcloud/packages/README.md
+++ b/pkgs/servers/nextcloud/packages/README.md
@@ -1,0 +1,44 @@
+= Adding apps =
+
+To extend the nextcloudPackages set, add a new line to the corresponding json
+file with the id of the app:
+
+- `nextcloud-apps.json` for apps
+
+The app must be available in the official
+[Nextcloud app store](https://apps.nextcloud.com).
+https://apps.nextcloud.com. The id corresponds to the last part in the app url,
+for example `breezedark` for the app with the url
+`https://apps.nextcloud.com/apps/breezedark`.
+
+To regenerate the nixpkgs nextcloudPackages set, run:
+
+``` 
+./generate.sh
+``` 
+
+After that you can commit and submit the changes.
+
+= Usage with the Nextcloud module =
+
+The apps will be available in the namespace `nextcloud25Packages.apps`.
+Using it together with the Nextcloud module could look like this:
+
+```
+services.nextcloud = {
+  enable = true;
+  package = pkgs.nextcloud25;
+  hostName = "localhost";
+  config.adminpassFile = "${pkgs.writeText "adminpass" "hunter2"}";
+  extraApps = with pkgs.nextcloud25Packages.apps; [
+    mail
+    calendar
+    contacts
+  ];
+  extraAppsEnable = true;
+};
+```
+
+Adapt the version number in the Nextcloud package and nextcloudPackages set
+according to the Nextcloud version you wish to use. There are several supported
+stable Nextcloud versions available in the repository.

--- a/pkgs/servers/nextcloud/packages/default.nix
+++ b/pkgs/servers/nextcloud/packages/default.nix
@@ -1,0 +1,23 @@
+# Source: https://git.helsinki.tools/helsinki-systems/wp4nix/-/blob/master/default.nix
+# Licensed under: MIT
+# Slightly modified
+
+{ lib, pkgs, newScope, apps }:
+
+let packages = self:
+  let
+    generatedJson = {
+      inherit apps;
+    };
+
+  in {
+    # Create a derivation from the official Nextcloud apps.
+    # This takes the data generated from the go tool.
+    mkNextcloudDerivation = self.callPackage ({ }: { data }:
+      pkgs.fetchNextcloudApp {
+        inherit (data) url sha256;
+      }) {};
+
+  } // lib.mapAttrs (type: pkgs: lib.makeExtensible (_: lib.mapAttrs (pname: data: self.mkNextcloudDerivation { inherit data; }) pkgs)) generatedJson;
+
+in (lib.makeExtensible (_: (lib.makeScope newScope packages))).extend (selfNC: superNC: {})

--- a/pkgs/servers/nextcloud/packages/generate.sh
+++ b/pkgs/servers/nextcloud/packages/generate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -I nixpkgs=../../../.. -i bash -p nc4nix
+
+set -e
+set -u
+set -o pipefail
+set -x
+
+export NEXTCLOUD_VERSIONS=$(nix-instantiate --eval -E 'import ./nc-versions.nix {}' -A e)
+
+APPS=`cat nextcloud-apps.json | jq -r '.[]' | sed -z 's/\n/,/g;s/,$/\n/'`
+
+nc4nix -a $APPS
+rm *.log

--- a/pkgs/servers/nextcloud/packages/nc-versions.nix
+++ b/pkgs/servers/nextcloud/packages/nc-versions.nix
@@ -1,0 +1,13 @@
+# Source: https://git.helsinki.tools/helsinki-systems/nc4nix/-/raw/main/nc-versions.nix
+# Licensed under: MIT
+
+# this file is used to figure out which versions of nextcloud we have in nixpkgs
+{ pkgs ? import <nixpkgs> {}, lib ? pkgs.lib }:
+let
+  n = lib.mapAttrsToList (_: v: v.version) (
+      lib.filterAttrs (k: v: builtins.match "nextcloud[0-9]+" k != null && (builtins.tryEval v.version).success)
+    pkgs);
+in {
+  inherit n;
+  e = lib.concatStringsSep "," n;
+}

--- a/pkgs/servers/nextcloud/packages/nextcloud-apps.json
+++ b/pkgs/servers/nextcloud/packages/nextcloud-apps.json
@@ -1,0 +1,14 @@
+[
+  "bookmarks"
+, "calendar"
+, "contacts"
+, "deck"
+, "keeweb"
+, "mail"
+, "news"
+, "notes"
+, "onlyoffice"
+, "polls"
+, "tasks"
+, "twofactor_webauthn"
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9602,6 +9602,16 @@ with pkgs;
   inherit (callPackage ../servers/nextcloud {})
     nextcloud23 nextcloud24 nextcloud25;
 
+  nextcloud23Packages = ( callPackage ../servers/nextcloud/packages {
+    apps = lib.importJSON ../servers/nextcloud/packages/23.json;
+  });
+  nextcloud24Packages = ( callPackage ../servers/nextcloud/packages {
+    apps = lib.importJSON ../servers/nextcloud/packages/24.json;
+  });
+  nextcloud25Packages = ( callPackage ../servers/nextcloud/packages {
+    apps = lib.importJSON ../servers/nextcloud/packages/25.json;
+  });
+
   nextcloud-client = libsForQt5.callPackage ../applications/networking/nextcloud-client { };
 
   nextcloud-news-updater = callPackage ../servers/nextcloud/news-updater.nix { };


### PR DESCRIPTION
###### Description of changes

Ability to package and install Nextcloud apps like this:
```
  services.nextcloud = {
    enable = true;
    package = pkgs.nextcloud25;
    hostName = "localhost";
    config.adminpassFile = "${pkgs.writeText "adminpass" "hunter2"}";
    extraApps = with pkgs.nextcloud25Packages.apps; {
      inherit mail news contacts;
    };
    extraAppsEnable = true;
  };
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
