### PR TITLE
nvme-cli: 1.16 -> 2.1.2

### DIFF
--- a/pkgs/os-specific/linux/nvme-cli/default.nix
+++ b/pkgs/os-specific/linux/nvme-cli/default.nix
@@ -1,26 +1,40 @@
 { lib, stdenv, fetchFromGitHub, pkg-config
+, meson
+, ninja
 , libuuid
+, libnvme
+, json_c
+, zlib
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "nvme-cli";
-  version = "1.16";
+  version = "2.1.2";
 
   src = fetchFromGitHub {
     owner = "linux-nvme";
     repo = "nvme-cli";
     rev = "v${version}";
-    sha256 = "sha256-/wDQxsN1sji56zfcvqx02iciYnyxjIbL85bNaRwrHYw=";
+    hash = "sha256-ZjgysgWMmBlN+aalI5u2vQ58XrtEbJlDPCqUN6avv08=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libuuid ];
+  mesonFlags = [
+    "-Dversion-tag=${version}"
+  ];
 
-  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
-
-  # To omit the hostnqn and hostid files that are impure and should be unique
-  # for each target host:
-  installTargets = [ "install-spec" ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3.pkgs.nose2
+  ];
+  buildInputs = [
+    libuuid
+    libnvme
+    json_c
+    zlib
+  ];
 
   meta = with lib; {
     inherit (src.meta) homepage; # https://nvmexpress.org/


### PR DESCRIPTION
###### Description of changes
supersedes #194537 (cc @felixsinger)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).