### PR TITLE
nushell: 0.69.1 -> 0.70.0

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -24,16 +24,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nushell";
-  version = "0.69.1";
+  version = "0.70.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-aEEuzl3HRWNk2zJq+Vh5ZLyT26Qk7oI3bQKUr4SlDr8=";
+    sha256 = "sha256-krsycaqT+MmpWEVNVqQQO2zrO9ymZIskgGgrzEMFP1s=";
   };
 
-  cargoSha256 = "sha256-qaBiTZUe4RSYdXAEWPVv0ATWDN/+aOYiEpq+oztwNEc=";
+  cargoSha256 = "sha256-Etw8F5alUNMlH0cvREPk2LdBQKl70dj6JklFZWInvow=";
 
   # enable pkg-config feature of zstd
   cargoPatches = [ ./zstd-pkg-config.patch ];

--- a/pkgs/shells/nushell/zstd-pkg-config.patch
+++ b/pkgs/shells/nushell/zstd-pkg-config.patch
@@ -1,31 +1,31 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index d4c2ebe3a..bc78478c3 100644
+index 7376ffe6a..a7d3335cc 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2641,6 +2641,7 @@ dependencies = [
-  "wax",
+@@ -2751,6 +2751,7 @@ dependencies = [
   "which",
   "windows",
+  "winreg",
 + "zstd",
  ]
  
  [[package]]
-@@ -5604,4 +5605,5 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+@@ -5881,4 +5882,5 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
  dependencies = [
   "cc",
   "libc",
 + "pkg-config",
  ]
 diff --git a/crates/nu-command/Cargo.toml b/crates/nu-command/Cargo.toml
-index 8a9d29562..374ffa153 100644
+index d293f3e39..a462d67dc 100644
 --- a/crates/nu-command/Cargo.toml
 +++ b/crates/nu-command/Cargo.toml
-@@ -89,6 +89,8 @@ wax = { version =  "0.5.0", features = ["diagnostics"] }
+@@ -93,6 +93,8 @@ wax = { version =  "0.5.0", features = ["diagnostics"] }
  rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
- sqlparser = { version = "0.16.0", features = ["serde"], optional = true }
+ sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
  
 +zstd = { version = "*", features = [ "pkg-config" ] }
 +
- [target.'cfg(unix)'.dependencies]
- umask = "2.0.0"
- users = "0.11.0"
+ [target.'cfg(windows)'.dependencies]
+ winreg = "0.10.1"
+ 


### PR DESCRIPTION
###### Description of changes
https://github.com/nushell/nushell/releases/tag/0.70.0
https://www.nushell.sh/blog/2022-10-18-nushell-0_70.html
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
