### PR TITLE
rocsparse: init at 2.3.2-5.3.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -546,6 +546,7 @@ in {
   restic = handleTest ./restic.nix {};
   retroarch = handleTest ./retroarch.nix {};
   robustirc-bridge = handleTest ./robustirc-bridge.nix {};
+  rocsparse = handleTest ./rocsparse.nix {};
   roundcube = handleTest ./roundcube.nix {};
   rspamd = handleTest ./rspamd.nix {};
   rss2email = handleTest ./rss2email.nix {};

--- a/nixos/tests/rocsparse.nix
+++ b/nixos/tests/rocsparse.nix
@@ -1,0 +1,15 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+
+with lib;
+
+{
+  name = "rocsparse";
+  meta.maintainers = with maintainers; [ Madouura ];
+  nodes.machine = { };
+
+  # This will likely always fail due to this being a virtual machine with no gpu
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.succeed("${(pkgs.rocsparse.override { buildTests = true; }).test}/bin/rocsparse-test")
+  '';
+})

--- a/pkgs/development/libraries/rocsparse/default.nix
+++ b/pkgs/development/libraries/rocsparse/default.nix
@@ -1,0 +1,148 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, rocm-cmake
+, rocm-runtime
+, rocm-device-libs
+, rocm-comgr
+, rocprim
+, hip
+, gfortran
+, git
+, fetchzip ? null
+, gtest ? null
+, boost ? null
+, python3Packages ? null
+, buildTests ? false
+, buildBenchmarks ? false # Seems to depend on tests
+}:
+
+assert (buildTests || buildBenchmarks) -> fetchzip != null;
+assert (buildTests || buildBenchmarks) -> gtest != null;
+assert (buildTests || buildBenchmarks) -> boost != null;
+assert (buildTests || buildBenchmarks) -> python3Packages != null;
+
+let
+  matrices = lib.optionalAttrs (buildTests || buildBenchmarks) import ./deps.nix {
+    inherit fetchzip;
+    mirror1 = "https://sparse.tamu.edu/MM";
+    mirror2 = "https://www.cise.ufl.edu/research/sparse/MM";
+  };
+in stdenv.mkDerivation rec {
+  pname = "rocsparse";
+  rocmVersion = "5.3.1";
+  version = "2.3.2-${rocmVersion}";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals (buildTests || buildBenchmarks) [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "rocSPARSE";
+    rev = "rocm-${rocmVersion}";
+    hash = "sha256-1069oBrIpZ4M9CAkzoQ9a5j3WlCXErirTbgTUZuT6b0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+    gfortran
+  ];
+
+  buildInputs = [
+    rocm-runtime
+    rocm-device-libs
+    rocm-comgr
+    rocprim
+    git
+  ] ++ lib.optionals (buildTests || buildBenchmarks) [
+    gtest
+    boost
+    python3Packages.python
+    python3Packages.pyyaml
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals (buildTests || buildBenchmarks) [
+    "-DBUILD_CLIENTS_TESTS=ON"
+    "-DCMAKE_MATRICES_DIR=/build/source/matrices"
+    "-Dpython=python3"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DBUILD_CLIENTS_BENCHMARKS=ON"
+  ];
+
+  # We have to manually generate the matrices
+  postPatch = lib.optionalString (buildTests || buildBenchmarks) ''
+    mkdir -p matrices
+
+    ln -s ${matrices.matrix-01}/*.mtx matrices
+    ln -s ${matrices.matrix-02}/*.mtx matrices
+    ln -s ${matrices.matrix-03}/*.mtx matrices
+    ln -s ${matrices.matrix-04}/*.mtx matrices
+    ln -s ${matrices.matrix-05}/*.mtx matrices
+    ln -s ${matrices.matrix-06}/*.mtx matrices
+    ln -s ${matrices.matrix-07}/*.mtx matrices
+    ln -s ${matrices.matrix-08}/*.mtx matrices
+    ln -s ${matrices.matrix-09}/*.mtx matrices
+    ln -s ${matrices.matrix-10}/*.mtx matrices
+    ln -s ${matrices.matrix-11}/*.mtx matrices
+    ln -s ${matrices.matrix-12}/*.mtx matrices
+    ln -s ${matrices.matrix-13}/*.mtx matrices
+    ln -s ${matrices.matrix-14}/*.mtx matrices
+    ln -s ${matrices.matrix-15}/*.mtx matrices
+    ln -s ${matrices.matrix-16}/*.mtx matrices
+    ln -s ${matrices.matrix-17}/*.mtx matrices
+    ln -s ${matrices.matrix-18}/*.mtx matrices
+    ln -s ${matrices.matrix-19}/*.mtx matrices
+    ln -s ${matrices.matrix-20}/*.mtx matrices
+    ln -s ${matrices.matrix-21}/*.mtx matrices
+    ln -s ${matrices.matrix-22}/*.mtx matrices
+    ln -s ${matrices.matrix-23}/*.mtx matrices
+    ln -s ${matrices.matrix-24}/*.mtx matrices
+
+    # Not used by the original cmake, causes an error
+    rm matrices/*_b.mtx
+
+    echo "deps/convert.cpp -> deps/mtx2csr"
+    hipcc deps/convert.cpp -O3 -o deps/mtx2csr
+
+    for mat in $(ls -1 matrices | cut -d "." -f 1); do
+      echo "mtx2csr: $mat.mtx -> $mat.csr"
+      deps/mtx2csr matrices/$mat.mtx matrices/$mat.csr
+      unlink matrices/$mat.mtx
+    done
+  '';
+
+  postInstall = lib.optionalString buildBenchmarks ''
+    mkdir -p $benchmark/bin
+    cp -a $out/bin/* $benchmark/bin
+    rm $benchmark/bin/rocsparse-test
+  '' + lib.optionalString (buildTests || buildBenchmarks) ''
+    mkdir -p $test/bin
+    mv $out/bin/* $test/bin
+    rm $test/bin/rocsparse-bench || true
+    mv /build/source/matrices $test
+    rmdir $out/bin
+  '';
+
+  meta = with lib; {
+    description = "ROCm SPARSE implementation";
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocSPARSE";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ Madouura ];
+    broken = rocmVersion != hip.version;
+  };
+}

--- a/pkgs/development/libraries/rocsparse/default.nix
+++ b/pkgs/development/libraries/rocsparse/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nixosTests
 , cmake
 , rocm-cmake
 , rocm-runtime
@@ -137,6 +138,10 @@ in stdenv.mkDerivation rec {
     mv /build/source/matrices $test
     rmdir $out/bin
   '';
+
+  passthru.tests = {
+    smoke-test = nixosTests.rocsparse;
+  };
 
   meta = with lib; {
     description = "ROCm SPARSE implementation";

--- a/pkgs/development/libraries/rocsparse/deps.nix
+++ b/pkgs/development/libraries/rocsparse/deps.nix
@@ -1,0 +1,222 @@
+{ fetchzip
+, mirror1
+, mirror2
+}:
+
+{
+  matrix-01 = fetchzip {
+    sha256 = "sha256-AHur5ZIDZTFRrO2GV0ieXrffq4KUiGWiZ59pv0fUtEQ=";
+
+    urls = [
+      "${mirror1}/SNAP/amazon0312.tar.gz"
+      "${mirror2}/SNAP/amazon0312.tar.gz"
+    ];
+  };
+
+  matrix-02 = fetchzip {
+    sha256 = "sha256-0rSxaN4lQcdaCLsvlgicG70FXUxXeERPiEmQ4MzbRdE=";
+
+    urls = [
+      "${mirror1}/Muite/Chebyshev4.tar.gz"
+      "${mirror2}/Muite/Chebyshev4.tar.gz"
+    ];
+  };
+
+  matrix-03 = fetchzip {
+    sha256 = "sha256-hDzDWDUnHEyFedX/tMNq83ZH8uWyM4xtZYUUAD3rizo=";
+
+    urls = [
+      "${mirror1}/FEMLAB/sme3Dc.tar.gz"
+      "${mirror2}/FEMLAB/sme3Dc.tar.gz"
+    ];
+  };
+
+  matrix-04 = fetchzip {
+    sha256 = "sha256-GmN2yOt/MoX01rKe05aTyB3ypUP4YbQGOITZ0BqPmC0=";
+
+    urls = [
+      "${mirror1}/Williams/webbase-1M.tar.gz"
+      "${mirror2}/Williams/webbase-1M.tar.gz"
+    ];
+  };
+
+  matrix-05 = fetchzip {
+    sha256 = "sha256-gQNjfVyWzNM9RwImJGhkhahRmZz74LzDs1oijL7mI7k=";
+
+    urls = [
+      "${mirror1}/Williams/mac_econ_fwd500.tar.gz"
+      "${mirror2}/Williams/mac_econ_fwd500.tar.gz"
+    ];
+  };
+
+  matrix-06 = fetchzip {
+    sha256 = "sha256-87cdZjntNcTuz5BtO59irhcuRbPllWSbhCEX3Td02qc=";
+
+    urls = [
+      "${mirror1}/Williams/mc2depi.tar.gz"
+      "${mirror2}/Williams/mc2depi.tar.gz"
+    ];
+  };
+
+  matrix-07 = fetchzip {
+    sha256 = "sha256-WRamuJX3D8Tm+k0q67RjUDG3DeNAxhKiaPkk5afY5eU=";
+
+    urls = [
+      "${mirror1}/Bova/rma10.tar.gz"
+      "${mirror2}/Bova/rma10.tar.gz"
+    ];
+  };
+
+  matrix-08 = fetchzip {
+    sha256 = "sha256-5dhkm293Mc3lzakKxHy5W5XIn4Rw+gihVh7gyrjEHXo=";
+
+    urls = [
+      "${mirror1}/JGD_BIBD/bibd_22_8.tar.gz"
+      "${mirror2}/JGD_BIBD/bibd_22_8.tar.gz"
+    ];
+  };
+
+  matrix-09 = fetchzip {
+    sha256 = "sha256-czjLWCjXAjZCk5TGYHaEkwSAzQu3TQ3QyB6eNKR4G88=";
+
+    urls = [
+      "${mirror1}/Hamm/scircuit.tar.gz"
+      "${mirror2}/Hamm/scircuit.tar.gz"
+    ];
+  };
+
+  matrix-10 = fetchzip {
+    sha256 = "sha256-bYuLnJViAIcIejAkh69/bsNAVIDU4wfTLtD+nmHd6FM=";
+
+    urls = [
+      "${mirror1}/Sandia/ASIC_320k.tar.gz"
+      "${mirror2}/Sandia/ASIC_320k.tar.gz"
+    ];
+  };
+
+  matrix-11 = fetchzip {
+    sha256 = "sha256-aDwn8P1khYjo2Agbq5m9ZBInJUxf/knJNvyptt0fak0=";
+
+    urls = [
+      "${mirror1}/GHS_psdef/bmwcra_1.tar.gz"
+      "${mirror2}/GHS_psdef/bmwcra_1.tar.gz"
+    ];
+  };
+
+  matrix-12 = fetchzip {
+    sha256 = "sha256-8OJqA/byhlAZd869TPUzZFdsOiwOoRGfKyhM+RMjXoY=";
+
+    urls = [
+      "${mirror1}/HB/nos1.tar.gz"
+      "${mirror2}/HB/nos1.tar.gz"
+    ];
+  };
+
+  matrix-13 = fetchzip {
+    sha256 = "sha256-FS0rKqmg+uHwsM/yGfQLBdd7LH/rUrdutkNGBD/Mh1I=";
+
+    urls = [
+      "${mirror1}/HB/nos2.tar.gz"
+      "${mirror2}/HB/nos2.tar.gz"
+    ];
+  };
+
+  matrix-14 = fetchzip {
+    sha256 = "sha256-DANnlrNJikrI7Pst9vRedtbuxepyHmCIu2yhltc4Qcs=";
+
+    urls = [
+      "${mirror1}/HB/nos3.tar.gz"
+      "${mirror2}/HB/nos3.tar.gz"
+    ];
+  };
+
+  matrix-15 = fetchzip {
+    sha256 = "sha256-21mUgqjWGUfYgiWwSrKh9vH8Vdt3xzcefmqYNYRpxiY=";
+
+    urls = [
+      "${mirror1}/HB/nos4.tar.gz"
+      "${mirror2}/HB/nos4.tar.gz"
+    ];
+  };
+
+  matrix-16 = fetchzip {
+    sha256 = "sha256-FOuXvGqBBFNkVS6cexmkluret54hCfCOdK+DOZllE4c=";
+
+    urls = [
+      "${mirror1}/HB/nos5.tar.gz"
+      "${mirror2}/HB/nos5.tar.gz"
+    ];
+  };
+
+  matrix-17 = fetchzip {
+    sha256 = "sha256-+7NI1rA/qQxYPpjXKHvAaCZ+LSaAJ4xuJvMRMBEUYxg=";
+
+    urls = [
+      "${mirror1}/HB/nos6.tar.gz"
+      "${mirror2}/HB/nos6.tar.gz"
+    ];
+  };
+
+  matrix-18 = fetchzip {
+    sha256 = "sha256-q3NxJjbwGGcFiQ9nhWfUKgZmdVwCfPmgQoqy0AqOsNc=";
+
+    urls = [
+      "${mirror1}/HB/nos7.tar.gz"
+      "${mirror2}/HB/nos7.tar.gz"
+    ];
+  };
+
+  matrix-19 = fetchzip {
+    sha256 = "sha256-0GAN6qmVfD+tprIigzuUUUwm5KVhkN9X65wMEvFltDY=";
+
+    urls = [
+      "${mirror1}/DNVS/shipsec1.tar.gz"
+      "${mirror2}/DNVS/shipsec1.tar.gz"
+    ];
+  };
+
+  matrix-20 = fetchzip {
+    sha256 = "sha256-f28Du/Urxsiq5NkRmRO10Zz9vvGRjEchquzHzbZpZ7U=";
+
+    urls = [
+      "${mirror1}/Cote/mplate.tar.gz"
+      "${mirror2}/Cote/mplate.tar.gz"
+    ];
+  };
+
+  matrix-21 = fetchzip {
+    sha256 = "sha256-O+Wy0NfCU1hVUOfNR1dJpvDHLBwwa301IRJDrQJnhak=";
+
+    urls = [
+      "${mirror1}/Bai/qc2534.tar.gz"
+      "${mirror2}/Bai/qc2534.tar.gz"
+    ];
+  };
+
+  matrix-22 = fetchzip {
+    sha256 = "sha256-oxMnt8U5Cf1ILWcBdU6W9jdSMMm+U6bIVl8nm3n3+OA=";
+
+    urls = [
+      "${mirror1}/Chevron/Chevron2.tar.gz"
+      "${mirror2}/Chevron/Chevron2.tar.gz"
+    ];
+  };
+
+  matrix-23 = fetchzip {
+    sha256 = "sha256-MFD9BxFI/3IS7yatW121BAI04fbqrXpgYDT5UKjeKcU=";
+
+    urls = [
+      "${mirror1}/Chevron/Chevron3.tar.gz"
+      "${mirror2}/Chevron/Chevron3.tar.gz"
+    ];
+  };
+
+  matrix-24 = fetchzip {
+    sha256 = "sha256-ikS8O51pe1nt3BNyhvfvqCbVL0+bg/da9bqGqeBDkTg=";
+
+    urls = [
+      "${mirror1}/Chevron/Chevron4.tar.gz"
+      "${mirror2}/Chevron/Chevron4.tar.gz"
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14859,6 +14859,8 @@ with pkgs;
 
   rocminfo = callPackage ../development/tools/rocminfo { };
 
+  rocsparse = callPackage ../development/libraries/rocsparse { };
+
   rtags = callPackage ../development/tools/rtags {
     inherit (darwin) apple_sdk;
   };


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
Third part in a whole bunch of porting...
``rocsparse.passthru.tests`` will likely always fail due to it being in a vm, but I have confirmed ~~a subset of tests (there are like 284K of them...) generated do work on hardware~~ all tests work!.
We may want to consider how many of these tests we want to do whenever it is possible to use GPU acceleration (emulated or real) in testing vms.
Depends on #197337
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
