### PR TITLE
wordpressPackages.plugins.wp-fastest-cache: init at 1.0.6

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -101,17 +101,17 @@
     "sha256": "1flggxd6hw0ps3b0y32a2aj9g3zfpzbaiwzx1zn2s7zpxn508y1b",
     "version": "5.3.1"
   },
-  "wordpress-seo": {
-    "path": "wordpress-seo/tags/19.8",
-    "rev": "2796969",
-    "sha256": "0vnj7b37s9rra2m957baz8ki4z6x6acl76wgx8yj2063823q0pl2",
-    "version": "19.8"
-  },
   "webp-express": {
     "path": "webp-express/tags/0.25.5",
     "rev": "2728620",
     "sha256": "0m8hbz72kvzlrcb5jnyfka90xfk1dg602rwmf22xnawzbw52532p",
     "version": "0.25.5"
+  },
+  "wordpress-seo": {
+    "path": "wordpress-seo/tags/19.8",
+    "rev": "2796969",
+    "sha256": "0vnj7b37s9rra2m957baz8ki4z6x6acl76wgx8yj2063823q0pl2",
+    "version": "19.8"
   },
   "worker": {
     "path": "worker/tags/4.9.14",
@@ -124,6 +124,12 @@
     "rev": "2796798",
     "sha256": "1wkj15vclbh4l38fkrmbmc4w7lapfydq9rrpn508ki19f4544dam",
     "version": "1.0"
+  },
+  "wp-fastest-cache": {
+    "path": "wp-fastest-cache/tags/1.0.6",
+    "rev": "2793013",
+    "sha256": "14xqqnv1snc2nc4y7cc6mmjkfkds18lk4xh7x75cbhy5cd8nqx8x",
+    "version": "1.0.6"
   },
   "wp-gdpr-compliance": {
     "path": "wp-gdpr-compliance/tags/2.0.20",
@@ -138,10 +144,10 @@
     "version": "3.6.1"
   },
   "wp-statistics": {
-    "path": "wp-statistics/tags/13.2.6",
-    "rev": "2781181",
-    "sha256": "0vzlhlnna2dx4kyi24rqhbrx5n5zsw51hqgsaslfiyyir64dkzgz",
-    "version": "13.2.6"
+    "path": "wp-statistics/tags/13.2.7",
+    "rev": "2803072",
+    "sha256": "001b9q8vmpj3rvlv2s8h7c9m2xvd58mcvcas99n4bmllzrxy2pji",
+    "version": "13.2.7"
   },
   "wp-user-avatars": {
     "path": "wp-user-avatars/trunk",

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -19,9 +19,10 @@
 , "webp-express"
 , "wordpress-seo"
 , "worker"
-, "wp-mail-smtp"
+, "wp-change-email-sender"
+, "wp-fastest-cache"
 , "wp-gdpr-compliance"
+, "wp-mail-smtp"
 , "wp-statistics"
 , "wp-user-avatars"
-, "wp-change-email-sender"
 ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
