### PR TITLE
postgresql11Packages.plv8: Fix build on crypt

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/plv8/default.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8/default.nix
@@ -4,6 +4,7 @@
 , v8
 , perl
 , postgresql
+, libxcrypt
 # For test
 , runCommand
 , coreutils
@@ -34,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     v8
     postgresql
+  ] ++ lib.optionals (lib.versionOlder postgresql.version "14") [
+    libxcrypt
   ];
 
   buildFlags = [ "all" ];


### PR DESCRIPTION
###### Description of changes

Likely a downfall from https://github.com/NixOS/nixpkgs/pull/181764, the package would no longer build for Postgres < 14:

    In file included from /nix/store/ybkyabc23chdfy48n3h1zqwa57vp38wd-glibc-2.35-163-dev/include/bits/sigstksz.h:24,
                     from /nix/store/ybkyabc23chdfy48n3h1zqwa57vp38wd-glibc-2.35-163-dev/include/signal.h:328,
                     from /nix/store/cm4akn9l84yqfcmz0hhn8jkm59s7sdjz-postgresql-11.17/include/server/storage/sinval.h:17,
                     from /nix/store/cm4akn9l84yqfcmz0hhn8jkm59s7sdjz-postgresql-11.17/include/server/access/xact.h:21,
                     from plv8.cc:23:
    /nix/store/ybkyabc23chdfy48n3h1zqwa57vp38wd-glibc-2.35-163-dev/include/unistd.h:1159:14: error: declaration of 'char* crypt(const char*, const char*) noexcept' has a different exception specifier
     1159 | extern char *crypt (const char *__key, const char *__salt)
          |              ^~~~~
    In file included from /nix/store/cm4akn9l84yqfcmz0hhn8jkm59s7sdjz-postgresql-11.17/include/server/c.h:1248,
                     from /nix/store/cm4akn9l84yqfcmz0hhn8jkm59s7sdjz-postgresql-11.17/include/server/postgres.h:46,
                     from plv8.h:20,
                     from plv8.cc:8:
    /nix/store/cm4akn9l84yqfcmz0hhn8jkm59s7sdjz-postgresql-11.17/include/server/port.h:317:14: note: from previous declaration 'char* crypt(const char*, const char*)'
      317 | extern char *crypt(const char *key, const char *setting);
          |              ^~~~~
    plv8.cc: In function 'v8::Local<v8::Value> DoCall(v8::Local<v8::Context>, v8::Handle<v8::Function>, v8::Handle<v8::Object>, int, v8::Handle<v8::Value>*, bool)':
    plv8.cc:863:1: warning: control reaches end of non-void function [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wreturn-type-Wreturn-type8;;]
      863 | }
          | ^

Not sure why it works without this on newer versions.

cc @mweinelt 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
