### PR TITLE
python3Packages.apache-beam: relax protobuf dependency to fix build

### DIFF
--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -27,18 +27,20 @@
 , pymongo
 , pytestCheckHook
 , python
-, pythonAtLeast
 , python-dateutil
+, pythonAtLeast
+, pythonRelaxDepsHook
 , pytz
 , pyyaml
 , requests
 , requests-mock
+, scikit-learn
 , setuptools
 , sqlalchemy
 , tenacity
-, typing-extensions
 , testcontainers
-, scikit-learn }:
+, typing-extensions
+}:
 
 buildPythonPackage rec {
   pname = "apache-beam";
@@ -51,14 +53,16 @@ buildPythonPackage rec {
     sha256 = "sha256-0S7Dj6PMSbZkEAY6ZLUpKVfe/tFxsq60TTAFj0Qhtv0=";
   };
 
-  # See https://github.com/NixOS/nixpkgs/issues/156957.
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "dill>=0.3.1.1,<0.3.2" "dill" \
-      --replace "pyarrow>=0.15.1,<8.0.0" "pyarrow" \
-      --replace "numpy>=1.14.3,<1.23.0" "numpy" \
-      --replace "pymongo>=3.8.0,<4.0.0" "pymongo"
-  '';
+  pythonRelaxDeps = [
+    # See https://github.com/NixOS/nixpkgs/issues/156957
+    "dill"
+    "numpy"
+    "pyarrow"
+    "pymongo"
+
+    # See https://github.com/NixOS/nixpkgs/issues/193613
+    "protobuf"
+  ];
 
   sourceRoot = "source/sdks/python";
 
@@ -66,6 +70,7 @@ buildPythonPackage rec {
     cython
     grpcio-tools
     mypy-protobuf
+    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Fix https://github.com/NixOS/nixpkgs/issues/193613.

This is a bit awkward since the protobuf version constraint is on the python package called `protobuf` and not on the generic `protobuf` library as defined in `all-packages.nix`. Unlike the generic library, the python package does not have alternative versions packaged, so we can't fix it with an argument override.

Also odd: the error message says `ERROR: No matching distribution found for protobuf<4,>=3.12.2` but the current protobuf version is 3.21.6, so it's not clear why it's failing...

Fixing with `pythonRelaxDepsHook` seems to do the trick and does not lead to any test failures, so I think it should be fair game.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
