### PR TITLE
rocthrust: init at 2.16.0-5.3.1

### DIFF
--- a/pkgs/development/libraries/rocthrust/default.nix
+++ b/pkgs/development/libraries/rocthrust/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, rocm-cmake
+, rocm-runtime
+, rocm-device-libs
+, rocm-comgr
+, rocprim
+, hip
+, gtest ? null
+, buildTests ? false
+, buildBenchmarks ? false
+}:
+
+assert buildTests -> gtest != null;
+
+# Doesn't seem to work, thousands of errors compiling with no clear fix
+# Is this an upstream issue? We don't seem to be missing dependencies
+assert buildTests == false;
+assert buildBenchmarks == false;
+
+stdenv.mkDerivation rec {
+  pname = "rocthrust";
+  rocmVersion = "5.3.1";
+  version = "2.16.0-${rocmVersion}";
+
+  # Comment out these outputs until tests/benchmarks are fixed (upstream?)
+  # outputs = [
+  #   "out"
+  # ] ++ lib.optionals buildTests [
+  #   "test"
+  # ] ++ lib.optionals buildBenchmarks [
+  #   "benchmark"
+  # ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "rocThrust";
+    rev = "rocm-${rocmVersion}";
+    hash = "sha256-cT0VyEVz86xR6qubAY2ncTxtCRTwXrNTWcFyf3mV+y0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    rocprim
+    hip
+  ];
+
+  buildInputs = [
+    rocm-runtime
+    rocm-device-libs
+    rocm-comgr
+  ] ++ lib.optionals buildTests [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    "-DHIP_ROOT_DIR=${hip}"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_TEST=ON"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DBUILD_BENCHMARKS=ON"
+  ];
+
+  # Comment out these outputs until tests/benchmarks are fixed (upstream?)
+  # postInstall = lib.optionalString buildTests ''
+  #   mkdir -p $test/bin
+  #   mv $out/bin/test_* $test/bin
+  # '' + lib.optionalString buildBenchmarks ''
+  #   mkdir -p $benchmark/bin
+  #   mv $out/bin/benchmark_* $benchmark/bin
+  # '' + lib.optionalString (buildTests || buildBenchmarks) ''
+  #   rmdir $out/bin
+  # '';
+
+  meta = with lib; {
+    description = "ROCm parallel algorithm library";
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocThrust";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ Madouura ];
+    broken = rocmVersion != hip.version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14859,6 +14859,8 @@ with pkgs;
 
   rocminfo = callPackage ../development/tools/rocminfo { };
 
+  rocthrust = callPackage ../development/libraries/rocthrust { };
+
   rtags = callPackage ../development/tools/rtags {
     inherit (darwin) apple_sdk;
   };


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
Seventh part in a whole bunch of porting...
No ``nixosTests`` for this one for now.
Tests and benchmarks are completely borked with no clear fix or if it's even a packaging issue. They're commented out for use later when this is fixed here or upstream.
Depends on #197337
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
