### PR TITLE
ocamlPackages.lablgtk: 2.18.12 → 2.18.13

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -1,16 +1,19 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, ocaml, findlib, pkg-config, gtk2, libgnomecanvas, gtksourceview }:
+{ lib, stdenv, fetchurl, fetchFromGitHub, ocaml, findlib, pkg-config, gtk2, libgnomecanvas, gtksourceview
+, camlp-streams
+}:
 
 let param =
   let check = lib.versionAtLeast ocaml.version; in
   if check "4.06" then rec {
-    version = "2.18.12";
+    version = "2.18.13";
     src = fetchFromGitHub {
       owner = "garrigue";
       repo = "lablgtk";
       rev = version;
-      sha256 = "sha256:0asib87c42apwf1ln8541x6i3mvyajqbarifvz11in0mqn5k7g7h";
+      sha256 = "sha256-69Svno0qLaUifMscnVuPUJlCo9d8Lee+1qiYx34G3Po=";
     };
     NIX_CFLAGS_COMPILE = null;
+    buildInputs = [ camlp-streams ];
   } else if check "3.12" then {
     version = "2.18.5";
     src = fetchurl {
@@ -26,11 +29,12 @@ let param =
 in
 
 stdenv.mkDerivation {
-  pname = "lablgtk";
+  pname = "ocaml${ocaml.version}-lablgtk";
   inherit (param) version src NIX_CFLAGS_COMPILE;
 
   nativeBuildInputs = [ pkg-config ocaml findlib ];
-  buildInputs = [ gtk2 libgnomecanvas gtksourceview ];
+  buildInputs = [ gtk2 libgnomecanvas gtksourceview ]
+  ++ param.buildInputs or [];
 
   configureFlags = [ "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
   buildFlags = [ "world" ];


### PR DESCRIPTION
###### Description of changes

Ready for OCaml 5: https://github.com/garrigue/lablgtk/blob/2.18.13/CHANGES

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

