### PR TITLE
ligo: 0.53 -> 0.54

### DIFF
--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -9,12 +9,12 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "ligo";
-  version = "0.53.0";
+  version = "0.54.0";
   src = fetchFromGitLab {
     owner = "ligolang";
     repo = "ligo";
     rev = version;
-    sha256 = "sha256-WNiN9UrwXCwfxWnR5oPm9sGWelQCpooCXh43T2QaOnI=";
+    sha256 = "sha256-Iq72gDaS05yhxAYjIUrqiCwBkx5aWbVpYPcQlgojhNU=";
     fetchSubmodules = true;
   };
 
@@ -78,6 +78,7 @@ ocamlPackages.buildDunePackage rec {
     ipaddr
     bls12-381
     bls12-381-legacy
+    bls12-381-signature
     ptime
     mtime
     lwt_log

--- a/pkgs/development/ocaml-modules/bls12-381/default.nix
+++ b/pkgs/development/ocaml-modules/bls12-381/default.nix
@@ -4,12 +4,12 @@
 
 buildDunePackage rec {
   pname = "bls12-381";
-  version = "4.0.0";
+  version = "5.0.0";
   src = fetchFromGitLab {
     owner = "dannywillems";
     repo = "ocaml-bls12-381";
     rev = version;
-    sha256 = "sha256-K9AsYUAUdk4XnspUalJKX5kycDFwO8PZx4bGaD3qZv8=";
+    sha256 = "sha256-Hy/I+743HSToZgGPFFiAbx7nrybHsE2PwycDsu3DuHM=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/resto/default.nix
+++ b/pkgs/development/ocaml-modules/resto/default.nix
@@ -2,12 +2,12 @@
 
 buildDunePackage rec {
   pname = "resto";
-  version = "0.7";
+  version = "1.0";
   src = fetchFromGitLab {
     owner = "nomadic-labs";
     repo = "resto";
     rev = "v${version}";
-    sha256 = "sha256-aX7w/rsoOmbni8BOXa0WnoQ47Y5zl91vWvMobuNFT3Y=";
+    sha256 = "sha256-DIm7fmISsCgRDi4p3NsUk7Cvs/dHpIKMdAOVdYLX2mc=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

`bls12-381` and `resto` breaks current LIGO version so needs to go in at the same time, the other packages can go in separately.
~~Opening as draft until 0.54 is tagged~~ 0.54.0 is now released and this is ready to go.

- [x] #197494
- [x] #197507

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
