### PR TITLE
bundlewrap: init at 4.15.0

### DIFF
--- a/pkgs/development/python-modules/bundlewrap/default.nix
+++ b/pkgs/development/python-modules/bundlewrap/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pythonOlder
+, cryptography
+, jinja2
+, Mako
+, passlib
+, pytest
+, pyyaml
+, requests
+, rtoml
+, setuptools
+, tomlkit
+, librouteros
+}:
+
+buildPythonPackage rec {
+  pname = "bundlewrap";
+  version = "4.15.0";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bundlewrap";
+    repo = "bundlewrap";
+    rev = "${version}";
+    sha256 = "sha256-O31lh43VyaFnd/IUkx44wsgxkWubZKzjsKXzHwcGox0";
+  };
+
+  propagatedBuildInputs = [
+    cryptography jinja2 Mako passlib pyyaml requests setuptools tomlkit librouteros
+  ] ++ lib.optional (pythonOlder "3.11") [ rtoml ];
+
+  pythonImportsCheck = [ pname ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    # only unit tests as integration tests need a OpenSSH client/server setup
+    py.test tests/unit
+  '';
+
+  meta = with lib; {
+    homepage = "https://bundlewrap.org/";
+    description = "Easy, Concise and Decentralized Config management with Python";
+    license = [ licenses.gpl3 ] ;
+    maintainers = with maintainers; [ wamserma ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/python-modules/bundlewrap/default.nix
+++ b/pkgs/development/python-modules/bundlewrap/default.nix
@@ -13,6 +13,7 @@
 , setuptools
 , tomlkit
 , librouteros
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -24,28 +25,28 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "bundlewrap";
     repo = "bundlewrap";
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256-O31lh43VyaFnd/IUkx44wsgxkWubZKzjsKXzHwcGox0";
   };
 
+  nativeBuildInputs = [ setuptools ];
   propagatedBuildInputs = [
-    cryptography jinja2 Mako passlib pyyaml requests setuptools tomlkit librouteros
+    cryptography jinja2 Mako passlib pyyaml requests tomlkit librouteros
   ] ++ lib.optional (pythonOlder "3.11") [ rtoml ];
 
-  pythonImportsCheck = [ pname ];
+  pythonImportsCheck = [ "bundlewrap" ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytestCheckHook ];
 
-  checkPhase = ''
+  pytestFlagsArray = [
     # only unit tests as integration tests need a OpenSSH client/server setup
-    py.test tests/unit
-  '';
+    "tests/unit"
+  ];
 
   meta = with lib; {
     homepage = "https://bundlewrap.org/";
     description = "Easy, Concise and Decentralized Config management with Python";
     license = [ licenses.gpl3 ] ;
     maintainers = with maintainers; [ wamserma ];
-    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16386,6 +16386,8 @@ with pkgs;
   # until more issues are fixed default to libbpf 0.x
   libbpf = libbpf_0;
 
+  bundlewrap = with python3.pkgs; toPythonApplication bundlewrap;
+
   bpftools = callPackage ../os-specific/linux/bpftools { };
 
   bcc = callPackage ../os-specific/linux/bcc {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1583,6 +1583,8 @@ in {
 
   bunch = callPackage ../development/python-modules/bunch { };
 
+  bundlewrap = callPackage ../development/python-modules/bundlewrap { };
+
   bx-python = callPackage ../development/python-modules/bx-python { };
 
   bwapy = callPackage ../development/python-modules/bwapy { };


### PR DESCRIPTION
###### Description of changes

Add https://bundlewrap.org/, a (semi) declarative config-management tool with a low learning curve.
I've been maintaining it in my personal NUR for some years and use it with a small Debian VPS.
The tool is now mature enough (e.g. update frequency is low enough) to move this to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [Y] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
