### PR TITLE
release-notes: Move PolyMC from "highlights"

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -40,24 +40,6 @@
       </listitem>
       <listitem>
         <para>
-          The <literal>polymc</literal> package has been removed due to
-          a rogue maintainer. It has been replaced by
-          <literal>prismlauncher</literal>, a fork by the rest of the
-          maintainers. For more details, see
-          <link xlink:href="https://github.com/NixOS/nixpkgs/pull/196624">the
-          pull request that made this change</link> and
-          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/196460">this
-          issue detailing the vulnerability</link>. Users with existing
-          installations should rename
-          <literal>~/.local/share/polymc</literal> to
-          <literal>~/.local/share/PrismLauncher</literal>. The main
-          config file’s path has also moved from
-          <literal>~/.local/share/polymc/polymc.cfg</literal> to
-          <literal>~/.local/share/PrismLauncher/prismlauncher.cfg</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
           The <literal>nixpkgs.hostPlatform</literal> and
           <literal>nixpkgs.buildPlatform</literal> options have been
           added. These cover and override the
@@ -865,6 +847,24 @@
         <para>
           The <literal>networking.wireguard</literal> module now can set
           the mtu on interfaces and tag its packets with an fwmark.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>polymc</literal> package has been removed due to
+          a rogue maintainer. It has been replaced by
+          <literal>prismlauncher</literal>, a fork by the rest of the
+          maintainers. For more details, see
+          <link xlink:href="https://github.com/NixOS/nixpkgs/pull/196624">the
+          pull request that made this change</link> and
+          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/196460">this
+          issue detailing the vulnerability</link>. Users with existing
+          installations should rename
+          <literal>~/.local/share/polymc</literal> to
+          <literal>~/.local/share/PrismLauncher</literal>. The main
+          config file’s path has also moved from
+          <literal>~/.local/share/polymc/polymc.cfg</literal> to
+          <literal>~/.local/share/PrismLauncher/prismlauncher.cfg</literal>.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -20,16 +20,6 @@ In addition to numerous new and upgraded packages, this release has the followin
   built for `stdenv.hostPlatform` (i.e. produced by `stdenv.cc`) by evaluating
   `stdenv.buildPlatform.canExecute stdenv.hostPlatform`.
 
-- The `polymc` package has been removed due to a rogue maintainer. It has been
-  replaced by `prismlauncher`, a fork by the rest of the maintainers. For more
-  details, see [the pull request that made this
-  change](https://github.com/NixOS/nixpkgs/pull/196624) and [this issue
-  detailing the vulnerability](https://github.com/NixOS/nixpkgs/issues/196460).
-  Users with existing installations should rename `~/.local/share/polymc` to
-  `~/.local/share/PrismLauncher`. The main config file's path has also moved
-  from `~/.local/share/polymc/polymc.cfg` to
-  `~/.local/share/PrismLauncher/prismlauncher.cfg`.
-
 - The `nixpkgs.hostPlatform` and `nixpkgs.buildPlatform` options have been added.
   These cover and override the `nixpkgs.{system,localSystem,crossSystem}` options.
 
@@ -279,6 +269,16 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 - Neo4j was updated from version 3 to version 4. See this [migration guide](https://neo4j.com/docs/upgrade-migration-guide/current/) on how to migrate your Neo4j instance.
 
 - The `networking.wireguard` module now can set the mtu on interfaces and tag its packets with an fwmark.
+
+- The `polymc` package has been removed due to a rogue maintainer. It has been
+  replaced by `prismlauncher`, a fork by the rest of the maintainers. For more
+  details, see [the pull request that made this
+  change](https://github.com/NixOS/nixpkgs/pull/196624) and [this issue
+  detailing the vulnerability](https://github.com/NixOS/nixpkgs/issues/196460).
+  Users with existing installations should rename `~/.local/share/polymc` to
+  `~/.local/share/PrismLauncher`. The main config file's path has also moved
+  from `~/.local/share/polymc/polymc.cfg` to
+  `~/.local/share/PrismLauncher/prismlauncher.cfg`.
 
 - The `services.matrix-synapse` systemd unit has been hardened.
 


### PR DESCRIPTION
###### Description of changes

- Previously PolyMC's removal was counted as a release highlight
- It probably shouldn't be, as it's more a notable change rather than a highlight
- Thanks @Ma27 for noticing this

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).