### PR TITLE
build2: 0.14 -> 0.15

### DIFF
--- a/pkgs/development/libraries/libbpkg/default.nix
+++ b/pkgs/development/libraries/libbpkg/default.nix
@@ -8,12 +8,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libbpkg";
-  version = "0.14.0";
+  version = "0.15.0";
   outputs = [ "out" "dev" "doc" ];
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/libbpkg-${version}.tar.gz";
-    sha256 = "sha256-K5KkhJa4qsh3AMDtCV4eA7bh3oU5DYEYMAacLmDoulU=";
+    sha256 = "sha256-KfvkG6bHSU8wTZDKGeEfI1AV9T8uSYZHePMlmjpBXHc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libbutl/default.nix
+++ b/pkgs/development/libraries/libbutl/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libbutl";
-  version = "0.14.0";
+  version = "0.15.0";
 
   outputs = [ "out" "dev" "doc" ];
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/libbutl-${version}.tar.gz";
-    sha256 = "sha256-zKufrUsLZmjw6pNbOAv+dPyolWpgXgygEnW0Lka6zw8=";
+    sha256 = "sha256-yzs6DFt6peJPPaMQ3rtx+kiYu7H+bUuShcdnEN90WWI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libodb-sqlite/default.nix
+++ b/pkgs/development/libraries/libodb-sqlite/default.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "libodb-sqlite";
-  version = "2.5.0-b.21";
+  version = "2.5.0-b.23";
 
   outputs = [ "out" "dev" "doc" ];
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/beta/odb/libodb-sqlite-${version}.tar.gz";
-    sha256 = "sha256-dxU8HyzowFGNYCrZIKrZEZDGi9zo3G0x3/L7nfQKo0Y=";
+    sha256 = "sha256-HjEFfNDXduHOexNm82S+vqKRQM3SwgEYiDBZcPXsr/w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libodb/default.nix
+++ b/pkgs/development/libraries/libodb/default.nix
@@ -6,13 +6,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "libodb";
-  version = "2.5.0-b.21";
+  version = "2.5.0-b.23";
 
   outputs = [ "out" "dev" "doc" ];
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/beta/odb/libodb-${version}.tar.gz";
-    sha256 = "sha256-Q4HZ8zU5osZ9Phz59ZAjXh0dbB8ELBY5gMRbDnawCWs=";
+    sha256 = "sha256-j+lW9WFdjwIlP24/GUZsezyMf7/31XTfkuY2WGLdaeA=";
   };
 
   nativeBuildInputs = [ build2 ];

--- a/pkgs/development/tools/build-managers/build2/bdep.nix
+++ b/pkgs/development/tools/build-managers/build2/bdep.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , build2
 , fetchurl
+, pkg-config
 , libbpkg
 , libbutl
 , libodb
