### PR TITLE
vscode, vscodium: fix/add insiders build

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14458,6 +14458,12 @@
     github = "wdavidw";
     githubId = 46896;
   };
+  weathercold = {
+    email = "weathercold.scr@gmail.com";
+    github = "Weathercold";
+    githubId = 49368953;
+    name = "Weathercold";
+  };
   WeebSorceress = {
     name = "WeebSorceress";
     email = "hello@weebsorceress.anonaddy.me";

--- a/pkgs/applications/editors/vscode/update-vscodium.sh
+++ b/pkgs/applications/editors/vscode/update-vscodium.sh
@@ -16,25 +16,31 @@ fi
 
 update_vscodium () {
   VSCODIUM_VER=$1
-  ARCH=$2
-  ARCH_LONG=$3
-  ARCHIVE_FMT=$4
-  VSCODIUM_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-${ARCH}-${VSCODIUM_VER}.${ARCHIVE_FMT}"
+  IS_INSIDERS=$2
+  ARCH=$3
+  ARCH_LONG=$4
+  ARCHIVE_FMT=$5
+  CHANNEL=$($IS_INSIDERS && echo "insider" || echo "stable")
+  CHANNEL_SUFFIX=$($IS_INSIDERS && echo "-insiders" || echo "")
+  VSCODIUM_URL="https://github.com/VSCodium/vscodium${CHANNEL_SUFFIX}/releases/download/${VSCODIUM_VER}/VSCodium-${ARCH}-${VSCODIUM_VER}.${ARCHIVE_FMT}"
   VSCODIUM_SHA256=$(nix-prefetch-url ${VSCODIUM_URL})
-  sed -i "s/${ARCH_LONG} = \".\{52\}\"/${ARCH_LONG} = \"${VSCODIUM_SHA256}\"/" "$ROOT/vscodium.nix"
+  sed -i "s/${CHANNEL}-${ARCH_LONG} = \".\{52\}\"/${CHANNEL}-${ARCH_LONG} = \"${VSCODIUM_SHA256}\"/" "$ROOT/vscodium.nix"
 }
 
 # VSCodium
 
-VSCODIUM_VER=$(curl -Ls -w %{url_effective} -o /dev/null https://github.com/VSCodium/vscodium/releases/latest | awk -F'/' '{print $NF}')
-sed -i "s/version = \".*\"/version = \"${VSCODIUM_VER}\"/" "$ROOT/vscodium.nix"
+VSCODIUM_STABLE_VER=$(curl -Ls -w %{url_effective} -o /dev/null https://github.com/VSCodium/vscodium/releases/latest | awk -F'/' '{print $NF}')
+VSCODIUM_INSIDERS_VER=$(curl -Ls -w %{url_effective} -o /dev/null https://github.com/VSCodium/vscodium-insiders/releases/latest | awk -F'/' '{print $NF}')
+sed -i "s/version = if isInsiders then \".*\" else \".*\"/version = if isInsiders then \"${VSCODIUM_INSIDERS_VER}\" else \"${VSCODIUM_STABLE_VER}\"/" "$ROOT/vscodium.nix"
 
-update_vscodium $VSCODIUM_VER linux-x64 x86_64-linux tar.gz
+update_vscodium $VSCODIUM_STABLE_VER false linux-x64 x86_64-linux tar.gz
+update_vscodium $VSCODIUM_STABLE_VER false darwin-x64 x86_64-darwin zip
+update_vscodium $VSCODIUM_STABLE_VER false linux-arm64 aarch64-linux tar.gz
+update_vscodium $VSCODIUM_STABLE_VER false darwin-arm64 aarch64-darwin zip
+update_vscodium $VSCODIUM_STABLE_VER false linux-armhf armv7l-linux tar.gz
 
-update_vscodium $VSCODIUM_VER darwin-x64 x86_64-darwin zip
-
-update_vscodium $VSCODIUM_VER linux-arm64 aarch64-linux tar.gz
-
-update_vscodium $VSCODIUM_VER darwin-arm64 aarch64-darwin zip
-
-update_vscodium $VSCODIUM_VER linux-armhf armv7l-linux tar.gz
+update_vscodium $VSCODIUM_INSIDERS_VER true linux-x64 x86_64-linux tar.gz
+update_vscodium $VSCODIUM_INSIDERS_VER true darwin-x64 x86_64-darwin zip
+update_vscodium $VSCODIUM_INSIDERS_VER true linux-arm64 aarch64-linux tar.gz
+update_vscodium $VSCODIUM_INSIDERS_VER true darwin-arm64 aarch64-darwin zip
+update_vscodium $VSCODIUM_INSIDERS_VER true linux-armhf armv7l-linux tar.gz

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -6,6 +6,7 @@
 let
   inherit (stdenv.hostPlatform) system;
   throwSystem = throw "Unsupported system: ${system}";
+  channel = if isInsiders then "insider" else "stable";
 
   plat = {
     x86_64-linux = "linux-x64";
@@ -18,17 +19,23 @@ let
   archive_fmt = if stdenv.isDarwin then "zip" else "tar.gz";
 
   sha256 = {
-    x86_64-linux = "0cf6zlwslii30877p5vb0varxs6ai5r1g9wxx1b45yrmp7rvda91";
-    x86_64-darwin = "0j9kb7j2rvrgc2dzxhi1nzs78lzhpkfk3gcqcq84hcsga0n59y03";
-    aarch64-linux = "1bf2kvnd2pz2sk26bq1wm868bvvmrg338ipysmryilhk0l490vcx";
-    aarch64-darwin = "1rwwrzabxgw2wryi6rp8sc1jqps54p7a3cjpn4q94kds8rk5j0qn";
-    armv7l-linux = "0p2kwfq74lz43vpfh90xfrqsz7nwgcjsvqwkifkchp1m3xnil742";
-  }.${system} or throwSystem;
+    stable-x86_64-linux = "0cf6zlwslii30877p5vb0varxs6ai5r1g9wxx1b45yrmp7rvda91";
+    stable-x86_64-darwin = "0j9kb7j2rvrgc2dzxhi1nzs78lzhpkfk3gcqcq84hcsga0n59y03";
+    stable-aarch64-linux = "1bf2kvnd2pz2sk26bq1wm868bvvmrg338ipysmryilhk0l490vcx";
+    stable-aarch64-darwin = "1rwwrzabxgw2wryi6rp8sc1jqps54p7a3cjpn4q94kds8rk5j0qn";
+    stable-armv7l-linux = "0p2kwfq74lz43vpfh90xfrqsz7nwgcjsvqwkifkchp1m3xnil742";
+
+    insider-x86_64-linux = "08yw98bcj7d1v2shapgddsc2ma8jxl7xnyq8nvgqb4cqw8nmd4p6";
+    insider-x86_64-darwin = "08wizyz65abg8frl2v0vzxl4wy0m0zb90rhz636n3kwbzzxyd5d4";
+    insider-aarch64-linux = "0v14yshs816qspffs1gh7mk0jv6m5jmabjfnwmdsljqnf23hj221";
+    insider-aarch64-darwin = "1jcblhr7565d2kzsazskdlrzylxfcmci8npd5g38v1znmpgrmby9";
+    insider-armv7l-linux = "00w6kmafpssm70l58ivp0gcdql8g7w4dbzah7iw3cr1qnhjpxc5i";
+  }."${channel}-${system}" or throwSystem;
 in
   callPackage ./generic.nix rec {
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
-    version = "1.72.2";
+    version = if isInsiders then "1.73.0-insider" else "1.72.2";
     pname = "vscode";
 
     executableName = "code" + lib.optionalString isInsiders "-insiders";
@@ -38,7 +45,7 @@ in
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";
-      url = "https://update.code.visualstudio.com/${version}/${plat}/stable";
+      url = "https://update.code.visualstudio.com/${version}/${plat}/${channel}";
       inherit sha256;
     };
 
@@ -51,7 +58,7 @@ in
         Open source source code editor developed by Microsoft for Windows,
         Linux and macOS
       '';
-      mainProgram = "code";
+      mainProgram = if isInsiders then "code-insiders" else "code";
       longDescription = ''
         Open source source code editor developed by Microsoft for Windows,
         Linux and macOS. It includes support for debugging, embedded Git
@@ -62,7 +69,7 @@ in
       homepage = "https://code.visualstudio.com/";
       downloadPage = "https://code.visualstudio.com/Updates";
       license = licenses.unfree;
-      maintainers = with maintainers; [ eadwu synthetica maxeaubrey bobby285271 ];
+      maintainers = with maintainers; [ eadwu synthetica maxeaubrey bobby285271 weathercold ];
       platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" "armv7l-linux" ];
     };
   }

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -1,8 +1,13 @@
-{ lib, stdenv, callPackage, fetchurl, nixosTests, commandLineArgs ? "" }:
+{ stdenv, lib, callPackage, fetchurl, nixosTests
+, isInsiders ? false
+, commandLineArgs ? ""
+}:
 
 let
   inherit (stdenv.hostPlatform) system;
   throwSystem = throw "Unsupported system: ${system}";
+  channel = if isInsiders then "insider" else "stable";
+  channelSuffix = lib.optionalString isInsiders "-insiders";
 
   plat = {
     x86_64-linux = "linux-x64";
@@ -15,12 +20,18 @@ let
   archive_fmt = if stdenv.isDarwin then "zip" else "tar.gz";
 
   sha256 = {
-    x86_64-linux = "1qchwn6dccmq81bmz4zpv5pc6g2gyd7avi9hi1dd099jcxl9xgc8";
-    x86_64-darwin = "099s32kbv64s90jy1yrafwmn49f80x4qzq3kwpwpkp6vfsclvnvw";
-    aarch64-linux = "1a1rp0gki86dw03lhlnn5l378jd6z7v736x17qsbyc3qfm5schil";
-    aarch64-darwin = "153jp14zjzrdw4nwfg9mja0vy9m376dfxf2d6iwb7gl6byvqa1jj";
-    armv7l-linux = "1g5dxcly41bxdnfvmybwxrlf2qm3lkb3k0i538wfwxzy8k73i5h5";
-  }.${system} or throwSystem;
+    stable-x86_64-linux = "0bc95mdl19la63yvqrpfcvq9sx68wfv60a3xrz2z5lk308khfpr6";
+    stable-x86_64-darwin = "0qb8610ilf69j0zl7z031bmqdsxsj15w1maz7lx0z09yrdyvgi7c";
+    stable-aarch64-linux = "157arn7wsxgh3qr4bzhy75y7zw9qwz1zch7ny36kr53135d2nhz6";
+    stable-aarch64-darwin = "0dwzqv1j1gcjyc1w41f9k1pijazr62r569arh4l53xi7amrp7hx8";
+    stable-armv7l-linux = "1lam1z8hqdav4al07d1ahq4qh2npv191n2gqpdxg5b1fs7zv3k85";
+
+    insider-x86_64-linux = "10dp68wl6vba2sgka4j6bkr2vzbmgcq2lppp1nhqm9fh4skixvl6";
+    insider-x86_64-darwin = "0n6fyz0ij26bd0xchg92i3qgrgf41xqsx0hr727img9lccpc0hvi";
+    insider-aarch64-linux = "1ay5scqcmd7mz16l83xbfim2h51nyvz0s1v1yjzyz0p7gqaig994";
+    insider-aarch64-darwin = "0l97i5zc3r422ph29dpq0d1h2yy99r74jy4w7w5lcyc2khi55xlb";
+    insider-armv7l-linux = "19s13shbr6v6dllpaq4rpmlcj0dysx1p9lgfpcarjdwsca5a03gn";
+  }."${channel}-${system}" or throwSystem;
 
   sourceRoot = if stdenv.isDarwin then "" else ".";
 in
@@ -29,15 +40,15 @@ in
 
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
-    version = "1.72.2.22286";
+    version = if isInsiders then "1.73.0.22295-insider" else "1.72.2.22289";
     pname = "vscodium";
 
-    executableName = "codium";
-    longName = "VSCodium";
-    shortName = "vscodium";
+    executableName = "codium" + channelSuffix;
+    longName = "VSCodium" + lib.optionalString isInsiders " - Insiders";
+    shortName = "Codium" + lib.optionalString isInsiders " - Insiders";
 
     src = fetchurl {
-      url = "https://github.com/VSCodium/vscodium/releases/download/${version}/VSCodium-${plat}-${version}.${archive_fmt}";
+      url = "https://github.com/VSCodium/vscodium${channelSuffix}/releases/download/${version}/VSCodium-${plat}-${version}.${archive_fmt}";
       inherit sha256;
     };
 
@@ -61,8 +72,8 @@ in
       downloadPage = "https://github.com/VSCodium/vscodium/releases";
       license = licenses.mit;
       sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-      maintainers = with maintainers; [ synthetica turion bobby285271 ];
-      mainProgram = "codium";
+      maintainers = with maintainers; [ synthetica turion bobby285271 weathercold ];
+      mainProgram = "codium" + channelSuffix;
       platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" "armv7l-linux" ];
     };
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32574,6 +32574,8 @@ with pkgs;
   vscode-extensions = recurseIntoAttrs (callPackage ../applications/editors/vscode/extensions { });
 
   vscodium = callPackage ../applications/editors/vscode/vscodium.nix { };
+  vscodium-insiders = vscodium.override { isInsiders = true; };
+
   vscodium-fhs = vscodium.fhs;
   vscodium-fhsWithPackages = vscodium.fhsWithPackages;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32561,10 +32561,13 @@ with pkgs;
   };
 
   vscode = callPackage ../applications/editors/vscode/vscode.nix { };
+  vscode-insiders = vscode.override { isInsiders = true; };
+
   vscode-fhs = vscode.fhs;
   vscode-fhsWithPackages = vscode.fhsWithPackages;
 
   vscode-with-extensions = callPackage ../applications/editors/vscode/with-extensions.nix { };
+  vscode-insiders-with-extensions = vscode-with-extensions.override { vscode = vscode-insiders; };
 
   vscode-utils = callPackage ../applications/editors/vscode/extensions/vscode-utils.nix { };
 


### PR DESCRIPTION
###### Description of changes

- Fix VSCode Insiders (`vscode.override { isInsiders = true; }`). Apparently it was broken for a long time.
- Add option `isInsiders` to vscodium to build the insiders version.
- Add `vscode-insiders`, `vscode-insiders-with-extensions`, and `vscodium-insiders` in all-packages.
- Update the autoupdate script to also update the insiders build.
- Add myself to maintainers.

Still unfinished.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).