### PR TITLE
ocamlPackages.stdint: 0.7.0 → 0.7.2

### DIFF
--- a/pkgs/development/ocaml-modules/stdint/default.nix
+++ b/pkgs/development/ocaml-modules/stdint/default.nix
@@ -1,25 +1,17 @@
-{ lib, fetchurl, fetchpatch, buildDunePackage, ocaml, qcheck }:
+{ lib, fetchurl, buildDunePackage, ocaml, qcheck }:
 
 buildDunePackage rec {
   pname = "stdint";
-  version = "0.7.0";
+  version = "0.7.2";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/andrenth/ocaml-stdint/releases/download/${version}/stdint-${version}.tbz";
-    sha256 = "4fcc66aef58e2b96e7af3bbca9d910aa239e045ba5fb2400aaef67d0041252dc";
+    sha256 = "sha256-FWAZjYvJx68+qVLEDavoJmZpQhDsw/35u/60MhHpd+Y=";
   };
-
-  patches = [
-    # fix test bug, remove at next release
-    (fetchpatch {
-      url = "https://github.com/andrenth/ocaml-stdint/commit/fc64293f99f597cdfd4470954da6fb323988e2af.patch";
-      sha256 = "0nxck14vfjfzldsf8cdj2jg1cvhnyh37hqnrcxbdkqmpx4rxkbxs";
-    })
-  ];
 
   # 1. disable remaining broken tests, see
   #    https://github.com/andrenth/ocaml-stdint/issues/59
@@ -30,9 +22,7 @@ buildDunePackage rec {
       --replace 'test "An integer should perform left-shifts correctly"' \
                 'skip "An integer should perform left-shifts correctly"' \
       --replace 'test "Logical shifts must not sign-extend"' \
-                'skip "Logical shifts must not sign-extend"' \
-      --replace 'let pos_int = QCheck.map_same_type abs in_range' \
-                'let pos_int = QCheck.int_range 0 maxi'
+                'skip "Logical shifts must not sign-extend"'
   '';
 
   doCheck = lib.versionAtLeast ocaml.version "4.08";


### PR DESCRIPTION
###### Description of changes

Ready for OCaml 5: https://github.com/andrenth/ocaml-stdint/blob/0.7.2/CHANGES.md#072-18102022

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