@@ -11,17 +12,17 @@
 
 stdenv.mkDerivation rec {
   pname = "bdep";
-  version = "0.14.0";
+  version = "0.15.0";
 
   outputs = [ "out" "doc" "man" ];
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/bdep-${version}.tar.gz";
-    sha256 = "sha256-sizrGmSixkkJL9nocA4B1I5n9OySxyuZ2bNc1Z4zmPg=";
+    sha256 = "sha256-dZldNVeQJWim3INBtOaPYP8yQMH3sjBzCLEHemvdxnU=";
   };
 
   strictDeps = true;
   nativeBuildInputs = [
-    build2
+    build2 pkg-config
   ];
   buildInputs = [
     libbpkg

--- a/pkgs/development/tools/build-managers/build2/bootstrap.nix
+++ b/pkgs/development/tools/build-managers/build2/bootstrap.nix
@@ -5,10 +5,10 @@
 }:
 stdenv.mkDerivation rec {
   pname = "build2-bootstrap";
-  version = "0.14.0";
+  version = "0.15.0";
   src = fetchurl {
     url = "https://download.build2.org/${version}/build2-toolchain-${version}.tar.xz";
-    sha256 = "sha256-GO/GstQUmPdRbnqKXJECP2GCyGfUI3kjmDkN0MAEz90=";
+    sha256 = "sha256-UVL2edrrlif5cQxg74jeFZHAIJcUYmi+L1rqkp0oN8Q=";
   };
   patches = [
     # Pick up sysdirs from NIX_LDFLAGS

--- a/pkgs/development/tools/build-managers/build2/bpkg.nix
+++ b/pkgs/development/tools/build-managers/build2/bpkg.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bpkg";
-  version = "0.14.0";
+  version = "0.15.0";
 
   outputs = [ "out" "doc" "man" ];
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/bpkg-${version}.tar.gz";
-    sha256 = "sha256-4WTFm0NYZOujxQ3PR9MyjXEJ4ql4qZ9OM5BePuHIK1M=";
+    sha256 = "sha256-3F4Pv8YX++cNa6aKhPM67mrt/5oE1IeoZUSmljHqBfI=";
   };
 
   strictDeps = true;

--- a/pkgs/development/tools/build-managers/build2/default.nix
+++ b/pkgs/development/tools/build-managers/build2/default.nix
@@ -16,7 +16,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "build2";
-  version = "0.14.0";
+  version = "0.15.0";
 
   outputs = [ "out" "dev" "doc" "man" ];
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/build2-${version}.tar.gz";
-    sha256 = "sha256-/pWj68JmBthOJ2CTQHo9Ww3MCv4xBOw0SusJpMfX5Y8=";
+    sha256 = "sha256-OShFkA7UR38J6Pmt3wYtJFx/gpzElCSmNU3Rb/hLZhw=";
   };
 
   patches = [
@@ -66,6 +66,7 @@ stdenv.mkDerivation rec {
   build2ConfigureFlags = [
     "config.bin.lib=${configSharedStatic enableShared enableStatic}"
     "config.cc.poptions+=-I${lib.getDev libpkgconf}/include/pkgconf"
+    "config.build2.libpkgconf=true"
   ];
 
   postInstall = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/tools/build-managers/build2/remove-config-store-paths.patch
+++ b/pkgs/development/tools/build-managers/build2/remove-config-store-paths.patch
@@ -1,14 +1,18 @@
 --- a/libbuild2/buildfile
 +++ b/libbuild2/buildfile
-@@ -73,7 +73,11 @@ config/cxx{host-config}: config/in{host-config}
+@@ -83,10 +83,14 @@ config/cxx{host-config}: config/in{host-
+   # want it).
    #
-   build2_config = $regex.replace_lines(                              \
-+    $regex.replace_lines(                                            \
-     $config.save(),                                                  \
-     '^ *(#|(config\.(dist\.|install\.chroot|config\.hermetic))).*$', \
-     [null],                                                          \
-+    return_lines),                                                   \
-+    '^.*'$getenv(NIX_STORE)'/[a-z0-9]{32}-.*$',                      \
-+    [null],                                                          \
-     return_lines)
- 
+   build2_config = $regex.replace_lines(                                          \
++    $regex.replace_lines(                                                        \
+     $config.save(),                                                              \
+     '^( *(#|(config\.(test[. ]|dist\.|install\.chroot|config\.hermetic))).*|)$', \
+     [null],                                                                      \
+-    return_lines)
++    return_lines),                                                               \
++    '^.*'$getenv(NIX_STORE)'/[a-z0-9]{32}-.*$',                                  \
++    [null],                                                                      \
++    return_lines)                                                                \
+
+   # Also preserve config.version.
+   #

--- a/pkgs/development/tools/build-managers/build2/remove-const-void-param.patch
+++ b/pkgs/development/tools/build-managers/build2/remove-const-void-param.patch
@@ -1,11 +1,11 @@
---- build2-0.14.0_/libbuild2/cc/pkgconfig.cxx	2022-10-04 14:18:24.864604892 -0400
-+++ build2-0.14.0/libbuild2/cc/pkgconfig.cxx	2022-10-04 14:20:58.153254961 -0400
-@@ -186,7 +186,7 @@
-     ;
-
-   static bool
--  pkgconf_error_handler (const char* msg, const pkgconf_client_t*, const void*)
-+  pkgconf_error_handler (const char* msg, const pkgconf_client_t*, void*)
-   {
-     error << runtime_error (msg); // Sanitize the message.
-     return true;
+--- build2-0.15.0.orig/libbuild2/cc/pkgconfig-libpkgconf.cxx	2022-07-06 08:17:46.000000000 -0400
++++ build2-0.15.0/libbuild2/cc/pkgconfig-libpkgconf.cxx	2022-10-25 00:06:43.222518357 -0400
+@@ -84,7 +84,7 @@ namespace build2
+     static bool
+     pkgconf_error_handler (const char* msg,
+                            const pkgconf_client_t*,
+-                           const void*)
++                           void*)
+     {
+       error << runtime_error (msg); // Sanitize the message (trailing dot).
+       return true;


### PR DESCRIPTION
upgrades build2 to the 0.15 version.

build2 0.14 cannot read anymore metadata from https://cppget.org/.

All these packages are interdependent and upgraded in step

build2: 0.14.0 -> 0.15.0
bdep: 0.14.0 -> 0.15.0
bpkg: 0.14.0 -> 0.15.0
libutl: 0.14.0 -> 0.15.0
libpkg: 0.14.0 -> 0.15.0
libodb-sqlite: 2.5.0-b.21 -> 2.5.0-b.23
libodb: 2.5.0-b.21 -> 2.5.0-b.23

Signed-off-by: Jan Stranik <jan@stranik.org>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
