### PR TITLE
quartus-prime-lite : add missing library and refactor

### DIFF
--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -44,6 +44,7 @@ in buildFHSUserEnv rec {
     xorg.libXext
     xorg.libXrender
     libudev0-shim
+    libxcrypt
   ];
 
   passthru = { inherit unwrapped; };

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -1,11 +1,43 @@
-{ stdenv, lib, buildFHSUserEnv, callPackage, makeDesktopItem, writeScript
-, supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
-, unwrapped ? callPackage ./quartus.nix { inherit supportedDevices; }
+{ stdenv
+, lib
+, buildFHSUserEnv
+, callPackage
+, makeDesktopItem
+, writeScript
+, version ? "20.1.1.720"
+, supportedDevices ? {
+  arria_lite = {
+    name = "Arria II";
+    hash = "140jqnb97vrxx6398cpgpw35zrrx3z5kv1x5gr9is1xdbnf4fqhy";
+  };
+  cyclonev = {
+    name = "Cyclone V";
+    hash = "11baa9zpmmfkmyv33w1r57ipf490gnd3dpi2daripf38wld8lgak";
+  };
+  cyclone = {
+    name = "Cyclone IV";
+    hash = "116kf69ryqcmlc2k8ra0v32jy7nrk7w4s5z3yll7h3c3r68xcsfr";
+  };
+  cyclone10lp = {
+    name = "Cyclone 10 LP";
+    hash = "07wpgx9bap6rlr5bcmr9lpsxi3cy4yar4n3pxfghazclzqfi2cyl";
+  };
+  max = {
+    name = "MAX II/V";
+    hash = "1zy2d42dqmn97fwmv4x6pmihh4m23jypv3nd830m1mj7jkjx9kcq";
+  };
+  max10 = {
+    name = "MAX 10 FPGA";
+    hash = "1hvi9cpcjgbih3l6nh8x1vsp0lky5ax85jb2yqmzla80n7dl9ahs";
+  };
+}
+, unwrapped ? callPackage ./quartus.nix { inherit version supportedDevices; }
 }:
 
 let
+  name = "quartus-prime-lite";
   desktopItem = makeDesktopItem {
-    name = "quartus-prime-lite";
+    inherit name;
     exec = "quartus";
     icon = "quartus";
     desktopName = "Quartus";
@@ -13,8 +45,8 @@ let
     categories = [ "Development" ];
   };
 # I think modelsim_ase/linux/vlm checksums itself, so use FHSUserEnv instead of `patchelf`
-in buildFHSUserEnv rec {
-  name = "quartus-prime-lite"; # wrapped
+in buildFHSUserEnv {
+  inherit name;
 
   targetPkgs = pkgs: with pkgs; [
     # quartus requirements

--- a/pkgs/applications/editors/quartus-prime/quartus.nix
+++ b/pkgs/applications/editors/quartus-prime/quartus.nix
@@ -1,66 +1,44 @@
-{ stdenv, lib, unstick, fetchurl
-, supportedDevices ? [ "Arria II" "Cyclone V" "Cyclone IV" "Cyclone 10 LP" "MAX II/V" "MAX 10 FPGA" ]
+{ stdenv
+, lib
+, unstick
+, fetchurl
+, version
+, supportedDevices
 }:
 
 let
-  deviceIds = {
-    "Arria II" = "arria_lite";
-    "Cyclone V" = "cyclonev";
-    "Cyclone IV" = "cyclone";
-    "Cyclone 10 LP" = "cyclone10lp";
-    "MAX II/V" = "max";
-    "MAX 10 FPGA" = "max10";
-  };
-
-  supportedDeviceIds =
-    assert lib.assertMsg (lib.all (name: lib.hasAttr name deviceIds) supportedDevices)
-      "Supported devices are: ${lib.concatStringsSep ", " (lib.attrNames deviceIds)}";
-    lib.listToAttrs (map (name: {
-      inherit name;
-      value = deviceIds.${name};
-    }) supportedDevices);
-
-  unsupportedDeviceIds = lib.filterAttrs (name: value:
-    !(lib.hasAttr name supportedDeviceIds)
-  ) deviceIds;
-
-  componentHashes = {
-    "arria_lite" = "140jqnb97vrxx6398cpgpw35zrrx3z5kv1x5gr9is1xdbnf4fqhy";
-    "cyclone" = "116kf69ryqcmlc2k8ra0v32jy7nrk7w4s5z3yll7h3c3r68xcsfr";
-    "cyclone10lp" = "07wpgx9bap6rlr5bcmr9lpsxi3cy4yar4n3pxfghazclzqfi2cyl";
-    "cyclonev" = "11baa9zpmmfkmyv33w1r57ipf490gnd3dpi2daripf38wld8lgak";
-    "max" = "1zy2d42dqmn97fwmv4x6pmihh4m23jypv3nd830m1mj7jkjx9kcq";
-    "max10" = "1hvi9cpcjgbih3l6nh8x1vsp0lky5ax85jb2yqmzla80n7dl9ahs";
-  };
-
-  version = "20.1.1.720";
-
   download = {name, sha256}: fetchurl {
     inherit name sha256;
     # e.g. "20.1.1.720" -> "20.1std.1/720"
     url = "https://downloads.intel.com/akdlm/software/acdsinst/${lib.versions.majorMinor version}std.${lib.versions.patch version}/${lib.elemAt (lib.splitVersion version) 3}/ib_installers/${name}";
   };
-
-in stdenv.mkDerivation rec {
+  installers = builtins.map download [
+    {
+      name = "QuartusLiteSetup-${version}-linux.run";
+      sha256 = "0mjp1rg312dipr7q95pb4nf4b8fwvxgflnd1vafi3g9cshbb1c3k";
+    }
+    {
+      name = "ModelSimSetup-${version}-linux.run";
+      sha256 = "1cqgv8x6vqga8s4v19yhmgrr886rb6p7sbx80528df5n4rpr2k4i";
+    }
+  ];
+  components = with builtins; lib.pipe supportedDevices [
+    (mapAttrs (id: {name, hash}: {
+      name = "${id}-${version}.qdz";
+      sha256 = hash;
+    }))
+    (attrValues)
+    (map download)
+  ];
+in stdenv.mkDerivation {
   inherit version;
   pname = "quartus-prime-lite-unwrapped";
 
-  src = map download ([{
-    name = "QuartusLiteSetup-${version}-linux.run";
-    sha256 = "0mjp1rg312dipr7q95pb4nf4b8fwvxgflnd1vafi3g9cshbb1c3k";
-  } {
-    name = "ModelSimSetup-${version}-linux.run";
-    sha256 = "1cqgv8x6vqga8s4v19yhmgrr886rb6p7sbx80528df5n4rpr2k4i";
-  }] ++ (map (id: {
-    name = "${id}-${version}.qdz";
-    sha256 = lib.getAttr id componentHashes;
-  }) (lib.attrValues supportedDeviceIds)));
+  src = installers ++ components;
 
   nativeBuildInputs = [ unstick ];
 
   buildCommand = let
-    installers = lib.sublist 0 2 src;
-    components = lib.sublist 2 ((lib.length src) - 2) src;
     copyInstaller = installer: ''
         # `$(cat $NIX_CC/nix-support/dynamic-linker) $src[0]` often segfaults, so cp + patchelf
         cp ${installer} $TEMP/${installer.name}
@@ -74,7 +52,7 @@ in stdenv.mkDerivation rec {
       "quartus_update"
       # not modelsim_ase
       "modelsim_ae"
-    ] ++ (lib.attrValues unsupportedDeviceIds);
+    ];
   in ''
       ${lib.concatMapStringsSep "\n" copyInstaller installers}
       ${lib.concatMapStringsSep "\n" copyComponent components}


### PR DESCRIPTION
###### Description of changes

Fix quartus-prime-lite error "missing library libcrypt.so.1"

Code refactoring was also applied

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
