### PR TITLE
imhex: 1.19.3 -> 1.24.3

### DIFF
--- a/pkgs/applications/editors/imhex/default.nix
+++ b/pkgs/applications/editors/imhex/default.nix
@@ -22,13 +22,13 @@
 
 let
   # when bumping the version, check if imhex has gotten support for the capstone version in nixpkgs
-  version = "1.19.3";
+  version = "1.26.2";
 
   patterns_src = fetchFromGitHub {
     owner = "WerWolv";
     repo = "ImHex-Patterns";
     rev = "ImHex-v${version}";
-    hash = "sha256-mukGPN2TugJZLLuZ5FTvZ4DxUsMGfVNhBFAPnBRC0qs=";
+    hash = "sha256-2+7bJzgwHfXcINM5oxwi3vEbUtq9gGJc/uxFOwT4RnM=";
   };
 
 in
@@ -41,7 +41,7 @@ gcc12Stdenv.mkDerivation rec {
     owner = "WerWolv";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-SFv5ulyjm5Yf+3Gpx+A74so2YClCJx1sx0LE5fh5eG4=";
+    hash = "sha256-H2bnRByCUAltngmVWgPW4vW8k5AWecOAzwtBKsjbpTw=";
   };
 
   nativeBuildInputs = [ cmake llvm python3 perl pkg-config ];
@@ -72,10 +72,8 @@ gcc12Stdenv.mkDerivation rec {
     "-DUSE_SYSTEM_YARA=ON"
   ];
 
-  # for reasons unknown, the built-in plugin isn't found unless made available under $out/bin
   postInstall = ''
-    ln -s $out/share/imhex/plugins $out/bin/
-
+    mkdir -p $out/share/imhex
     for d in ${patterns_src}/{constants,encodings,includes,magic,patterns}; do
       cp -r $d $out/share/imhex/
     done


### PR DESCRIPTION
###### Description of changes

Package update for various bug fixes and improvements: https://github.com/WerWolv/ImHex/releases

I tried to build it with `USE_SYSTEM_CAPSTONE=ON`, but compilation failed. So I kept it switched `OFF`.

Opening a file and similar operations shows an error complaining about missing `xdg-desktop-portal` executables in the path, but drag & drop a file to the imhex GUI works. That is the [same  limitation](https://github.com/NixOS/nixpkgs/pull/184488#issuecomment-1207767466) as with the previous version. Maybe it is an issue on my system and I would have to set [xdg.portal.enable](https://github.com/NixOS/nixpkgs/blob/nixos-22.05/nixos/modules/config/xdg/portal.nix) in my NixOS config, but I am not sure.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>imhex</li>
  </ul>
</details>