### PR TITLE
python3Packages.connexion: add missing dependency on 'packages'

### DIFF
--- a/pkgs/development/python-modules/connexion/default.nix
+++ b/pkgs/development/python-modules/connexion/default.nix
@@ -11,6 +11,7 @@
 , inflection
 , jsonschema
 , openapi-spec-validator
+, packaging
 , pytest-aiohttp
 , pytestCheckHook
 , pythonOlder
@@ -43,6 +44,7 @@ buildPythonPackage rec {
     inflection
     jsonschema
     openapi-spec-validator
+    packaging
     pyyaml
     requests
     swagger-ui-bundle


### PR DESCRIPTION
Without 'packages' dependency:
$ nix-shell -I nixpkgs=./default.nix --pure -p python3Packages.connexion \
    --command "python -m connexion --version"
...
ModuleNotFoundError: No module named 'packaging'

With 'packages' dependency added:
$ nix-shell -I nixpkgs=./default.nix --pure -p python3Packages.connexion \
    --command "python -m connexion --version"
Connexion 2020.0.dev1

nix-info -m:
 - system: `"x86_64-darwin"`
 - host os: `Darwin 20.6.0, macOS 10.16`
 - multi-user?: `no`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.10.3`

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>