### PR TITLE
nixos/xserver: add xkbCompat option

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -327,6 +327,15 @@ in
         '';
       };
 
+      xkbCompat = mkOption {
+        type = types.str;
+        default = "complete";
+        example = "basic";
+        description = lib.mdDoc ''
+          X keyboard compatibility maps for XKB-unaware clients.
+        '';
+      };
+
       xkbModel = mkOption {
         type = types.str;
         default = "pc104";
@@ -645,6 +654,7 @@ in
               Option "XkbLayout" "${cfg.layout}"
               Option "XkbOptions" "${cfg.xkbOptions}"
               Option "XkbVariant" "${cfg.xkbVariant}"
+              Option "XkbCompat" "${cfg.xkbCompat}"
             EndSection
           '';
         }


### PR DESCRIPTION
###### Description of changes

Add a single option `xkbCompat` to be passed to xkb. This can be used for, amongst other things, re-purposing keyboard LEDs to show modifiers or alternative layouts. For some reason this is scarcely documented. I only found out it exists by selecting the relevant option in KDE System Settings and then using `setxkbmap -print`

https://www.x.org/releases/X11R7.5/doc/input/XKB-Config.html

I couldn't find any relevant module tests to add to, but maybe I didn't look in the right place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
