### PR TITLE
ocamlPackages.bls12-381-signature: init at 1.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/bls12-381-signature/default.nix
+++ b/pkgs/development/ocaml-modules/bls12-381-signature/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchzip,
+  buildDunePackage,
+  bls12-381,
+  alcotest,
+  bisect_ppx,
+  integers_stubs_js,
+}:
+
+buildDunePackage rec {
+  pname = "bls12-381-signature";
+  version = "1.0.0";
+  src = fetchzip {
+    url = "https://gitlab.com/nomadic-labs/cryptography/ocaml-${pname}/-/archive/${version}/ocaml-bls12-381-signature-${version}.tar.bz2";
+    sha256 = "sha256-KaUpAT+BWxmUP5obi4loR9vVUeQmz3p3zG3CBolUuL4=";
+  };
+
+  minimalOCamlVersion = "4.08";
+
+  propagatedBuildInputs = [ bls12-381 ];
+
+  checkInputs = [alcotest bisect_ppx integers_stubs_js];
+
+  doCheck = true;
+
+  meta = {
+    description = "Implementation of BLS signatures for the pairing-friendly curve BLS12-381";
+    license = lib.licenses.mit;
+    homepage = "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature";
+    maintainers = [lib.maintainers.ulrikstrid];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -94,6 +94,8 @@ let
     bls12-381-gen = callPackage ../development/ocaml-modules/bls12-381/gen.nix { };
     bls12-381-legacy = callPackage ../development/ocaml-modules/bls12-381/legacy.nix { };
 
+    bls12-381-signature = callPackage ../development/ocaml-modules/bls12-381-signature { };
+
     bos = callPackage ../development/ocaml-modules/bos { };
 
     brisk-reconciler = callPackage ../development/ocaml-modules/brisk-reconciler { };


### PR DESCRIPTION
###### Description of changes

In preparation for the next LIGO release

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
