### PR TITLE
Revert "meson: expose python3 in passthru"

### DIFF
--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -14,6 +14,7 @@
 , lz4
 , xxHash
 , meson
+, python3
 , cmake
 , ninja
 , capstone
@@ -43,7 +44,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     meson
-    meson.python3.pkgs.pyyaml
+    (python3.withPackages (pp: with pp; [
+      pyyaml
+    ]))
     ninja
     cmake
   ];
@@ -78,6 +81,14 @@ stdenv.mkDerivation rec {
     tree-sitter
     xxHash
   ];
+
+  postPatch = ''
+    # find_installation without arguments uses Meson’s Python interpreter,
+    # which does not have any extra modules.
+    # https://github.com/mesonbuild/meson/pull/9904
+    substituteInPlace meson.build \
+      --replace "import('python').find_installation()" "find_program('python3')"
+  '';
 
   meta = {
     description = "UNIX-like reverse engineering framework and command-line toolset.";

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -103,10 +103,6 @@ python3.pkgs.buildPythonApplication rec {
     installShellCompletion --bash data/shell-completions/bash/meson
   '';
 
-  passthru = {
-    inherit python3;
-  };
-
   meta = with lib; {
     homepage = "https://mesonbuild.com";
     description = "An open source, fast and friendly build system made in Python";


### PR DESCRIPTION
###### Description of changes

This should be fixed in rizin upstream, see https://github.com/NixOS/nixpkgs/pull/191582#issuecomment-1250134437

This reverts commit 38f48cfc4f060ddfd4c03187ed3f75b702a114c3.

cc @risicle

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
