### PR TITLE
pokemonsay: unstable-2021-10-05 -> 1.0.0

### DIFF
--- a/pkgs/tools/misc/pokemonsay/default.nix
+++ b/pkgs/tools/misc/pokemonsay/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, fetchpatch
 , cowsay
 , coreutils
 , findutils
@@ -8,14 +9,22 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "pokemonsay";
-  version = "unstable-2021-10-05";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "HRKings";
     repo = "pokemonsay-newgenerations";
-    rev = "baccc6d2fe1897c48f60d82ff9c4d4c018f5b594";
+    rev = "v${version}";
     hash = "sha256-IDTAZmOzkUg0kLUM0oWuVbi8EwE4sEpLWrNAtq/he+g=";
   };
+
+  patches = [
+    (fetchpatch { # https://github.com/HRKings/pokemonsay-newgenerations/pull/5
+      name = "word-wrap-fix.patch";
+      url = "https://github.com/pbsds/pokemonsay-newgenerations/commit/7056d7ba689479a8e6c14ec000be1dfcd83afeb0.patch";
+      hash = "sha256-aqUJkyJDWArLjChxLZ4BbC6XAB53LAqARzTvEAxrFCI=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pokemonsay.sh \
@@ -51,8 +60,11 @@ stdenvNoCC.mkDerivation rec {
     cp pokemons/*.cow $out/share/pokemonsay
   '';
 
-  checkPhase = ''
-    $out/bin/pokemonsay --list-pokemon
+  doInstallCheck = true;
+  installCheckPhase = ''
+    (set -x
+      test "$($out/bin/pokemonsay --list | wc -l)" -ge 891
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Only the version tag changes, as the same rev got tagged
1.0.0 as of https://github.com/HRKings/pokemonsay-newgenerations/issues/4.
This was verified by removing the hash and building it, resulting i the same hash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
