### PR TITLE
nixos/sonarr: add package option

### DIFF
--- a/nixos/modules/services/misc/sonarr.nix
+++ b/nixos/modules/services/misc/sonarr.nix
@@ -40,7 +40,7 @@ in
         type = types.package;
         default = pkgs.sonarr;
         defaultText = literalExpression "pkgs.sonarr";
-        description = ''
+        description = lib.mdDoc ''
           Sonarr package to use.
         '';
       };

--- a/nixos/modules/services/misc/sonarr.nix
+++ b/nixos/modules/services/misc/sonarr.nix
@@ -35,6 +35,15 @@ in
         default = "sonarr";
         description = lib.mdDoc "Group under which Sonaar runs.";
       };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.sonarr;
+        defaultText = literalExpression "pkgs.sonarr";
+        description = ''
+          Sonarr package to use.
+        '';
+      };
     };
   };
 
@@ -52,7 +61,7 @@ in
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
-        ExecStart = "${pkgs.sonarr}/bin/NzbDrone -nobrowser -data='${cfg.dataDir}'";
+        ExecStart = "${cfg.package}/bin/NzbDrone -nobrowser -data='${cfg.dataDir}'";
         Restart = "on-failure";
       };
     };


### PR DESCRIPTION
###### Description of changes

At the moment when Sonarr service is enabled on the system, we get the default package available for that system version. This commit introduces an option to override the package, giving the ability to pinpoint to a specific version of the software.

###### Things done

Didn't get to testing. Based of a different package.
