### PR TITLE
module system: Improve error messages around faulty imports

### DIFF
--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -47,7 +47,7 @@ let
   optionsDoc = pkgs.nixosOptionsDoc {
     inherit (pkgs.lib.evalModules {
       modules = [ ../../pkgs/top-level/config.nix ];
-      specialArgs.class = "nixpkgsConfig";
+      class = "nixpkgsConfig";
     }) options;
     documentType = "none";
     transformOptions = opt:

--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -45,7 +45,10 @@ let
   # NB: This file describes the Nixpkgs manual, which happens to use module
   #     docs infra originally developed for NixOS.
   optionsDoc = pkgs.nixosOptionsDoc {
-    inherit (pkgs.lib.evalModules { modules = [ ../../pkgs/top-level/config.nix ]; }) options;
+    inherit (pkgs.lib.evalModules {
+      modules = [ ../../pkgs/top-level/config.nix ];
+      specialArgs.class = "nixpkgsConfig";
+    }) options;
     documentType = "none";
     transformOptions = opt:
       opt // {

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -12,7 +12,11 @@
   <xi:include href="using/configuration.chapter.xml" />
   <xi:include href="using/overlays.chapter.xml" />
   <xi:include href="using/overrides.chapter.xml" />
+ </part>
+ <part>
+  <title>Nixpkgs <code>lib</code></title>
   <xi:include href="functions.xml" />
+  <xi:include href="module-system/module-system.chapter.xml" />
  </part>
  <part xml:id="part-stdenv">
   <title>Standard environment</title>

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -28,11 +28,11 @@ An attribute set of module arguments that can be used in `imports`.
 
 This is in contrast to `config._module.args`, which is only available after all `imports` have been resolved.
 
-#### `specialArgs.class` {#module-system-lib-evalModules-param-specialArgs-class}
+#### `class` {#module-system-lib-evalModules-param-class}
 
-If the `class` attribute is set in `specialArgs`, the module system will reject modules with a different `class`.
+If the `class` attribute is set and non-`null`, the module system will reject `imports` with a different `class`.
 
-The `class` value should be in lower [camel case](https://en.wikipedia.org/wiki/Camel_case).
+The `class` value should be a string in lower [camel case](https://en.wikipedia.org/wiki/Camel_case).
 
 If applicable, the `class` should match the "prefix" of the attributes used in (experimental) [flakes](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#description). Some examples are:
 

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -75,11 +75,20 @@ A function similar to `evalModules` but building on top of the already passed [`
 
 If you're familiar with prototype inheritance, you can think of the current, actual `evalModules` invocation as the prototype, and the return value of `extendModules` as the instance.
 
+This functionality is also available to modules as the `extendModules` module argument.
+
+::: {.note}
+
+**Evaluation Performance**
+
+`extendModules` returns a configuration that shares very little with the original `evalModules` invocation, because the module arguments may be different.
+
+So if you have a configuration that has been (or will be) largely evaluated, almost none of the computation is shared with the configuration returned by `extendModules`.
+
 The real work of module evaluation happens while computing the values in `config` and `options`, so multiple invocations of `extendModules` have a particularly small cost, as long as only the final `config` and `options` are evaluated.
 
 If you do reference multiple `config` (or `options`) from before and after `extendModules`, evaluation performance is the same as with multiple `evalModules` invocations, because the new modules' ability to override existing configuration fundamentally requires constructing a new `config` and `options` fixpoint.
-
-This functionality is also available to modules as the `extendModules` module argument.
+:::
 
 #### `_module` {#module-system-lib-evalModules-return-value-_module}
 

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -100,6 +100,6 @@ A portion of the configuration tree which is elided from `config`.
 
 A nominal type marker, always `"configuration"`.
 
-#### `configurationClass` {#module-system-lib-evalModules-return-value-_configurationClass}
+#### `class` {#module-system-lib-evalModules-return-value-_configurationClass}
 
-Equal to the [`class` parameter](#module-system-lib-evalModules-param-class).
+The [`class` argument](#module-system-lib-evalModules-param-class).

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -92,6 +92,6 @@ If you do reference multiple `config` (or `options`) from before and after `exte
 
 #### `_module` {#module-system-lib-evalModules-return-value-_module}
 
-A portion of the configuration tree which is elided from `config`. It contains some values that are mostly internal to the module system implementation.
+A portion of the configuration tree which is elided from `config`.
 
 <!-- TODO: when markdown migration is complete, make _module docs visible again and reference _module docs. Maybe move those docs into this chapter? -->

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -30,7 +30,7 @@ This is in contrast to `config._module.args`, which is only available after all 
 
 #### `class` {#module-system-lib-evalModules-param-class}
 
-If the `class` attribute is set and non-`null`, the module system will reject `imports` with a different `class`.
+If the `class` attribute is set and non-`null`, the module system will reject `imports` with a different `_class` declaration.
 
 The `class` value should be a string in lower [camel case](https://en.wikipedia.org/wiki/Camel_case).
 

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -64,11 +64,16 @@ The option definitions that are typed with this type will extend the current set
 
 However, the value returned from the type is just the [`config`](#module-system-lib-evalModules-return-value-config), like any submodule.
 
+If you're familiar with prototype inheritance, you can think of this `evalModules` invocation as the prototype, and usages of this type as the instances.
+
 This type is also available to the [`modules`](#module-system-lib-evalModules-param-modules) as the module argument `moduleType`.
+<!-- TODO: document the module arguments. Using moduleType is like saying: suppose this configuration was extended. -->
 
 #### `extendModules` {#module-system-lib-evalModules-return-value-extendModules}
 
 A function similar to `evalModules` but building on top of the already passed [`modules`](#module-system-lib-evalModules-param-modules). Its arguments, `modules` and `specialArgs` are added to the existing values.
+
+If you're familiar with prototype inheritance, you can think of the current, actual `evalModules` invocation as the prototype, and the return value of `extendModules` as the instance.
 
 The real work of module evaluation happens while computing the values in `config` and `options`, so multiple invocations of `extendModules` have a particularly small cost, as long as only the final `config` and `options` are evaluated.
 

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -6,34 +6,39 @@ The module system is a language for handling configuration, implemented as a Nix
 
 Compared to plain Nix, it adds documentation, type checking and composition or extensibility.
 
-NOTE: This chapter is new and not complete yet. For a gentle introduction to the module system, in the context of NixOS, see [Writing NixOS Modules](https://nixos.org/manual/nixos/unstable/index.html#sec-writing-modules) in the NixOS manual.
+::: {.note}
+This chapter is new and not complete yet. For a gentle introduction to the module system, in the context of NixOS, see [Writing NixOS Modules](https://nixos.org/manual/nixos/unstable/index.html#sec-writing-modules) in the NixOS manual.
+:::
+
 
 ## `lib.evalModules` {#module-system-lib-evalModules}
 
-Evaluate a set of modules.  The result is a set with the attributes:
+Evaluate a set of modules. This function is typically only used once per application (e.g. once in NixOS, once in Home Manager, ...).
 
 ### Parameters {#module-system-lib-evalModules-parameters}
 
 #### `modules` {#module-system-lib-evalModules-param-modules}
 
-A list of modules. These are merged together using various methods to form the final configuration.
+A list of modules. These are merged together to form the final configuration.
+<!-- TODO link to section about merging, TBD -->
 
 #### `specialArgs` {#module-system-lib-evalModules-param-specialArgs}
 
 An attribute set of module arguments that can be used in `imports`.
 
-This is in contrast to `config._module.args`, which is only available within the module fixpoint, which does not exist before all imports are resolved.
+This is in contrast to `config._module.args`, which is only available after all `imports` have been resolved.
 
 #### `specialArgs.class` {#module-system-lib-evalModules-param-specialArgs-class}
 
-If the `class` attribute is set in `specialArgs`, the module system will rejected modules with a different `class`.
+If the `class` attribute is set in `specialArgs`, the module system will reject modules with a different `class`.
 
-This improves the error message that users will encounter when they import an incompatible module that was designed for a different class of configurations.
+The `class` value should be in lower [camel case](https://en.wikipedia.org/wiki/Camel_case).
 
-The `class` value should be in camelcase, and, if applicable, it should match the prefix of the attributes used in (experimental) flakes. Some examples are:
+If applicable, the `class` should match the "prefix" of the attributes used in (experimental) [flakes](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#description). Some examples are:
 
- - `nixos`: NixOS modules
+ - `nixos` as in `flake.nixosModules`
  - `nixosTest`: modules that constitute a [NixOS VM test](https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests)
+<!-- We've only just started with `class`. You're invited to add a few more. -->
 
 #### `prefix` {#module-system-lib-evalModules-param-prefix}
 
@@ -41,29 +46,38 @@ A list of strings representing the location at or below which all options are ev
 
 ### Return value {#module-system-lib-evalModules-return-value}
 
+The result is an attribute set with the following attributes:
+
 #### `options` {#module-system-lib-evalModules-return-value-options}
 
-The nested set of all option declarations.
+The nested attribute set of all option declarations.
 
 #### `config` {#module-system-lib-evalModules-return-value-config}
 
-The nested set of all option values.
+The nested attribute set of all option values.
 
 #### `type` {#module-system-lib-evalModules-return-value-type}
 
-A module system type representing the module set as a submodule, to be extended by configuration from the containing module set.
+A module system type. This type is an instance of `types.submoduleWith` containing the current [`modules`](#module-system-lib-evalModules-param-modules).
 
-This is also available as the module argument `moduleType`.
+The option definitions that are typed with this type will extend the current set of modules, like [`extendModules`](#module-system-lib-evalModules-return-value-extendModules).
+
+However, the value returned from the type is just the [`config`](#module-system-lib-evalModules-return-value-config), like any submodule.
+
+This type is also available to the [`modules`](#module-system-lib-evalModules-param-modules) as the module argument `moduleType`.
 
 #### `extendModules` {#module-system-lib-evalModules-return-value-extendModules}
 
-A function similar to `evalModules` but building on top of the module set. Its arguments, `modules` and `specialArgs` are added to the existing values.
+A function similar to `evalModules` but building on top of the already passed [`modules`](#module-system-lib-evalModules-param-modules). Its arguments, `modules` and `specialArgs` are added to the existing values.
 
-Using `extendModules` a few times has no performance impact as long as you only reference the final `options` and `config`.
-If you do reference multiple `config` (or `options`) from before and after `extendModules`, performance is the same as with multiple `evalModules` invocations, because the new modules' ability to override existing configuration fundamentally requires a new fixpoint to be constructed.
+The real work of module evaluation happens while computing the values in `config` and `options`, so multiple invocations of `extendModules` have a particularly small cost, as long as only the final `config` and `options` are evaluated.
 
-This is also available as a module argument.
+If you do reference multiple `config` (or `options`) from before and after `extendModules`, evaluation performance is the same as with multiple `evalModules` invocations, because the new modules' ability to override existing configuration fundamentally requires constructing a new `config` and `options` fixpoint.
+
+This functionality is also available to modules as the `extendModules` module argument.
 
 #### `_module` {#module-system-lib-evalModules-return-value-_module}
 
 A portion of the configuration tree which is elided from `config`. It contains some values that are mostly internal to the module system implementation.
+
+<!-- TODO: when markdown migration is complete, make _module docs visible again and reference _module docs. Maybe move those docs into this chapter? -->

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -95,3 +95,11 @@ If you do reference multiple `config` (or `options`) from before and after `exte
 A portion of the configuration tree which is elided from `config`.
 
 <!-- TODO: when markdown migration is complete, make _module docs visible again and reference _module docs. Maybe move those docs into this chapter? -->
+
+#### `_type` {#module-system-lib-evalModules-return-value-_type}
+
+A nominal type marker, always `"configuration"`.
+
+#### `configurationClass` {#module-system-lib-evalModules-return-value-_configurationClass}
+
+Equal to the [`class` parameter](#module-system-lib-evalModules-param-class).

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -1,0 +1,69 @@
+# Module System {#module-system}
+
+## Introduction {#module-system-introduction}
+
+The module system is a language for handling configuration, implemented as a Nix library.
+
+Compared to plain Nix, it adds documentation, type checking and composition or extensibility.
+
+NOTE: This chapter is new and not complete yet. For a gentle introduction to the module system, in the context of NixOS, see [Writing NixOS Modules](https://nixos.org/manual/nixos/unstable/index.html#sec-writing-modules) in the NixOS manual.
+
+## `lib.evalModules` {#module-system-lib-evalModules}
+
+Evaluate a set of modules.  The result is a set with the attributes:
+
+### Parameters {#module-system-lib-evalModules-parameters}
+
+#### `modules` {#module-system-lib-evalModules-param-modules}
+
+A list of modules. These are merged together using various methods to form the final configuration.
+
+#### `specialArgs` {#module-system-lib-evalModules-param-specialArgs}
+
+An attribute set of module arguments that can be used in `imports`.
+
+This is in contrast to `config._module.args`, which is only available within the module fixpoint, which does not exist before all imports are resolved.
+
+#### `specialArgs.class` {#module-system-lib-evalModules-param-specialArgs-class}
+
+If the `class` attribute is set in `specialArgs`, the module system will rejected modules with a different `class`.
+
+This improves the error message that users will encounter when they import an incompatible module that was designed for a different class of configurations.
+
+The `class` value should be in camelcase, and, if applicable, it should match the prefix of the attributes used in (experimental) flakes. Some examples are:
+
+ - `nixos`: NixOS modules
+ - `nixosTest`: modules that constitute a [NixOS VM test](https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests)
+
+#### `prefix` {#module-system-lib-evalModules-param-prefix}
+
+A list of strings representing the location at or below which all options are evaluated. This is used by `types.submodule` to improve error reporting and find the implicit `name` module argument.
+
+### Return value {#module-system-lib-evalModules-return-value}
+
+#### `options` {#module-system-lib-evalModules-return-value-options}
+
+The nested set of all option declarations.
+
+#### `config` {#module-system-lib-evalModules-return-value-config}
+
+The nested set of all option values.
+
+#### `type` {#module-system-lib-evalModules-return-value-type}
+
+A module system type representing the module set as a submodule, to be extended by configuration from the containing module set.
+
+This is also available as the module argument `moduleType`.
+
+#### `extendModules` {#module-system-lib-evalModules-return-value-extendModules}
+
+A function similar to `evalModules` but building on top of the module set. Its arguments, `modules` and `specialArgs` are added to the existing values.
+
+Using `extendModules` a few times has no performance impact as long as you only reference the final `options` and `config`.
+If you do reference multiple `config` (or `options`) from before and after `extendModules`, performance is the same as with multiple `evalModules` invocations, because the new modules' ability to override existing configuration fundamentally requires a new fixpoint to be constructed.
+
+This is also available as a module argument.
+
+#### `_module` {#module-system-lib-evalModules-return-value-_module}
+
+A portion of the configuration tree which is elided from `config`. It contains some values that are mostly internal to the module system implementation.

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1251,7 +1251,6 @@ let
     {
       inherit
         applyModuleArgsIfFunction
-        collectModules
         dischargeProperties
         evalOptionValue
         mergeModules
@@ -1259,6 +1258,7 @@ let
         pushDownProperties
         unifyModuleSyntax
         ;
+      collectModules = collectModules null;
     };
 
 in

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -220,16 +220,6 @@ let
               within a configuration, but can be used in module imports.
             '';
           };
-
-          _module.class = mkOption {
-            readOnly = true;
-            internal = true;
-            description = lib.mdDoc ''
-              If the `class` attribute is set and non-`null`, the module system will reject `imports` with a different `class`.
-
-              This option contains the expected `class` attribute of the current module evaluation.
-            '';
-          };
         };
 
         config = {
@@ -237,7 +227,6 @@ let
             inherit extendModules;
             moduleType = type;
           };
-          _module.class = class;
           _module.specialArgs = specialArgs;
         };
       };
@@ -337,6 +326,7 @@ let
         config = checked (removeAttrs config [ "_module" ]);
         _module = checked (config._module);
         inherit extendModules type;
+        configurationClass = class;
       };
     in result;
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -326,7 +326,7 @@ let
         config = checked (removeAttrs config [ "_module" ]);
         _module = checked (config._module);
         inherit extendModules type;
-        configurationClass = class;
+        class = class;
       };
     in result;
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -63,35 +63,8 @@ let
           decls
       ));
 
-  /*
-    Evaluate a set of modules.  The result is a set with the attributes:
-
-      ‘options’: The nested set of all option declarations,
-
-      ‘config’: The nested set of all option values.
-
-      ‘type’: A module system type representing the module set as a submodule,
-            to be extended by configuration from the containing module set.
-
-            This is also available as the module argument ‘moduleType’.
-
-      ‘extendModules’: A function similar to ‘evalModules’ but building on top
-            of the module set. Its arguments, ‘modules’ and ‘specialArgs’ are
-            added to the existing values.
-
-            Using ‘extendModules’ a few times has no performance impact as long
-            as you only reference the final ‘options’ and ‘config’.
-            If you do reference multiple ‘config’ (or ‘options’) from before and
-            after ‘extendModules’, performance is the same as with multiple
-            ‘evalModules’ invocations, because the new modules' ability to
-            override existing configuration fundamentally requires a new
-            fixpoint to be constructed.
-
-            This is also available as a module argument.
-
-      ‘_module’: A portion of the configuration tree which is elided from
-            ‘config’. It contains some values that are mostly internal to the
-            module system implementation.
+  /* See https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules
+     or file://./../doc/module-system/module-system.chapter.md
 
      !!! Please think twice before adding to this argument list! The more
      that is specified here instead of in the modules themselves the harder

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -63,10 +63,6 @@ let
           decls
       ));
 
-in
-
-rec {
-
   /*
     Evaluate a set of modules.  The result is a set with the attributes:
 
@@ -1218,4 +1214,56 @@ rec {
     _file = file;
     config = lib.importTOML file;
   };
+
+in
+{
+  inherit
+    applyModuleArgsIfFunction
+    collectModules
+    defaultOrderPriority
+    defaultOverridePriority
+    defaultPriority
+    dischargeProperties
+    doRename
+    evalModules
+    evalOptionValue
+    filterOverrides
+    filterOverrides'
+    fixMergeModules
+    fixupOptionType
+    importJSON
+    importTOML
+    mergeDefinitions
+    mergeModules
+    mergeModules'
+    mergeOptionDecls
+    mkAfter
+    mkAliasAndWrapDefinitions
+    mkAliasAndWrapDefsWithPriority
+    mkAliasDefinitions
+    mkAliasIfDef
+    mkAliasOptionModule
+    mkAliasOptionModuleMD
+    mkAssert
+    mkBefore
+    mkChangedOptionModule
+    mkDefault
+    mkDerivedConfig
+    mkFixStrictness
+    mkForce
+    mkIf
+    mkImageMediaOverride
+    mkMerge
+    mkMergedOptionModule
+    mkOptionDefault
+    mkOrder
+    mkOverride
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    mkRenamedOptionModuleWith
+    mkVMOverride
+    pushDownProperties
+    setDefaultModuleLocation
+    sortProperties
+    unifyModuleSyntax;
 }

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -347,6 +347,7 @@ let
       };
 
       result = withWarnings {
+        _type = "configuration";
         options = checked options;
         config = checked (removeAttrs config [ "_module" ]);
         _module = checked (config._module);

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -511,7 +511,7 @@ let
         imports = m.require or [] ++ m.imports or [];
         options = {};
         config = addFreeformType (removeAttrs m ["_file" "key" "disabledModules" "require" "imports" "freeformType"]);
-        class = m.class or null;
+        class = null;
       };
 
   applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1215,28 +1215,41 @@ let
     config = lib.importTOML file;
   };
 
+  private = lib.mapAttrs
+    (k: lib.warn "External use of `lib.modules.${k}` is deprecated. If your use case isn't covered by non-deprecated functions, we'd like to know more and perhaps support your use case well, instead of providing access to these low level functions. In this case please open an issue in https://github.com/nixos/nixpkgs/issues/.")
+    {
+      inherit
+        applyModuleArgsIfFunction
+        collectModules
+        dischargeProperties
+        evalOptionValue
+        mergeModules
+        mergeModules'
+        pushDownProperties
+        unifyModuleSyntax
+        ;
+    };
+
 in
+private //
 {
+  # NOTE: not all of these functions are necessarily public interfaces; some
+  #       are just needed by types.nix, but are not meant to be consumed
+  #       externally.
   inherit
-    applyModuleArgsIfFunction
-    collectModules
     defaultOrderPriority
     defaultOverridePriority
     defaultPriority
-    dischargeProperties
     doRename
     evalModules
-    evalOptionValue
     filterOverrides
     filterOverrides'
     fixMergeModules
-    fixupOptionType
+    fixupOptionType  # should be private?
     importJSON
     importTOML
     mergeDefinitions
-    mergeModules
-    mergeModules'
-    mergeOptionDecls
+    mergeOptionDecls  # should be private?
     mkAfter
     mkAliasAndWrapDefinitions
     mkAliasAndWrapDefsWithPriority
@@ -1262,8 +1275,6 @@ in
     mkRenamedOptionModule
     mkRenamedOptionModuleWith
     mkVMOverride
-    pushDownProperties
     setDefaultModuleLocation
-    sortProperties
-    unifyModuleSyntax;
+    sortProperties;
 }

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -367,7 +367,7 @@ let
           unifyModuleSyntax fallbackFile fallbackKey (applyModuleArgsIfFunction fallbackKey m args)
         else if isAttrs m then
           if m._type or "module" == "module" then
-            unifyModuleSyntax fallbackFile fallbackKey (applyModuleArgsIfFunction fallbackKey m args)
+            unifyModuleSyntax fallbackFile fallbackKey m
           else if m._type == "if" || m._type == "override" then
             loadModule args fallbackFile fallbackKey { config = m; }
           else

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -364,7 +364,7 @@ let
       # Like unifyModuleSyntax, but also imports paths and calls functions if necessary
       loadModule = args: fallbackFile: fallbackKey: m:
         if isFunction m then
-          unifyModuleSyntax fallbackFile fallbackKey (applyModuleArgsIfFunction fallbackKey m args)
+          unifyModuleSyntax fallbackFile fallbackKey (applyModuleArgs fallbackKey m args)
         else if isAttrs m then
           if m._type or "module" == "module" then
             unifyModuleSyntax fallbackFile fallbackKey m
@@ -514,7 +514,10 @@ let
         class = m.class or null;
       };
 
-  applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }: if isFunction f then
+  applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }:
+    if isFunction f then applyModuleArgs key f args else f;
+
+  applyModuleArgs = key: f: args@{ config, options, lib, ... }:
     let
       # Module arguments are resolved in a strict manner when attribute set
       # deconstruction is used.  As the arguments are now defined with the
@@ -538,9 +541,7 @@ let
       # context on the explicit arguments of "args" too. This update
       # operator is used to make the "args@{ ... }: with args.lib;" notation
       # works.
-    in f (args // extraArgs)
-  else
-    f;
+    in f (args // extraArgs);
 
   /* Merge a list of modules.  This will recurse over the option
      declarations in all modules, combining them into a single set.

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -371,10 +371,10 @@ let
         if class != null
         then
           m:
-            if m.class != null -> m.class == class
+            if m._class != null -> m._class == class
             then m
             else
-              throw "The module ${m._file or m.key} was imported into ${class} instead of ${m.class}."
+              throw "The module ${m._file or m.key} was imported into ${class} instead of ${m._class}."
         else
           m: m;
 
@@ -475,28 +475,28 @@ let
         else config;
     in
     if m ? config || m ? options then
-      let badAttrs = removeAttrs m ["_file" "key" "disabledModules" "imports" "options" "config" "meta" "freeformType" "class"]; in
+      let badAttrs = removeAttrs m ["_class" "_file" "key" "disabledModules" "imports" "options" "config" "meta" "freeformType"]; in
       if badAttrs != {} then
         throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by introducing a top-level `config' or `options' attribute. Add configuration attributes immediately on the top level instead, or move all of them (namely: ${toString (attrNames badAttrs)}) into the explicit `config' attribute."
       else
         { _file = toString m._file or file;
+          _class = m._class or null;
           key = toString m.key or key;
           disabledModules = m.disabledModules or [];
           imports = m.imports or [];
           options = m.options or {};
           config = addFreeformType (addMeta (m.config or {}));
-          class = m.class or null;
         }
     else
       # shorthand syntax
       lib.throwIfNot (isAttrs m) "module ${file} (${key}) does not look like a module."
       { _file = toString m._file or file;
+        _class = m._class or null;
         key = toString m.key or key;
         disabledModules = m.disabledModules or [];
         imports = m.require or [] ++ m.imports or [];
         options = {};
-        config = addFreeformType (removeAttrs m ["_file" "key" "disabledModules" "require" "imports" "freeformType"]);
-        class = null;
+        config = addFreeformType (removeAttrs m ["_class" "_file" "key" "disabledModules" "require" "imports" "freeformType"]);
       };
 
   applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }:

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -365,6 +365,10 @@ checkConfigOutput '^{ }$' config.ok.config ./class-check.nix
 checkConfigError 'The module .*/module-class-is-darwin.nix was imported into nixos instead of darwin.' config.fail.config ./class-check.nix
 checkConfigError 'The module foo.nix#darwinModules.default was imported into nixos instead of darwin.' config.fail-anon.config ./class-check.nix
 
+# _type check
+checkConfigError 'Could not load a value as a module, because it is of type "flake", in file .*/module-imports-_type-check.nix' config.ok.config ./module-imports-_type-check.nix
+checkConfigOutput '^true$' "$@" config.enable ./declare-enable.nix ./define-enable-with-top-level-mkIf.nix
+
 # doRename works when `warnings` does not exist.
 checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix
 # doRename adds a warning.

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -166,6 +166,7 @@ checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*' 
 checkConfigOutput '^true$' "$@" ./define-module-check.nix
 
 # Check coerced value.
+set --
 checkConfigOutput '^"42"$' config.value ./declare-coerced-value.nix
 checkConfigOutput '^"24"$' config.value ./declare-coerced-value.nix ./define-value-string.nix
 checkConfigError 'A definition for option .* is not.*string or signed integer convertible to it.*. Definition values:\n\s*- In .*: \[ \]' config.value ./declare-coerced-value.nix ./define-value-list.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -364,6 +364,7 @@ checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-i
 
 # Class checks, evalModules
 checkConfigOutput '^{ }$' config.ok.config ./class-check.nix
+checkConfigOutput '"nixos"' config.ok.configurationClass ./class-check.nix
 checkConfigError 'The module .*/module-class-is-darwin.nix was imported into nixos instead of darwin.' config.fail.config ./class-check.nix
 checkConfigError 'The module foo.nix#darwinModules.default was imported into nixos instead of darwin.' config.fail-anon.config ./class-check.nix
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -368,7 +368,7 @@ checkConfigError 'The module foo.nix#darwinModules.default was imported into nix
 # _type check
 checkConfigError 'Could not load a value as a module, because it is of type "flake", in file .*/module-imports-_type-check.nix' config.ok.config ./module-imports-_type-check.nix
 checkConfigOutput '^true$' "$@" config.enable ./declare-enable.nix ./define-enable-with-top-level-mkIf.nix
-checkConfigError 'Could not load a value as a module, because it is of type "configuration", in file .*/import-configuration.nix' config ./import-configuration.nix
+checkConfigError 'Could not load a value as a module, because it is of type "configuration", in file .*/import-configuration.nix.*please only import the modules that make up the configuration.*' config ./import-configuration.nix
 
 # doRename works when `warnings` does not exist.
 checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -364,7 +364,7 @@ checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-i
 
 # Class checks, evalModules
 checkConfigOutput '^{ }$' config.ok.config ./class-check.nix
-checkConfigOutput '"nixos"' config.ok.configurationClass ./class-check.nix
+checkConfigOutput '"nixos"' config.ok.class ./class-check.nix
 checkConfigError 'The module .*/module-class-is-darwin.nix was imported into nixos instead of darwin.' config.fail.config ./class-check.nix
 checkConfigError 'The module foo.nix#darwinModules.default was imported into nixos instead of darwin.' config.fail-anon.config ./class-check.nix
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -368,6 +368,7 @@ checkConfigError 'The module foo.nix#darwinModules.default was imported into nix
 # _type check
 checkConfigError 'Could not load a value as a module, because it is of type "flake", in file .*/module-imports-_type-check.nix' config.ok.config ./module-imports-_type-check.nix
 checkConfigOutput '^true$' "$@" config.enable ./declare-enable.nix ./define-enable-with-top-level-mkIf.nix
+checkConfigError 'Could not load a value as a module, because it is of type "configuration", in file .*/import-configuration.nix' config ./import-configuration.nix
 
 # doRename works when `warnings` does not exist.
 checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -255,6 +255,8 @@ checkConfigError 'A definition for option .* is not of type .*' \
 ## Freeform modules
 # Assigning without a declared option should work
 checkConfigOutput '^"24"$' config.value ./freeform-attrsOf.nix ./define-value-string.nix
+# Shorthand modules interpret `meta` and `class` as config items
+checkConfigOutput '^true$' options._module.args.value.result ./freeform-attrsOf.nix ./define-freeform-keywords-shorthand.nix
 # No freeform assignments shouldn't make it error
 checkConfigOutput '^{ }$' config ./freeform-attrsOf.nix
 # but only if the type matches

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -362,10 +362,17 @@ checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survive
 # because of an `extendModules` bug, issue 168767.
 checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-imports.nix
 
-# Class checks
+# Class checks, evalModules
 checkConfigOutput '^{ }$' config.ok.config ./class-check.nix
 checkConfigError 'The module .*/module-class-is-darwin.nix was imported into nixos instead of darwin.' config.fail.config ./class-check.nix
 checkConfigError 'The module foo.nix#darwinModules.default was imported into nixos instead of darwin.' config.fail-anon.config ./class-check.nix
+
+# Class checks, submoduleWith
+checkConfigOutput '^{ }$' config.sub.nixosOk ./class-check.nix
+checkConfigError 'The module .*/module-class-is-darwin.nix was imported into nixos instead of darwin.' config.sub.nixosFail.config ./class-check.nix
+
+# submoduleWith type merge with different class
+checkConfigError 'error: A submoduleWith option is declared multiple times with conflicting class values "darwin" and "nixos".' config.sub.mergeFail.config ./class-check.nix
 
 # _type check
 checkConfigError 'Could not load a value as a module, because it is of type "flake", in file .*/module-imports-_type-check.nix' config.ok.config ./module-imports-_type-check.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -360,6 +360,11 @@ checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survive
 # because of an `extendModules` bug, issue 168767.
 checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-imports.nix
 
+# Class checks
+checkConfigOutput '^{ }$' config.ok.config ./class-check.nix
+checkConfigError 'The module .*/module-class-is-darwin.nix was imported into nixos instead of darwin.' config.fail.config ./class-check.nix
+checkConfigError 'The module foo.nix#darwinModules.default was imported into nixos instead of darwin.' config.fail-anon.config ./class-check.nix
+
 # doRename works when `warnings` does not exist.
 checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix
 # doRename adds a warning.

--- a/lib/tests/modules/class-check.nix
+++ b/lib/tests/modules/class-check.nix
@@ -1,0 +1,34 @@
+{ lib, ... }: {
+  config = {
+    _module.freeformType = lib.types.anything;
+    ok =
+      lib.evalModules {
+        specialArgs.class = "nixos";
+        modules = [
+          ./module-class-is-nixos.nix
+        ];
+      };
+
+    fail =
+      lib.evalModules {
+        specialArgs.class = "nixos";
+        modules = [
+          ./module-class-is-nixos.nix
+          ./module-class-is-darwin.nix
+        ];
+      };
+
+    fail-anon =
+      lib.evalModules {
+        specialArgs.class = "nixos";
+        modules = [
+          ./module-class-is-nixos.nix
+          { _file = "foo.nix#darwinModules.default";
+            class = "darwin";
+            imports = [];
+          }
+        ];
+      };
+
+  };
+}

--- a/lib/tests/modules/class-check.nix
+++ b/lib/tests/modules/class-check.nix
@@ -1,4 +1,43 @@
 { lib, ... }: {
+  options = {
+    sub = {
+      nixosOk = lib.mkOption {
+        type = lib.types.submoduleWith {
+          class = "nixos";
+          modules = [ ];
+        };
+      };
+      # Same but will have bad definition
+      nixosFail = lib.mkOption {
+        type = lib.types.submoduleWith {
+          class = "nixos";
+          modules = [ ];
+        };
+      };
+
+      mergeFail = lib.mkOption {
+        type = lib.types.submoduleWith {
+          class = "nixos";
+          modules = [ ];
+        };
+        default = { };
+      };
+    };
+  };
+  imports = [
+    {
+      options = {
+        sub = {
+          mergeFail = lib.mkOption {
+            type = lib.types.submoduleWith {
+              class = "darwin";
+              modules = [ ];
+            };
+          };
+        };
+      };
+    }
+  ];
   config = {
     _module.freeformType = lib.types.anything;
     ok =
@@ -31,5 +70,7 @@
         ];
       };
 
+    sub.nixosOk = { config = {}; class = "nixos"; };
+    sub.nixosFail = { imports = [ ./module-class-is-darwin.nix ]; };
   };
 }

--- a/lib/tests/modules/class-check.nix
+++ b/lib/tests/modules/class-check.nix
@@ -25,6 +25,7 @@
           ./module-class-is-nixos.nix
           { _file = "foo.nix#darwinModules.default";
             class = "darwin";
+            config = {};
             imports = [];
           }
         ];

--- a/lib/tests/modules/class-check.nix
+++ b/lib/tests/modules/class-check.nix
@@ -63,14 +63,14 @@
         modules = [
           ./module-class-is-nixos.nix
           { _file = "foo.nix#darwinModules.default";
-            class = "darwin";
+            _class = "darwin";
             config = {};
             imports = [];
           }
         ];
       };
 
-    sub.nixosOk = { config = {}; class = "nixos"; };
+    sub.nixosOk = { _class = "nixos"; };
     sub.nixosFail = { imports = [ ./module-class-is-darwin.nix ]; };
   };
 }

--- a/lib/tests/modules/class-check.nix
+++ b/lib/tests/modules/class-check.nix
@@ -3,7 +3,7 @@
     _module.freeformType = lib.types.anything;
     ok =
       lib.evalModules {
-        specialArgs.class = "nixos";
+        class = "nixos";
         modules = [
           ./module-class-is-nixos.nix
         ];
@@ -11,7 +11,7 @@
 
     fail =
       lib.evalModules {
-        specialArgs.class = "nixos";
+        class = "nixos";
         modules = [
           ./module-class-is-nixos.nix
           ./module-class-is-darwin.nix
@@ -20,7 +20,7 @@
 
     fail-anon =
       lib.evalModules {
-        specialArgs.class = "nixos";
+        class = "nixos";
         modules = [
           ./module-class-is-nixos.nix
           { _file = "foo.nix#darwinModules.default";

--- a/lib/tests/modules/define-enable-with-top-level-mkIf.nix
+++ b/lib/tests/modules/define-enable-with-top-level-mkIf.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+# I think this might occur more realistically in a submodule
+{
+  imports = [ (lib.mkIf true { enable = true; }) ];
+}

--- a/lib/tests/modules/define-freeform-keywords-shorthand.nix
+++ b/lib/tests/modules/define-freeform-keywords-shorthand.nix
@@ -1,0 +1,15 @@
+{ config, ... }: {
+  class = { "just" = "data"; };
+  a = "one";
+  b = "two";
+  meta = "meta";
+
+  _module.args.result =
+    let r = builtins.removeAttrs config [ "_module" ];
+    in builtins.trace (builtins.deepSeq r r) (r == {
+      a = "one";
+      b = "two";
+      class = { "just" = "data"; };
+      meta = "meta";
+    });
+}

--- a/lib/tests/modules/import-configuration.nix
+++ b/lib/tests/modules/import-configuration.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+let
+  myconf = lib.evalModules { modules = [ { } ]; };
+in
+{
+  imports = [
+    # We can't do this. A configuration is not equal to its set of a modules.
+    # Equating those would lead to a mess, as specialArgs, anonymous modules
+    # that can't be deduplicated, and possibly more come into play.
+    myconf
+  ];
+}

--- a/lib/tests/modules/module-class-is-darwin.nix
+++ b/lib/tests/modules/module-class-is-darwin.nix
@@ -1,0 +1,4 @@
+{
+  class = "darwin";
+  config = {};
+}

--- a/lib/tests/modules/module-class-is-darwin.nix
+++ b/lib/tests/modules/module-class-is-darwin.nix
@@ -1,4 +1,4 @@
 {
-  class = "darwin";
+  _class = "darwin";
   config = {};
 }

--- a/lib/tests/modules/module-class-is-nixos.nix
+++ b/lib/tests/modules/module-class-is-nixos.nix
@@ -1,0 +1,4 @@
+{
+  class = "nixos";
+  config = {};
+}

--- a/lib/tests/modules/module-class-is-nixos.nix
+++ b/lib/tests/modules/module-class-is-nixos.nix
@@ -1,4 +1,4 @@
 {
-  class = "nixos";
+  _class = "nixos";
   config = {};
 }

--- a/lib/tests/modules/module-imports-_type-check.nix
+++ b/lib/tests/modules/module-imports-_type-check.nix
@@ -1,0 +1,3 @@
+{
+  imports = [ { _type = "flake"; } ];
+}

--- a/nixos/lib/eval-cacheable-options.nix
+++ b/nixos/lib/eval-cacheable-options.nix
@@ -33,6 +33,7 @@ let
     ];
     specialArgs = {
       inherit config pkgs utils;
+      class = "nixos";
     };
   };
   docs = import "${nixosPath}/doc/manual" {

--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -40,7 +40,9 @@ let
     inherit prefix modules;
     specialArgs = {
       modulesPath = builtins.toString ../modules;
-    } // specialArgs;
+    } // specialArgs // {
+      class = "nixos";
+    };
   };
 
 in

--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -38,11 +38,10 @@ let
   #       is experimental.
   lib.evalModules {
     inherit prefix modules;
+    class = "nixos";
     specialArgs = {
       modulesPath = builtins.toString ../modules;
-    } // specialArgs // {
-      class = "nixos";
-    };
+    } // specialArgs;
   };
 
 in

--- a/nixos/lib/testing/default.nix
+++ b/nixos/lib/testing/default.nix
@@ -3,7 +3,7 @@ let
 
   evalTest = module: lib.evalModules {
     modules = testModules ++ [ module ];
-    specialArgs.class = "nixosTest";
+    class = "nixosTest";
   };
   runTest = module: (evalTest ({ config, ... }: { imports = [ module ]; result = config.test; })).config.result;
 

--- a/nixos/lib/testing/default.nix
+++ b/nixos/lib/testing/default.nix
@@ -1,7 +1,10 @@
 { lib }:
 let
 
-  evalTest = module: lib.evalModules { modules = testModules ++ [ module ]; };
+  evalTest = module: lib.evalModules {
+    modules = testModules ++ [ module ];
+    specialArgs.class = "nixosTest";
+  };
   runTest = module: (evalTest ({ config, ... }: { imports = [ module ]; result = config.test; })).config.result;
 
   testModules = [

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -38,8 +38,8 @@ let
           modules = [ {
             _module.check = false;
           } ] ++ docModules.eager;
+          class = "nixos";
           specialArgs = specialArgs // {
-            class = "nixos";
             pkgs = scrubDerivations "pkgs" pkgs;
             # allow access to arbitrary options for eager modules, eg for getting
             # option types from lazy modules

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -39,6 +39,7 @@ let
             _module.check = false;
           } ] ++ docModules.eager;
           specialArgs = specialArgs // {
+            class = "nixos";
             pkgs = scrubDerivations "pkgs" pkgs;
             # allow access to arbitrary options for eager modules, eg for getting
             # option types from lazy modules

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -82,7 +82,7 @@ in let
         config = config1;
       })
     ];
-    specialArgs.class = "nixpkgsConfig";
+    class = "nixpkgsConfig";
   };
 
   # take all the rest as-is

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -82,6 +82,7 @@ in let
         config = config1;
       })
     ];
+    specialArgs.class = "nixpkgsConfig";
   };
 
   # take all the rest as-is


### PR DESCRIPTION
###### Description of changes

- Make explicit the module "class", which identifies the module system application, such as `"nixos"`, `"darwin"` or `"homeManager"`. This allows us to print an appropriate error when importing for example a home-manager module into NixOS:

  `The module foo.nix#darwinModules.default was imported into nixos instead of home-manager.`

  I do not expect users or module authors to set the `class` attribute in their modules (although they may). Instead I envision a library like [flake-parts](https://flake.parts) to set this for us.

- ~Use the new class information to automatically import the appropriate default module from a flake.~

- Detect other mistakes that involve the importing `_type`-carrying values. For instance importing a `nixosSystem` result into NixOps network appears to be a somewhat common mistake, and for good reason. These changes detect this scenario and explain what to do instead.

Depends on https://github.com/NixOS/nix/issues/7186

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
