### PR TITLE
flake.nix: NixOS `nixpkgs` registry pin as `nixos`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
                 system.nixos.versionSuffix =
                   ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
                 system.nixos.revision = final.mkIf (self ? rev) self.rev;
+                nix.registry.nixos.flake = "${self}";
               }];
             } // lib.optionalAttrs (! args?system) {
               # Allow system to be set modularly in nixpkgs.system.


### PR DESCRIPTION
###### Description of changes

On a given NixOS system, if a user discovers the `nix.registry` option, they may wish to set the nixpkgs of their system as a pin for convenience, and rightfully so.

However, pinning the global nixpkgs to a `/nix/store` path can wreak havoc with the lockfile of any other flake with an indirect reference to nixpkgs, borking it for anyone who tries to call it remotely.

This is simply bad UX. It should be hard to do the wrong thing, but this is nearly inevitable.

Instead of expecting the user to discover this on their own, we should offer them the convenience of a pinning of their system's nixpkgs as `nixos` and encourage them to use it as their "goto" nixpkgs, analogous to `<nixpkgs>` in "pre-flake" material, but more precise.

Since we can expect this reference to exist we can always point to it in documentation and reference material.

Anecdotally, I don't think we want a users first impression of a flakes based NixOS system to be that `nix shell nixpkgs#*` always seems to redownload the world, and if they are keen enough to quickly discover the root cause and attempt to address it with `nix.registry.nixpkgs.flake` they will run into an even trickier, opaque breakage.

This is also consistent with the previous channels semantic, where on nixos the system channel was labeled `nixos`, and on other systems it was `nixpkgs`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Always pin a `nixos` flake reference in the NixOS system registry, pointing to the nixpkgs used to evaluate the system.
- [ ] Documentation
 
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->