### PR TITLE
unixODBCDrivers.msodbcsql18: init at 18.1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15283,6 +15283,12 @@
     githubId = 171470;
     name = "Sam Hug";
   };
+  SamirTalwar = {
+    email = "lazy.git@functional.computer";
+    github = "SamirTalwar";
+    githubId = 47852;
+    name = "Samir Talwar";
+  };
   samlich = {
     email = "nixos@samli.ch";
     github = "samlich";

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,6 +1,19 @@
 { fetchurl, stdenv, unixODBC, cmake, postgresql, mariadb, sqlite, zlib, libxml2, dpkg, lib, openssl, libkrb5, libuuid, patchelf, libiconv, fixDarwinDylibNames, fetchFromGitHub }:
 
-# I haven't done any parameter tweaking.. So the defaults provided here might be bad
+# Each of these ODBC drivers can be configured in your odbcinst.ini file using
+# the various passthru and meta values. Of note are:
+#
+#   * `passthru.fancyName`, the typical name used to reference the driver
+#   * `passthru.driver`, the path to the driver within the built package
+#   * `meta.description`, a short description of the ODBC driver
+#
+# For example, you might generate it as follows:
+#
+# ''
+# [${package.fancyName}]
+# Description = ${package.meta.description}
+# Driver = ${package}/${package.driver}
+# ''
 
 {
   psql = stdenv.mkDerivation rec {
@@ -14,6 +27,7 @@
 
     buildInputs = [ unixODBC postgresql ];
 
+    # see the top of the file for an explanation
     passthru = {
       fancyName = "PostgreSQL";
       driver = "lib/psqlodbcw.so";
@@ -59,6 +73,7 @@
       "-DWITH_IODBC=OFF"
     ];
 
+    # see the top of the file for an explanation
     passthru = {
       fancyName = "MariaDB";
       driver = "lib/libmaodbc${stdenv.hostPlatform.extensions.sharedLibrary}";
@@ -87,6 +102,7 @@
 
     cmakeFlags = [ "-DWITH_UNIXODBC=1" ];
 
+    # see the top of the file for an explanation
     passthru = {
       fancyName = "MySQL";
       driver = "lib/libmyodbc3-3.51.12.so";
@@ -122,6 +138,7 @@
       mv "$out"/*.* "$out/lib"
     '';
 
+    # see the top of the file for an explanation
     passthru = {
       fancyName = "SQLite";
       driver = "lib/libsqlite3odbc.so";
@@ -165,6 +182,7 @@
         $out/lib/libmsodbcsql-${versionMajor}.${versionMinor}.so.${versionAdditional}
     '';
 
+    # see the top of the file for an explanation
     passthru = {
       fancyName = "ODBC Driver ${versionMajor} for SQL Server";
       driver = "lib/libmsodbcsql-${versionMajor}.${versionMinor}.so.${versionAdditional}";
@@ -249,6 +267,7 @@
         $out/${finalAttrs.passthru.driver}
     '';
 
+    # see the top of the file for an explanation
     passthru = {
       fancyName = "ODBC Driver ${finalAttrs.versionMajor} for SQL Server";
       driver = "lib/libmsodbcsql${if stdenv.isDarwin then ".${finalAttrs.versionMajor}.dylib" else "-${finalAttrs.versionMajor}.${finalAttrs.versionMinor}.so.${finalAttrs.versionAdditional}"}";
@@ -293,6 +312,7 @@
 
     buildInputs = [ unixODBC ];
 
+    # see the top of the file for an explanation
     passthru = {
       fancyName = "Amazon Redshift (x64)";
       driver = "lib/libamazonredshiftodbc64.so";


### PR DESCRIPTION
###### Description of changes

This is the ODBC Driver 18 for SQL Server, which now supports arm64 (and therefore modern Mac hardware). Download links were acquired from the [Linux](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver16) and [macOS](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver16) installation pages.

I used the Debian packages, as that's what the `msodbcsql17` package uses.

I have verified these build appropriately. I haven't tested them thoroughly in nixpkgs, but I have tested them at length as part of [hasura/graphql-engine](https://github.com/hasura/graphql-engine). The contents are copied from [_nix/msodbcsql18-linux.nix_](https://github.com/hasura/graphql-engine/blob/c3afa0fdd7eece8eb1bc708e4e241efe36c18618/nix/msodbcsql18-linux.nix) and [_nix/msodbcsql18-darwin.nix_](https://github.com/hasura/graphql-engine/blob/c3afa0fdd7eece8eb1bc708e4e241efe36c18618/nix/msodbcsql18-darwin.nix).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

