### PR TITLE
python3Packages.flit-scm: init at 1.7.0

### DIFF
--- a/pkgs/development/python-modules/flit-scm/default.nix
+++ b/pkgs/development/python-modules/flit-scm/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitLab
+, pythonOlder
+, git
+, flit-core
+, setuptools-scm
+, tomli
+}:
+
+buildPythonPackage rec {
+  pname = "flit-scm";
+  version = "1.7.0";
+
+  format = "pyproject";
+
+  src = fetchFromGitLab {
+    owner = "WillDaSilva";
+    repo = "flit_scm";
+    rev = version;
+    sha256 = "sha256-K5sH+oHgX/ftvhkY+vIg6wUokAP96YxrTWds3tnEtyg=";
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = [ flit-core setuptools-scm tomli git ];
+  propagatedBuildInputs = [ flit-core setuptools-scm ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
+
+  meta = with lib; {
+    description = "A PEP 518 build backend that uses setuptools_scm to generate a version file from your version control system, then flit to build the package.";
+    homepage = "https://gitlab.com/WillDaSilva/flit_scm";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3525,6 +3525,8 @@ in {
 
   flit-core = callPackage ../development/python-modules/flit-core { };
 
+  flit-scm = callPackage ../development/python-modules/flit-scm { };
+
   flow-record = callPackage ../development/python-modules/flow-record { };
 
   flower = callPackage ../development/python-modules/flower { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the [`flit-scm`](https://gitlab.com/WillDaSilva/flit_scm) Python build backend.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
