### PR TITLE
nixos/kernel: cleanup kernel configuration names

### DIFF
--- a/nixos/doc/manual/configuration/config-file.section.md
+++ b/nixos/doc/manual/configuration/config-file.section.md
@@ -145,7 +145,7 @@ Lists
     separated by whitespace, like this:
 
     ```nix
-    boot.kernelModules = [ "fuse" "kvm-intel" "coretemp" ];
+    boot.kernel.modules = [ "fuse" "kvm-intel" "coretemp" ];
     ```
 
     List elements can be any other type, e.g. sets:

--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -1,11 +1,11 @@
 # Linux Kernel {#sec-kernel-config}
 
 You can override the Linux kernel and associated packages using the
-option `boot.kernelPackages`. For instance, this selects the Linux 3.10
+option `boot.kernel.packages`. For instance, this selects the Linux 3.10
 kernel:
 
 ```nix
-boot.kernelPackages = pkgs.linuxKernel.packages.linux_3_10;
+boot.kernel.packages = pkgs.linuxKernel.packages.linux_3_10;
 ```
 
 Note that this not only replaces the kernel, but also packages that are
@@ -56,17 +56,17 @@ something as a kernel module).
 
 Kernel modules for hardware devices are generally loaded automatically
 by `udev`. You can force a module to be loaded via
-[](#opt-boot.kernelModules), e.g.
+[](#opt-boot.kernel.modules), e.g.
 
 ```nix
-boot.kernelModules = [ "fuse" "kvm-intel" "coretemp" ];
+boot.kernel.modules = [ "fuse" "kvm-intel" "coretemp" ];
 ```
 
 If the module is required early during the boot (e.g. to mount the root
-file system), you can use [](#opt-boot.initrd.kernelModules):
+file system), you can use [](#opt-boot.initrd.kernel.modules):
 
 ```nix
-boot.initrd.kernelModules = [ "cifs" ];
+boot.initrd.kernel.modules = [ "cifs" ];
 ```
 
 This causes the specified modules and their dependencies to be added to
@@ -108,7 +108,7 @@ affect the generated configuration. You can also build a custom version of Linux
 To use your custom kernel package in your NixOS configuration, set
 
 ```nix
-boot.kernelPackages = pkgs.linuxPackagesFor yourCustomKernel;
+boot.kernel.packages = pkgs.linuxPackagesFor yourCustomKernel;
 ```
 
 Note that this method will use the common configuration defined in `pkgs/os-specific/linux/kernel/common-config.nix`,
@@ -167,7 +167,7 @@ version *that is supported by ZFS* like this:
 
 ```nix
 {
-  boot.kernelPackages = pkgs.zfs.latestCompatibleLinuxPackages;
+  boot.kernel.packages = pkgs.zfs.latestCompatibleLinuxPackages;
 }
 ```
 

--- a/nixos/doc/manual/configuration/modularity.section.md
+++ b/nixos/doc/manual/configuration/modularity.section.md
@@ -42,7 +42,7 @@ merged last, so for list-type options, it will appear at the end of the
 merged list. If you want it to appear first, you can use `mkBefore`:
 
 ```nix
-boot.kernelModules = mkBefore [ "kvm-intel" ];
+boot.kernel.modules = mkBefore [ "kvm-intel" ];
 ```
 
 This causes the `kvm-intel` kernel module to be loaded before any other
@@ -98,7 +98,7 @@ out:
 $ nixos-option services.xserver.enable
 true
 
-$ nixos-option boot.kernelModules
+$ nixos-option boot.kernel.modules
 [ "tun" "ipv6" "loop" ... ]
 ```
 

--- a/nixos/doc/manual/installation/building-nixos.chapter.md
+++ b/nixos/doc/manual/installation/building-nixos.chapter.md
@@ -48,10 +48,10 @@ file at `modules/installer/cd-dvd/installation-cd-graphical-gnome-macbook.nix`:
 {
   imports = [ ./installation-cd-graphical-gnome.nix ];
 
-  boot.initrd.kernelModules = [ "wl" ];
+  boot.initrd.kernel.modules = [ "wl" ];
 
-  boot.kernelModules = [ "kvm-intel" "wl" ];
-  boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
+  boot.kernel.modules = [ "kvm-intel" "wl" ];
+  boot.extraModulePackages = [ config.boot.kernel.packages.broadcom_sta ];
 }
 ```
 

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -467,7 +467,7 @@ Use the following commands:
 
     ::: {.note}
     Depending on your hardware configuration or type of file system, you
-    may need to set the option `boot.initrd.kernelModules` to include
+    may need to set the option `boot.initrd.kernel.modules` to include
     the kernel modules that are necessary for mounting the root file
     system, otherwise the installed system will not be able to boot. (If
     this happens, boot from the installation media again, mount the

--- a/nixos/doc/manual/manpages/nixos-generate-config.8
+++ b/nixos/doc/manual/manpages/nixos-generate-config.8
@@ -111,7 +111,7 @@ might look like this:
     ];
 
   boot.initrd.availableKernelModules = [ "ehci_hcd" "ahci" ];
-  boot.kernelModules = [ "kvm-intel" ];
+  boot.kernel.modules = [ "kvm-intel" ];
   boot.extraModulePackages = [ ];
 
   fileSystems."/" =

--- a/nixos/doc/manual/release-notes/rl-1603.section.md
+++ b/nixos/doc/manual/release-notes/rl-1603.section.md
@@ -244,7 +244,7 @@ When upgrading from a previous release, please be aware of the following incompa
   error: path ‘/nix/store/*-broadcom-sta-*’ does not exist and cannot be created
   ```
 
-  you should either re-run `nixos-generate-config` or manually replace `"${config.boot.kernelPackages.broadcom_sta}"` by `config.boot.kernelPackages.broadcom_sta` in your `/etc/nixos/hardware-configuration.nix`. More discussion is on [ the github issue](https://github.com/NixOS/nixpkgs/pull/12595).
+  you should either re-run `nixos-generate-config` or manually replace `"${config.boot.kernel.packages.broadcom_sta}"` by `config.boot.kernel.packages.broadcom_sta` in your `/etc/nixos/hardware-configuration.nix`. More discussion is on [ the github issue](https://github.com/NixOS/nixpkgs/pull/12595).
 
 - The `services.xserver.startGnuPGAgent` option has been removed. GnuPG 2.1.x changed the way the gpg-agent works, and that new approach no longer requires (or even supports) the "start everything as a child of the agent" scheme we've implemented in NixOS for older versions. To configure the gpg-agent for your X session, add the following code to `~/.bashrc` or some file that's sourced when your shell is started:
 

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -517,7 +517,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The [services.syncoid.enable](options.html#opt-services.syncoid.enable) module now properly drops ZFS permissions after usage. Before it delegated permissions to whole pools instead of datasets and didn't clean up after execution. You can manually look this up for your pools by running `zfs allow your-pool-name` and use `zfs unallow syncoid your-pool-name` to clean this up.
 
-- Zfs: `latestCompatibleLinuxPackages` is now exported on the zfs package. One can use `boot.kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;` to always track the latest compatible kernel with a given version of zfs.
+- Zfs: `latestCompatibleLinuxPackages` is now exported on the zfs package. One can use `boot.kernel.packages = config.boot.zfs.package.latestCompatibleLinuxPackages;` to always track the latest compatible kernel with a given version of zfs.
 
 - Nginx will use the value of `sslTrustedCertificate` if provided for a virtual host, even if `enableACME` is set. This is useful for providers not using the same certificate to sign OCSP responses and server certificates.
 

--- a/nixos/lib/make-multi-disk-zfs-image.nix
+++ b/nixos/lib/make-multi-disk-zfs-image.nix
@@ -120,7 +120,7 @@ let
   };
 
   modulesTree = pkgs.aggregateModules
-    (with config.boot.kernelPackages; [ kernel zfs ]);
+    (with config.boot.kernel.packages; [ kernel zfs ]);
 
   tools = lib.makeBinPath (
     with pkgs; [

--- a/nixos/lib/make-single-disk-zfs-image.nix
+++ b/nixos/lib/make-single-disk-zfs-image.nix
@@ -105,7 +105,7 @@ let
   };
 
   modulesTree = pkgs.aggregateModules
-    (with config.boot.kernelPackages; [ kernel zfs ]);
+    (with config.boot.kernel.packages; [ kernel zfs ]);
 
   tools = lib.makeBinPath (
     with pkgs; [

--- a/nixos/maintainers/scripts/azure-new/examples/basic/system.nix
+++ b/nixos/maintainers/scripts/azure-new/examples/basic/system.nix
@@ -22,7 +22,7 @@ in
   virtualisation.azureImage.diskSize = 2500;
 
   system.stateVersion = "20.03";
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.kernel.packages = pkgs.linuxPackages_latest;
 
   # test user doesn't have a password
   services.openssh.passwordAuthentication = false;

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -15,7 +15,7 @@ in {
   # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
   config.boot.kernelParams =
     let timeout =
-      if pkgs.lib.versionAtLeast config.boot.kernelPackages.kernel.version "4.15"
+      if pkgs.lib.versionAtLeast config.boot.kernel.packages.kernel.version "4.15"
       then "4294967295"
       else  "255";
     in [ "nvme_core.io_timeout=${timeout}" ];

--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -112,7 +112,7 @@ in
 
     # Disabling this for the moment, as it would create and mkswap devices twice,
     # once in stage 2 boot, and again when the zram-reloader service starts.
-    # boot.kernelModules = [ "zram" ];
+    # boot.kernel.modules = [ "zram" ];
 
     systemd.packages = [ pkgs.zram-generator ];
     systemd.services."systemd-zram-setup@".path = [ pkgs.util-linux ]; # for mkswap

--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -63,7 +63,7 @@ in {
         sof-firmware
         libreelec-dvb-firmware
       ] ++ optional pkgs.stdenv.hostPlatform.isAarch raspberrypiWirelessFirmware
-        ++ optionals (versionOlder config.boot.kernelPackages.kernel.version "4.13") [
+        ++ optionals (versionOlder config.boot.kernel.packages.kernel.version "4.13") [
         rtl8723bs-firmware
       ];
       hardware.wirelessRegulatoryDatabase = true;

--- a/nixos/modules/hardware/device-tree.nix
+++ b/nixos/modules/hardware/device-tree.nix
@@ -116,8 +116,8 @@ in
         };
 
         kernelPackage = mkOption {
-          default = config.boot.kernelPackages.kernel;
-          defaultText = literalExpression "config.boot.kernelPackages.kernel";
+          default = config.boot.kernel.packages.kernel;
+          defaultText = literalExpression "config.boot.kernel.packages.kernel";
           example = literalExpression "pkgs.linux_latest";
           type = types.path;
           description = lib.mdDoc ''

--- a/nixos/modules/hardware/i2c.nix
+++ b/nixos/modules/hardware/i2c.nix
@@ -25,7 +25,7 @@ in
 
   config = mkIf cfg.enable {
 
-    boot.kernelModules = [ "i2c-dev" ];
+    boot.kernel.modules = [ "i2c-dev" ];
 
     users.groups = mkIf (cfg.group == "i2c") {
       i2c = { };

--- a/nixos/modules/hardware/network/ath-user-regd.nix
+++ b/nixos/modules/hardware/network/ath-user-regd.nix
@@ -2,7 +2,7 @@
 
 with lib;
 let
-  kernelVersion = config.boot.kernelPackages.kernel.version;
+  kernelVersion = config.boot.kernel.packages.kernel.version;
   linuxKernelMinVersion = "5.8";
   kernelPatch = pkgs.kernelPatches.ath_regd_optional // {
     extraConfig = ''

--- a/nixos/modules/hardware/network/b43.nix
+++ b/nixos/modules/hardware/network/b43.nix
@@ -2,7 +2,7 @@
 
 with lib;
 
-let kernelVersion = config.boot.kernelPackages.kernel.version; in
+let kernelVersion = config.boot.kernel.packages.kernel.version; in
 
 {
 

--- a/nixos/modules/hardware/new-lg4ff.nix
+++ b/nixos/modules/hardware/new-lg4ff.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.hardware.new-lg4ff;
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
 in {
   options.hardware.new-lg4ff = {
     enable = mkOption {
@@ -21,7 +21,7 @@ in {
   config = lib.mkIf cfg.enable {
     boot = {
       extraModulePackages = [ kernelPackages.new-lg4ff ];
-      kernelModules = [ "hid-logitech-new" ];
+      kernel.modules = [ "hid-logitech-new" ];
     };
   };
 

--- a/nixos/modules/hardware/opengl.nix
+++ b/nixos/modules/hardware/opengl.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.hardware.opengl;
 
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
 
   videoDrivers = config.services.xserver.videoDrivers;
 
@@ -133,7 +133,7 @@ in
       { assertion = cfg.driSupport32Bit -> pkgs.stdenv.isx86_64;
         message = "Option driSupport32Bit only makes sense on a 64-bit system.";
       }
-      { assertion = cfg.driSupport32Bit -> (config.boot.kernelPackages.kernel.features.ia32Emulation or false);
+      { assertion = cfg.driSupport32Bit -> (config.boot.kernel.packages.kernel.features.ia32Emulation or false);
         message = "Option driSupport32Bit requires a kernel that supports 32bit emulation";
       }
     ];

--- a/nixos/modules/hardware/openrazer.nix
+++ b/nixos/modules/hardware/openrazer.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.hardware.openrazer;
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
 
   toPyBoolStr = b: if b then "True" else "False";
 
@@ -108,7 +108,7 @@ in
 
   config = mkIf cfg.enable {
     boot.extraModulePackages = [ kernelPackages.openrazer ];
-    boot.kernelModules = drivers;
+    boot.kernel.modules = drivers;
 
     # Makes the man pages available so you can successfully run
     # > systemctl --user help openrazer-daemon

--- a/nixos/modules/hardware/pcmcia.nix
+++ b/nixos/modules/hardware/pcmcia.nix
@@ -49,7 +49,7 @@ in
 
   config = mkIf config.hardware.pcmcia.enable {
 
-    boot.kernelModules = [ "pcmcia" ];
+    boot.kernel.modules = [ "pcmcia" ];
 
     services.udev.packages = [ pcmciaUtils ];
 

--- a/nixos/modules/hardware/raid/hpsa.nix
+++ b/nixos/modules/hardware/raid/hpsa.nix
@@ -56,7 +56,7 @@ in {
 
   config = mkIf config.hardware.raid.HPSmartArray.enable {
 
-    boot.initrd.kernelModules = [ "sg" ]; /* hpssacli wants it */
+    boot.initrd.kernel.modules = [ "sg" ]; /* hpssacli wants it */
     boot.initrd.availableKernelModules = [ "hpsa" ];
 
     environment.systemPackages = [ hpssacli ];

--- a/nixos/modules/hardware/steam-hardware.nix
+++ b/nixos/modules/hardware/steam-hardware.nix
@@ -27,6 +27,6 @@ in
     #
     # If the udev rules are not triggered, some controllers won't work with
     # steam.
-    boot.kernelModules = [ "uinput" ];
+    boot.kernel.modules = [ "uinput" ];
   };
 }

--- a/nixos/modules/hardware/system-76.nix
+++ b/nixos/modules/hardware/system-76.nix
@@ -5,13 +5,13 @@ let
   cfg = config.hardware.system76;
   opt = options.hardware.system76;
 
-  kpkgs = config.boot.kernelPackages;
+  kpkgs = config.boot.kernel.packages;
   modules = [ "system76" "system76-io" ] ++ (optional (versionOlder kpkgs.kernel.version "5.5") "system76-acpi");
   modulePackages = map (m: kpkgs.${m}) modules;
   moduleConfig = mkIf cfg.kernel-modules.enable {
     boot.extraModulePackages = modulePackages;
 
-    boot.kernelModules = modules;
+    boot.kernel.modules = modules;
 
     services.udev.packages = modulePackages;
   };
@@ -36,7 +36,7 @@ let
     };
   };
 
