### PR TITLE
open-stage-control: only regen node deps when version changes

### DIFF
--- a/pkgs/applications/audio/open-stage-control/update.sh
+++ b/pkgs/applications/audio/open-stage-control/update.sh
@@ -8,18 +8,20 @@ nixpkgs="$(git rev-parse --show-toplevel || (printf 'Could not find root of nixp
 # Get latest release tag
 tag="$(curl -s https://api.github.com/repos/jean-emmanuel/open-stage-control/releases/latest | jq -r .tag_name)"
 
-# Download package.json from the latest release
-curl -sSL https://raw.githubusercontent.com/jean-emmanuel/open-stage-control/"$tag"/package.json | grep -v '"electron"\|"electron-installer-debian"' >"$nixpkgs"/pkgs/applications/audio/open-stage-control/package.json
-
-# Lock dependencies with node2nix
-node2nix \
-  --node-env "$nixpkgs"/pkgs/development/node-packages/node-env.nix \
-  --nodejs-16 \
-  --input "$nixpkgs"/pkgs/applications/audio/open-stage-control/package.json \
-  --output "$nixpkgs"/pkgs/applications/audio/open-stage-control/node-packages.nix \
-  --composition "$nixpkgs"/pkgs/applications/audio/open-stage-control/node-composition.nix
-
-rm -f "$nixpkgs"/pkgs/applications/audio/open-stage-control/package.json
-
 # Update hash
-(cd "$nixpkgs" && update-source-version "${UPDATE_NIX_ATTR_PATH:-open-stage-control}" "${tag#v}")
+updated="$(cd "$nixpkgs" && update-source-version "${UPDATE_NIX_ATTR_PATH:-open-stage-control}" "${tag#v}" --print-changes | jq -r length)"
+
+if [ "$updated" -gt 0 ]; then
+    # Download package.json from the latest release
+    curl -sSL https://raw.githubusercontent.com/jean-emmanuel/open-stage-control/"$tag"/package.json | grep -v '"electron"\|"electron-installer-debian"' >"$nixpkgs"/pkgs/applications/audio/open-stage-control/package.json
+
+    # Lock dependencies with node2nix
+    node2nix \
+      --node-env "$nixpkgs"/pkgs/development/node-packages/node-env.nix \
+      --nodejs-16 \
+      --input "$nixpkgs"/pkgs/applications/audio/open-stage-control/package.json \
+      --output "$nixpkgs"/pkgs/applications/audio/open-stage-control/node-packages.nix \
+      --composition "$nixpkgs"/pkgs/applications/audio/open-stage-control/node-composition.nix
+
+    rm -f "$nixpkgs"/pkgs/applications/audio/open-stage-control/package.json
+fi


### PR DESCRIPTION
###### Description of changes

@r-ryantm opened a PR (#197644) from the open-stage-control updateScript where the only thing that changed were node dependencies deep in the dependency tree

This is not particularly necessary (and an artifact of upstream not providing a package-lock.json), so this PR makes the node-packages.nix regeneration conditional on whether the version actually updated first

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).