### PR TITLE
lispPackages_new.coalton: init at 2022-10-17

### DIFF
--- a/pkgs/development/lisp-modules-new/packages.nix
+++ b/pkgs/development/lisp-modules-new/packages.nix
@@ -332,6 +332,21 @@ let
     version = "f19162e76";
   });
 
+  coalton = build-asdf-system {
+    pname = "coalton";
+    version = "2022-10-17";
+    src = pkgs.fetchFromGitHub {
+      owner = "coalton-lang";
+      repo = "coalton";
+      rev = "d91d11d95d70a38d199bf1b4e68ff342f1815d94";
+      sha256 = "sha256-2kAxoAVu0lWealRc9sKTNjzi+7/ovazcefnwVnw8WkY=";
+    };
+    lispLibs = with ql; [ alexandria trivia fset float-features split-sequence uiop
+                          trivial-garbage fiasco yason trivial-benchmark
+                          html-entities ];
+
+  };
+
   };
 
 in packages

--- a/pkgs/development/lisp-modules-new/packages.nix
+++ b/pkgs/development/lisp-modules-new/packages.nix
@@ -344,7 +344,21 @@ let
     lispLibs = with ql; [ alexandria trivia fset float-features split-sequence uiop
                           trivial-garbage fiasco yason trivial-benchmark
                           html-entities ];
+  };
 
+  kons-9 = build-asdf-system {
+    pname = "kons-9";
+    version = "2022-11-05";
+    src = pkgs.fetchFromGitHub {
+      owner = "kaveh808";
+      repo = "kons-9";
+      rev = "308b1215b9fb964d55be528511e68d84e6de2c03";
+      sha256 = "sha256-1GZ+zycQ5xNMHVrNbW7zTL+u69TFQI/dpZBphqekFyo=";
+    };
+    lispLibs = with ql; [
+      closer-mop trivial-main-thread trivial-backtrace cffi cl-opengl
+      cl-glu cl-glfw3 cl-vectors cl-paths-ttf clobber origin
+    ];
   };
 
   };


### PR DESCRIPTION
Coalton is not included in Quicklisp and so for now we need to package it manually.

This works in light testing at the REPL.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
