### PR TITLE
temporalite: init at 0.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/temporalite/default.nix
+++ b/pkgs/applications/networking/cluster/temporalite/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "temporalite";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "temporalio";
+    repo = "temporalite";
+    rev = "v${version}";
+    sha256 = "sha256-rLEkWg5LNVb7i/2IARKGuP9ugaVJA9pwYbKLm0QLmOc=";
+  };
+
+  vendorSha256 = "sha256-vjuwh/HRRYfB6J49rfJxif12nYPnbBodWF9hTiGygS8=";
+
+  CGO_ENABLED = 0;
+
+  ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
+
+  subPackages = [ "./cmd/temporalite" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An experimental distribution of Temporal that runs as a single process";
+    homepage = "https://temporal.io";
+    changelog = "https://github.com/temporalio/temporalite/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sagikazarmark ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32108,6 +32108,8 @@ with pkgs;
 
   temporal-cli = callPackage ../applications/networking/cluster/temporal-cli { };
 
+  temporalite = callPackage ../applications/networking/cluster/temporalite { };
+
   tenacity = callPackage ../applications/audio/tenacity { };
 
   tendermint = callPackage ../tools/networking/tendermint { };


### PR DESCRIPTION
###### Description of changes

Temporalite is a lite version of Temporal (already part of nixpkgs). It runs in a single process and uses sqlite as a storage layer.

https://github.com/temporalio/temporalite

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
