### PR TITLE
blueman: 2.3.2 -> 2.3.4

### DIFF
--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -1,24 +1,23 @@
 { config, stdenv, lib, fetchurl, intltool, pkg-config, python3Packages, bluez, gtk3
 , obex_data_server, xdg-utils, dnsmasq, dhcp, libappindicator, iproute2
-, gnome, librsvg, wrapGAppsHook, gobject-introspection, autoreconfHook
-, networkmanager, withPulseAudio ? config.pulseaudio or stdenv.isLinux, libpulseaudio, fetchpatch }:
+, gnome, librsvg, wrapGAppsHook, gobject-introspection
+, networkmanager, withPulseAudio ? config.pulseaudio or stdenv.isLinux, libpulseaudio }:
 
 let
   pythonPackages = python3Packages;
 
 in stdenv.mkDerivation rec {
   pname = "blueman";
-  version = "2.3.2";
+  version = "2.3.4";
 
   src = fetchurl {
     url = "https://github.com/blueman-project/blueman/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-hM99f9Fzh1HHfgYF9y5M3UtyMHindo/j81MJmToDUK4=";
+    sha256 = "sha256-wgYzghQ38yydPRkOzXDR4vclXXSn1pefInEb3C5WAVI=";
   };
 
   nativeBuildInputs = [
     gobject-introspection intltool pkg-config pythonPackages.cython
     pythonPackages.wrapPython wrapGAppsHook
-    autoreconfHook # drop when below patch is removed
   ];
 
   buildInputs = [ bluez gtk3 pythonPackages.python librsvg


### PR DESCRIPTION
###### Description of changes

https://github.com/blueman-project/blueman/compare/2.3.2...2.3.4

Finally no more [duplicate tray icon](https://github.com/blueman-project/blueman/issues/1870) in cinnamon!

<img src="https://user-images.githubusercontent.com/20080233/197519958-3dc992c8-2b47-4fdb-8d5e-ce6eda3d184b.png" width=50%>

The patch in https://github.com/NixOS/nixpkgs/commit/6b98d70f61219e32efbab3e6658608b286fc5756 has been removed a while (?) ago so let's drop autoreconfHook.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
