### PR TITLE
Add support for gnuradio on darwin

### DIFF
--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -271,11 +271,11 @@ stdenv.mkDerivation rec {
     # order to build, see https://github.com/qradiolink/qradiolink/issues/67
     ++ lib.optionals (hasFeature "gr-vocoder") [
       "-DLIBCODEC2_FOUND=TRUE"
-      "-DLIBCODEC2_LIBRARIES=${codec2}/lib/libcodec2.so"
+      "-DLIBCODEC2_LIBRARIES=${codec2}/lib/libcodec2${stdenv.hostPlatform.extensions.sharedLibrary}"
       "-DLIBCODEC2_INCLUDE_DIRS=${codec2}/include"
       "-DLIBCODEC2_HAS_FREEDV_API=ON"
       "-DLIBGSM_FOUND=TRUE"
-      "-DLIBGSM_LIBRARIES=${gsm}/lib/libgsm.so"
+      "-DLIBGSM_LIBRARIES=${gsm}/lib/libgsm${stdenv.hostPlatform.extensions.sharedLibrary}"
       "-DLIBGSM_INCLUDE_DIRS=${gsm}/include/gsm"
     ]
     ++ lib.optionals (hasFeature "volk" && volk != null) [

--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -296,7 +296,7 @@ stdenv.mkDerivation rec {
     # This is the only python reference worth removing, if needed.
     + lib.optionalString (!hasFeature "python-support") ''
       ${removeReferencesTo}/bin/remove-references-to -t ${python} $out/lib/cmake/gnuradio/GnuradioConfig.cmake
-      ${removeReferencesTo}/bin/remove-references-to -t ${python} $(readlink -f $out/lib/libgnuradio-runtime.so)
+      ${removeReferencesTo}/bin/remove-references-to -t ${python} $(readlink -f $out/lib/libgnuradio-runtime${stdenv.hostPlatform.extensions.sharedLibrary})
       ${removeReferencesTo}/bin/remove-references-to -t ${python.pkgs.pybind11} $out/lib/cmake/gnuradio/gnuradio-runtimeTargets.cmake
     ''
   ;

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -317,7 +317,7 @@ stdenv.mkDerivation rec {
     # This is the only python reference worth removing, if needed.
     + lib.optionalString (!hasFeature "python-support") ''
       ${removeReferencesTo}/bin/remove-references-to -t ${python} $out/lib/cmake/gnuradio/GnuradioConfig.cmake
-      ${removeReferencesTo}/bin/remove-references-to -t ${python} $(readlink -f $out/lib/libgnuradio-runtime.so)
+      ${removeReferencesTo}/bin/remove-references-to -t ${python} $(readlink -f $out/lib/libgnuradio-runtime${stdenv.hostPlatform.extensions.sharedLibrary})
       ${removeReferencesTo}/bin/remove-references-to -t ${python.pkgs.pybind11} $out/lib/cmake/gnuradio/gnuradio-runtimeTargets.cmake
     ''
   ;

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -129,6 +129,6 @@ rec {
     homepage = "https://www.gnuradio.org";
     license = licenses.gpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ doronbehar bjornfor fpletz ];
+    maintainers = with maintainers; [ doronbehar bjornfor fpletz jiegec ];
   };
 }

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -84,7 +84,11 @@ rec {
   postInstall = ""
     # Gcc references
     + lib.optionalString (hasFeature "gnuradio-runtime") ''
-      ${removeReferencesTo}/bin/remove-references-to -t ${stdenv.cc} $(readlink -f $out/lib/libgnuradio-runtime.so)
+      ${removeReferencesTo}/bin/remove-references-to -t ${stdenv.cc} $(readlink -f $out/lib/libgnuradio-runtime${stdenv.hostPlatform.extensions.sharedLibrary})
+    ''
+    # Clang references in InstalledDir
+    + lib.optionalString (hasFeature "gnuradio-runtime" && stdenv.isDarwin) ''
+      ${removeReferencesTo}/bin/remove-references-to -t ${stdenv.cc.cc} $(readlink -f $out/lib/libgnuradio-runtime${stdenv.hostPlatform.extensions.sharedLibrary})
     ''
   ;
   # NOTE: Outputs are disabled due to upstream not using GNU InstallDIrs cmake
@@ -112,7 +116,6 @@ rec {
   doCheck = false;
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Software Defined Radio (SDR) software";
     longDescription = ''
       GNU Radio is a free & open-source software development toolkit that

--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -98,19 +98,21 @@ let
           "${
             lib.makeSearchPath
             unwrapped.qt.qtbase.qtPluginPrefix
-            (builtins.map lib.getBin [
+            (builtins.map lib.getBin ([
               unwrapped.qt.qtbase
+            ] ++ lib.optionals stdenv.isLinux [
               unwrapped.qt.qtwayland
-            ])
+            ]))
           }"
           "--prefix" "QML2_IMPORT_PATH" ":"
           "${
             lib.makeSearchPath
             unwrapped.qt.qtbase.qtQmlPrefix
-            (builtins.map lib.getBin [
+            (builtins.map lib.getBin ([
               unwrapped.qt.qtbase
+            ] ++ lib.optionals stdenv.isLinux [
               unwrapped.qt.qtwayland
-            ])
+            ]))
           }"
         ]
       else

--- a/pkgs/development/gnuradio-modules/grnet/default.nix
+++ b/pkgs/development/gnuradio-modules/grnet/default.nix
@@ -1,6 +1,7 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , gnuradio
 , cmake
 , pkg-config
@@ -53,6 +54,16 @@ mkDerivation {
   version = version.name;
   inherit src;
   disabledForGRafter = "3.10";
+
+  patches = [
+    # Use cross platform struct ip instead of iphdr
+    # https://github.com/ghostop14/gr-grnet/pull/19
+    (fetchpatch {
+      name = "fix-compilation-on-darwin.patch";
+      url = "https://github.com/ghostop14/gr-grnet/commit/52c07daa9ba595b76ffa5dd90c0c96694d95d140.patch";
+      sha256 = "sha256-1gJaYLIn09blOhALMfBPROt5YBXaosG41Vsd3+5h518=";
+    })
+  ];
 
   buildInputs = [
     boost

--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -1,4 +1,6 @@
 { lib
+, stdenv
+, darwin
 , mkDerivation
 , fetchgit
 , gnuradio
@@ -58,6 +60,9 @@ in mkDerivation {
   ] ++ lib.optionals (gnuradio.hasFeature "gr-ctrlport") [
     thrift
     python.pkgs.thrift
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.IOKit
+    darwin.apple_sdk.frameworks.Security
   ];
   cmakeFlags = [
     (if (gnuradio.hasFeature "python-support") then

--- a/pkgs/development/libraries/libad9361/default.nix
+++ b/pkgs/development/libraries/libad9361/default.nix
@@ -15,11 +15,19 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libiio ];
 
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    # Fix iio include path on darwin to match linux
+    for i in test/*.c; do
+      substituteInPlace $i \
+        --replace 'iio/iio.h' 'iio.h'
+    done
+  '';
+
   meta = with lib; {
     description = "IIO AD9361 library for filter design and handling, multi-chip sync, etc";
     homepage = "http://analogdevicesinc.github.io/libad9361-iio/";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ sikmir ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -10,11 +10,12 @@
 , libaio
 , runtimeShell
 , lib
+, pkg-config
 }:
 
 stdenv.mkDerivation rec {
   pname = "libiio";
-  version = "0.23";
+  version = "0.24";
 
   outputs = [ "out" "lib" "dev" "python" ];
 
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "analogdevicesinc";
     repo = "libiio";
     rev = "v${version}";
-    sha256 = "0awny9zb43dcnxa5jpxay2zxswydblnbn4x6vi5mlw1r48pzhjf8";
+    sha256 = "sha256-c5HsxCdp1cv5BGTQ/8dc8J893zk9ntbfAudLpqoQ1ow=";
   };
 
   # Revert after https://github.com/NixOS/nixpkgs/issues/125008 is
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
     cmake
     flex
     bison
+    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -11,6 +11,8 @@
 , runtimeShell
 , lib
 , pkg-config
+, CFNetwork
+, CoreServices
 }:
 
 stdenv.mkDerivation rec {
@@ -42,12 +44,17 @@ stdenv.mkDerivation rec {
     libxml2
     libusb1
     avahi
-    libaio
-  ] ++ lib.optional python.isPy3k python.pkgs.setuptools;
+  ] ++ lib.optional python.isPy3k python.pkgs.setuptools
+    ++ lib.optional stdenv.isLinux libaio
+    ++ lib.optionals stdenv.isDarwin [ CFNetwork CoreServices ];
 
   cmakeFlags = [
     "-DUDEV_RULES_INSTALL_DIR=${placeholder "out"}/lib/udev/rules.d"
     "-DPYTHON_BINDINGS=on"
+    # osx framework is disabled,
+    # the linux-like directory structure is used for proper output splitting
+    "-DOSX_PACKAGE=off"
+    "-DOSX_FRAMEWORK=off"
   ];
 
   postPatch = ''
@@ -67,7 +74,7 @@ stdenv.mkDerivation rec {
     description = "API for interfacing with the Linux Industrial I/O Subsystem";
     homepage = "https://github.com/analogdevicesinc/libiio";
     license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/development/libraries/qwt/default.nix
+++ b/pkgs/development/libraries/qwt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, qtbase, qtsvg, qttools, qmake }:
+{ lib, stdenv, fetchurl, qtbase, qtsvg, qttools, qmake, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   pname = "qwt";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   propagatedBuildInputs = [ qtbase qtsvg qttools ];
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   postPatch = ''
     sed -e "s|QWT_INSTALL_PREFIX.*=.*|QWT_INSTALL_PREFIX = $out|g" -i qwtconfig.pri

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20030,6 +20030,7 @@ with pkgs;
   libgxps = callPackage ../development/libraries/libgxps { };
 
   libiio = callPackage ../development/libraries/libiio {
+    inherit (darwin.apple_sdk.frameworks) CFNetwork CoreServices;
     python = python3;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28266,7 +28266,7 @@ with pkgs;
       python = python3;
     };
   };
-  gnuradio3_9Packages = lib.recurseIntoAttrs gnuradio.pkgs;
+  gnuradio3_9Packages = lib.recurseIntoAttrs gnuradio3_9.pkgs;
   # A build without gui components and other utilites not needed for end user
   # libraries
   gnuradio3_9Minimal = gnuradio.override {


### PR DESCRIPTION
###### Description of changes

- libiio: 0.23 -> 0.24
- libiio: unbreak on darwin
- libad9361: unbreak on darwin
- qwt: fix dylib names on darwin
- gnuradio: fix build on darwin
- gnuradio3_8Packages.osmosdr: add missing framework on darwin
- gnuradio3_8Packages.grnet: fix compilation on darwin
- gnuradio3_9Packages: fix alias
- gnuradio: add jiegec as maintainer

I can launch gnuradio-companion and run a FM receiver with this pr.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
