### PR TITLE
Allow override allowGoReference for gophernotes

### DIFF
--- a/pkgs/applications/editors/gophernotes/default.nix
+++ b/pkgs/applications/editors/gophernotes/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, allowGoReference ? false
 }:
 
 buildGoModule rec {
@@ -15,6 +16,10 @@ buildGoModule rec {
   };
 
   vendorSha256 = "sha256-iIBqx52fD12R+7MSjQNihMYYtZ9vPAdJndOG4YJVhy4=";
+  
+  # Allow gophernotes to reach go paths when pulling down third party modules
+  # or it might fail, complaining that it cannot find GOROOT
+  allowGoReference = allowGoReference;
 
   meta = with lib; {
     description = "Go kernel for Jupyter notebooks";

--- a/pkgs/applications/editors/gophernotes/default.nix
+++ b/pkgs/applications/editors/gophernotes/default.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
   
   # Allow gophernotes to reach go paths when pulling down third party modules
   # or it might fail, complaining that it cannot find GOROOT
-  allowGoReference = allowGoReference;
+  inherit allowGoReference;
 
   meta = with lib; {
     description = "Go kernel for Jupyter notebooks";

--- a/pkgs/applications/editors/gophernotes/default.nix
+++ b/pkgs/applications/editors/gophernotes/default.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   };
 
   vendorSha256 = "sha256-iIBqx52fD12R+7MSjQNihMYYtZ9vPAdJndOG4YJVhy4=";
-  
+
   # Allow gophernotes to reach go paths when pulling down third party modules
   # or it might fail, complaining that it cannot find GOROOT
   inherit allowGoReference;


### PR DESCRIPTION
###### Description of changes

Add an argument to allow overriding allowGoReference.

> Hi, I'm quite new to Nix and NixOS and I'm still learning about the Nix Language. Please tell me if there is further improvement or correction to do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).