-  power-pkg = config.boot.kernelPackages.system76-power;
+  power-pkg = config.boot.kernel.packages.system76-power;
   powerConfig = mkIf cfg.power-daemon.enable {
     # Make system76-power usable by root from the command line.
     environment.systemPackages = [ power-pkg ];

--- a/nixos/modules/hardware/tuxedo-keyboard.nix
+++ b/nixos/modules/hardware/tuxedo-keyboard.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.hardware.tuxedo-keyboard;
-  tuxedo-keyboard = config.boot.kernelPackages.tuxedo-keyboard;
+  tuxedo-keyboard = config.boot.kernel.packages.tuxedo-keyboard;
 in
   {
     options.hardware.tuxedo-keyboard = {
@@ -29,7 +29,7 @@ in
 
     config = mkIf cfg.enable
     {
-      boot.kernelModules = ["tuxedo_keyboard"];
+      boot.kernel.modules = ["tuxedo_keyboard"];
       boot.extraModulePackages = [ tuxedo-keyboard ];
     };
   }

--- a/nixos/modules/hardware/uinput.nix
+++ b/nixos/modules/hardware/uinput.nix
@@ -8,7 +8,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    boot.kernelModules = [ "uinput" ];
+    boot.kernel.modules = [ "uinput" ];
 
     users.groups.uinput = {};
 

--- a/nixos/modules/hardware/video/amdgpu-pro.nix
+++ b/nixos/modules/hardware/video/amdgpu-pro.nix
@@ -10,7 +10,7 @@ let
 
   enabled = elem "amdgpu-pro" drivers;
 
-  package = config.boot.kernelPackages.amdgpu-pro;
+  package = config.boot.kernel.packages.amdgpu-pro;
   package32 = pkgs.pkgsi686Linux.linuxPackages.amdgpu-pro.override { kernel = null; };
 
   opengl = config.hardware.opengl;
@@ -32,7 +32,7 @@ in
 
     boot.extraModulePackages = [ package.kmod ];
 
-    boot.kernelPackages = pkgs.linuxKernel.packagesFor
+    boot.kernel.packages = pkgs.linuxKernel.packagesFor
       (pkgs.linuxKernel.kernels.linux_5_10.override {
         structuredExtraConfig = {
           DEVICE_PRIVATE = kernel.yes;

--- a/nixos/modules/hardware/video/bumblebee.nix
+++ b/nixos/modules/hardware/video/bumblebee.nix
@@ -4,7 +4,7 @@ with lib;
 let
   cfg = config.hardware.bumblebee;
 
-  kernel = config.boot.kernelPackages;
+  kernel = config.boot.kernel.packages;
 
   useNvidia = cfg.driver == "nvidia";
 
@@ -76,7 +76,7 @@ in
 
   config = mkIf cfg.enable {
     boot.blacklistedKernelModules = [ "nvidia-drm" "nvidia" "nouveau" ];
-    boot.kernelModules = optional useBbswitch "bbswitch";
+    boot.kernel.modules = optional useBbswitch "bbswitch";
     boot.extraModulePackages = optional useBbswitch kernel.bbswitch ++ optional useNvidia kernel.nvidia_x11.bin;
 
     environment.systemPackages = [ bumblebee primus ];

--- a/nixos/modules/hardware/video/capture/mwprocapture.nix
+++ b/nixos/modules/hardware/video/capture/mwprocapture.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.hardware.mwProCapture;
 
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
 
 in
 
@@ -16,7 +16,7 @@ in
 
   config = mkIf cfg.enable {
 
-    boot.kernelModules = [ "ProCapture" ];
+    boot.kernel.modules = [ "ProCapture" ];
 
     environment.systemPackages = [ kernelPackages.mwprocapture ];
 

--- a/nixos/modules/hardware/video/displaylink.nix
+++ b/nixos/modules/hardware/video/displaylink.nix
@@ -6,7 +6,7 @@ let
 
   enabled = elem "displaylink" config.services.xserver.videoDrivers;
 
-  evdi = config.boot.kernelPackages.evdi;
+  evdi = config.boot.kernel.packages.evdi;
 
   displaylink = pkgs.displaylink.override {
     inherit evdi;
@@ -19,7 +19,7 @@ in
   config = mkIf enabled {
 
     boot.extraModulePackages = [ evdi ];
-    boot.kernelModules = [ "evdi" ];
+    boot.kernel.modules = [ "evdi" ];
 
     environment.etc."X11/xorg.conf.d/40-displaylink.conf".text = ''
       Section "OutputClass"

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -226,12 +226,12 @@ in
 
     hardware.nvidia.package = lib.mkOption {
       type = types.package;
-      default = config.boot.kernelPackages.nvidiaPackages.stable;
-      defaultText = literalExpression "config.boot.kernelPackages.nvidiaPackages.stable";
+      default = config.boot.kernel.packages.nvidiaPackages.stable;
+      defaultText = literalExpression "config.boot.kernel.packages.nvidiaPackages.stable";
       description = lib.mdDoc ''
         The NVIDIA X11 derivation to use.
       '';
-      example = literalExpression "config.boot.kernelPackages.nvidiaPackages.legacy_340";
+      example = literalExpression "config.boot.kernel.packages.nvidiaPackages.legacy_340";
     };
 
     hardware.nvidia.open = lib.mkOption {
@@ -457,14 +457,14 @@ in
     hardware.firmware = lib.optional cfg.open nvidia_x11.firmware;
 
     # nvidia-uvm is required by CUDA applications.
-    boot.kernelModules = [ "nvidia-uvm" ] ++
+    boot.kernel.modules = [ "nvidia-uvm" ] ++
       optionals config.services.xserver.enable [ "nvidia" "nvidia_modeset" "nvidia_drm" ];
 
     # If requested enable modesetting via kernel parameter.
     boot.kernelParams = optional (offloadCfg.enable || cfg.modesetting.enable) "nvidia-drm.modeset=1"
       ++ optional cfg.powerManagement.enable "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
       ++ optional cfg.open "nvidia.NVreg_OpenRmEnableUnsupportedGpus=1"
-      ++ optional (config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport) "ibt=off";
+      ++ optional (config.boot.kernel.packages.kernel.kernelAtLeast "6.2" && !ibtSupport) "ibt=off";
 
     services.udev.extraRules =
       ''
@@ -475,7 +475,7 @@ in
         KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 0'"
         KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm-tools c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 1'"
       '' + optionalString cfg.powerManagement.finegrained (
-      optionalString (versionOlder config.boot.kernelPackages.kernel.version "5.5") ''
+      optionalString (versionOlder config.boot.kernel.packages.kernel.version "5.5") ''
         # Remove NVIDIA USB xHCI Host Controller devices, if present
         ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{remove}="1"
 

--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.hardware.facetimehd;
 
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
 
 in
 
@@ -28,7 +28,7 @@ in
 
   config = mkIf cfg.enable {
 
-    boot.kernelModules = [ "facetimehd" ];
+    boot.kernel.modules = [ "facetimehd" ];
 
     boot.blacklistedKernelModules = [ "bdc_pci" ];
 

--- a/nixos/modules/hardware/video/webcam/ipu6.nix
+++ b/nixos/modules/hardware/video/webcam/ipu6.nix
@@ -25,7 +25,7 @@ in
 
   config = mkIf cfg.enable {
 
-    boot.extraModulePackages = with config.boot.kernelPackages; [
+    boot.extraModulePackages = with config.boot.kernel.packages; [
       ipu6-drivers
     ];
 

--- a/nixos/modules/hardware/xone.nix
+++ b/nixos/modules/hardware/xone.nix
@@ -12,7 +12,7 @@ in
   config = mkIf cfg.enable {
     boot = {
       blacklistedKernelModules = [ "xpad" "mt76x2u" ];
-      extraModulePackages = with config.boot.kernelPackages; [ xone ];
+      extraModulePackages = with config.boot.kernel.packages; [ xone ];
     };
     hardware.firmware = [ pkgs.xow_dongle-firmware ];
   };

--- a/nixos/modules/hardware/xpadneo.nix
+++ b/nixos/modules/hardware/xpadneo.nix
@@ -16,11 +16,11 @@ in
       extraModprobeConfig =
         mkIf
           (config.hardware.bluetooth.enable &&
-            (lib.versionOlder config.boot.kernelPackages.kernel.version "5.12"))
+            (lib.versionOlder config.boot.kernel.packages.kernel.version "5.12"))
           "options bluetooth disable_ertm=1";
 
-      extraModulePackages = with config.boot.kernelPackages; [ xpadneo ];
-      kernelModules = [ "hid_xpadneo" ];
+      extraModulePackages = with config.boot.kernel.packages; [ xpadneo ];
+      kernel.modules = [ "hid_xpadneo" ];
     };
   };
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5-new-kernel.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5-new-kernel.nix
@@ -3,5 +3,5 @@
 {
   imports = [ ./installation-cd-graphical-plasma5.nix ];
 
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.kernel.packages = pkgs.linuxPackages_latest;
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-minimal-new-kernel.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-minimal-new-kernel.nix
@@ -3,5 +3,5 @@
 {
   imports = [ ./installation-cd-minimal.nix ];
 
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.kernel.packages = pkgs.linuxPackages_latest;
 }

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -754,7 +754,7 @@ in
 
     boot.initrd.availableKernelModules = [ "squashfs" "iso9660" "uas" "overlay" ];
 
-    boot.initrd.kernelModules = [ "loop" "overlay" ];
+    boot.initrd.kernel.modules = [ "loop" "overlay" ];
 
     # Closures to be copied to the Nix store on the CD, namely the init
     # script and the top-level system configuration directory.
@@ -773,7 +773,7 @@ in
     # store on the CD.
     isoImage.contents =
       [
-        { source = config.boot.kernelPackages.kernel + "/" + config.system.boot.loader.kernelFile;
+        { source = config.boot.kernel.packages.kernel + "/" + config.system.boot.loader.kernelFile;
           target = "/boot/" + config.system.boot.loader.kernelFile;
         }
         { source = config.system.build.initialRamdisk + "/" + config.system.boot.loader.initrdFile;

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -81,7 +81,7 @@ with lib;
 
     boot.initrd.availableKernelModules = [ "squashfs" "overlay" ];
 
-    boot.initrd.kernelModules = [ "loop" "overlay" ];
+    boot.initrd.kernel.modules = [ "loop" "overlay" ];
 
     # Closures to be copied to the Nix store, namely the init
     # script and the top-level system configuration directory.

--- a/nixos/modules/installer/sd-card/sd-image-aarch64-new-kernel.nix
+++ b/nixos/modules/installer/sd-card/sd-image-aarch64-new-kernel.nix
@@ -3,5 +3,5 @@
 {
   imports = [ ./sd-image-aarch64.nix ];
 
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.kernel.packages = pkgs.linuxPackages_latest;
 }

--- a/nixos/modules/installer/sd-card/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/sd-card/sd-image-armv7l-multiplatform.nix
@@ -12,7 +12,7 @@
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.consoleLogLevel = lib.mkDefault 7;
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.kernel.packages = pkgs.linuxPackages_latest;
   # The serial ports listed here are:
   # - ttyS0: for Tegra (Jetson TK1)
   # - ttymxc0: for i.MX6 (Wandboard)

--- a/nixos/modules/installer/sd-card/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/sd-card/sd-image-raspberrypi.nix
@@ -12,7 +12,7 @@
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.consoleLogLevel = lib.mkDefault 7;
-  boot.kernelPackages = pkgs.linuxKernel.packages.linux_rpi1;
+  boot.kernel.packages = pkgs.linuxKernel.packages.linux_rpi1;
 
   sdImage = {
     populateFirmwareCommands = let

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -174,7 +174,7 @@ sub pciCheck {
          $device eq "0x4331" || $device eq "0x43a0" || $device eq "0x43b1"
         ) )
      {
-        push @modulePackages, "config.boot.kernelPackages.broadcom_sta";
+        push @modulePackages, "config.boot.kernel.packages.broadcom_sta";
         push @kernelModules, "wl";
      }
 
@@ -585,8 +585,8 @@ my $hwConfig = <<EOF;
   imports =${\multiLineList("    ", @imports)};
 
   boot.initrd.availableKernelModules = [$initrdAvailableKernelModules ];
-  boot.initrd.kernelModules = [$initrdKernelModules ];
-  boot.kernelModules = [$kernelModules ];
+  boot.initrd.kernel.modules = [$initrdKernelModules ];
+  boot.kernel.modules = [$kernelModules ];
   boot.extraModulePackages = [$modulePackages ];
 $fsAndSwap
 $networkingDhcpConfig

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -15,7 +15,7 @@ with lib;
     maintainers = [ maintainers.joachifm maintainers.emily ];
   };
 
-  boot.kernelPackages = mkDefault pkgs.linuxPackages_hardened;
+  boot.kernel.packages = mkDefault pkgs.linuxPackages_hardened;
 
   nix.settings.allowed-users = mkDefault [ "@users" ];
 

--- a/nixos/modules/profiles/qemu-guest.nix
+++ b/nixos/modules/profiles/qemu-guest.nix
@@ -5,7 +5,7 @@
 
 {
   boot.initrd.availableKernelModules = [ "virtio_net" "virtio_pci" "virtio_mmio" "virtio_blk" "virtio_scsi" "9p" "9pnet_virtio" ];
-  boot.initrd.kernelModules = [ "virtio_balloon" "virtio_console" "virtio_rng" ];
+  boot.initrd.kernel.modules = [ "virtio_balloon" "virtio_console" "virtio_rng" ];
 
   boot.initrd.postDeviceCommands = lib.mkIf (!config.boot.initrd.systemd.enable)
     ''

--- a/nixos/modules/programs/appgate-sdp.nix
+++ b/nixos/modules/programs/appgate-sdp.nix
@@ -10,7 +10,7 @@ with lib;
   };
 
   config = mkIf config.programs.appgate-sdp.enable {
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
     environment.systemPackages = [ pkgs.appgate-sdp ];
     services.dbus.packages = [ pkgs.appgate-sdp ];
     systemd = {

--- a/nixos/modules/programs/atop.nix
+++ b/nixos/modules/programs/atop.nix
@@ -36,8 +36,8 @@ in
         };
         package = mkOption {
           type = types.package;
-          default = config.boot.kernelPackages.netatop;
-          defaultText = literalExpression "config.boot.kernelPackages.netatop";
+          default = config.boot.kernel.packages.netatop;
+          defaultText = literalExpression "config.boot.kernel.packages.netatop";
           description = lib.mdDoc ''
             Which package to use for netatop.
           '';

--- a/nixos/modules/programs/cdemu.nix
+++ b/nixos/modules/programs/cdemu.nix
@@ -42,8 +42,8 @@ in {
   config = mkIf cfg.enable {
 
     boot = {
-      extraModulePackages = [ config.boot.kernelPackages.vhba ];
-      kernelModules = [ "vhba" ];
+      extraModulePackages = [ config.boot.kernel.packages.vhba ];
+      kernel.modules = [ "vhba" ];
     };
 
     services = {

--- a/nixos/modules/programs/droidcam.nix
+++ b/nixos/modules/programs/droidcam.nix
@@ -10,7 +10,7 @@ with lib;
   config = lib.mkIf config.programs.droidcam.enable {
     environment.systemPackages = [ pkgs.droidcam ];
 
-    boot.extraModulePackages = [ config.boot.kernelPackages.v4l2loopback ];
-    boot.kernelModules = [ "v4l2loopback" "snd-aloop" ];
+    boot.extraModulePackages = [ config.boot.kernel.packages.v4l2loopback ];
+    boot.kernel.modules = [ "v4l2loopback" "snd-aloop" ];
   };
 }

--- a/nixos/modules/programs/nbd.nix
+++ b/nixos/modules/programs/nbd.nix
@@ -14,6 +14,6 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = with pkgs; [ nbd ];
-    boot.kernelModules = [ "nbd" ];
+    boot.kernel.modules = [ "nbd" ];
   };
 }

--- a/nixos/modules/programs/sysdig.nix
+++ b/nixos/modules/programs/sysdig.nix
@@ -9,6 +9,6 @@ in {
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.sysdig ];
-    boot.extraModulePackages = [ config.boot.kernelPackages.sysdig ];
+    boot.extraModulePackages = [ config.boot.kernel.packages.sysdig ];
   };
 }

--- a/nixos/modules/programs/systemtap.nix
+++ b/nixos/modules/programs/systemtap.nix
@@ -22,7 +22,7 @@ in {
     ];
     boot.kernel.features.debug = true;
     environment.systemPackages = [
-      config.boot.kernelPackages.systemtap
+      config.boot.kernel.packages.systemtap
     ];
   };
 

--- a/nixos/modules/programs/usbtop.nix
+++ b/nixos/modules/programs/usbtop.nix
@@ -14,7 +14,7 @@ in {
       usbtop
     ];
 
-    boot.kernelModules = [
+    boot.kernel.modules = [
       "usbmon"
     ];
   };

--- a/nixos/modules/security/lock-kernel-modules.nix
+++ b/nixos/modules/security/lock-kernel-modules.nix
@@ -15,13 +15,13 @@ with lib;
         Disable kernel module loading once the system is fully initialised.
         Module loading is disabled until the next reboot. Problems caused
         by delayed module loading can be fixed by adding the module(s) in
-        question to {option}`boot.kernelModules`.
+        question to {option}`boot.kernel.modules`.
       '';
     };
   };
 
   config = mkIf config.security.lockKernelModules {
-    boot.kernelModules = concatMap (x:
+    boot.kernel.modules = concatMap (x:
       if x.device != null
         then
           if x.fsType == "vfat"

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -96,7 +96,7 @@ in
     # ALSA provides a udev rule for restoring volume settings.
     services.udev.packages = [ alsa-utils ];
 
-    boot.kernelModules = optional config.sound.enableOSSEmulation "snd_pcm_oss";
+    boot.kernel.modules = optional config.sound.enableOSSEmulation "snd_pcm_oss";
 
     systemd.services.alsa-store =
       { description = "Store Sound Card State";

--- a/nixos/modules/services/audio/jack.nix
+++ b/nixos/modules/services/audio/jack.nix
@@ -142,7 +142,7 @@ in {
     })
 
     (mkIf loopback {
-      boot.kernelModules = [ "snd-aloop" ];
+      boot.kernel.modules = [ "snd-aloop" ];
       boot.kernelParams = [ "snd-aloop.index=${toString cfg.loopback.index}" ];
       sound.extraConfig = cfg.loopback.config;
     })

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -340,7 +340,7 @@ in
       # Always include cni plugins
       services.kubernetes.kubelet.cni.packages = [pkgs.cni-plugins pkgs.cni-plugin-flannel];
 
-      boot.kernelModules = ["br_netfilter" "overlay"];
+      boot.kernel.modules = ["br_netfilter" "overlay"];
 
       services.kubernetes.kubelet.hostname =
         mkDefault config.networking.fqdnOrHostName;

--- a/nixos/modules/services/cluster/patroni/default.nix
+++ b/nixos/modules/services/cluster/patroni/default.nix
@@ -245,7 +245,7 @@ in
       };
     };
 
-    boot.kernelModules = mkIf cfg.softwareWatchdog [ "softdog" ];
+    boot.kernel.modules = mkIf cfg.softwareWatchdog [ "softdog" ];
 
     services.udev.extraRules = mkIf cfg.softwareWatchdog ''
       KERNEL=="watchdog", OWNER="${cfg.user}", GROUP="${cfg.group}", MODE="0600"

--- a/nixos/modules/services/desktops/system76-scheduler.nix
+++ b/nixos/modules/services/desktops/system76-scheduler.nix
@@ -95,8 +95,8 @@ in {
 
       package = mkOption {
         type = types.package;
-        default = config.boot.kernelPackages.system76-scheduler;
-        defaultText = literalExpression "config.boot.kernelPackages.system76-scheduler";
+        default = config.boot.kernel.packages.system76-scheduler;
+        defaultText = literalExpression "config.boot.kernel.packages.system76-scheduler";
         description = mdDoc "Which System76-Scheduler package to use.";
       };
 

--- a/nixos/modules/services/hardware/ddccontrol.nix
+++ b/nixos/modules/services/hardware/ddccontrol.nix
@@ -21,7 +21,7 @@ in
 
   config = lib.mkIf cfg.enable {
     # Load the i2c-dev module
-    boot.kernelModules = [ "i2c_dev" ];
+    boot.kernel.modules = [ "i2c_dev" ];
 
     # Give users access to the "gddccontrol" tool
     environment.systemPackages = [

--- a/nixos/modules/services/hardware/joycond.nix
+++ b/nixos/modules/services/hardware/joycond.nix
@@ -2,7 +2,7 @@
 
 let
   cfg = config.services.joycond;
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
 in
 
 with lib;

--- a/nixos/modules/services/hardware/nvidia-optimus.nix
+++ b/nixos/modules/services/hardware/nvidia-optimus.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 
-let kernel = config.boot.kernelPackages; in
+let kernel = config.boot.kernel.packages; in
 
 {
 
@@ -24,7 +24,7 @@ let kernel = config.boot.kernelPackages; in
 
   config = lib.mkIf config.hardware.nvidiaOptimus.disable {
     boot.blacklistedKernelModules = ["nouveau" "nvidia" "nvidiafb" "nvidia-drm"];
-    boot.kernelModules = [ "bbswitch" ];
+    boot.kernel.modules = [ "bbswitch" ];
     boot.extraModulePackages = [ kernel.bbswitch ];
 
     systemd.services.bbswitch = {

--- a/nixos/modules/services/hardware/openrgb.nix
+++ b/nixos/modules/services/hardware/openrgb.nix
@@ -33,7 +33,7 @@ in {
     environment.systemPackages = [ cfg.package ];
     services.udev.packages = [ cfg.package ];
 
-    boot.kernelModules = [ "i2c-dev" ]
+    boot.kernel.modules = [ "i2c-dev" ]
      ++ lib.optionals (cfg.motherboard == "amd") [ "i2c-piix4" ]
      ++ lib.optionals (cfg.motherboard == "intel") [ "i2c-i801" ];
 

--- a/nixos/modules/services/hardware/rasdaemon.nix
+++ b/nixos/modules/services/hardware/rasdaemon.nix
@@ -103,7 +103,7 @@ in
         aer-inject
       ]);
 
-    boot.initrd.kernelModules = cfg.extraModules
+    boot.initrd.kernel.modules = cfg.extraModules
       ++ optionals (cfg.testing) [
         # edac_core and amd64_edac should get loaded automatically
         # i7core_edac may not be, and may not be required, but should load successfully

--- a/nixos/modules/services/hardware/sane_extra_backends/dsseries.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/dsseries.nix
@@ -20,7 +20,7 @@ with lib;
 
     hardware.sane.extraBackends = [ pkgs.dsseries ];
     services.udev.packages = [ pkgs.dsseries ];
-    boot.kernelModules = [ "sg" ];
+    boot.kernel.modules = [ "sg" ];
 
   };
 }

--- a/nixos/modules/services/hardware/throttled.nix
+++ b/nixos/modules/services/hardware/throttled.nix
@@ -30,7 +30,7 @@ in {
     # Kernel 5.9 spams warnings whenever userspace writes to CPU MSRs.
     # See https://github.com/erpalma/throttled/issues/215
     boot.kernelParams =
-      optional (versionAtLeast config.boot.kernelPackages.kernel.version "5.9")
+      optional (versionAtLeast config.boot.kernel.packages.kernel.version "5.9")
       "msr.allow_writes=on";
   };
 }

--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -47,7 +47,7 @@ in
 
   ###### implementation
   config = mkIf cfg.enable {
-    boot.kernelModules = [ "msr" ];
+    boot.kernel.modules = [ "msr" ];
 
     warnings = optional (cfg.extraConfig != "") ''
       Using config.services.tlp.extraConfig is deprecated and will become unsupported in a future release. Use config.services.tlp.settings instead.

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -166,7 +166,7 @@ let
       mv etc/udev/hwdb.bin $out
     '';
 
-  compressFirmware = firmware: if (config.boot.kernelPackages.kernelAtLeast "5.3" && (firmware.compressFirmware or true)) then
+  compressFirmware = firmware: if (config.boot.kernel.packages.kernelAtLeast "5.3" && (firmware.compressFirmware or true)) then
     pkgs.compressFirmwareXz firmware
   else
     id firmware;

--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -159,7 +159,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    boot.kernelModules = [ "msr" ];
+    boot.kernel.modules = [ "msr" ];
 
     environment.systemPackages = [ cfg.package ];
 

--- a/nixos/modules/services/misc/autofs.nix
+++ b/nixos/modules/services/misc/autofs.nix
@@ -74,7 +74,7 @@ in
 
   config = mkIf cfg.enable {
 
-    boot.kernelModules = [ "autofs4" ];
+    boot.kernel.modules = [ "autofs4" ];
 
     systemd.services.autofs =
       { description = "Automounts filesystems on demand";

--- a/nixos/modules/services/misc/mbpfan.nix
+++ b/nixos/modules/services/misc/mbpfan.nix
@@ -77,7 +77,7 @@ in {
       general.max_temp = mkDefault 70;
     };
 
-    boot.kernelModules = [ "coretemp" "applesmc" ];
+    boot.kernel.modules = [ "coretemp" "applesmc" ];
     environment.systemPackages = [ cfg.package ];
     environment.etc."mbpfan.conf".source = settingsFile;
 

--- a/nixos/modules/services/misc/xmrig.nix
+++ b/nixos/modules/services/misc/xmrig.nix
@@ -52,7 +52,7 @@ with lib;
   };
 
   config = mkIf cfg.enable {
-    boot.kernelModules = [ "msr" ];
+    boot.kernel.modules = [ "msr" ];
 
     systemd.services.xmrig = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/monitoring/hdaps.nix
+++ b/nixos/modules/services/monitoring/hdaps.nix
@@ -16,7 +16,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    boot.kernelModules = [ "hdapsd" ];
+    boot.kernel.modules = [ "hdapsd" ];
     services.udev.packages = hdapsd;
     systemd.packages = hdapsd;
   };

--- a/nixos/modules/services/network-filesystems/cachefilesd.nix
+++ b/nixos/modules/services/network-filesystems/cachefilesd.nix
@@ -43,7 +43,7 @@ in
 
   config = mkIf cfg.enable {
 
-    boot.kernelModules = [ "cachefiles" ];
+    boot.kernel.modules = [ "cachefiles" ];
 
     systemd.services.cachefilesd = {
       description = "Local network file caching management daemon";

--- a/nixos/modules/services/network-filesystems/drbd.nix
+++ b/nixos/modules/services/network-filesystems/drbd.nix
@@ -40,7 +40,7 @@ let cfg = config.services.drbd; in
 
     services.udev.packages = [ pkgs.drbd ];
 
-    boot.kernelModules = [ "drbd" ];
+    boot.kernel.modules = [ "drbd" ];
 
     boot.extraModprobeConfig =
       ''

--- a/nixos/modules/services/network-filesystems/openafs/client.nix
+++ b/nixos/modules/services/network-filesystems/openafs/client.nix
@@ -147,8 +147,8 @@ in
 
       packages = {
         module = mkOption {
-          default = config.boot.kernelPackages.openafs;
-          defaultText = literalExpression "config.boot.kernelPackages.openafs";
+          default = config.boot.kernel.packages.openafs;
+          defaultText = literalExpression "config.boot.kernel.packages.openafs";
           type = types.package;
           description = lib.mdDoc "OpenAFS kernel module package. MUST match the userland package!";
         };

--- a/nixos/modules/services/network-filesystems/orangefs/client.nix
+++ b/nixos/modules/services/network-filesystems/orangefs/client.nix
@@ -63,7 +63,7 @@ in {
     environment.systemPackages = [ pkgs.orangefs ];
 
     boot.supportedFilesystems = [ "pvfs2" ];
-    boot.kernelModules = [ "orangefs" ];
+    boot.kernel.modules = [ "orangefs" ];
 
     systemd.services.orangefs-client = {
       requires = [ "network-online.target" ];

--- a/nixos/modules/services/networking/cjdns.nix
+++ b/nixos/modules/services/networking/cjdns.nix
@@ -229,7 +229,7 @@ in
 
   config = mkIf cfg.enable {
 
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
 
     # networking.firewall.allowedUDPPorts = ...
 

--- a/nixos/modules/services/networking/expressvpn.nix
+++ b/nixos/modules/services/networking/expressvpn.nix
@@ -11,7 +11,7 @@ with lib;
   };
 
   config = mkIf config.services.expressvpn.enable {
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
 
     systemd.services.expressvpn = {
       description = "ExpressVPN Daemon";

--- a/nixos/modules/services/networking/firewall-iptables.nix
+++ b/nixos/modules/services/networking/firewall-iptables.nix
@@ -38,7 +38,7 @@ let
 
   cfg = config.networking.firewall;
 
-  inherit (config.boot.kernelPackages) kernel;
+  inherit (config.boot.kernel.packages) kernel;
 
   kernelHasRPFilter = ((kernel.config.isEnabled or (x: false)) "IP_NF_MATCH_RPFILTER") || (kernel.features.netfilterRPFilter or false);
 

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -270,7 +270,7 @@ in
         message = "filterForward only works with the nftables based firewall";
       }
       {
-        assertion = cfg.autoLoadConntrackHelpers -> lib.versionOlder config.boot.kernelPackages.kernel.version "6";
+        assertion = cfg.autoLoadConntrackHelpers -> lib.versionOlder config.boot.kernel.packages.kernel.version "6";
         message = "conntrack helper autoloading has been removed from kernel 6.0 and newer";
       }
     ];
@@ -279,7 +279,7 @@ in
 
     environment.systemPackages = [ cfg.package ] ++ cfg.extraPackages;
 
-    boot.kernelModules = (optional cfg.autoLoadConntrackHelpers "nf_conntrack")
+    boot.kernel.modules = (optional cfg.autoLoadConntrackHelpers "nf_conntrack")
       ++ map (x: "nf_conntrack_${x}") cfg.connectionTrackingModules;
     boot.extraModprobeConfig = optionalString cfg.autoLoadConntrackHelpers ''
       options nf_conntrack nf_conntrack_helper=1

--- a/nixos/modules/services/networking/hans.nix
+++ b/nixos/modules/services/networking/hans.nix
@@ -106,7 +106,7 @@ in
       "net.ipv4.icmp_echo_ignore_all" = 1;
     };
 
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
 
     systemd.services =
     let

--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -123,7 +123,7 @@ in
 
   config = mkIf (cfg.server.enable || cfg.clients != {}) {
     environment.systemPackages = [ pkgs.iodine ];
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
 
     systemd.services =
       let

--- a/nixos/modules/services/networking/iscsi/initiator.nix
+++ b/nixos/modules/services/networking/iscsi/initiator.nix
@@ -79,6 +79,6 @@ in
     };
 
     environment.systemPackages = [ cfg.package ];
-    boot.kernelModules = [ "iscsi_tcp" ];
+    boot.kernel.modules = [ "iscsi_tcp" ];
   };
 }

--- a/nixos/modules/services/networking/iscsi/root-initiator.nix
+++ b/nixos/modules/services/networking/iscsi/root-initiator.nix
@@ -108,7 +108,7 @@ in
       # the network not work.
       network.flushBeforeStage2 = false;
 
-      kernelModules = [ "iscsi_tcp" ];
+      kernel.modules = [ "iscsi_tcp" ];
 
       extraUtilsCommands = ''
         copy_bin_and_libs ${pkgs.openiscsi}/bin/iscsid

--- a/nixos/modules/services/networking/iscsi/target.nix
+++ b/nixos/modules/services/networking/iscsi/target.nix
@@ -31,7 +31,7 @@ in
 
     environment.systemPackages = with pkgs; [ targetcli ];
 
-    boot.kernelModules = [ "configfs" "target_core_mod" "iscsi_target_mod" ];
+    boot.kernel.modules = [ "configfs" "target_core_mod" "iscsi_target_mod" ];
 
     systemd.services.iscsi-target = {
       enable = true;

--- a/nixos/modules/services/networking/ivpn.nix
+++ b/nixos/modules/services/networking/ivpn.nix
@@ -16,7 +16,7 @@ with lib;
   };
 
   config = mkIf cfg.enable {
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
 
     environment.systemPackages = with pkgs; [ ivpn ivpn-service ];
 

--- a/nixos/modules/services/networking/jibri/default.nix
+++ b/nixos/modules/services/networking/jibri/default.nix
@@ -409,7 +409,7 @@ in
       extraModprobeConfig = ''
         options snd-aloop enable=1,1,1,1,1,1,1,1
       '';
-      kernelModules = [ "snd-aloop" ];
+      kernel.modules = [ "snd-aloop" ];
     };
   };
 

--- a/nixos/modules/services/networking/mullvad-vpn.nix
+++ b/nixos/modules/services/networking/mullvad-vpn.nix
@@ -34,7 +34,7 @@ with lib;
   };
 
   config = mkIf cfg.enable {
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
 
     environment.systemPackages = [ cfg.package ];
 

--- a/nixos/modules/services/networking/multipath.nix
+++ b/nixos/modules/services/networking/multipath.nix
@@ -541,12 +541,12 @@ in {
     systemd.packages = [ cfg.package ];
 
     environment.systemPackages = [ cfg.package ];
-    boot.kernelModules = [ "dm-multipath" "dm-service-time" ];
+    boot.kernel.modules = [ "dm-multipath" "dm-service-time" ];
 
     # We do not have systemd in stage-1 boot so must invoke `multipathd`
     # with the `-1` argument which disables systemd calls. Invoke `multipath`
     # to display the multipath mappings in the output of `journalctl -b`.
-    boot.initrd.kernelModules = [ "dm-multipath" "dm-service-time" ];
+    boot.initrd.kernel.modules = [ "dm-multipath" "dm-service-time" ];
     boot.initrd.postDeviceCommands = ''
       modprobe -a dm-multipath dm-service-time
       multipathd -s

--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -176,7 +176,7 @@ in
     environment.systemPackages = [ config.networking.firewall.package ];
 
     boot = {
-      kernelModules = [ "nf_nat_ftp" ];
+      kernel.modules = [ "nf_nat_ftp" ];
       kernel.sysctl = {
         "net.ipv4.conf.all.forwarding" = mkOverride 99 true;
         "net.ipv4.conf.default.forwarding" = mkOverride 99 true;

--- a/nixos/modules/services/networking/nbd.nix
+++ b/nixos/modules/services/networking/nbd.nix
@@ -114,7 +114,7 @@ in
       }
     ];
 
-    boot.kernelModules = [ "nbd" ];
+    boot.kernel.modules = [ "nbd" ];
 
     systemd.services.nbd-server = {
       after = [ "network-online.target" ];

--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.services.netbird;
-  kernel = config.boot.kernelPackages;
+  kernel = config.boot.kernel.packages;
   interfaceName = "wt0";
 in {
   meta.maintainers = with maintainers; [ misuzu ];

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -528,7 +528,7 @@ in {
       }
     ];
 
-    boot.kernelModules = [ "ctr" ];
+    boot.kernel.modules = [ "ctr" ];
 
     security.polkit.enable = true;
     security.polkit.extraConfig = polkitConf;

--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -228,7 +228,7 @@ in
 
     environment.systemPackages = [ openvpn ];
 
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
 
   };
 

--- a/nixos/modules/services/networking/softether.nix
+++ b/nixos/modules/services/networking/softether.nix
@@ -155,7 +155,7 @@ in
             ${cfg.vpnclient.down}
         '';
       };
-      boot.kernelModules = [ "tun" ];
+      boot.kernel.modules = [ "tun" ];
     })
 
   ]);

--- a/nixos/modules/services/networking/wg-quick.nix
+++ b/nixos/modules/services/networking/wg-quick.nix
@@ -4,7 +4,7 @@ with lib;
 let
   cfg = config.networking.wg-quick;
 
-  kernel = config.boot.kernelPackages;
+  kernel = config.boot.kernel.packages;
 
   # interface options
 

--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -7,7 +7,7 @@ let
   cfg = config.networking.wireguard;
   opt = options.networking.wireguard;
 
-  kernel = config.boot.kernelPackages;
+  kernel = config.boot.kernel.packages;
 
   # interface options
 

--- a/nixos/modules/services/security/hologram-agent.nix
+++ b/nixos/modules/services/security/hologram-agent.nix
@@ -33,7 +33,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    boot.kernelModules = [ "dummy" ];
+    boot.kernel.modules = [ "dummy" ];
 
     networking.interfaces.dummy0.ipv4.addresses = [
       { address = "169.254.169.254"; prefixLength = 32; }

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -337,7 +337,7 @@ in
       };
       path = with pkgs; [
         # unfree:
-        # config.boot.kernelPackages.nvidiaPackages.latest.bin
+        # config.boot.kernel.packages.nvidiaPackages.latest.bin
         ffmpeg_5-headless
         libva-utils
         procps

--- a/nixos/modules/services/video/v4l2-relayd.nix
+++ b/nixos/modules/services/video/v4l2-relayd.nix
@@ -7,7 +7,7 @@ let
 
   cfg = config.services.v4l2-relayd;
 
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
 
   gst = (with pkgs.gst_all_1; [
     gst-plugins-bad
@@ -188,7 +188,7 @@ in
 
       boot = mkIf ((length enabledInstances) > 0) {
         extraModulePackages = [ kernelPackages.v4l2loopback ];
-        kernelModules = [ "v4l2loopback" ];
+        kernel.modules = [ "v4l2loopback" ];
       };
 
       systemd.services = mkInstanceServices enabledInstances;

--- a/nixos/modules/services/x11/clight.nix
+++ b/nixos/modules/services/x11/clight.nix
@@ -73,7 +73,7 @@ in {
         message = "You must specify a valid latitude and longitude if manually providing location"; }
     ];
 
-    boot.kernelModules = [ "i2c_dev" ];
+    boot.kernel.modules = [ "i2c_dev" ];
     environment.systemPackages = with pkgs; [ clight clightd ];
     services.dbus.packages = with pkgs; [ clight clightd ];
     services.upower.enable = true;

--- a/nixos/modules/services/x11/hardware/digimend.nix
+++ b/nixos/modules/services/x11/hardware/digimend.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.services.xserver.digimend;
 
-  pkg = config.boot.kernelPackages.digimend;
+  pkg = config.boot.kernel.packages.digimend;
 
 in
 

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -21,10 +21,10 @@ let
           (cfg.extensions //
           {
             "org.nixos.bootspec.v1" = {
-              system = config.boot.kernelPackages.stdenv.hostPlatform.system;
-              kernel = "${config.boot.kernelPackages.kernel}/${config.system.boot.loader.kernelFile}";
+              system = config.boot.kernel.packages.stdenv.hostPlatform.system;
+              kernel = "${config.boot.kernel.packages.kernel}/${config.system.boot.loader.kernelFile}";
               kernelParams = config.boot.kernelParams;
-              label = "${config.system.nixos.distroName} ${config.system.nixos.codeName} ${config.system.nixos.label} (Linux ${config.boot.kernelPackages.kernel.modDirVersion})";
+              label = "${config.system.nixos.distroName} ${config.system.nixos.codeName} ${config.system.nixos.label} (Linux ${config.boot.kernel.packages.kernel.modDirVersion})";
             } // lib.optionalAttrs config.boot.initrd.enable {
               initrd = "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}";
               initrdSecrets = "${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets";

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -5,7 +5,7 @@ with lib;
 let
   systemBuilder =
     let
-      kernelPath = "${config.boot.kernelPackages.kernel}/" +
+      kernelPath = "${config.boot.kernel.packages.kernel}/" +
         "${config.system.boot.loader.kernelFile}";
       initrdPath = "${config.system.build.initialRamdisk}/" +
         "${config.system.boot.loader.initrdFile}";
@@ -61,7 +61,7 @@ let
 
       echo -n "systemd ${toString config.systemd.package.interfaceVersion}" > $out/init-interface-version
       echo -n "$nixosLabel" > $out/nixos-version
-      echo -n "${config.boot.kernelPackages.stdenv.hostPlatform.system}" > $out/system
+      echo -n "${config.boot.kernel.packages.stdenv.hostPlatform.system}" > $out/system
 
       mkdir $out/bin
       export localeArchive="${config.i18n.glibcLocales}/lib/locale/locale-archive"

--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -103,7 +103,7 @@ in
 
   config = mkIf cfg.enable {
 
-    boot.initrd.kernelModules = [ "af_packet" ];
+    boot.initrd.kernel.modules = [ "af_packet" ];
 
     boot.initrd.extraUtilsCommands = ''
       copy_bin_and_libs ${pkgs.klibc}/lib/klibc/bin.static/ipconfig

--- a/nixos/modules/system/boot/initrd-openvpn.nix
+++ b/nixos/modules/system/boot/initrd-openvpn.nix
@@ -47,7 +47,7 @@ in
     ];
 
     # Add kernel modules needed for OpenVPN
-    boot.initrd.kernelModules = [ "tun" "tap" ];
+    boot.initrd.kernel.modules = [ "tun" "tap" ];
 
     # Add openvpn and ip binaries to the initrd
     # The shared libraries are required for DNS resolution

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -243,7 +243,7 @@ in {
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = (config.boot.kernelPackages.kernel.features or { efiBootStub = true; }) ? efiBootStub;
+        assertion = (config.boot.kernel.packages.kernel.features or { efiBootStub = true; }) ? efiBootStub;
         message = "This kernel does not support the EFI boot stub";
       }
     ] ++ concatMap (filename: [

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   luks = config.boot.initrd.luks;
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
   defaultPrio = (mkOptionDefault {}).priority;
 
   commonFunctions = ''

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -3208,7 +3208,7 @@ let
         "${config.boot.initrd.systemd.package}/lib/systemd/systemd-networkd-wait-online"
         "${config.boot.initrd.systemd.package}/lib/systemd/systemd-network-generator"
       ];
-      kernelModules = [ "af_packet" ];
+      kernel.modules = [ "af_packet" ];
 
       systemd.services.nixos-flush-networkd = mkIf config.boot.initrd.network.flushBeforeStage2 {
         description = "Flush Network Configuration";

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -93,12 +93,12 @@ let
 
   needMakefs = lib.any (fs: fs.autoFormat) fileSystems;
 
-  kernel-name = config.boot.kernelPackages.kernel.name or "kernel";
+  kernel-name = config.boot.kernel.packages.kernel.name or "kernel";
   modulesTree = config.system.modulesTree.override { name = kernel-name + "-modules"; };
   firmware = config.hardware.firmware;
   # Determine the set of modules that we need to mount the root FS.
   modulesClosure = pkgs.makeModulesClosure {
-    rootModules = config.boot.initrd.availableKernelModules ++ config.boot.initrd.kernelModules;
+    rootModules = config.boot.initrd.availableKernelModules ++ config.boot.initrd.kernel.modules;
     kernel = modulesTree;
     firmware = firmware;
     allowMissing = false;
@@ -371,7 +371,7 @@ in {
         "/lib/modules".source = "${modulesClosure}/lib/modules";
         "/lib/firmware".source = "${modulesClosure}/lib/firmware";
 
-        "/etc/modules-load.d/nixos.conf".text = concatStringsSep "\n" config.boot.initrd.kernelModules;
+        "/etc/modules-load.d/nixos.conf".text = concatStringsSep "\n" config.boot.initrd.kernel.modules;
 
         # We can use either ! or * to lock the root account in the
         # console, but some software like OpenSSH won't even allow you

--- a/nixos/modules/system/boot/uvesafb.nix
+++ b/nixos/modules/system/boot/uvesafb.nix
@@ -16,10 +16,10 @@ in {
       v86d.package = mkOption {
         type = types.package;
         description = mdDoc "Which v86d package to use with uvesafb";
-        defaultText = ''config.boot.kernelPackages.v86d.overrideAttrs (old: {
+        defaultText = ''config.boot.kernel.packages.v86d.overrideAttrs (old: {
           hardeningDisable = [ "all" ];
         })'';
-        default = config.boot.kernelPackages.v86d.overrideAttrs (old: {
+        default = config.boot.kernel.packages.v86d.overrideAttrs (old: {
           hardeningDisable = [ "all" ];
         });
       };
@@ -27,7 +27,7 @@ in {
   };
   config = mkIf cfg.enable {
     boot.initrd = {
-      kernelModules = [ "uvesafb" ];
+      kernel.modules = [ "uvesafb" ];
       extraFiles."/usr/v86d".source = cfg.v86d.package;
     };
 

--- a/nixos/modules/tasks/cpu-freq.nix
+++ b/nixos/modules/tasks/cpu-freq.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  cpupower = config.boot.kernelPackages.cpupower;
+  cpupower = config.boot.kernel.packages.cpupower;
   cfg = config.powerManagement;
 in
 
@@ -65,7 +65,7 @@ in
     in
     mkIf enable {
 
-      boot.kernelModules = optional governorEnable "cpufreq_${cfg.cpuFreqGovernor}";
+      boot.kernel.modules = optional governorEnable "cpufreq_${cfg.cpuFreqGovernor}";
 
       environment.systemPackages = [ cpupower ];
 

--- a/nixos/modules/tasks/filesystems/apfs.nix
+++ b/nixos/modules/tasks/filesystems/apfs.nix
@@ -13,9 +13,9 @@ in
 
     system.fsPackages = [ pkgs.apfsprogs ];
 
-    boot.extraModulePackages = [ config.boot.kernelPackages.apfs ];
+    boot.extraModulePackages = [ config.boot.kernel.packages.apfs ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "apfs" ];
+    boot.initrd.kernel.modules = mkIf inInitrd [ "apfs" ];
 
     # Don't copy apfsck into the initramfs since it does not support repairing the filesystem
   };

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -49,7 +49,7 @@ in
       environment.systemPackages = lib.optional (config.boot.initrd.systemd.enable) pkgs.bcachefs-tools;
 
       # use kernel package with bcachefs support until it's in mainline
-      boot.kernelPackages = pkgs.linuxPackages_testing_bcachefs;
+      boot.kernel.packages = pkgs.linuxPackages_testing_bcachefs;
     }
 
     (mkIf ((elem "bcachefs" config.boot.initrd.supportedFilesystems) || (bootFs != {})) {

--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -53,10 +53,10 @@ in
     (mkIf enableBtrfs {
       system.fsPackages = [ pkgs.btrfs-progs ];
 
-      boot.initrd.kernelModules = mkIf inInitrd [ "btrfs" ];
+      boot.initrd.kernel.modules = mkIf inInitrd [ "btrfs" ];
       boot.initrd.availableKernelModules = mkIf inInitrd (
         [ "crc32c" ]
-        ++ optionals (config.boot.kernelPackages.kernel.kernelAtLeast "5.5") [
+        ++ optionals (config.boot.kernel.packages.kernel.kernelAtLeast "5.5") [
           # Needed for mounting filesystems with new checksums
           "xxhash_generic"
           "blake2b_generic"

--- a/nixos/modules/tasks/filesystems/exfat.nix
+++ b/nixos/modules/tasks/filesystems/exfat.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   config = mkIf (any (fs: fs == "exfat") config.boot.supportedFilesystems) {
-    system.fsPackages = if config.boot.kernelPackages.kernelOlder "5.7" then [
+    system.fsPackages = if config.boot.kernel.packages.kernelOlder "5.7" then [
       pkgs.exfat # FUSE
     ] else [
       pkgs.exfatprogs # non-FUSE

--- a/nixos/modules/tasks/filesystems/jfs.nix
+++ b/nixos/modules/tasks/filesystems/jfs.nix
@@ -10,7 +10,7 @@ in
 
     system.fsPackages = [ pkgs.jfsutils ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "jfs" ];
+    boot.initrd.kernel.modules = mkIf inInitrd [ "jfs" ];
 
     boot.initrd.extraUtilsCommands = mkIf (inInitrd && !config.boot.initrd.systemd.enable) ''
       copy_bin_and_libs ${pkgs.jfsutils}/sbin/fsck.jfs

--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -78,7 +78,7 @@ in
 
     system.fsPackages = [ pkgs.nfs-utils ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "nfs" ];
+    boot.initrd.kernel.modules = mkIf inInitrd [ "nfs" ];
 
     systemd.packages = [ pkgs.nfs-utils ];
 

--- a/nixos/modules/tasks/filesystems/reiserfs.nix
+++ b/nixos/modules/tasks/filesystems/reiserfs.nix
@@ -13,7 +13,7 @@ in
 
     system.fsPackages = [ pkgs.reiserfsprogs ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "reiserfs" ];
+    boot.initrd.kernel.modules = mkIf inInitrd [ "reiserfs" ];
 
     boot.initrd.extraUtilsCommands = mkIf (inInitrd && !config.boot.initrd.systemd.enable)
       ''

--- a/nixos/modules/tasks/filesystems/unionfs-fuse.nix
+++ b/nixos/modules/tasks/filesystems/unionfs-fuse.nix
@@ -4,7 +4,7 @@
   config = lib.mkMerge [
 
     (lib.mkIf (lib.any (fs: fs == "unionfs-fuse") config.boot.initrd.supportedFilesystems) {
-      boot.initrd.kernelModules = [ "fuse" ];
+      boot.initrd.kernel.modules = [ "fuse" ];
 
       boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
         copy_bin_and_libs ${pkgs.fuse}/sbin/mount.fuse

--- a/nixos/modules/tasks/filesystems/vboxsf.nix
+++ b/nixos/modules/tasks/filesystems/vboxsf.nix
@@ -17,7 +17,7 @@ in
 
     system.fsPackages = [ package ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "vboxsf" ];
+    boot.initrd.kernel.modules = mkIf inInitrd [ "vboxsf" ];
 
   };
 }

--- a/nixos/modules/tasks/filesystems/vfat.nix
+++ b/nixos/modules/tasks/filesystems/vfat.nix
@@ -13,7 +13,7 @@ in
 
     system.fsPackages = [ pkgs.dosfstools pkgs.mtools ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "vfat" "nls_cp437" "nls_iso8859-1" ];
+    boot.initrd.kernel.modules = mkIf inInitrd [ "vfat" "nls_cp437" "nls_iso8859-1" ];
 
     boot.initrd.extraUtilsCommands = mkIf (inInitrd && !config.boot.initrd.systemd.enable)
       ''

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -535,22 +535,22 @@ in
       ];
 
       boot = {
-        kernelModules = [ "zfs" ];
+        kernel.modules = [ "zfs" ];
         # https://github.com/openzfs/zfs/issues/260
         # https://github.com/openzfs/zfs/issues/12842
         # https://github.com/NixOS/nixpkgs/issues/106093
-        kernelParams = lib.optionals (!config.boot.zfs.allowHibernation) [ "nohibernate" ];
+        kernel.params = lib.optionals (!config.boot.zfs.allowHibernation) [ "nohibernate" ];
 
         extraModulePackages = [
           (if config.boot.zfs.enableUnstable then
-            config.boot.kernelPackages.zfsUnstable
+            config.boot.kernel.packages.zfsUnstable
            else
-            config.boot.kernelPackages.zfs)
+            config.boot.kernel.packages.zfs)
         ];
       };
 
       boot.initrd = mkIf inInitrd {
-        kernelModules = [ "zfs" ] ++ optional (!cfgZfs.enableUnstable) "spl";
+        kernel.modules = [ "zfs" ] ++ optional (!cfgZfs.enableUnstable) "spl";
         extraUtilsCommands =
           ''
             copy_bin_and_libs ${cfgZfs.package}/sbin/zfs

--- a/nixos/modules/tasks/lvm.nix
+++ b/nixos/modules/tasks/lvm.nix
@@ -58,7 +58,7 @@ in {
     })
     (mkIf cfg.boot.thin.enable {
       boot.initrd = {
-        kernelModules = [ "dm-snapshot" "dm-thin-pool" ];
+        kernel.modules = [ "dm-snapshot" "dm-thin-pool" ];
 
         systemd.initrdBin = lib.mkIf config.boot.initrd.services.lvm.enable [ pkgs.thin-provisioning-tools ];
 
@@ -84,7 +84,7 @@ in {
     (mkIf cfg.boot.vdo.enable {
       boot = {
         initrd = {
-          kernelModules = [ "kvdo" ];
+          kernel.modules = [ "kvdo" ];
 
           systemd.initrdBin = lib.mkIf config.boot.initrd.services.lvm.enable [ pkgs.vdo ];
 
@@ -102,7 +102,7 @@ in {
             done
           '';
         };
-        extraModulePackages = [ config.boot.kernelPackages.kvdo ];
+        extraModulePackages = [ config.boot.kernel.packages.kvdo ];
       };
 
       services.lvm.package = mkOverride 999 pkgs.lvm2_vdo;  # this overrides mkDefault

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1359,7 +1359,7 @@ in
         }
       ];
 
-    boot.kernelModules = [ ]
+    boot.kernel.modules = [ ]
       ++ optional hasVirtuals "tun"
       ++ optional hasSits "sit"
       ++ optional hasGres "gre"

--- a/nixos/modules/tasks/scsi-link-power-management.nix
+++ b/nixos/modules/tasks/scsi-link-power-management.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.powerManagement.scsiLinkPolicy;
 
-  kernel = config.boot.kernelPackages.kernel;
+  kernel = config.boot.kernel.packages.kernel;
 
   allowedValues = [
     "min_power"

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -47,9 +47,9 @@ in
     boot.zfs.devNodes = mkIf cfg.zfs.enable "/dev/";
 
     boot.extraModulePackages = [
-      config.boot.kernelPackages.ena
+      config.boot.kernel.packages.ena
     ];
-    boot.initrd.kernelModules = [ "xen-blkfront" ];
+    boot.initrd.kernel.modules = [ "xen-blkfront" ];
     boot.initrd.availableKernelModules = [ "nvme" ];
     boot.kernelParams = [ "console=ttyS0,115200n8" "random.trust_cpu=on" ];
 

--- a/nixos/modules/virtualisation/anbox.nix
+++ b/nixos/modules/virtualisation/anbox.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.virtualisation.anbox;
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
   addrOpts = v: addr: pref: name: {
     address = mkOption {
       default = addr;
@@ -67,7 +67,7 @@ in
   config = mkIf cfg.enable {
 
     assertions = singleton {
-      assertion = versionAtLeast (getVersion config.boot.kernelPackages.kernel) "4.18";
+      assertion = versionAtLeast (getVersion config.boot.kernel.packages.kernel) "4.18";
       message = "Anbox needs user namespace support to work properly";
     };
 

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -43,7 +43,7 @@ in
         message = "Windows Azure Linux Agent is not compatible with NetworkManager";
       }];
 
-    boot.initrd.kernelModules = [ "ata_piix" ];
+    boot.initrd.kernel.modules = [ "ata_piix" ];
     networking.firewall.allowedUDPPorts = [ 68 ];
 
 

--- a/nixos/modules/virtualisation/azure-common.nix
+++ b/nixos/modules/virtualisation/azure-common.nix
@@ -8,7 +8,7 @@ with lib;
   virtualisation.azure.agent.enable = true;
 
   boot.kernelParams = [ "console=ttyS0" "earlyprintk=ttyS0" "rootdelay=300" "panic=1" "boot.panic_on_fail" ];
-  boot.initrd.kernelModules = [ "hv_vmbus" "hv_netvsc" "hv_utils" "hv_storvsc" ];
+  boot.initrd.kernel.modules = [ "hv_vmbus" "hv_netvsc" "hv_utils" "hv_storvsc" ];
 
   # Generate a GRUB menu.
   boot.loader.grub.device = "/dev/sda";

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -120,7 +120,7 @@ in
       engine = {
         init_path = "${pkgs.catatonit}/bin/catatonit";
       } // lib.optionalAttrs cfg.ociSeccompBpfHook.enable {
-        hooks_dir = [ config.boot.kernelPackages.oci-seccomp-bpf-hook ];
+        hooks_dir = [ config.boot.kernel.packages.oci-seccomp-bpf-hook ];
       };
     };
 

--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -118,7 +118,7 @@ in
         pinns_path = "${cfg.package}/bin/pinns";
         hooks_dir =
           optional (config.virtualisation.containers.ociSeccompBpfHook.enable)
-            config.boot.kernelPackages.oci-seccomp-bpf-hook;
+            config.boot.kernel.packages.oci-seccomp-bpf-hook;
 
         default_runtime = mkIf (cfg.runtime != null) cfg.runtime;
         runtimes = mkIf (cfg.runtime != null) {

--- a/nixos/modules/virtualisation/digital-ocean-config.nix
+++ b/nixos/modules/virtualisation/digital-ocean-config.nix
@@ -39,8 +39,8 @@ with lib;
       boot = {
         growPartition = true;
         kernelParams = [ "console=ttyS0" "panic=1" "boot.panic_on_fail" ];
-        initrd.kernelModules = [ "virtio_scsi" ];
-        kernelModules = [ "virtio_pci" "virtio_net" ];
+        initrd.kernel.modules = [ "virtio_scsi" ];
+        kernel.modules = [ "virtio_pci" "virtio_net" ];
         loader = {
           grub.device = "/dev/vda";
           timeout = 0;

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -163,7 +163,7 @@ in
   ###### implementation
 
   config = mkIf cfg.enable (mkMerge [{
-      boot.kernelModules = [ "bridge" "veth" "br_netfilter" "xt_nat" ];
+      boot.kernel.modules = [ "bridge" "veth" "br_netfilter" "xt_nat" ];
       boot.kernel.sysctl = {
         "net.ipv4.conf.all.forwarding" = mkOverride 98 true;
         "net.ipv4.conf.default.forwarding" = mkOverride 98 true;

--- a/nixos/modules/virtualisation/google-compute-config.nix
+++ b/nixos/modules/virtualisation/google-compute-config.nix
@@ -25,8 +25,8 @@ in
 
   boot.growPartition = true;
   boot.kernelParams = [ "console=ttyS0" "panic=1" "boot.panic_on_fail" ];
-  boot.initrd.kernelModules = [ "virtio_scsi" ];
-  boot.kernelModules = [ "virtio_pci" "virtio_net" ];
+  boot.initrd.kernel.modules = [ "virtio_scsi" ];
+  boot.kernel.modules = [ "virtio_pci" "virtio_net" ];
 
   # Generate a GRUB menu.
   boot.loader.grub.device = "/dev/sda";

--- a/nixos/modules/virtualisation/hyperv-guest.nix
+++ b/nixos/modules/virtualisation/hyperv-guest.nix
@@ -27,7 +27,7 @@ in {
 
   config = mkIf cfg.enable {
     boot = {
-      initrd.kernelModules = [
+      initrd.kernel.modules = [
         "hv_balloon" "hv_netvsc" "hv_storvsc" "hv_utils" "hv_vmbus"
       ];
 
@@ -38,7 +38,7 @@ in {
       ];
     };
 
-    environment.systemPackages = [ config.boot.kernelPackages.hyperv-daemons.bin ];
+    environment.systemPackages = [ config.boot.kernel.packages.hyperv-daemons.bin ];
 
     # enable hotadding cpu/memory
     services.udev.packages = lib.singleton (pkgs.writeTextFile {
@@ -54,7 +54,7 @@ in {
     });
 
     systemd = {
-      packages = [ config.boot.kernelPackages.hyperv-daemons.lib ];
+      packages = [ config.boot.kernel.packages.hyperv-daemons.lib ];
 
       targets.hyperv-daemons = {
         wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/virtualisation/kvmgt.nix
+++ b/nixos/modules/virtualisation/kvmgt.nix
@@ -5,7 +5,7 @@ with lib;
 let
   cfg = config.virtualisation.kvmgt;
 
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
 
   vgpuOptions = {
     uuid = mkOption {
@@ -48,7 +48,7 @@ in {
       message = "KVMGT is not properly supported for kernels older than 4.16";
     };
 
-    boot.kernelModules = [ "kvmgt" ];
+    boot.kernel.modules = [ "kvmgt" ];
     boot.kernelParams = [ "i915.enable_gvt=1" ];
 
     services.udev.extraRules = ''

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -277,7 +277,7 @@ in
       etc.ethertypes.source = "${pkgs.iptables}/etc/ethertypes";
     };
 
-    boot.kernelModules = [ "tun" ];
+    boot.kernel.modules = [ "tun" ];
 
     users.groups.libvirtd.gid = config.ids.gids.libvirtd;
 

--- a/nixos/modules/virtualisation/linode-config.nix
+++ b/nixos/modules/virtualisation/linode-config.nix
@@ -49,8 +49,8 @@ with lib;
     ];
 
     # Set Up LISH Serial Connection
-    kernelParams = [ "console=ttyS0,19200n8" ];
-    kernelModules = [ "virtio_net" ];
+    kernel.params = [ "console=ttyS0,19200n8" ];
+    kernel.modules = [ "virtio_net" ];
 
     loader = {
       # Increase Timeout to Allow LISH Connection

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -184,7 +184,7 @@ in {
       "kernel.keys.maxkeys" = 2000;
     };
 
-    boot.kernelModules = [ "veth" "xt_comment" "xt_CHECKSUM" "xt_MASQUERADE" ]
+    boot.kernel.modules = [ "veth" "xt_comment" "xt_CHECKSUM" "xt_MASQUERADE" ]
       ++ optionals (!config.networking.nftables.enable) [ "iptable_mangle" ];
   };
 }

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -290,7 +290,7 @@ let
     DeviceAllow = map (d: "${d.node} ${d.modifier}") cfg.allowedDevices;
   };
 
-  kernelVersion = config.boot.kernelPackages.kernel.version;
+  kernelVersion = config.boot.kernel.packages.kernel.version;
 
   bindMountOpts = { name, ... }: {
 
@@ -890,7 +890,7 @@ in
       nixos-container
     ];
 
-    boot.kernelModules = [
+    boot.kernel.modules = [
       "bridge"
       "macvlan"
       "tap"

--- a/nixos/modules/virtualisation/openvswitch.nix
+++ b/nixos/modules/virtualisation/openvswitch.nix
@@ -56,7 +56,7 @@ in {
 
   in {
     environment.systemPackages = [ cfg.package ];
-    boot.kernelModules = [ "tun" "openvswitch" ];
+    boot.kernel.modules = [ "tun" "openvswitch" ];
 
     boot.extraModulePackages = [ cfg.package ];
 

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -33,9 +33,9 @@ in
 
       package = mkOption {
         type = types.nullOr types.package;
-        default = config.boot.kernelPackages.prl-tools;
-        defaultText = "config.boot.kernelPackages.prl-tools";
-        example = literalExpression "config.boot.kernelPackages.prl-tools";
+        default = config.boot.kernel.packages.prl-tools;
+        defaultText = "config.boot.kernel.packages.prl-tools";
+        example = literalExpression "config.boot.kernel.packages.prl-tools";
         description = lib.mdDoc ''
           Defines which package to use for prl-tools. Override to change the version.
         '';
@@ -52,7 +52,7 @@ in
 
     boot.extraModulePackages = [ prl-tools ];
 
-    boot.kernelModules = [ "prl_fs" "prl_fs_freeze" "prl_tg" ]
+    boot.kernel.modules = [ "prl_fs" "prl_fs_freeze" "prl_tg" ]
       ++ optional (pkgs.stdenv.hostPlatform.system == "aarch64-linux") "prl_notifier";
 
     services.timesyncd.enable = false;

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -961,7 +961,7 @@ in
     boot.loader.grub.device = mkVMOverride (if cfg.useEFIBoot then "nodev" else cfg.bootLoaderDevice);
     boot.loader.grub.gfxmodeBios = with cfg.resolution; "${toString x}x${toString y}";
 
-    boot.initrd.kernelModules = optionals (cfg.useNixStoreImage && !cfg.writableStore) [ "erofs" ];
+    boot.initrd.kernel.modules = optionals (cfg.useNixStoreImage && !cfg.writableStore) [ "erofs" ];
 
     boot.loader.supportsInitrdSecrets = mkIf (!cfg.useBootLoader) (mkVMOverride false);
 

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -7,7 +7,7 @@ with lib;
 let
 
   cfg = config.virtualisation.virtualbox.guest;
-  kernel = config.boot.kernelPackages;
+  kernel = config.boot.kernel.packages;
 
 in
 

--- a/nixos/modules/virtualisation/virtualbox-host.nix
+++ b/nixos/modules/virtualisation/virtualbox-host.nix
@@ -10,7 +10,7 @@ let
     extensionPack = if cfg.enableExtensionPack then pkgs.virtualboxExtpack else null;
   };
 
-  kernelModules = config.boot.kernelPackages.virtualbox.override {
+  kernelModules = config.boot.kernel.packages.virtualbox.override {
     inherit virtualbox;
   };
 
@@ -93,7 +93,7 @@ in
   config = mkIf cfg.enable (mkMerge [{
     warnings = mkIf (config.nixpkgs.config.virtualbox.enableExtensionPack or false)
       ["'nixpkgs.virtualbox.enableExtensionPack' has no effect, please use 'virtualisation.virtualbox.host.enableExtensionPack'"];
-    boot.kernelModules = [ "vboxdrv" "vboxnetadp" "vboxnetflt" ];
+    boot.kernel.modules = [ "vboxdrv" "vboxnetadp" "vboxnetflt" ];
     boot.extraModulePackages = [ kernelModules ];
     environment.systemPackages = [ virtualbox ];
 

--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -29,7 +29,7 @@ in
     } ];
 
     boot.initrd.availableKernelModules = [ "mptspi" ];
-    boot.initrd.kernelModules = [ "vmw_pvscsi" ];
+    boot.initrd.kernel.modules = [ "vmw_pvscsi" ];
 
     environment.systemPackages = [ open-vm-tools ];
 

--- a/nixos/modules/virtualisation/vmware-host.nix
+++ b/nixos/modules/virtualisation/vmware-host.nix
@@ -63,9 +63,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    boot.extraModulePackages = [ config.boot.kernelPackages.vmware ];
+    boot.extraModulePackages = [ config.boot.kernel.packages.vmware ];
     boot.extraModprobeConfig = "alias char-major-10-229 fuse";
-    boot.kernelModules = [ "vmw_pvscsi" "vmw_vmci" "vmmon" "vmnet" "fuse" ];
+    boot.kernel.modules = [ "vmw_pvscsi" "vmw_vmci" "vmmon" "vmnet" "fuse" ];
 
     environment.systemPackages = [ cfg.package ] ++ cfg.extraPackages;
     services.printing.drivers = [ cfg.package ];

--- a/nixos/modules/virtualisation/waydroid.nix
+++ b/nixos/modules/virtualisation/waydroid.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.virtualisation.waydroid;
-  kernelPackages = config.boot.kernelPackages;
+  kernelPackages = config.boot.kernel.packages;
   waydroidGbinderConf = pkgs.writeText "waydroid.conf" ''
     [Protocol]
     /dev/binder = aidl2
@@ -27,7 +27,7 @@ in
 
   config = mkIf cfg.enable {
     assertions = singleton {
-      assertion = versionAtLeast (getVersion config.boot.kernelPackages.kernel) "4.18";
+      assertion = versionAtLeast (getVersion config.boot.kernel.packages.kernel) "4.18";
       message = "Waydroid needs user namespace support to work properly";
     };
 

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -161,7 +161,7 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    boot.kernelModules =
+    boot.kernel.modules =
       [ "xen-evtchn" "xen-gntdev" "xen-gntalloc" "xen-blkback" "xen-netback"
         "xen-pciback" "evtchn" "gntdev" "netbk" "blkbk" "xen-scsibk"
         "usbbk" "pciback" "xen-acpi-processor" "blktap2" "tun" "netxen_nic"
@@ -172,7 +172,7 @@ in
     # The xenfs module is needed in system.activationScripts.xen, but
     # the modprobe command there fails silently. Include xenfs in the
     # initrd as a work around.
-    boot.initrd.kernelModules = [ "xenfs" ];
+    boot.initrd.kernel.modules = [ "xenfs" ];
 
     # The radeonfb kernel module causes the screen to go black as soon
     # as it's loaded, so don't load it.

--- a/nixos/modules/virtualisation/xen-domU.nix
+++ b/nixos/modules/virtualisation/xen-domU.nix
@@ -5,7 +5,7 @@
 {
   boot.loader.grub.device = "nodev";
 
-  boot.initrd.kernelModules =
+  boot.initrd.kernel.modules =
     [ "xen-blkfront" "xen-tpmfront" "xen-kbdfront" "xen-fbfront"
       "xen-netfront" "xen-pcifront" "xen-scsifront"
     ];

--- a/nixos/tests/boot-stage1.nix
+++ b/nixos/tests/boot-stage1.nix
@@ -5,8 +5,8 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     boot.extraModulePackages = let
       compileKernelModule = name: source: pkgs.runCommandCC name rec {
         inherit source;
-        kdev = config.boot.kernelPackages.kernel.dev;
-        kver = config.boot.kernelPackages.kernel.modDirVersion;
+        kdev = config.boot.kernel.packages.kernel.dev;
+        kver = config.boot.kernel.packages.kernel.modDirVersion;
         ksrc = "${kdev}/lib/modules/${kver}/build";
         hardeningDisable = [ "pic" ];
         nativeBuildInputs = kdev.moduleBuildDependencies;
@@ -67,7 +67,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     in lib.singleton kcanary;
 
-    boot.initrd.kernelModules = [ "kcanary" ];
+    boot.initrd.kernel.modules = [ "kcanary" ];
 
     boot.initrd.extraUtilsCommands = let
       compile = name: source: pkgs.runCommandCC name { inherit source; } ''

--- a/nixos/tests/ceph-multi-node.nix
+++ b/nixos/tests/ceph-multi-node.nix
@@ -51,7 +51,7 @@ let
       libressl.nc
     ];
 
-    boot.kernelModules = [ "xfs" ];
+    boot.kernel.modules = [ "xfs" ];
 
     services.ceph = cephConfig;
   };

--- a/nixos/tests/ceph-single-node-bluestore.nix
+++ b/nixos/tests/ceph-single-node-bluestore.nix
@@ -47,7 +47,7 @@ let
       xfsprogs
     ];
 
-    boot.kernelModules = [ "xfs" ];
+    boot.kernel.modules = [ "xfs" ];
 
     services.ceph = cephConfig;
   };

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -47,7 +47,7 @@ let
       xfsprogs
     ];
 
-    boot.kernelModules = [ "xfs" ];
+    boot.kernel.modules = [ "xfs" ];
 
     services.ceph = cephConfig;
   };

--- a/nixos/tests/chrony-ptp.nix
+++ b/nixos/tests/chrony-ptp.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ lib, ... }:
 
   nodes = {
     qemuGuest = { lib, ... }: {
-      boot.kernelModules = [ "ptp_kvm" ];
+      boot.kernel.modules = [ "ptp_kvm" ];
 
       services.chrony = {
         enable = true;

--- a/nixos/tests/cockroachdb.nix
+++ b/nixos/tests/cockroachdb.nix
@@ -61,7 +61,7 @@ let
       # device to appear as a reference clock, synchronized to the host clock.
       # Because CockroachDB *requires* a time-synchronization mechanism for
       # the system time in a cluster scenario, this is necessary to work.
-      boot.kernelModules = [ "ptp_kvm" ];
+      boot.kernel.modules = [ "ptp_kvm" ];
 
       # Enable and configure Chrony, using the given virtualized clock passed
       # through by KVM.

--- a/nixos/tests/connman.nix
+++ b/nixos/tests/connman.nix
@@ -39,7 +39,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
     virtualisation.vlans = [ 1 ];
 
     # add a virtual wlan interface
-    boot.kernelModules = [ "mac80211_hwsim" ];
+    boot.kernel.modules = [ "mac80211_hwsim" ];
     boot.extraModprobeConfig = ''
       options mac80211_hwsim radios=1
     '';

--- a/nixos/tests/containers-names.nix
+++ b/nixos/tests/containers-names.nix
@@ -7,7 +7,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   nodes.machine = { ... }: {
     # We're using the newest kernel, so that we can test containers with long names.
     # Please see https://github.com/NixOS/nixpkgs/issues/38509 for details.
-    boot.kernelPackages = pkgs.linuxPackages_latest;
+    boot.kernel.packages = pkgs.linuxPackages_latest;
 
     containers = let
       container = subnet: {

--- a/nixos/tests/ecryptfs.nix
+++ b/nixos/tests/ecryptfs.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix ({ ... }:
 
   nodes.machine = { pkgs, ... }: {
     imports = [ ./common/user-account.nix ];
-    boot.kernelModules = [ "ecryptfs" ];
+    boot.kernel.modules = [ "ecryptfs" ];
     security.pam.enableEcryptfs = true;
     environment.systemPackages = with pkgs; [ keyutils ];
   };

--- a/nixos/tests/env.nix
+++ b/nixos/tests/env.nix
@@ -6,7 +6,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
   nodes.machine = { pkgs, ... }:
     {
-      boot.kernelPackages = pkgs.linuxPackages;
+      boot.kernel.packages = pkgs.linuxPackages;
       environment.etc.plainFile.text = ''
         Hello World
       '';

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -24,7 +24,7 @@ in
 
       # Create a virtual sound device, with mixing
       # and all, for recording audio.
-      boot.kernelModules = [ "snd-aloop" ];
+      boot.kernel.modules = [ "snd-aloop" ];
       sound.enable = true;
       sound.extraConfig = ''
         pcm.!default {

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -28,9 +28,9 @@ import ./make-test-python.nix ({ pkgs, ... } : {
         };
       };
       boot.extraModulePackages =
-        optional (versionOlder config.boot.kernelPackages.kernel.version "5.6")
-          config.boot.kernelPackages.wireguard;
-      boot.kernelModules = [ "wireguard" ];
+        optional (versionOlder config.boot.kernel.packages.kernel.version "5.6")
+          config.boot.kernel.packages.wireguard;
+      boot.kernel.modules = [ "wireguard" ];
     };
 
   testScript =

--- a/nixos/tests/initrd-secrets.nix
+++ b/nixos/tests/initrd-secrets.nix
@@ -24,7 +24,7 @@ let
       '';
       boot.initrd.compressor = compressor;
       # zstd compression is only supported from 5.9 onwards. Remove when 5.10 becomes default.
-      boot.kernelPackages = pkgs.linuxPackages_latest;
+      boot.kernel.packages = pkgs.linuxPackages_latest;
     };
 
     testScript = ''

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -201,7 +201,7 @@ let
 
       # FIXME: Nix 2.4 broke nixos-option, someone has to fix it.
       # with subtest("Test nixos-option"):
-      #     kernel_modules = machine.succeed("nixos-option boot.initrd.kernelModules")
+      #     kernel_modules = machine.succeed("nixos-option boot.initrd.kernel.modules")
       #     assert "virtio_console" in kernel_modules
       #     assert "List of modules" in kernel_modules
       #     assert "qemu-guest.nix" in kernel_modules

--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -14,7 +14,7 @@ let
 
     nodes.machine = { ... }:
       {
-        boot.kernelPackages = linuxPackages;
+        boot.kernel.packages = linuxPackages;
       };
 
     testScript =

--- a/nixos/tests/kernel-latest-ath-user-regd.nix
+++ b/nixos/tests/kernel-latest-ath-user-regd.nix
@@ -6,7 +6,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
   nodes.machine = { pkgs, ... }:
     {
-      boot.kernelPackages = pkgs.linuxPackages_latest;
+      boot.kernel.packages = pkgs.linuxPackages_latest;
       networking.wireless.athUserRegulatoryDomain = true;
     };
 

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... }:
 
   nodes.machine =
     { pkgs, lib, ... }:
-    { boot.kernelPackages = lib.mkIf latestKernel pkgs.linuxPackages_latest;
+    { boot.kernel.packages = lib.mkIf latestKernel pkgs.linuxPackages_latest;
       sound.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     };
 

--- a/nixos/tests/lvm2/systemd-stage-1.nix
+++ b/nixos/tests/lvm2/systemd-stage-1.nix
@@ -19,7 +19,7 @@
 
   extraConfig = {
     raid = {
-      boot.initrd.kernelModules = [
+      boot.initrd.kernel.modules = [
         "dm-raid"
         "raid0"
       ];

--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -36,7 +36,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
     };
 
     mkServer = { mpd, musicService, }:
-      { boot.kernelModules = [ "snd-dummy" ];
+      { boot.kernel.modules = [ "snd-dummy" ];
         sound.enable = true;
         services.mpd = mpd;
         systemd.services.musicService = musicService;

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -985,7 +985,7 @@ let
     in {
       name = "WlanInterface";
       nodes.machine = { pkgs, ... }: {
-        boot.kernelModules = [ "mac80211_hwsim" ];
+        boot.kernel.modules = [ "mac80211_hwsim" ];
         networking.wlanInterfaces = {
           wlan0 = { device = "wlan0"; };
           wap0 = { device = "wlan0"; mac = testMac; };

--- a/nixos/tests/systemd-analyze.nix
+++ b/nixos/tests/systemd-analyze.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... }:
 
   nodes.machine =
     { pkgs, lib, ... }:
-    { boot.kernelPackages = lib.mkIf latestKernel pkgs.linuxPackages_latest;
+    { boot.kernel.packages = lib.mkIf latestKernel pkgs.linuxPackages_latest;
       sound.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     };
 

--- a/nixos/tests/systemd-initrd-modprobe.nix
+++ b/nixos/tests/systemd-initrd-modprobe.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
 
   nodes.machine = { pkgs, ... }: {
     boot.initrd.systemd.enable = true;
-    boot.initrd.kernelModules = [ "loop" ]; # Load module in initrd.
+    boot.initrd.kernel.modules = [ "loop" ]; # Load module in initrd.
     boot.extraModprobeConfig = ''
       options loop max_loop=42
     '';

--- a/nixos/tests/systemd-initrd-swraid.nix
+++ b/nixos/tests/systemd-initrd-swraid.nix
@@ -25,7 +25,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
           ARRAY /dev/md0 devices=/dev/vdb,/dev/vdc
         '';
       };
-      kernelModules = [ "raid0" ];
+      kernel.modules = [ "raid0" ];
     };
 
     specialisation.boot-swraid.configuration.virtualisation.rootDevice = "/dev/disk/by-label/testraid";

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -57,7 +57,7 @@ let
 
     virtualisation.virtualbox.guest.enable = true;
 
-    boot.initrd.kernelModules = [
+    boot.initrd.kernel.modules = [
       "af_packet" "vboxsf"
       "virtio" "virtio_pci" "virtio_ring" "virtio_net" "vboxguest"
     ];

--- a/nixos/tests/wireguard/wg-quick.nix
+++ b/nixos/tests/wireguard/wg-quick.nix
@@ -3,7 +3,7 @@ import ../make-test-python.nix ({ pkgs, lib, kernelPackages ? null, nftables ? f
     wg-snakeoil-keys = import ./snakeoil-keys.nix;
     peer = import ./make-peer.nix { inherit lib; };
     commonConfig = {
-      boot.kernelPackages = lib.mkIf (kernelPackages != null) kernelPackages;
+      boot.kernel.packages = lib.mkIf (kernelPackages != null) kernelPackages;
       networking.nftables.enable = nftables;
       # Make sure iptables doesn't work with nftables enabled
       boot.blacklistedKernelModules = lib.mkIf nftables [ "nft_compat" ];

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
     imports = [ ../modules/profiles/minimal.nix ];
 
     # add a virtual wlan interface
-    boot.kernelModules = [ "mac80211_hwsim" ];
+    boot.kernel.modules = [ "mac80211_hwsim" ];
 
     # wireless access point
     services.hostapd = {

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -34,7 +34,7 @@ let
         boot.loader.timeout = 0;
         boot.loader.efi.canTouchEfiVariables = true;
         networking.hostId = "deadbeef";
-        boot.kernelPackages = kernelPackage;
+        boot.kernel.packages = kernelPackage;
         boot.supportedFilesystems = [ "zfs" ];
         boot.zfs.enableUnstable = enableUnstable;
         boot.initrd.systemd.enable = enableSystemdStage1;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
