### PR TITLE
gnome.gnome-settings-daemon338: avoid libsoup2 symbols

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-settings-daemon/3.38/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-settings-daemon/3.38/default.nix
@@ -31,7 +31,7 @@
 , modemmanager
 , networkmanager
 , gnome-desktop
-, geocode-glib
+, geocode-glib_2
 , docbook_xsl
 , wrapGAppsHook
 , python3
@@ -93,6 +93,13 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/f390e6e9d56ce7d3e3a725b8204d81c0b6240515.patch";
       sha256 = "8mfnlhkSF9ogjVWE+IESzRQzrxHQSwUWsq5OLBM08iM=";
     })
+
+    # Use geocode-glib_2 dependency
+    # https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/300
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/03739474621e579e10b72577960ff94b4001e7ff.patch";
+      sha256 = "W4uD4ChNPZSsmQfmfmmXFA2Sm1RDkV7MqG8DmT4qeCY=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -126,7 +133,7 @@ stdenv.mkDerivation rec {
     libgweather
     nss
     polkit
-    geocode-glib
+    geocode-glib_2
     geoclue2
     systemd
     libgudev


### PR DESCRIPTION
###### Description of changes

https://hydra.nixos.org/build/196447174/log

```
machine # [   22.250467] .gsd-datetime-w[1271]: libsoup2 symbols detected. Using libsoup2 and libsoup3 in the same process is not supported.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] `grep` the error msg in https://logs.nix.ci/?key=nixos/nixpkgs.197681&attempt_id=aedad177-584b-4bb1-a4a0-68285b583c78
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
