### PR TITLE
chromium{Beta,Dev}: Fix the configuration phase

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -293,6 +293,9 @@ let
       rtc_use_pipewire = true;
       # Disable PGO because the profile data requires a newer compiler version (LLVM 14 isn't sufficient):
       chrome_pgo_phase = 0;
+    } // optionalAttrs (chromiumVersionAtLeast "107") {
+      clang_base_path = "${llvmPackages.clang}";
+      use_qt = false;
     } // optionalAttrs proprietaryCodecs {
       # enable support for the H.264 codec
       proprietary_codecs = true;


### PR DESCRIPTION
Setting `clang_base_path` [0] does skip [1] a clang version check [2] that would fail in our case:
```
configuring
ERROR at //build/config/compiler/BUILD.gn:1314:22: Script returned non-zero exit code.
    clang_revision = exec_script("//tools/clang/scripts/update.py",
                     ^----------
Current dir: /tmp/nix-build-chromium-unwrapped-107.0.5304.29.drv-0/chromium-107.0.5304.29/out/Release/
Command: python3 /tmp/nix-build-chromium-unwrapped-107.0.5304.29.drv-0/chromium-107.0.5304.29/tools/clang/scripts/update.py --print-revision --verify-version=16.0.0
Returned 1 and printed out:

The expected clang version is llvmorg-16-init-4609-g025a5b22-2 but the actual version is
Did you run "gclient sync"?

See //build/config/BUILDCONFIG.gn:329:3: which caused the file to be included.
  "//build/config/compiler:afdo",
  ^-----------------------------
error: builder for '/nix/store/02riyhzvrgn2vaab29d3gipxzkx6nb44-chromium-unwrapped-107.0.5304.29.drv' failed with exit code 1
```

I also chose to disable the Qt support for now. The Qt support is enabled by default on Linux [3] but we need to add the required dependencies first to fix the build (and my current priority is to get a basic build working for the security critical stable channel update):
```
configuring
ERROR at //build/config/linux/pkg_config.gni:104:17: Script returned non-zero exit code.
    pkgresult = exec_script(pkg_config_script, args, "value")
                ^----------
Current dir: /tmp/nix-build-chromium-unwrapped-107.0.5304.62.drv-0/chromium-107.0.5304.62/out/Release/
Command: python3 /tmp/nix-build-chromium-unwrapped-107.0.5304.62.drv-0/chromium-107.0.5304.62/build/config/linux/pkg-config.py Qt5Core Qt5Widgets
Returned 1.
stderr:

Package Qt5Core was not found in the pkg-config search path.
Perhaps you should add the directory containing `Qt5Core.pc'
to the PKG_CONFIG_PATH environment variable
No package 'Qt5Core' found
Package Qt5Widgets was not found in the pkg-config search path.
Perhaps you should add the directory containing `Qt5Widgets.pc'
to the PKG_CONFIG_PATH environment variable
No package 'Qt5Widgets' found
Could not run pkg-config.

See //ui/qt/BUILD.gn:13:1: whence it was called.
pkg_config("qt5_config") {
^-------------------------
See //ui/linux/BUILD.gn:54:15: which caused the file to be included.
    deps += [ "//ui/qt" ]
              ^--------
error: builder for '/nix/store/3zzddkh74cnhvq6nql32y9pnbvzf2jv9-chromium-unwrapped-107.0.5304.62.drv' failed with exit code 1
```

[0]: https://source.chromium.org/chromium/chromium/src/+/refs/tags/107.0.5304.62:docs/clang.md
[1]: https://source.chromium.org/chromium/chromium/src/+/refs/tags/107.0.5304.62:build/config/compiler/BUILD.gn;l=1306
[2]: https://source.chromium.org/chromium/chromium/src/+/refs/tags/107.0.5304.62:tools/clang/scripts/update.py;l=358
[3]: https://source.chromium.org/chromium/chromium/src/+/refs/tags/107.0.5304.62:ui/qt/qt.gni;l=8

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
