### PR TITLE
transmission-rss: init at 0.3.1

### DIFF
--- a/pkgs/tools/networking/transmission-rss/default.nix
+++ b/pkgs/tools/networking/transmission-rss/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform, pkg-config, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  version = "0.3.1";
+  pname = "transmission-rss";
+
+  src = fetchFromGitHub {
+    owner = "herlon214";
+    repo = pname;
+    rev = "5bbad7a81621a194b7a8b11a56051308a7ccbf06";
+    sha256 = "sha256-SkEgxinqPA9feOIF68oewVyRKv3SY6fWWZLGJeH+r4M=";
+  };
+
+  cargoPatches = [ ./update-cargo-lock-version.patch ];
+
+  cargoSha256 = "sha256-QNMdqoxxY8ao2O44hJxZNgLrPwzu9+ieweTPc7pfFY4=";
+
+  nativeBuildInputs = [pkg-config];
+  buildInputs = [openssl];
+
+  OPENSSL_NO_VENDOR = 1;
+
+  meta = with lib; {
+    description = "Add torrents to transmission based on RSS list";
+    homepage = "https://github.com/herlon214/transmission-rss";
+    maintainers = with maintainers; [ icewind1991 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/tools/networking/transmission-rss/update-cargo-lock-version.patch
+++ b/pkgs/tools/networking/transmission-rss/update-cargo-lock-version.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index e75aca4..88321ec 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2148,7 +2148,7 @@ dependencies = [
+
+ [[package]]
+ name = "transmission-rss"
+-version = "0.3.0"
++version = "0.3.1"
+ dependencies = [
+  "clap",
+  "env_logger",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1817,6 +1817,8 @@ with pkgs;
 
   topicctl = callPackage ../tools/misc/topicctl { };
 
+  transmission-rss = callPackage ../tools/networking/transmission-rss { };
+
   trigger-control = callPackage ../tools/games/trigger-control { };
 
   ttchat = callPackage ../tools/misc/ttchat { };


### PR DESCRIPTION
###### Description of changes

Add [transmission-rss](https://github.com/herlon214/transmission-rss) 0.3.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
