### PR TITLE
arch-install-scripts: 26 -> 27

### DIFF
--- a/pkgs/tools/misc/arch-install-scripts/default.nix
+++ b/pkgs/tools/misc/arch-install-scripts/default.nix
@@ -22,13 +22,13 @@
 
 resholve.mkDerivation rec {
   pname = "arch-install-scripts";
-  version = "26";
+  version = "27";
 
   src = fetchFromGitHub {
     owner = "archlinux";
     repo = "arch-install-scripts";
     rev = "v${version}";
-    hash = "sha256-TRo1ANKSt3njw4HdBMUymMJDpTkL/i5/hdSqxHZnuYw=";
+    hash = "sha256-owJImToG8GIk1TfkSKJyXCu9RTJ1qYlvQ6DTMSazaeQ=";
   };
 
   nativeBuildInputs = [ asciidoc gnum4 ];
@@ -63,6 +63,8 @@ resholve.mkDerivation rec {
 
       # packages resholve should resolve executables from
       inputs = [ coreutils gawk gnugrep pacman util-linux ];
+
+      execer = [ "cannot:${pacman}/bin/pacman-key" ];
 
       # TODO: no good way to resolve mount/umount in Nix builds for now
       # see https://github.com/abathur/resholve/issues/29


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This update introduces `-K` option to `pacstrap`, which initializes an empty pacman keyring in the target root instead of copying the existing keyring from the host. This option won't work without https://github.com/NixOS/nixpkgs/pull/192896 or manually adding `pacman` package to PATH.

~~However, even with the above change applied, I found `pacstrap -K` not automatically populating `archlinux-keyring` after installing it to the new root, and I had to manually run `pacman-key --populate` before installing packages in the chroot. :confused:~~

~~UPDATE: Using `pacstrap` without `-K` doesn't trigger `pacman-key --populate` either, but it'll copy the gpgdir from the host to the target, so I didn't notice this problem before. Maybe I'll open an issue to track it later.~~

My bad! That was because I added `etc/pacman.d/mirrorlist` to `NoExtract` in my `pacman.conf`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
