### PR TITLE
cargo-show-asm: 0.1.24 -> 0.2.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-show-asm/default.nix
+++ b/pkgs/development/tools/rust/cargo-show-asm/default.nix
@@ -1,42 +1,28 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
-, curl
 , installShellFiles
-, pkg-config
-, openssl
 , stdenv
-, darwin
 , nix-update-script
 , callPackage
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-asm";
-  version = "0.1.24";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "pacak";
     repo = "cargo-show-asm";
     rev = version;
-    hash = "sha256-ahkKUtg5M88qddzEwYxPecDtBofGfPVxKuYKgmsbWYc=";
+    hash = "sha256-qsr28zuvu+i7P/MpwhDKQFFXTyFFo+vWrjBrpD1V8PY=";
   };
 
-  cargoHash = "sha256-S7OpHNjiTfQg7aPmHEx6Q/OV5QA9pB29F3MTIeiLAXg=";
+  cargoHash = "sha256-IL+BB08uZr5fm05ITxpm66jTb+pYYlLKOwQ8uf5rKSs=";
 
   nativeBuildInputs = [
-    curl.dev
     installShellFiles
-    pkg-config
   ];
-
-  buildInputs = [
-    curl
-    openssl
-  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    CoreFoundation
-    SystemConfiguration
-  ]);
 
   postInstall = ''
     installShellCompletion --cmd cargo-asm \


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Version bump 0.1.24 -> 0.2.0
Changelog: https://github.com/pacak/cargo-show-asm/blob/0.2.0/Changelog.md#020---2022-10-22

With dependency to lib `cargo` removed, `openssl` and `libgit` are also removed. It would be easier for darwin build.
~I removed darwin SDK to see if it builds in CI.~ It builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
