### PR TITLE
sunshine: init at 0.14.1

### DIFF
--- a/pkgs/servers/sunshine/default.nix
+++ b/pkgs/servers/sunshine/default.nix
@@ -1,0 +1,112 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, avahi
+, libevdev
+, libpulseaudio
+, xorg
+, libxcb
+, openssl
+, libopus
+, ffmpeg-full
+, boost
+, pkg-config
+, libdrm
+, wayland
+, libffi
+, libcap
+, mesa
+, cudaSupport ? false
+, cudaPackages ? {}
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sunshine";
+  version = "0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "LizardByte";
+    repo = "Sunshine";
+    rev = "v${version}";
+    sha256 = "sha256-SB2DAOYf2izIwwRWEw2wt5L5oCDbb6YOqXw/z/PD1pQ=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.autoAddOpenGLRunpathHook
+  ];
+
+  buildInputs = [
+    avahi
+    ffmpeg-full
+    libevdev
+    libpulseaudio
+    xorg.libX11
+    libxcb
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libXtst
+    openssl
+    libopus
+    boost
+    libdrm
+    wayland
+    libffi
+    libevdev
+    libcap
+    libdrm
+    mesa
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.cudatoolkit
+  ];
+
+  CXXFLAGS = [
+    "-Wno-format-security"
+  ];
+  CFLAGS = [
+    "-Wno-format-security"
+  ];
+
+  cmakeFlags = [
+    "-D" "FFMPEG_LIBRARIES=${ffmpeg-full}/lib"
+    "-D" "FFMPEG_INCLUDE_DIRS=${ffmpeg-full}/include"
+    "-D" "LIBAVCODEC_INCLUDE_DIR=${ffmpeg-full}/include"
+    "-D" "LIBAVCODEC_LIBRARIES=${ffmpeg-full}/lib/libavcodec.so"
+    "-D" "LIBAVDEVICE_INCLUDE_DIR=${ffmpeg-full}/include"
+    "-D" "LIBAVDEVICE_LIBRARIES=${ffmpeg-full}/lib/libavdevice.so"
+    "-D" "LIBAVFORMAT_INCLUDE_DIR=${ffmpeg-full}/include"
+    "-D" "LIBAVFORMAT_LIBRARIES=${ffmpeg-full}/lib/libavformat.so"
+    "-D" "LIBAVUTIL_INCLUDE_DIR=${ffmpeg-full}/include"
+    "-D" "LIBAVUTIL_LIBRARIES=${ffmpeg-full}/lib/libavutil.so"
+    "-D" "LIBSWSCALE_LIBRARIES=${ffmpeg-full}/lib/libswscale.so"
+    "-D" "LIBSWSCALE_INCLUDE_DIR=${ffmpeg-full}/include"
+  ];
+
+  postPatch = ''
+    # Don't force the need for a static boost, fix hardcoded libevdev path
+    substituteInPlace CMakeLists.txt \
+      --replace 'set(Boost_USE_STATIC_LIBS ON)' '# set(Boost_USE_STATIC_LIBS ON)' \
+      --replace '/usr/include/libevdev-1.0' '${libevdev}/include/libevdev-1.0'
+
+    # fix libgbm path
+    substituteInPlace src/platform/linux/graphics.cpp \
+      --replace 'handle = dyn::handle({ "libgbm.so.1", "libgbm.so" });' 'handle = dyn::handle({ "${mesa}/lib/libgbm.so.1", "${mesa}/lib/libgbm.so" });'
+
+    # fix avahi path
+    substituteInPlace src/platform/linux/publish.cpp \
+      --replace 'handle = dyn::handle({ "libavahi-client.so.3", "libavahi-client.so" });' 'handle = dyn::handle({ "${avahi}/lib/libavahi-client.so.3", "${avahi}/lib/libavahi-client.so" });' \
+      --replace 'handle = dyn::handle({ "libavahi-common.so.3", "libavahi-common.so" });' 'handle = dyn::handle({ "${avahi}/lib/libavahi-common.so.3", "${avahi}/lib/libavahi-common.so" });'
+  '';
+
+  meta = with lib; {
+    description = "Sunshine is a Game stream host for Moonlight.";
+    homepage = "https://docs.lizardbyte.dev/projects/sunshine/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ devusb ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37699,6 +37699,8 @@ with pkgs;
 
   stayrtr = callPackage ../servers/stayrtr {};
 
+  sunshine = callPackage ../servers/sunshine {};
+
   sentencepiece = callPackage ../development/libraries/sentencepiece {};
 
   kaf = callPackage ../development/tools/kaf { };


### PR DESCRIPTION
###### Description of changes

Sunshine is a Game stream host for Moonlight. Sunshine is a self hosted, low latency, cloud gaming solution with support for AMD, Intel, and Nvidia gpus. It is an open source implementation of NVIDIA's GameStream, as used by the NVIDIA Shield.

https://github.com/LizardByte/Sunshine

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
