### PR TITLE
localstack: 1.0.4 -> 1.2.0, fix build

### DIFF
--- a/pkgs/development/python-modules/localstack-client/default.nix
+++ b/pkgs/development/python-modules/localstack-client/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "localstack-client";
-  version = "1.36";
+  version = "1.39";
 
   src = fetchFromGitHub {
     owner = "localstack";
     repo = "localstack-python-client";
     # Request for proper tags: https://github.com/localstack/localstack-python-client/issues/38
-    rev = "92229c02c5b3cd0cef006e99c3d47db15aefcb4f";
-    sha256 = "sha256-pbDpe/5o4YU/2UIi8YbhzhIlXigOb/M2vjW9DKcIxoI=";
+    rev = "f1e538ad23700e5b1afe98720404f4801475e470";
+    sha256 = "sha256-MBXTiTzCwkduJPPRN7OKaWy2q9J8xCX/GGu09tyac3A=";
   };
 
   propagatedBuildInputs = [
@@ -25,6 +25,8 @@ buildPythonPackage rec {
     "localstack_client"
   ];
 
+  # All commands test `localstack` which is a downstream dependency
+  doCheck = false;
   checkInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/localstack-client/default.nix
+++ b/pkgs/development/python-modules/localstack-client/default.nix
@@ -3,6 +3,9 @@
 , fetchFromGitHub
 , boto3
 , pytestCheckHook
+
+# downstream dependencies
+, localstack
 }:
 
 buildPythonPackage rec {
@@ -38,6 +41,10 @@ buildPythonPackage rec {
 
   # For tests
   __darwinAllowLocalNetworking = true;
+
+  passthru.tests = {
+    inherit localstack;
+  };
 
   meta = with lib; {
     description = "A lightweight Python client for LocalStack";

--- a/pkgs/development/python-modules/localstack-ext/default.nix
+++ b/pkgs/development/python-modules/localstack-ext/default.nix
@@ -9,6 +9,9 @@
 , python-jose
 , requests
 , tabulate
+
+# Sensitive downstream dependencies
+, localstack
 }:
 
 buildPythonPackage rec {
@@ -49,6 +52,10 @@ buildPythonPackage rec {
 
   # No tests in repo
   doCheck = false;
+
+  passthru.tests = {
+    inherit localstack;
+  };
 
   meta = with lib; {
     description = "Extensions for LocalStack";

--- a/pkgs/development/python-modules/localstack-ext/default.nix
+++ b/pkgs/development/python-modules/localstack-ext/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "localstack-ext";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-EpFkam2xqRSiIhLkcBFSFKr9j0P5oRP4CIUVcjKT5gM=";
+    sha256 = "sha256-F+FQJwvB1WH7qcfOG6IGY+ZlfKwz39UE5rwoQKnxaac=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/localstack/default.nix
+++ b/pkgs/development/python-modules/localstack/default.nix
@@ -19,13 +19,13 @@
 
 buildPythonPackage rec {
   pname = "localstack";
-  version = "1.0.4";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "localstack";
     repo = "localstack";
     rev = "v${version}";
-    sha256 = "sha256-JDF3wM5AVhfkAFlxmy1f3aMxs4J5LWd0JOY8MzRAzT4=";
+    sha256 = "sha256-en/9kxhiW4aesc2SOpg/jRXiRa222iBQuq1O3cHeBJs=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

`localstack-client` was updated, but not the rest :(

Added `localstack` as a test dependency for coupled localstack packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
