### PR TITLE
Dspdfviewer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8651,6 +8651,12 @@
     github = "SuperSamus";
     githubId = 40663462;
   };
+  martiert = {
+    name = "Martin Ertsås";
+    email = "martiert@gmail.com";
+    github = "martiert";
+    githubId = 223288;
+  };
   marzipankaiser = {
     email = "nixos@gaisseml.de";
     github = "marzipankaiser";

--- a/pkgs/applications/office/dspdfviewer/default.nix
+++ b/pkgs/applications/office/dspdfviewer/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, boost
+, qtbase
+, qttools
+, libsForQt512
+, wrapQtAppsHook}:
+
+stdenv.mkDerivation rec {
+  pname = "dspdfviewer";
+  version = "1.15.1";
+
+  src = fetchFromGitHub {
+    owner = "dannyedel";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0n1biiyi77inkyfmzfvl84jp69hqlnsphbr9j97gsh0np6pxnf1l";
+  };
+
+  buildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    boost
+    qtbase
+    qttools
+    libsForQt512.poppler
+    wrapQtAppsHook
+  ];
+
+  cmakeFlags = [
+    "-DBuildTests=Off"
+  ];
+
+  meta = with lib; {
+    description = "Multi screen pdf presentation viewer designed for latex-beamer";
+    homepage = "https://dspdfviewer.danny-edel.de";
+    license = with licenses; [ gpl2Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ martiert ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6357,6 +6357,8 @@ with pkgs;
 
   dsp = callPackage ../tools/audio/dsp { };
 
+  dspdfviewer = qt512.callPackage ../applications/office/dspdfviewer {};
+
   dirdiff = callPackage ../tools/text/dirdiff {
     tcl = tcl-8_5;
     tk = tk-8_5;


### PR DESCRIPTION
###### Description of changes

dspdfviewer is a pre-rendering and caching (read: fast) full-screen pdf viewer specifically designed for latex-beamer presentations, that were created with the show notes on second screen=right option.

https://dspdfviewer.danny-edel.de

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
