### PR TITLE
zinc: init at 0.3.5

### DIFF
--- a/pkgs/servers/search/zinc/default.nix
+++ b/pkgs/servers/search/zinc/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, buildNpmPackage
+}:
+let
+  version = "0.3.5";
+  src = fetchFromGitHub {
+    owner = "zinclabs";
+    repo = "zinc";
+    rev = "v${version}";
+    sha256 = "sha256-qu3foI5Rnt2sf+B+roJOwUNvOfawKmcKq7UrmviQsHA=";
+  };
+
+  webui = buildNpmPackage {
+    inherit src version;
+    pname = "zinc-ui";
+
+    sourceRoot = "source/web";
+
+    npmDepsHash = "sha256-Ao/kDryui4thurqap/d/+82z058HoF2ZJSVKQqVwfVg=";
+
+    CYPRESS_INSTALL_BINARY = 0; # cypress tries to download binaries otherwise
+
+    installPhase = ''
+      mkdir -p $out/share
+      mv dist $out/share/zinc-ui
+    '';
+  };
+in
+buildGoModule rec {
+  pname = "zinc";
+  inherit src version;
+
+  preBuild = ''
+    cp -r ${webui}/share/zinc-ui web/dist
+  '';
+
+  vendorSha256 = "sha256-akjb0cxHbITKS26c+7lVSHWO/KRoQVVKzAOra+tdAD8=";
+  subPackages = [ "cmd/zinc" ];
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/zinclabs/zinc/pkg/meta.Version=${version}"
+  ];
+
+  meta = with lib; {
+    description = "A lightweight alternative to elasticsearch that requires minimal resources, written in Go";
+    homepage = "https://github.com/zinclabs/zinc";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13195,6 +13195,8 @@ with pkgs;
 
   zip = callPackage ../tools/archivers/zip { };
 
+  zinc = callPackage ../servers/search/zinc { };
+
   zkfuse = callPackage ../tools/filesystems/zkfuse { };
 
   zpaq = callPackage ../tools/archivers/zpaq { };


### PR DESCRIPTION
###### Description of changes
 ZincSearch. A lightweight alternative to elasticsearch that requires minimal resources, written in Go. 
https://github.com/zinclabs/zinc
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
