### PR TITLE
gtimelog: fix and update to latest master

### DIFF
--- a/pkgs/development/python-modules/gtimelog/default.nix
+++ b/pkgs/development/python-modules/gtimelog/default.nix
@@ -1,27 +1,43 @@
-{ lib, fetchFromGitHub, makeWrapper
-, glibcLocales, gobject-introspection, gtk3, libsoup, libsecret
-, buildPythonPackage, python
-, pygobject3, freezegun, mock
+{ lib
+, fetchFromGitHub
+, makeWrapper
+, python
+, buildPythonPackage
+, atk
+, gdk-pixbuf
+, glibcLocales
+, glib-networking
+, gobject-introspection
+, gtk3
+, harfbuzz
+, libsecret
+, libsoup
+, pango
 }:
-
 buildPythonPackage rec {
   pname = "gtimelog";
-  version = "unstable-2020-05-16";
+  version = "unstable-2022-10-28";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "80682ddbf9e0d68b8c67257289784f3b49b543d8";
-    sha256 = "0qv2kv7vc3qqlzxsisgg31cmrkkqgnmxspbj10c5fhdmwzzwi0i9";
+    rev = "73d2228cea7e500858075a139fd321b1ccbae0d1";
+    sha256 = "sha256-g6gU95uvBhBbB4b1McE2LuVPDCjdmmhBX3lVyCY96zA=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [
-    glibcLocales gobject-introspection gtk3 libsoup libsecret
+    glibcLocales
+    gobject-introspection
+    gtk3
+    libsoup
+    libsecret
   ];
 
-  propagatedBuildInputs = [
-    pygobject3 freezegun mock
+  propagatedBuildInputs = with python.pkgs; [
+    pygobject3
+    freezegun
+    mock
   ];
 
   checkPhase = ''
@@ -30,6 +46,26 @@ buildPythonPackage rec {
   '';
 
   pythonImportsCheck = [ "gtimelog" ];
+
+  # found this fix at Matrix
+  # see https://matrix.to/#/!KqkRjyTEzAGRiZFBYT:nixos.org/$reRwjXiP3c4q9-z3wnnnBF9Q5KYGi9w3DxeQLhEJhnI?via=nixos.org&via=matrix.org&via=tchncs.de
+  # resolves runtime error: Typelib files for Gtk-3.0 are not available.
+  makeWrapperArgs = [
+    "--set GI_TYPELIB_PATH ${lib.makeSearchPathOutput "lib"
+      "lib/girepository-1.0" ([
+        gtk3
+        libsoup
+        libsecret
+        pango
+        harfbuzz
+        gdk-pixbuf
+        atk
+      ])}"
+    "--set GIO_MODULE_DIR ${lib.makeSearchPathOutput "out"
+      "lib/gio/modules" ([
+        glib-networking
+      ])}"
+  ];
 
   preFixup = ''
     wrapProgram $out/bin/gtimelog \
@@ -42,18 +78,16 @@ buildPythonPackage rec {
     longDescription = ''
       GTimeLog is a small time tracking application for GNOME.
       It's main goal is to be as unintrusive as possible.
-
       To run gtimelog successfully on a system that does not have full GNOME 3
       installed, the following NixOS options should be set:
       - programs.dconf.enable = true;
       - services.gnome.gnome-keyring.enable = true;
-
       In addition, the following packages should be added to the environment:
       - gnome.adwaita-icon-theme
       - gnome.dconf
     '';
     homepage = "https://gtimelog.org/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ oxzi ];
+    maintainers = with maintainers; [ oxzi nazarewk ];
   };
 }


### PR DESCRIPTION
it was not working before, exiting with:
```
Typelib files for Gtk-3.0 are not available.

If you're on Ubuntu or another Debian-like distribution, please install
them with

    sudo apt install gir1.2-gtk-3.0
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
