### PR TITLE
kestrel: init at 0.10.0

### DIFF
--- a/pkgs/tools/security/kestrel/default.nix
+++ b/pkgs/tools/security/kestrel/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, installShellFiles
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kestrel";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "finfet";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-aJKqx/PY7BanzE5AtqmKxvkULgXXqueGnDniLd9tHOg=";
+  };
+
+  cargoHash = "sha256-UnXaDdQzoYP1N2FnLjOQgiJKnCyCojXKKxVlWYZT0DE=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    installManPage docs/man/kestrel.1
+    installShellCompletion --bash --name ${pname} completion/kestrel.bash-completion
+  '';
+
+  meta = with lib; {
+    description = "File encryption done right";
+    longDescription = "
+      Kestrel is a data-at-rest file encryption program
+      that lets you encrypt files to anyone with a public key.
+    ";
+    homepage = "https://getkestrel.com";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8233,6 +8233,8 @@ with pkgs;
 
   keepalived = callPackage ../tools/networking/keepalived { };
 
+  kestrel = callPackage ../tools/security/kestrel { };
+
   kexec-tools = callPackage ../os-specific/linux/kexec-tools { };
 
   keepkey_agent = with python3Packages; toPythonApplication keepkey_agent;


### PR DESCRIPTION
###### Description of changes

Kestrel is a data-at-rest file encryption program that lets you encrypt files to anyone with a public key.

https://github.com/finfet/kestrel

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
