### PR TITLE
eduke32: 20210910 -> 20221026

### DIFF
--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -18,13 +18,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "eduke32";
-  version = "20210910";
-  rev = "9603";
-  revExtra = "6c289cce4";
+  version = "20221026";
+  rev = "10165";
+  revExtra = "a9c797dcb";
 
   src = fetchurl {
     url = "https://dukeworld.com/eduke32/synthesis/${version}-${rev}-${revExtra}/eduke32_src_${version}-${rev}-${revExtra}.tar.xz";
-    sha256 = "sha256-/NQMsmT9z2N3KWBrP8hlGngQKJUgSP+vrNoFqJscRCk=";
+    sha256 = "sha256-8xvIe+kVOu2VIZACHis04tvyrl1IRrt0tY8D04n6ZjU=";
   };
 
   buildInputs = [
@@ -56,6 +56,11 @@ in stdenv.mkDerivation rec {
       substituteInPlace source/glad/src/$f \
         --replace libGL.so ${libGL}/lib/libGL.so
     done
+
+    substituteInPlace source/imgui/src/imgui_impl_sdl.cpp \
+      --replace '#include <SDL.h>' '#include <SDL2/SDL.h>' \
+      --replace '#include <SDL_syswm.h>' '#include <SDL2/SDL_syswm.h>' \
+      --replace '#include <SDL_vulkan.h>' '#include <SDL2/SDL_vulkan.h>'
   '';
 
   NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2}/include/SDL2 -I${lib.getDev SDL2_mixer}/include/SDL2";


### PR DESCRIPTION
###### Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/189158

ZHF: #199919 (see discussion below)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 197798"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
