### PR TITLE
gasket: init at 1.0-18

### DIFF
--- a/pkgs/os-specific/linux/gasket/default.nix
+++ b/pkgs/os-specific/linux/gasket/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchurl, dpkg, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "gasket";
+  version = "1.0";
+  revision = "18";
+  name = "gasket-${version}";
+
+  src = fetchurl {
+    url = "https://packages.cloud.google.com/apt/pool/gasket-dkms_1.0-18_all_00606bc20aed9a7d2a9da7a6d51a87dbc7f275be392fb3e1131ef6f627a49168.deb";
+    name = "gasket-dkms_${version}-${revision}.deb";
+    sha256 = "0s4ilhkzdxhy2ghv6brrprsz5iyvhwddb9m7klm7v6pd1b16nq00";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  KSRC = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildInputs = [ dpkg ];
+
+  unpackPhase = ''
+    dpkg-deb -x "$src" .
+    cd usr/src/gasket-1.0
+  '';
+
+  patchPhase = ''
+    sed -i "s|/lib/modules/\$(KVERSION)/build|${KSRC}|g" Makefile
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/staging/gasket
+    install -Dm644 apex.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/staging/gasket
+    install -Dm644 gasket.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/staging/gasket
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Gasket provides support for Google ASICs, e.g: the Coral EdgeTPU.";
+    homepage = "https://coral.withgoogle.com/";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.luker ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26172,6 +26172,8 @@ with pkgs;
 
   fxload = callPackage ../os-specific/linux/fxload { };
 
+  gasket = callPackage ../os-specific/linux/gasket { };
+
   gfxtablet = callPackage ../os-specific/linux/gfxtablet { };
 
   gmailctl = callPackage ../applications/networking/gmailctl { };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -338,6 +338,8 @@ in {
 
     fwts-efi-runtime = callPackage ../os-specific/linux/fwts/module.nix { };
 
+    gasket = callPackage ../os-specific/linux/gasket { };
+
     gcadapter-oc-kmod = callPackage ../os-specific/linux/gcadapter-oc-kmod { };
     hid-nintendo = callPackage ../os-specific/linux/hid-nintendo { };
 


### PR DESCRIPTION
###### Description of changes

Gasket-DKMS driver for TPU from [coral.ai](https://coral.ai/)

This provides two kernel modules, `gasket` and `apex` which were introduced in the linux kernel staging in version `4.19`  
Since the driver were maintained only off-tree and due to the lack of interest/quality, they were removed in `5.13`

Hardware that requires this driver is still being sold

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (no, linux-only)
  - [ ] aarch64-darwin (no. linux-only)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) (no binaries)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


I have this installed and running for the past year, in use by `frigate`/`home-assistant` for object recognition on cameras
