### PR TITLE
rpki-client: init at 8.0

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -309,6 +309,15 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://rpki-client.org/">rpki-client</link>
+          the OpenBSD validator for RPKI Route Origin Authorizations.
+          Can be used to generate filter config for BGP routing daemons.
+          Available as
+          <link linkend="opt-services.rpki-client.enable">services.rpki-client</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://git.sr.ht/~migadu/alps">alps</link>,
           a simple and extensible webmail. Available as
           <link linkend="opt-services.alps.enable">services.alps</link>.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -112,6 +112,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [ntfy.sh](https://ntfy.sh), a push notification service. Available as [services.ntfy-sh](#opt-services.ntfy-sh.enable)
 
+- [rpki-client](https://rpki-client.org/) the OpenBSD validator for RPKI Route Origin Authorizations. Can be used to generate filter config for BGP routing daemons. Available as [services.rpki-client](#opt-services.rpki-client.enable).
+
 - [alps](https://git.sr.ht/~migadu/alps), a simple and extensible webmail. Available as [services.alps](#opt-services.alps.enable).
 
 - [endlessh-go](https://github.com/shizunge/endlessh-go), an SSH tarpit that exposes Prometheus metrics. Available as [services.endlessh-go](#opt-services.endlessh-go.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -922,6 +922,7 @@
   ./services/networking/robustirc-bridge.nix
   ./services/networking/routedns.nix
   ./services/networking/rpcbind.nix
+  ./services/networking/rpki-client.nix
   ./services/networking/rxe.nix
   ./services/networking/sabnzbd.nix
   ./services/networking/seafile.nix

--- a/nixos/modules/services/networking/rpki-client.nix
+++ b/nixos/modules/services/networking/rpki-client.nix
@@ -1,0 +1,114 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.rpki-client;
+  tals = [
+    "${cfg.package}/etc/rpki/afrinic.tal" "${cfg.package}/etc/rpki/apnic.tal"
+    "${cfg.package}/etc/rpki/lacnic.tal" "${cfg.package}/etc/rpki/ripe.tal" ]
+    ++ optional cfg.accept-arin-rpa "${pkgs.rpki-arin-tal}/arin.tal"
+    ++ cfg.additional-tals;
+in {
+  options = {
+    services.rpki-client = {
+      enable = mkEnableOption (lib.mdDoc "Enable OpenBSD rpki-client");
+
+      package = mkOption {
+        description = lib.mdDoc "OpenBSD rpki-client";
+        type = types.package;
+        default = pkgs.rpki-client;
+        defaultText = literalExpression "pkgs.rpki-client";
+      };
+
+      accept-arin-rpa = mkOption {
+        description = lib.mdDoc "Accept the ARIN RPA and download the ARIN TAL";
+        type = types.bool;
+        default = false;
+      };
+
+      additional-tals = mkOption {
+        description = lib.mdDoc "List of additional RFC7730 TAL files to be used";
+        type = types.listOf types.str;
+        default = [ ];
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "rpki-client";
+        description = lib.mdDoc "User account under which rpki-client is started.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "rpki-client";
+        description = lib.mdDoc "Group under which rpki-client is started.";
+      };
+
+      interval = mkOption {
+        default = "1h";
+        type = types.str;
+        description = lib.mdDoc ''
+          The interval at which to run rpki-client and update the lists.
+          See {command}`man 7 systemd.time` for the format.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.rpki-client = {
+      description = "OpenBSD rpki-client";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/rpki-client${concatMapStrings (x: " -t " + x) tals}";
+        CacheDirectory = "rpki-client";
+        StateDirectory = "rpki-client";
+        PrivateDevices = "yes";
+        PrivateTmp = "yes";
+        ProtectClock = "yes";
+        ProtectControlGroups = "yes";
+        ProtectHome = "yes";
+        ProtectHostname = "yes";
+        ProtectKernelLogs = "yes";
+        ProtectKernelModules = "yes";
+        ProtectKernelTunables = "yes";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+        RestrictNamespaces = "yes";
+        RestrictRealtime = "yes";
+        RestrictSUIDSGID = "yes";
+        LockPersonality = "yes";
+        MemoryDenyWriteExecute = "yes";
+        NoNewPrivileges = "yes";
+        CapabilityBoundingSet = "";
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = "@system-service";
+      };
+    };
+
+    systemd.timers.rpki-client = {
+      description = "Run rpki-client";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = cfg.interval;
+        OnUnitInactiveSec = cfg.interval;
+      };
+    };
+
+    users = {
+      users.rpki-client = mkIf (cfg.user == "rpki-client") {
+        description = "OpenBSD rpki-client";
+        group = cfg.group;
+        isSystemUser = true;
+      };
+      groups.rpki-client = mkIf (cfg.group == "rpki-client") { };
+    };
+  };
+}

--- a/pkgs/tools/networking/rpki-arin-tal/default.nix
+++ b/pkgs/tools/networking/rpki-arin-tal/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "rpki-arin-tal";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "https://www.arin.net/resources/manage/rpki/arin.tal";
+    hash = "sha256-T2weRW/lq0aL6sFJXlfZmh7uqk2fnjRRnq9YhXwhr0g=";
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m 644 $src ${placeholder "out"}/arin.tal
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "ARINs RPKI Trust Anchor Locator";
+    longDescription = ''
+      ARIN's RPKI Trust Anchor Locator (TAL)
+      With downloading this package you aggree to the ARIN RPA
+      https://www.arin.net/resources/manage/rpki/rpa_092622.pdf
+
+      Context: https://mailman.nanog.org/pipermail/nanog/2022-October/220786.html
+    '';
+    homepage = "https://www.openbsd.org/rpki-client/portable.html";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ vidister ];
+    platforms = with platforms; all;
+  };
+}

--- a/pkgs/tools/networking/rpki-client/default.nix
+++ b/pkgs/tools/networking/rpki-client/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchurl, autoreconfHook, expat, libressl, rsync }:
+
+stdenv.mkDerivation rec {
+  pname = "rpki-client";
+  version = "8.0";
+
+  src = fetchurl {
+    url = "https://cdn.openbsd.org/pub/OpenBSD/${pname}/${pname}-${version}.tar.gz";
+    hash = "sha256-W3EMzuLn6UlYflTa+COBFnEXSlDGcXRuWidq+qDOVb4=";
+  };
+
+  propagatedBuildInputs = [
+    expat
+    libressl
+    rsync
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  configureFlags = [
+    "--with-output-dir=/var/lib/rpki-client"
+    "--localstatedir=/var"
+  ];
+
+  meta = with lib; {
+    description = "The OpenBSD RPKI Validator";
+    homepage = "https://www.openbsd.org/rpki-client/portable.html";
+    license = licenses.isc;
+    maintainers = with maintainers; [ vidister ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30570,6 +30570,10 @@ with pkgs;
 
   reproc = callPackage ../development/libraries/reproc { };
 
+  rpki-client = callPackage ../tools/networking/rpki-client { };
+
+  rpki-arin-tal = callPackage ../tools/networking/rpki-arin-tal { };
+
   sawfish = callPackage ../applications/window-managers/sawfish { };
 
   sc68 = callPackage ../applications/audio/sc68 { };


### PR DESCRIPTION
###### Description of changes

Adds the [OpenBSD RPKI Validator](http://rpki-client.org/)

The RPKI Client can be used to validate Route Origin Authorizations for BGP announcements. The module allows running it as a service for generating files which can be consumed by the Bird routing daemon.

The TAL (Trust Anchor Locator) for 4 of the 5 Internet regions are included; the one of ARIN is missing due to its unfree license. This PR adds an additional package `rpki-arin-tal` to agree the [Relying Partying Agreement (RPA)](https://www.arin.net/resources/manage/rpki/rpa.pdf) and download the missing TAL. The package is built in a generic fashion and can be used for other RPKI validators as well.
The `rpki-client` service module has the option `accept-arin-rpa` to automatically load the TAL and enable it.

###### Things done

* add pkg rpki-client
* add module rpki-client
* add pkg rpki-arin-tal (unfree)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
