### PR TITLE
hipsparse: init at 2.3.1-5.3.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -256,6 +256,7 @@ in {
   hbase3 = handleTest ./hbase.nix { package=pkgs.hbase3; };
   hedgedoc = handleTest ./hedgedoc.nix {};
   herbstluftwm = handleTest ./herbstluftwm.nix {};
+  hipsparse = handleTest ./hipsparse.nix {};
   installed-tests = pkgs.recurseIntoAttrs (handleTest ./installed-tests {});
   invidious = handleTest ./invidious.nix {};
   oci-containers = handleTestOn ["aarch64-linux" "x86_64-linux"] ./oci-containers.nix {};

--- a/nixos/tests/hipsparse.nix
+++ b/nixos/tests/hipsparse.nix
@@ -1,0 +1,15 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+
+with lib;
+
+{
+  name = "hipsparse";
+  meta.maintainers = with maintainers; [ Madouura ];
+  nodes.machine = { };
+
+  # This will likely always fail due to this being a virtual machine with no gpu
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.succeed("${(pkgs.hipsparse.override { buildTests = true; }).test}/bin/hipsparse-test ")
+  '';
+})

--- a/pkgs/development/libraries/hipsparse/default.nix
+++ b/pkgs/development/libraries/hipsparse/default.nix
@@ -1,0 +1,132 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, rocm-cmake
+, rocm-runtime
+, rocm-device-libs
+, rocm-comgr
+, rocsparse
+, hip
+, gfortran
+, git
+, fetchzip ? null
+, gtest ? null
+, buildTests ? false
+}:
+
+assert buildTests -> fetchzip != null;
+assert buildTests -> gtest != null;
+
+# This can also use cuSPARSE as a backend instead of rocSPARSE
+let
+  matrices = lib.optionalAttrs buildTests import ./deps.nix {
+    inherit fetchzip;
+    mirror1 = "https://sparse.tamu.edu/MM";
+    mirror2 = "https://www.cise.ufl.edu/research/sparse/MM";
+  };
+in stdenv.mkDerivation rec {
+  pname = "hipsparse";
+  rocmVersion = "5.3.1";
+  version = "2.3.1-${rocmVersion}";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "hipSPARSE";
+    rev = "rocm-${rocmVersion}";
+    hash = "sha256-Phcihat774ZSAe1QetE/GSZzGlnCnvS9GwsHBHCaD4c=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+    gfortran
+  ];
+
+  buildInputs = [
+    rocm-runtime
+    rocm-device-libs
+    rocm-comgr
+    rocsparse
+    git
+  ] ++ lib.optionals buildTests [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_CLIENTS_TESTS=ON"
+  ];
+
+  # We have to manually generate the matrices
+  # CMAKE_MATRICES_DIR seems to be reset in clients/tests/CMakeLists.txt
+  postPatch = ''
+    substituteInPlace clients/common/utility.cpp \
+      --replace "#ifdef __cpp_lib_filesystem" " #if true"
+  '' + lib.optionalString buildTests ''
+    mkdir -p matrices
+
+    ln -s ${matrices.matrix-01}/*.mtx matrices
+    ln -s ${matrices.matrix-02}/*.mtx matrices
+    ln -s ${matrices.matrix-03}/*.mtx matrices
+    ln -s ${matrices.matrix-04}/*.mtx matrices
+    ln -s ${matrices.matrix-05}/*.mtx matrices
+    ln -s ${matrices.matrix-06}/*.mtx matrices
+    ln -s ${matrices.matrix-07}/*.mtx matrices
+    ln -s ${matrices.matrix-08}/*.mtx matrices
+    ln -s ${matrices.matrix-09}/*.mtx matrices
+    ln -s ${matrices.matrix-10}/*.mtx matrices
+    ln -s ${matrices.matrix-11}/*.mtx matrices
+    ln -s ${matrices.matrix-12}/*.mtx matrices
+    ln -s ${matrices.matrix-13}/*.mtx matrices
+    ln -s ${matrices.matrix-14}/*.mtx matrices
+    ln -s ${matrices.matrix-15}/*.mtx matrices
+    ln -s ${matrices.matrix-16}/*.mtx matrices
+    ln -s ${matrices.matrix-17}/*.mtx matrices
+    ln -s ${matrices.matrix-18}/*.mtx matrices
+    ln -s ${matrices.matrix-19}/*.mtx matrices
+
+    # Not used by the original cmake, causes an error
+    rm matrices/*_b.mtx
+
+    echo "deps/convert.cpp -> deps/mtx2csr"
+    hipcc deps/convert.cpp -O3 -o deps/mtx2csr
+
+    for mat in $(ls -1 matrices | cut -d "." -f 1); do
+      echo "mtx2csr: $mat.mtx -> $mat.bin"
+      deps/mtx2csr matrices/$mat.mtx matrices/$mat.bin
+      unlink matrices/$mat.mtx
+    done
+
+    substituteInPlace clients/tests/CMakeLists.txt \
+      --replace "\''${PROJECT_BINARY_DIR}/matrices" "/build/source/matrices"
+  '';
+
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv $out/bin/hipsparse-test $test/bin
+    mv /build/source/matrices $test
+    rmdir $out/bin
+  '';
+
+  meta = with lib; {
+    description = "ROCm SPARSE marshalling library";
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipSPARSE";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ Madouura ];
+    broken = rocmVersion != hip.version;
+  };
+}

--- a/pkgs/development/libraries/hipsparse/default.nix
+++ b/pkgs/development/libraries/hipsparse/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nixosTests
 , cmake
 , rocm-cmake
 , rocm-runtime
@@ -121,6 +122,10 @@ in stdenv.mkDerivation rec {
     mv /build/source/matrices $test
     rmdir $out/bin
   '';
+
+  passthru.tests = {
+    smoke-test = nixosTests.hipsparse;
+  };
 
   meta = with lib; {
     description = "ROCm SPARSE marshalling library";

--- a/pkgs/development/libraries/hipsparse/deps.nix
+++ b/pkgs/development/libraries/hipsparse/deps.nix
@@ -1,0 +1,177 @@
+{ fetchzip
+, mirror1
+, mirror2
+}:
+
+{
+  matrix-01 = fetchzip {
+    sha256 = "sha256-AHur5ZIDZTFRrO2GV0ieXrffq4KUiGWiZ59pv0fUtEQ=";
+
+    urls = [
+      "${mirror1}/SNAP/amazon0312.tar.gz"
+      "${mirror2}/SNAP/amazon0312.tar.gz"
+    ];
+  };
+
+  matrix-02 = fetchzip {
+    sha256 = "sha256-0rSxaN4lQcdaCLsvlgicG70FXUxXeERPiEmQ4MzbRdE=";
+
+    urls = [
+      "${mirror1}/Muite/Chebyshev4.tar.gz"
+      "${mirror2}/Muite/Chebyshev4.tar.gz"
+    ];
+  };
+
+  matrix-03 = fetchzip {
+    sha256 = "sha256-hDzDWDUnHEyFedX/tMNq83ZH8uWyM4xtZYUUAD3rizo=";
+
+    urls = [
+      "${mirror1}/FEMLAB/sme3Dc.tar.gz"
+      "${mirror2}/FEMLAB/sme3Dc.tar.gz"
+    ];
+  };
+
+  matrix-04 = fetchzip {
+    sha256 = "sha256-GmN2yOt/MoX01rKe05aTyB3ypUP4YbQGOITZ0BqPmC0=";
+
+    urls = [
+      "${mirror1}/Williams/webbase-1M.tar.gz"
+      "${mirror2}/Williams/webbase-1M.tar.gz"
+    ];
+  };
+
+  matrix-05 = fetchzip {
+    sha256 = "sha256-gQNjfVyWzNM9RwImJGhkhahRmZz74LzDs1oijL7mI7k=";
+
+    urls = [
+      "${mirror1}/Williams/mac_econ_fwd500.tar.gz"
+      "${mirror2}/Williams/mac_econ_fwd500.tar.gz"
+    ];
+  };
+
+  matrix-06 = fetchzip {
+    sha256 = "sha256-87cdZjntNcTuz5BtO59irhcuRbPllWSbhCEX3Td02qc=";
+
+    urls = [
+      "${mirror1}/Williams/mc2depi.tar.gz"
+      "${mirror2}/Williams/mc2depi.tar.gz"
+    ];
+  };
+
+  matrix-07 = fetchzip {
+    sha256 = "sha256-WRamuJX3D8Tm+k0q67RjUDG3DeNAxhKiaPkk5afY5eU=";
+
+    urls = [
+      "${mirror1}/Bova/rma10.tar.gz"
+      "${mirror2}/Bova/rma10.tar.gz"
+    ];
+  };
+
+  matrix-08 = fetchzip {
+    sha256 = "sha256-5dhkm293Mc3lzakKxHy5W5XIn4Rw+gihVh7gyrjEHXo=";
+
+    urls = [
+      "${mirror1}/JGD_BIBD/bibd_22_8.tar.gz"
+      "${mirror2}/JGD_BIBD/bibd_22_8.tar.gz"
+    ];
+  };
+
+  matrix-09 = fetchzip {
+    sha256 = "sha256-czjLWCjXAjZCk5TGYHaEkwSAzQu3TQ3QyB6eNKR4G88=";
+
+    urls = [
+      "${mirror1}/Hamm/scircuit.tar.gz"
+      "${mirror2}/Hamm/scircuit.tar.gz"
+    ];
+  };
+
+  matrix-10 = fetchzip {
+    sha256 = "sha256-bYuLnJViAIcIejAkh69/bsNAVIDU4wfTLtD+nmHd6FM=";
+
+    urls = [
+      "${mirror1}/Sandia/ASIC_320k.tar.gz"
+      "${mirror2}/Sandia/ASIC_320k.tar.gz"
+    ];
+  };
+
+  matrix-11 = fetchzip {
+    sha256 = "sha256-aDwn8P1khYjo2Agbq5m9ZBInJUxf/knJNvyptt0fak0=";
+
+    urls = [
+      "${mirror1}/GHS_psdef/bmwcra_1.tar.gz"
+      "${mirror2}/GHS_psdef/bmwcra_1.tar.gz"
+    ];
+  };
+
+  matrix-12 = fetchzip {
+    sha256 = "sha256-8OJqA/byhlAZd869TPUzZFdsOiwOoRGfKyhM+RMjXoY=";
+
+    urls = [
+      "${mirror1}/HB/nos1.tar.gz"
+      "${mirror2}/HB/nos1.tar.gz"
+    ];
+  };
+
+  matrix-13 = fetchzip {
+    sha256 = "sha256-FS0rKqmg+uHwsM/yGfQLBdd7LH/rUrdutkNGBD/Mh1I=";
+
+    urls = [
+      "${mirror1}/HB/nos2.tar.gz"
+      "${mirror2}/HB/nos2.tar.gz"
+    ];
+  };
+
+  matrix-14 = fetchzip {
+    sha256 = "sha256-DANnlrNJikrI7Pst9vRedtbuxepyHmCIu2yhltc4Qcs=";
+
+    urls = [
+      "${mirror1}/HB/nos3.tar.gz"
+      "${mirror2}/HB/nos3.tar.gz"
+    ];
+  };
+
+  matrix-15 = fetchzip {
+    sha256 = "sha256-21mUgqjWGUfYgiWwSrKh9vH8Vdt3xzcefmqYNYRpxiY=";
+
+    urls = [
+      "${mirror1}/HB/nos4.tar.gz"
+      "${mirror2}/HB/nos4.tar.gz"
+    ];
+  };
+
+  matrix-16 = fetchzip {
+    sha256 = "sha256-FOuXvGqBBFNkVS6cexmkluret54hCfCOdK+DOZllE4c=";
+
+    urls = [
+      "${mirror1}/HB/nos5.tar.gz"
+      "${mirror2}/HB/nos5.tar.gz"
+    ];
+  };
+
+  matrix-17 = fetchzip {
+    sha256 = "sha256-+7NI1rA/qQxYPpjXKHvAaCZ+LSaAJ4xuJvMRMBEUYxg=";
+
+    urls = [
+      "${mirror1}/HB/nos6.tar.gz"
+      "${mirror2}/HB/nos6.tar.gz"
+    ];
+  };
+
+  matrix-18 = fetchzip {
+    sha256 = "sha256-q3NxJjbwGGcFiQ9nhWfUKgZmdVwCfPmgQoqy0AqOsNc=";
+
+    urls = [
+      "${mirror1}/HB/nos7.tar.gz"
+      "${mirror2}/HB/nos7.tar.gz"
+    ];
+  };
+
+  matrix-19 = fetchzip {
+    sha256 = "sha256-0GAN6qmVfD+tprIigzuUUUwm5KVhkN9X65wMEvFltDY=";
+
+    urls = [
+      "${mirror1}/DNVS/shipsec1.tar.gz"
+      "${mirror2}/DNVS/shipsec1.tar.gz"
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14833,6 +14833,8 @@ with pkgs;
     inherit (llvmPackages_rocm) clang llvm;
   };
 
+  hipsparse = callPackage ../development/libraries/hipsparse { };
+
   rocm-cmake = callPackage ../development/tools/build-managers/rocm-cmake { };
 
   rocm-comgr = callPackage ../development/libraries/rocm-comgr {


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
Fourth part in a whole bunch of porting...
~~For now, no ``nixosTests`` or enabled ``buildTests``.~~
~~Seems to be an upstream issue, AUR package also had to disable some things.~~
hipSPARSE tests working!
``hipsparse.passthru.tests`` will likely always fail due to it being in a vm, but I have confirmed the tests generated do work on hardware.
Depends on #197455
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
