### PR TITLE
cmctl: set passthru.updateScript option

### DIFF
--- a/pkgs/applications/networking/cluster/cmctl/default.nix
+++ b/pkgs/applications/networking/cluster/cmctl/default.nix
@@ -33,6 +33,8 @@ buildGoModule rec {
       --zsh <($out/bin/cmctl completion zsh)
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "A CLI tool for managing cert-manager service on Kubernetes clusters";
     longDescription = ''


### PR DESCRIPTION
Set passthru.updateScript option to point to `update.sh`. This should correctly now update cmctl automatically.

/assign @superherointj

See https://github.com/NixOS/nixpkgs/pull/184978#issuecomment-1286336497

PR correctly points the `pasthru.updateScript` to `update.sh` for automatic updates on [cert-manager](https://github.com/cert-manager/cert-manager) releases.