### PR TITLE
cargo-llvm-cov: fix tests, mark broken as needed

### DIFF
--- a/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
+++ b/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
@@ -1,36 +1,59 @@
 { stdenv
 , lib
-, fetchCrate
+, fetchurl
+, fetchFromGitHub
 , rustPlatform
+, rustc
 }:
 
-rustPlatform.buildRustPackage rec {
+let
   pname = "cargo-llvm-cov";
   version = "0.5.31";
 
-  src = fetchCrate {
-    inherit pname version;
-    sha256 = "sha256-HjnP9H1t660PJ5eXzgAhrdDEgqdzzb+9Dbk5RGUPjaQ=";
+  owner = "taiki-e";
+  homepage = "https://github.com/${owner}/${pname}";
+
+  llvm = rustc.llvmPackages.llvm;
+
+  # Download `Cargo.lock` from crates.io so we don't clutter up Nixpkgs
+  cargoLock = fetchurl {
+    name = "Cargo.lock";
+    url = "https://crates.io/api/v1/crates/${pname}/${version}/download";
+    sha256 = "sha256-BbrdyJgZSIz6GaTdQv1GiFHufRBSbcoHcqqEmr/HvAM=";
+    downloadToTemp = true;
+    postFetch = ''
+      tar xzf $downloadedFile ${pname}-${version}/Cargo.lock
+      mv ${pname}-${version}/Cargo.lock $out
+    '';
   };
-  cargoSha256 = "sha256-p6zpRRNX4g+jESNSwouWMjZlFhTBFJhe7LirYtFrZ1g=";
+in
 
-  # skip tests which require llvm-tools-preview
-  checkFlags = [
-    "--skip bin_crate"
-    "--skip cargo_config"
-    "--skip clean_ws"
-    "--skip instantiations"
-    "--skip merge"
-    "--skip merge_failure_mode_all"
-    "--skip no_test"
-    "--skip open_report"
-    "--skip real1"
-    "--skip show_env"
-    "--skip virtual1"
-  ];
+rustPlatform.buildRustPackage {
+  inherit pname version;
 
-  meta = rec {
-    homepage = "https://github.com/taiki-e/${pname}";
+  # Use `fetchFromGitHub` instead of `fetchCrate` because the latter does not
+  # pull in fixtures needed for the test suite
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-wRo94JVn4InkhrMHFSsEvm2FFIxUsltA57sMMOcL8b0=";
+  };
+
+  # Upstream doesn't include the lockfile so we need to add it back
+  postUnpack = ''
+    cp ${cargoLock} source/Cargo.lock
+  '';
+
+  cargoSha256 = "sha256-XcsognndhHenYnlJCNMbrNh+S8FX7qxXUjuV1j2qsmY=";
+
+  # `cargo-llvm-cov` reads these environment variables to find these binaries,
+  # which are needed to run the tests
+  LLVM_COV = "${llvm}/bin/llvm-cov";
+  LLVM_PROFDATA = "${llvm}/bin/llvm-profdata";
+
+  meta = {
+    inherit homepage;
     changelog = homepage + "/blob/v${version}/CHANGELOG.md";
     description = "Cargo subcommand to easily use LLVM source-based code coverage";
     longDescription = ''

--- a/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
+++ b/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
@@ -40,5 +40,8 @@ rustPlatform.buildRustPackage rec {
     '';
     license = with lib.licenses; [ asl20 /* or */ mit ];
     maintainers = with lib.maintainers; [ wucke13 matthiasbeyer CobaltCause ];
+
+    # The profiler runtime is (currently) disabled on non-Linux platforms
+    broken = !(stdenv.isLinux && !stdenv.targetPlatform.isRedox);
   };
 }

--- a/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
+++ b/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage rec {
       library (e.g. fenix or rust-overlay)
     '';
     license = with lib.licenses; [ asl20 /* or */ mit ];
-    maintainers = with lib.maintainers; [ wucke13 matthiasbeyer ];
+    maintainers = with lib.maintainers; [ wucke13 matthiasbeyer CobaltCause ];
   };
 }

--- a/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
+++ b/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
@@ -1,3 +1,20 @@
+# If the tests are broken, it's probably for one of two reasons:
+#
+# 1. The version of llvm used doesn't match the expectations of rustc and/or
+#    cargo-llvm-cov. This is relatively unlikely because we pull llvm out of
+#    rustc's attrset, so it *should* be the right version as long as this is the
+#    case.
+# 2. Nixpkgs has changed its rust infrastructure in a way that causes
+#    cargo-llvm-cov to misbehave under test. It's likely that even though the
+#    tests are failing, cargo-llvm-cov will still function properly in actual
+#    use. This has happened before, and is described [here][0] (along with a
+#    feature request that would fix this instance of the problem).
+#
+# For previous test-troubleshooting discussion, see [here][1].
+#
+# [0]: https://github.com/taiki-e/cargo-llvm-cov/issues/242
+# [1]: https://github.com/NixOS/nixpkgs/pull/197478
+
 { stdenv
 , lib
 , fetchurl


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~This packages [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov), a tool for generating code coverage reports using built-in features of recent Rust toolchains.~~

~~Supersedes https://github.com/NixOS/nixpkgs/pull/197453~~
~~Alternative to https://github.com/NixOS/nixpkgs/pull/185183~~

Notably, this PR has all the tests running and passing, and does not wrap the binary, allowing users to choose their own toolchain versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
