### PR TITLE
python3Packages.cgal-swig-bindings: init at unstable-2022-03-28

### DIFF
--- a/pkgs/development/python-modules/cgal-swig-bindings/default.nix
+++ b/pkgs/development/python-modules/cgal-swig-bindings/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, boost
+, cgal_5
+, cmake
+, eigen
+, gmp
+, mpfr
+, numpy
+, pytestCheckHook
+, swig
+, zlib
+}:
+
+buildPythonPackage rec {
+  pname = "cgal-swig-bindings";
+  version = "unstable-2022-03-28";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "CGAL";
+    repo = "cgal-swig-bindings";
+    rev = "422c3e2a3230e478dd609e1dc44d6529e2bc963d";
+    hash = "sha256-OBPm/VCeqGskmpkgaYWHuGhaDycOOTyWDhPt1Bi8Zns=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    numpy
+    swig
+  ];
+  buildInputs = [
+    boost
+    cgal_5
+    eigen
+    gmp
+    mpfr
+    zlib
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [
+    "CGAL.CGAL_Kernel"
+    "CGAL.CGAL_Triangulation_3"
+  ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "CGAL bindings using SWIG";
+    homepage = "https://github.com/CGAL/cgal-swig-bindings";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1745,6 +1745,8 @@ in {
 
   cftime = callPackage ../development/python-modules/cftime { };
 
+  cgal-swig-bindings = callPackage ../development/python-modules/cgal-swig-bindings { };
+
   cgen = callPackage ../development/python-modules/cgen { };
 
   cgroup-utils = callPackage ../development/python-modules/cgroup-utils { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
