### PR TITLE
jay: init at unstable-2022-10-10

### DIFF
--- a/pkgs/applications/window-managers/jay/default.nix
+++ b/pkgs/applications/window-managers/jay/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, libinput
+, libxkbcommon
+, mesa
+, pango
+, udev
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "jay";
+  version = "unstable-2022-11-20";
+
+  src = fetchFromGitHub {
+    owner = "mahkoh";
+    repo = pname;
+    rev = "09b4668a5363a6e93dfb8ba35b244835f4edb0f2";
+    sha256 = "sha256-0IIzXY7AFTGEe0TzJVKOtTPUZee0Wz40yKgEWLeIYJw=";
+  };
+
+  cargoSha256 = "sha256-zSq6YBlm6gJXGlF9xZ8gWSTMewdNqrJzwP58a0x8QIU=";
+
+  buildInputs = [
+    libxkbcommon
+    mesa
+    pango
+    udev
+    libinput
+  ];
+
+  RUSTC_BOOTSTRAP = 1;
+
+  meta = with lib; {
+    description = "A Wayland compositor written in Rust";
+    homepage = "https://github.com/mahkoh/jay";
+    license = licenses.gpl3;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29045,6 +29045,8 @@ with pkgs;
 
   jackline = callPackage ../applications/networking/instant-messengers/jackline { };
 
+  jay = callPackage ../applications/window-managers/jay { };
+
   keylight-controller-mschneider82 = callPackage ../applications/misc/keylight-controller-mschneider82 { };
 
   leftwm = callPackage ../applications/window-managers/leftwm { };


### PR DESCRIPTION
###### Description of changes

Jay is a Wayland compositor written and configured in the rust programming language with hot-reload support. Jay offers improved flexibility, configurability, stability, and performance.

https://github.com/mahkoh/jay

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
