### PR TITLE
[22.05] firefox-{,bin-}unwrapped: 106.0.1 -> 106.0.2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "106.0.1";
+  version = "106.0.2";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ach/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ach/firefox-106.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "73e8b50a234cf18ad9f4ee8d5ae54a3b33a560ad1555aaad92399d5d489c4127";
+      sha256 = "a95a15867548160d795cd1ecb56ae90b7aa9c7db6f15d5cae8cdb522c471cdd4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/af/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/af/firefox-106.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "c74ebe3630f36c9f07265c9fae64e6efa120851640c6b413a473777220cf79bc";
+      sha256 = "00d2e72c8317c8cd88520836589aebaaa97eb161e77ebf874d0b8c4395c8a5c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/an/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/an/firefox-106.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "dd1871d27579d521857d3c86e4bfb3eac6a229f1999cfc0ee621cb7e4be182b0";
+      sha256 = "628f5521bcaf38cdbaf748f523daf1a881fcb37da1cab7d7045841190ed70844";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ar/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ar/firefox-106.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "a2015703716433213ce8deaa99ddc521c248883359cdb6342e85e337c4ea606e";
+      sha256 = "15ae1a91abc73bddaa0cd6050a9fd4ed5bed116efc269bf086d40fc6b7d9e66d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ast/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ast/firefox-106.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "5ded0e6d3b3fe582f2b0700eb0e11c57d41f5bd0ae16d2d5f380e6d716e28d15";
+      sha256 = "b9d5c9e81c4ed5e13ac4c03e8cd8a7678879b96ec5b7ed3be246a6b3d9885136";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/az/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/az/firefox-106.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "10ac2f3970f2db6101aca9919bc2b3bc9939138e667710c3d6c8299a15c42642";
+      sha256 = "a55f10740870877967a526164ffe8ccb5bb4fdce3d94844656e169f2e5e7471c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/be/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/be/firefox-106.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "fdd878cb53813f28339d609a72fdc3da215310f6fad80dd912c667eaebbe804e";
+      sha256 = "dc0d2d3e5cfd38a6792ae32b83eae236f2d69ca38b7909014cfdbe437a7baa2e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/bg/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/bg/firefox-106.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "5875e2aeab9b270f2c0b2d07c039e12ce7d9d6470975b4a929ee854cfb9903b5";
+      sha256 = "0719c8d93c132ad4c0e1ca3fd766eb9eb4ae4a717c007d6a67e61f3f24baaefd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/bn/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/bn/firefox-106.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "a0377b5d4efbf79ab6bd3ab166dda109ed5448c171679e771d08cf8ad2ab1d02";
+      sha256 = "e15d4412acefee301cae865e5832cc874c1ff5bb848a14e5ae7a7d9e1b08a11f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/br/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/br/firefox-106.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "01215f4d29a1b4af05a7d8cbc4b26f22db5d37c39e1363b1493822791cf99b0e";
+      sha256 = "b420bcc5cb164ff7711cc140cc848a1651816037120ac8e0769ccf2c7d33002f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/bs/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/bs/firefox-106.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "ee6b84e55789a7c603c3354e5ffcccbd0b0bbbee529390f3f02678454b2d2bb6";
+      sha256 = "6f83923e2538169e91d75534bb2ccd18e7d9d5a2928ea0c156572644e50c3d02";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ca-valencia/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ca-valencia/firefox-106.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "af588ab3d57e3dd7e44354a7946da274b7db487a794b803b8ebd39b2ddefdf74";
+      sha256 = "6bbb1c08426d7cd8965e641cb682ab3c5fcb91f2a67c017ccdb7145084b83150";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ca/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ca/firefox-106.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "7d9b6451777d8ae449767d5349f78cab647969f5223c40a990d2032e358872c3";
+      sha256 = "9281bda763a73ecd6152d2a3d35508dbcd0f1eeb9f346add142266105629a2e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/cak/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/cak/firefox-106.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "895a24e38cb5ada57768ae44de17ac111f11dfc2305e9408d334a481b710f66a";
+      sha256 = "69065cf7bbe58b24f06202ecdf10b005f2da751528b447492e50b6b8cdd19f64";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/cs/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/cs/firefox-106.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "efdf4568777c9c33cfc84c2d966a06b1b2642185e0e2c2fd826dee2c402c0c7d";
+      sha256 = "657bf102caa80c87d77610ef41933f4690c9c20f937678b38b3db6203b2d1a71";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/cy/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/cy/firefox-106.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "1db8b754aba37a1b1212359681de5ab2735c3cd1eb663bf97496f18e84d0aa05";
+      sha256 = "e2080798d42f3067d0f0880cb391b5cbabe0ec8bef54fae40d02c4833dd3a876";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/da/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/da/firefox-106.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "03fc6a07c44099474f746ccd3d72dae0b40aa86347d0015db5660bfeb5a87ca5";
+      sha256 = "09918393e885c564f495ed22a6f417c5224fb781892d084d2509651769cab99d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/de/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/de/firefox-106.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "209cad4c90e876d2126db2cf828ba1610c956a133fd9cbb242de6466a43e07d5";
+      sha256 = "a33be323b31c8d9f882a920537f2ab2621e11c3d029a8d121d717527611c73f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/dsb/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/dsb/firefox-106.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "9edb173dc9532aa9de3dc740d31b107d7c8871fe1c82cbc8490277aab01c1b25";
+      sha256 = "32fad47a2d1dd6b63ad8f02b33aca3aa1d807b6944b0f602ff3d807f9f49655d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/el/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/el/firefox-106.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "fccf555e8e6e59a3b055f451d91b3ff1c8f9e03a9d6caa88d8cabe0bd45fe0b9";
+      sha256 = "9e01a4bbbd9181840f1a06ba740b76495e350dac97bc96b3ec1e7cfef406c05e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/en-CA/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/en-CA/firefox-106.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "9b51182e6e7c46c04bf90bf46a36c138943f506a274028c0168919a5b8b1b0a6";
+      sha256 = "74408046e004ed3929a025ad633247284a7e0882be7944b45869356e6f015610";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/en-GB/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/en-GB/firefox-106.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "83980222caa3a7e62385bd87e43f86da1a685638c9400064aebc4be0bea3d447";
+      sha256 = "38e421e36a84fc50942000a5af4158c925d2a3675dc8a5114e736d33db527e72";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/en-US/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/en-US/firefox-106.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "9158e760a1baf524d2dd5095f44e71cfb50062e00074bbd8368b88c9eb547085";
+      sha256 = "4867a211001cc289fbe8ee5eaa04f72691d9a61e44f7c5ddb339ba8a37501bac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/eo/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/eo/firefox-106.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0430f1e7c0284a7654fb207e68138da7aa3c8a6e788668cfe2c9921d5d013822";
+      sha256 = "9c18807ab6bc451596ddf83640ac916cae7f1fc6dfb70f4893cc51552cdcf5bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/es-AR/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/es-AR/firefox-106.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "2ac1a9880364afed678a259f9c3e2082b9d1cf774b2dbcfdb8a0cac66cddcabe";
+      sha256 = "7e25cf4a75e1ddfe8e9b793d675bd74790234f58092c42f8901093c1e963b4c8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/es-CL/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/es-CL/firefox-106.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "75abcd1c04e11dfc9043f9b934aafe40c443a9023e0c39a30848457cd364a40d";
+      sha256 = "8952eefcfea95e60954a4c97c2d8cfc3e542548c91221924ce5b4f68c54bbded";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/es-ES/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/es-ES/firefox-106.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "f4afd36de73083e46e62dd1a71ecbfa1eb6244f61c29ccd5763519474634ce27";
+      sha256 = "66e59163dd0ea4f156d71e3742b9adc1f22f5de1d1046e8b761988784a4df756";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/es-MX/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/es-MX/firefox-106.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "b3d9d0101ad8794c7591f407e49ab395ea9def5ed9bf7b51ab5fe2167c49b71d";
+      sha256 = "be08a87f8eda8845618524112a53cb427272e8365dbd637267d500b23258deca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/et/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/et/firefox-106.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "a518a583fef63e926931bd2a200293dcabf9a22ff1f7554f03f6ebef9c614e4f";
+      sha256 = "0d0660e2a7e5c4c17afad2a68f2f0d262f1fc8366d877b441eb0fd18450e57db";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/eu/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/eu/firefox-106.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "f98694a3a3c21d836b1efb322d60989f90f31af8c06e483739cd33c73053a5b7";
+      sha256 = "ca37cf5bc2efdb5636ea6ad654a64d73a285c46544d887ff8abc38fb6778ee09";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/fa/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/fa/firefox-106.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "1b6afbac73fbb4c54d83d7599a67062bf64bfba3e67bf9e4fbee9249efcd62c0";
+      sha256 = "445dd3b89c33b15e935b32a84e711859c55238b384b3ecb443f9093a4201906f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ff/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ff/firefox-106.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "d78fcd480fe27cb04c3e5e2677598312e45786a3100037fc3fcad5fe64ae073d";
+      sha256 = "6d101c69335026ae36ce9193dbd27487c0e6f47a3199d276263a523d71d302eb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/fi/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/fi/firefox-106.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "c2c05b0f0be4adbe9824f34e59ec131ecd53f1d41279dbe55db2f533d1837b3d";
+      sha256 = "267ea3695844ff090b5ff0a53d16bd5bbd6c7726485096be643fb5ba20e51e7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/fr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/fr/firefox-106.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "1b84a24eba4cdccbe9148ed3dae7f5990f8aceae9174c079ce735bae491592d5";
+      sha256 = "74ad72a8c00681707efbe993476a26571ed90e7ad4485d91b9f39d8b89ecfc18";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/fy-NL/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/fy-NL/firefox-106.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "11c46d35616eb8000030bba7ec711c3d2f0bd71d8fe1b00716ceb087b615949f";
+      sha256 = "f4623d18d7a63afb0643ccb7d7c3e1d93704bec786cf192561c463b9c6ebd33f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ga-IE/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ga-IE/firefox-106.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "c82a8582e7c7a290940f34747dbac10b82a3a7a1dd25f5ec29ea6760452f9ceb";
+      sha256 = "49d0044e38634a531334b356975bf4f023ab0161bb926c6ac7a608adc0f863f6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/gd/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/gd/firefox-106.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a134d92e8ba86138a4fe48abe30e99db22a0eda3d752388b4811f5ded602b2e2";
+      sha256 = "686f456dd0655f6047ae0e44be3acee9655f2cc51964fc9aebdaaf9a30c12e26";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/gl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/gl/firefox-106.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "917ddb3b29c5e79b3133228b2369eda2f1fa8a80e1df045c7f574de98cc20589";
+      sha256 = "b4d5ece230195e2f9b21640a924b74d93cd6da609ab7364ac3be82f49fbcd3f1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/gn/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/gn/firefox-106.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "62d6f290a6d2c5004475a69994238425d9f86809d8bb892ab5d024fc976eb95e";
+      sha256 = "a8e1079a2dc93d6c653f9ad423d554edfb8a85d8edccb00d0819d38d55096239";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/gu-IN/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/gu-IN/firefox-106.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "84b800fda564718c88aeabc8c80a93f81bfd793de36df1692037e5211439533d";
+      sha256 = "4397fb92b09bd037af12d36cba3dff684673d62b9e9c36ae9774ccb6901acfc4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/he/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/he/firefox-106.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "4a45350737358be849dd662ba00ed9678c02fc3c6ee976bbe604ba22973b03f8";
+      sha256 = "bb7d3e2ee215d73b0cfeb65aee4b4acbcc9524806fe5ec5ae5e7449456c841bc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/hi-IN/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/hi-IN/firefox-106.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "10893632acbc8e59a85aaa5f99e5995d483e79c707ae7b59c3db8f7538ad61fa";
+      sha256 = "03eebd1be19a3f2a6f4b869e2f6edc245c6be9001d99c645c280c09a35b7ed7e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/hr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/hr/firefox-106.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "f948c69b4aba2cbaa0bd64fa3bff0db6ea333db055a5977edeba19fd714d39b0";
+      sha256 = "6e17c3970a6af1ee74a04ff87886a309176a1f830d3bac1af7df097abcb1bc27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/hsb/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/hsb/firefox-106.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "b5420b68bc0ac11e84545cbec819f6845464e640591c2cb472e5ecf03c1067d2";
+      sha256 = "b8a8c4444cf5761daf104bad3e7e75e9bfd5fa5ceb3558176a4bb071b62e996f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/hu/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/hu/firefox-106.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "3699a369965dd8b33045dcc1add1d7b5bf3807e6ab0fe71738ad8a3d10c9b992";
+      sha256 = "12ea9f3811a0b37114cd86821261e95438011438dd10a109fe8aaf625db45e7c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/hy-AM/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/hy-AM/firefox-106.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "736ffa083db4fe0a09bee5180ce21a72d232ef93de39d328087d77c700177450";
+      sha256 = "971ec09c1904c6670266b82e2079f14e6643e628688b1b901f2b0a162b891edf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ia/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ia/firefox-106.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "e379bdbc02cbeea8a6ef08c699c31ab21c8a7c850165b3eadf14f9776acee0b4";
+      sha256 = "4f41904dce35a44ca6387bdf254bb115e3f2334bbed68c3a2ccc965b6b9c7410";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/id/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/id/firefox-106.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "494d9711fd6cb8a24a4f9ce8b5a469def31508acfa74a349f5847fab8877bdce";
+      sha256 = "2ce89ec7c303034099253792717099bb7452e9bca62dc6930102bbecb6795583";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/is/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/is/firefox-106.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "b9b5f39f8837b0196d23dcb6126649a163183a3f4a7beea9abf5d2cbc45b5431";
+      sha256 = "651d29de95edbf3e789259134629eae2cd0d6ac756ea602e133a9e7f7a7c4534";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/it/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/it/firefox-106.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "cf472e023000a836092a65c9bc13f3f4bbb1ccc019f0d3618f5f3901ba978c2e";
+      sha256 = "d9eaae70584e1d2523f0e10896e2f943b034445b24590151d83a11d10b8d6d80";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ja/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ja/firefox-106.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "24ad2d46cc17176061de745853dfa149b30006d32652af4bcca0da7852d61bb0";
+      sha256 = "27ffa5b43fc50b04ceb6bf8d83c06dc5eb0c594bdafcca5dfa3fa2911d4367c5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ka/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ka/firefox-106.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "4449b8e64a566f6db99c8474d1710dfdcb7cf9986f84ffe052fed4523a0de585";
+      sha256 = "b2458fd9e59a863ed9b2fc27df76c9d08751a4d8a38a7b75391ad7429b6007e6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/kab/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/kab/firefox-106.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "22891b7087460d0409b24feb8465e2262ae48a7ca672a04ee4aadf7d6c75a735";
+      sha256 = "5ae2300865c9b4259dcb0ad0c04ce7ee20220412590c14bfc0fa3f3fe6f499bf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/kk/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/kk/firefox-106.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "433d1cf6015a8bdeb1ad7ed8ab277d12d7d4bee0ea13e0b9a05d6f9e21485706";
+      sha256 = "18d9192ca60825e69e2ff2f20b9d80e15841b4357a15bfa1772b3dda1ac82338";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/km/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/km/firefox-106.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "797e9129412851205ad74f7b319babdb80510a5e3ad5f09d2f95660cc146fff7";
+      sha256 = "2d7c01f03a96679cb89db9006a16e8860ec66637c8ccaf442f11bd3546640cf0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/kn/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/kn/firefox-106.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "58ee62330f425ec58475012db703fdf28c0f44187fc68c64532b92812ceabbf5";
+      sha256 = "d86317c4e6e1c8401408e7ae6604d754d398f0f5c4ae98ca1ae31b56e3ef932f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ko/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ko/firefox-106.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "30634665e61e844b46f6ee8ccf6c746b233dd91677dde760453656e38913a241";
+      sha256 = "1e95325f28b3819ad65ff0349d56960c64bbd01a10a8a1686fbb43aa37cb2099";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/lij/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/lij/firefox-106.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "175284c0c30974322c1c95904de89b0745c14a78675e3251de90b5447831fa84";
+      sha256 = "e51203491e50b3fdd4fedf222de92530d0f643a4073da840a656ebbb6afa4814";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/lt/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/lt/firefox-106.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "a15760d13d2ffaec7d1836d283e9fb6273be0b7ff56c39fd2e90fbf8cbf7e4f2";
+      sha256 = "149a79f50070461c71725c2fa07177f660a6fb3bffe2b7f143def76cb3c35ae4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/lv/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/lv/firefox-106.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "784e762e4b4df65bf9b0b0a201c7a1e65d13420dedf453874d0c78d829ebbfa4";
+      sha256 = "bf19016f98ec6d300b6e7e1bddd8f101ca9367d886c8365d17bb44df1fbcc274";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/mk/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/mk/firefox-106.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "b963f3c63d25b2a8aad44c49251b2fc2db17fa7b3b72b2e98556533a495361b2";
+      sha256 = "663ef98d22e3ca66ac9c339ec5805bbe940aca63b1e321fb6fcc03bd26d1c949";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/mr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/mr/firefox-106.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "8f965d02d454a6e31a81ca735a91a5f9a350ccf45fab391c79bb030a7c8249e6";
+      sha256 = "a207db0ddf400cb54edaf6992a47e4bae65afc0262534fa37e5c4707abc87d5d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ms/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ms/firefox-106.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "e0709a20cb781ffb644696b50df6c5ce9add7db7dfcf0bed64a4847a45c46c6e";
+      sha256 = "8d1abd8672750bd881b62f2fd4ef7b3247a63cc1ded01c3c2ce991614b522996";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/my/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/my/firefox-106.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "8bd42bef785ec15afef51aabdf23decea06aa94eca556b3713f25c36288bf8e0";
+      sha256 = "fdf33de4e57d28e603a1577ec855be4626fac1db2ee9b73f5272729858a6dd4f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/nb-NO/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/nb-NO/firefox-106.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "83279396c312b820f37f34f11ec52bcba331e8d11ade896e27dc474624feb5c2";
+      sha256 = "1818f104a255c9dffd1e6bd8538cbd30c5c341711cd240335e317e176a696c71";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ne-NP/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ne-NP/firefox-106.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "1147aef4411e3e74d0d1ed1f3fa5dbdcdc2a36a7f67002c8eca481190d866531";
+      sha256 = "d38d2dd5faf44450fa64f415c360688c7acebfe4cef06dc89c8bac66455f64a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/nl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/nl/firefox-106.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "9697a3ab2b05108c01fc8434d8b59decac8a74340d50b3fbbdd406ea04b16a39";
+      sha256 = "5331aae4ab2dae40be77cb7e6a6a01f9c76e76c6a291d63ca2f344ed59ca615a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/nn-NO/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/nn-NO/firefox-106.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "976cb735ade2287ae2ea27faff1b9e9db115394e00adc75ece405da318df8270";
+      sha256 = "a79e4a6cea928c6d3ea0c0f555d1e6eff5213afc84202a582416d3b6ab2ff9f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/oc/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/oc/firefox-106.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "05c591c51075d01ac5b84b30b464ebf793431cb53eb9297e27f40023744e0b06";
+      sha256 = "eec2e9932a84a9604b0dcf049d28c41c6d7bda994b0e11c16293b977b1b65c89";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/pa-IN/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/pa-IN/firefox-106.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "c91e34d9f97ade64458c959977a2a311370afbdce2c9a3799d5805376c505e72";
+      sha256 = "0c85aed3085e28f1274dd09336ae5e577febfc9c9322187cb98f7ce2b077013d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/pl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/pl/firefox-106.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9d81b7ae684e7e17eace812a788dfa43206f694a8cda25199d9b570233157da4";
+      sha256 = "8562567e75385657e7ad682b5e9d2f6624e9569788e4c572a63f051d7a58a573";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/pt-BR/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/pt-BR/firefox-106.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "83ce307ea323ad4f09e4fde06f21074b6c02ad58a9f75634c85bf02218adce20";
+      sha256 = "a8645f76303929ddf2dd090e1ab58ec90fde03bd030a98f669a60afdb4d16e80";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/pt-PT/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/pt-PT/firefox-106.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "9cd2ef64b8b5a22a9f9a73a5a6722afc50b3a524f54205bc418b1d379304baf0";
+      sha256 = "aab96db900f43a32866fba9a5cb7996919155046e5bd4090a633aa842fb13829";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/rm/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/rm/firefox-106.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "3604fd722d51f94caf96a219f80f6f1407c375709c07a14191dedc53faa30ed6";
+      sha256 = "b310207c893c7d304d358e9b8cec9d94596b4c937158045afb0e620ae8b7926c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ro/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ro/firefox-106.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "4df00206ee7950b2406c2d3a1b25365dc7a3d2aaf5cf8c86dce4189f6b05c18b";
+      sha256 = "f18c3ff90f12195751faf4c0ad40d747fe459880f1ad2e0d2bc25f0671afe3a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ru/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ru/firefox-106.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "ae0913701bff929b5dfa6521b19aa207f2c89a841ffd2882e10b6011d406aa9c";
+      sha256 = "564b7750a35a85078335dc9b6f161bcfc62aec37732c251535c1b3e5414130a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/sco/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/sco/firefox-106.0.2.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "2e6386b04c8008f02d497e70a5be4b422ac700d99da925674e43c4567936d798";
+      sha256 = "24f797a7e3bb82cce34c273a4634576288b98dedaa87303bb1138fc6cb3a0ae1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/si/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/si/firefox-106.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "b386202c5e3fa869e30285cfec881589566cfbd147aeafd651e38a4da9ac8846";
+      sha256 = "1422779ad86ae676fc7c6260c744d9e2f719550d6290794e047027603991cc42";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/sk/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/sk/firefox-106.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "1f29f08de3dfb9f203003ecca1d841e580b4bf7c3df2078134d6de26be14ab35";
+      sha256 = "6ebe551cc3b405fb9faf3f0ac592577d8ae70b43b959e690a509adb2a32b996a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/sl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/sl/firefox-106.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "dd63a87c587ba9e2ba489cd9e100f732c60297ff09eea279f0c249a6ff392921";
+      sha256 = "93acd1a4f81e649056125a93d4b932ed6dd73349589169782d5e69754bca8641";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/son/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/son/firefox-106.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "39120dcd7f5b33066333fe47a0777bae144a90be97af8e7ca528ca746b717ff2";
+      sha256 = "296e7bb53bb44ffd7036dcd3cb683a6250e58ca8cca92a08d849fde8ef5a9aae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/sq/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/sq/firefox-106.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7aa0dc316eb51f0eb80fa744c2dfbc903bd4fffce228a675bc2fc1826592133d";
+      sha256 = "654693d85aab899cc0a7402654808bd1f1de4d662e89fc6911a1d76576f1eec3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/sr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/sr/firefox-106.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "d9dd66f19af5f1ba67b44a24856db0b9f880d77f37a9ece171fb358552487291";
+      sha256 = "35dded72957eaf0f41732ea266815b3e999306c89b09a34e469eb1870ab7e0d2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/sv-SE/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/sv-SE/firefox-106.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "546fad48ae858fded383618b9bf35b4d235f40bcc62ecf40efd964e52e9d3b57";
+      sha256 = "c163a543ab17a2455818961f7d05c21fad41aa1f058e72a6933062d9aeb46120";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/szl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/szl/firefox-106.0.2.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "7f1b7214249ccb4a041eab383860a5004de208cfb1040eb7712adc0f65d6871a";
+      sha256 = "89db4c0a6374cc59c79fc2c01f4b4708ee8945173f2d479c9f1bb874fc563f3c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ta/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ta/firefox-106.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "c9520b62c0516f9b7b6cfeee81d6a5880ae3ae8ecea8678428062744dc265fd0";
+      sha256 = "31a37e0bdfbe64bed707d638e99966d188cc19b4281373332f28897a23f1a823";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/te/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/te/firefox-106.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "294c701a6b47da257a7aef3acb864513c606dc68357f17ceff3f090610d9fb64";
+      sha256 = "ed43c3bcb25393c45fec508c2b7a186b831644c4dcbbea13b04d292b7e9d3d37";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/th/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/th/firefox-106.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "d2d57c38f19b735f9d0c63f1b90935ec5f59657b7824e46e5384f94bd6abeab6";
+      sha256 = "749bd07bb5688876a622929fd7c3d1b564b177e04c107f47ae3194a19d51c9e2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/tl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/tl/firefox-106.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "47f6a00479833afc6af7dc045a505fba7961b093715f16e5b8e33bb9697ccd6f";
+      sha256 = "e3b95230a96f2d21816652b3415606d058e1f61047fb12c8df8fa7faefb55fc4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/tr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/tr/firefox-106.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "5191edc55d2f0b7604094c30c0eaabaa319525ef084e8e18b7bc4de6442e188a";
+      sha256 = "6794ae7099b774eda4887f3991539ce1b332132da962664db665ba6c15bab3a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/trs/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/trs/firefox-106.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "b159860b09d16362d4f2655204a2c06fa48bb1c7be5c81749897eb57aa7a1799";
+      sha256 = "69880d46bbcbb7e1232f5d7591a951c04b0f53e949769eacd3dcc9d6b7e1b41e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/uk/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/uk/firefox-106.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "d76a4e4d240d1631724b285fbebdfd9e976378e60bbb07347533b56763683911";
+      sha256 = "44412afcec90e901dff146d7d7ddef253da1a287847ec0133c4403c1bbfc38e0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/ur/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/ur/firefox-106.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "2cf7d4e8e6658162e004de86db9d98ae1d456c661aefd6f6a1ef917fbbbc7233";
+      sha256 = "3dbdafb2cba4978141e59c34946eec2c85eee70d6af26a7b3a6f49f42ea21461";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/uz/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/uz/firefox-106.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "e2c3501af9eb9de310791ba9b94268fc2aedabe3936e200289c323fafeb718e7";
+      sha256 = "0fc317d758bd97acd29be9fd558c617ef2ba6b05ea191037f6186f4c2872a58e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/vi/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/vi/firefox-106.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "ff5f115d3359884681f3f7a28f3335d8df1c88911f8228a52ba9c5e80bd88ba8";
+      sha256 = "937fe371888bc6ed844117658d2cbc229a7bba72ef5976ba34c8d78b42315953";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/xh/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/xh/firefox-106.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "aa7a710d3c1359cc925aa6e6d503463c6eff67cf1e1f7b0db4b32e74d5140fd8";
+      sha256 = "862fad90ca797a244194728aae810bc6d71e597c56a8b278e279a61c1573e3d2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/zh-CN/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/zh-CN/firefox-106.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "5544af3676984c4500836e39a583d605bba5ddad08a8a6c818fa7821890af654";
+      sha256 = "45f36aa501abc63f03acb631e8cf473f0a85533b2eb7b37ceef64844388167f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-x86_64/zh-TW/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-x86_64/zh-TW/firefox-106.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "d449f7d3875ff492ed8afc7fa4ce3766937e698d6e03409d814719bd7174d5d6";
+      sha256 = "9c3f1a93c2f6681639e9341d9e94f14e095d69bdcad9491fca35a8b96aeda507";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ach/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ach/firefox-106.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "9f16b041726372d5d947f09ae20084e423a7d66522d10fc13bb310962f0ace1e";
+      sha256 = "ff7cb6615610da86deb65b637995c169e169883e34bf04d992978b34ca048c14";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/af/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/af/firefox-106.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "51635da47398168ee27f1c546ff7c30416957e0576225b5885fa0d5afd46944c";
+      sha256 = "751a67836897f9ca51c6bc05e14d9324d8338f8eb0336a9019279dc880a363ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/an/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/an/firefox-106.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "59c1fcbdfaf19665f1347fe07a26ba2744a44c7c9c946634968316dc6cd6abc8";
+      sha256 = "9be574726561492a29b979cb2fc991f71ae2c81da12539d8ced43d49414a7bbc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ar/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ar/firefox-106.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e51caa00e64b352573d9dc27f73a23c37e49a701e69a2fa77487156a9128787c";
+      sha256 = "81805067f99e3b36eb5978b2e1f2ff8a593f7f2b04b34899a23a819e445a3aa0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ast/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ast/firefox-106.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "0b0e9804abf625490d5ba732be309a40931a876fb5c4d92b527ed14fe16aa68d";
+      sha256 = "4aaefafb226f2332f863ce27ec660183f70dff35be2fbb9de92366f2ee5a7210";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/az/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/az/firefox-106.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "a3dbac31a3a24ba0803a8c90fd1ff918beca26d1823c8341ceed57fdfebfe466";
+      sha256 = "65876b65e0081365133f0b56cbd4c0408489f9e4774120a7174b468d33e63a95";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/be/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/be/firefox-106.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "6d1b85c455fa034cda37c57d259ebb1a7b261338a1fc1c36987401f9eb6c758d";
+      sha256 = "777a7acc4908be97fb1bc2cdce4a6556411544e3b08e12459d9768b97c780be2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/bg/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/bg/firefox-106.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "7b98a1b4caa746f20a1344b637ff2d02e63d6050014859202705d050caf9f797";
+      sha256 = "4a84f6843fe96ccc907e81446a903f00bb53f895d1908890ed986d7178b6b2a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/bn/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/bn/firefox-106.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "7cbb1f7c6a5edc7e6c601cb7b118705633f1ffea9a6841b906222192cc5f11d4";
+      sha256 = "082a903c25901df9c7ab899e7a64f873e54b0c2dba0a29c5cd28483e8811a2ed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/br/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/br/firefox-106.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "914174e70aadbbdd4f03eb917aa731b8635968366cc8446cc77cae657033a232";
+      sha256 = "096c99a050d60f5922207dd56e4e63ab979567393ac2b65815974594e4f05e98";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/bs/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/bs/firefox-106.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "9cf593de0045b3834159e60ce8029ae52708168dde86b24d131b0ed1a3ae1413";
+      sha256 = "94b8768283c4670b04e40dde655d2ca065e37accdac0e7e80bb55c95c95ab411";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ca-valencia/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ca-valencia/firefox-106.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "163bc54ff5fa0978c49221c005770a4717e0662a736c9c907148652be0cebf46";
+      sha256 = "bd3600ddd2e05aa75e18fc73bad52fb60cc2a4f2fbf73f6fa539e79b22796345";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ca/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ca/firefox-106.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "2c29871e0e6e5cd9017d4eaa24893f39adc9251f7be041ba51dadadce43e58b5";
+      sha256 = "3c6e4eaffd1b54ad058e7c121287cae86e1352a981962b142abdd4c49c8f1070";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/cak/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/cak/firefox-106.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "d60bc6e8c14b8a3afe33817e3930022ee244552443d04dd610c1944d7b90145b";
+      sha256 = "c2b86923123f53fa1b2b897945b17e30d5392b2105b20db00607e59e44c4f46a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/cs/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/cs/firefox-106.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "b9d729d027c86bb620bca4f2d0792a6242c0d1963f0e1c94f37caed59deea1df";
+      sha256 = "44a3ba503bb5a7ef7d2573025aa099e264e72aaf8030bf9e7d6c3ceb82a2e68c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/cy/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/cy/firefox-106.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "97d388f2fc00182366b4674eeffa8f96d0b05af2e39f500fce67e059343bdbbf";
+      sha256 = "0304334256b8d47d8a816852b78d3c29af989b7b0f2d7940e95b452fe104a5a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/da/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/da/firefox-106.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "155ccc093c3253ef01194e2bfbbffff0d19fe5d08a9a3895fd6a0c3ba6b1b7ed";
+      sha256 = "b37ade9536c34da27c8c91b22be1d45f165eadd84940f985d8497335751673a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/de/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/de/firefox-106.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "955c284fdc1b89e621d846f91fdd91dc3e7aac8101a037fe4b0fa1eb1f8053cb";
+      sha256 = "cad1df16c66cd4562162478f761ced90e4a1d12295e0ca463b9696cc0b008217";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/dsb/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/dsb/firefox-106.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "7f549ac2d20c33180439773c83a13abbef0f0056c8359604bfcab7d9635a9be3";
+      sha256 = "f95273407309ea09d910ca24b6006058cb0c9bd64d882b3e8f65fd35ae02a372";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/el/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/el/firefox-106.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "34fdcd82dc8583d8439a9df7ef5771cd33e9838ac4325681950e9c54a9eb7f92";
+      sha256 = "db63e09480f68a581826209a4b310a9613ab6ff121ad9acf8af08ef5ca62cd4e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/en-CA/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/en-CA/firefox-106.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9f16e13defab325482328d3f0466caa251ef5a3832712e51db5016f9bf6e5ed5";
+      sha256 = "fcdf6248e9af0e06b03dcb8d58c7bf83549c9be3870263493af726350c6132b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/en-GB/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/en-GB/firefox-106.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "8d7a94a808bba71e0ebfc017a96ec2c74fcfe28cf911777161f6a2908119de6a";
+      sha256 = "b16c35485e553e2696eeaf1edc5ff694ec305aa9d2f275f220a7edb07da63ea4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/en-US/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/en-US/firefox-106.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "7bd5efeb3b023624c61ddb4e0683e2573d0b6b49e5521ac8fc4474c8c0c09618";
+      sha256 = "c38e91cc105f2823867edb9f3fa1859dd9d2c8becbf233b92ed6c2a1f3db2098";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/eo/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/eo/firefox-106.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "53bee07b6caf2dab18cb842ae3573556eecf1c2ceed46cfb554037d25ad41a8b";
+      sha256 = "7c3772deb11133747b044f3a6154cc2bc5473b4aa7b62592b5468c0431a9142c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/es-AR/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/es-AR/firefox-106.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "8881872e1fa6f5303dc6cc7327a3e95da16d8f56cca34e63c66f7254f00e9658";
+      sha256 = "1d32eee719c6b3935ba7f9ad9ff09093ff023ab19b272b72062cbf2d600dcb46";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/es-CL/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/es-CL/firefox-106.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "35ba78d075be404efce761219c208d3def7ee403282fa705be692e0d71cb9c52";
+      sha256 = "542c76e72142bda3e0a30f6fef089870454a4e386c610a56a87f204af8e79333";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/es-ES/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/es-ES/firefox-106.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "89c9786196fca856a663502cbafdcb55a79a217fc220924fa3f3e91c3417de93";
+      sha256 = "96b6f287f95c21dc101f0a9c4777274bbd048273137144c8af0d3192d15d173f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/es-MX/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/es-MX/firefox-106.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "1ee912ea7423355dc51a966dc4d4d0b6c361a9f4186f24e9ee8c6d68f7f9f544";
+      sha256 = "ea9ab69d3845a3ca5c40f075322f396157df1fedf06f7532338edc0e56f00347";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/et/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/et/firefox-106.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "ff21dd87e571a32d55d5bfd5a9bc16ff90dfdbdf91714bc2526c004d703397aa";
+      sha256 = "5c6f31f84dfbedb6353f7ea1ad0b30afa6026cf097d1250657f7a53d4bac8f63";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/eu/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/eu/firefox-106.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "907163e0021cb42c55cb84ba5b428683890688d0e506a3293c2e6df7336b913c";
+      sha256 = "31ac00373c5b6225c196cb2d68777e84a40a7f45acb662c8b91348cdddc4f005";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/fa/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/fa/firefox-106.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "93dc288231d3b77cda50be5a3c12ea95281db2bb84068c9463ffd0bd20b93d22";
+      sha256 = "e9685352aa8739d9dc74eae40207cc2aa29789eb38d8b8c41b9d548009503748";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ff/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ff/firefox-106.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "a93a552e57909b286104c6d3b067beb770d3cbb3c2c6933f5769ede79e5297a0";
+      sha256 = "79e74b29f58825fc0f52a238c5427ebf17f1d2fae8832c938e1e9d9a8a56ad74";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/fi/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/fi/firefox-106.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "caf0865c18940bd33b38213fecf477e71ed76589f4f403f542adb1e3fe65c9ac";
+      sha256 = "87c64b2a7cdbe464971707fd815b3f85e3b474f697cd2930c3d1f7ab9967eaba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/fr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/fr/firefox-106.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "9ec7d97c4ba107b63daba71b4585e6fb2ac1ae5de66cd46bdce7afa188794dd6";
+      sha256 = "6641d4ab2f34c498abb20f6ae24684791f40d4c52ad3be8c3b36551fce8a2633";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/fy-NL/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/fy-NL/firefox-106.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "9ae4c647c4ed2710eff78cf3e9966cafa5ef3d92044a8b6e0df730259f6c7eb2";
+      sha256 = "2674a6ba3e045cd5408e6784751e0df57cbf3d8da78aaa2c96936ef469a4961f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ga-IE/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ga-IE/firefox-106.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "eea019930245e8ecdfe9bbba7d848f079119574a8efcc7efa726156ee8ffb777";
+      sha256 = "a2719929b4a7df16afd24f7cd34bec351ede6b9b6813cf2a4f8dd29ca3fe4e55";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/gd/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/gd/firefox-106.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "8740cebb2df60e63a2c5d68d369385aa7e4b00c83b6f21bf684b645a2747742b";
+      sha256 = "2cc0d55e9e850036d5a5e2e592259e7ec7ffb5ffd55d782a2fc7f75420ca0e0b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/gl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/gl/firefox-106.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "5a5678395eb604617f1f26bb088a0a8f490ee60accc943ddb7530c14cce47956";
+      sha256 = "b718dd6e7a4a88bbc0a5a0bb3adbeb3934e91c0d20366a4bd961cad5672f617b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/gn/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/gn/firefox-106.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "6c9e8ee762bdd01acf05d08b3ba78bc297b6752833a5155c8aa65f8a9b5608d2";
+      sha256 = "41f96a2050cdb77c973b836d5210deaea06d3a442e4fe26ff5507d5d46e56cd1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/gu-IN/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/gu-IN/firefox-106.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "778e5de0eb1f22ce6962b3a197b4b8667cd05207be4536f9fd1b83fb1ecd5416";
+      sha256 = "16bd5d310065f2212b1d82899a6c3b96a084b8aab5c056d513646860eaa62466";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/he/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/he/firefox-106.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d079b3279dbfb36b2a9fde267de7e11a71fce9ed9767c249033461908d1af647";
+      sha256 = "8d47900c31dd65267f3b69df8774d7c9d86adf61e6a24c71b35b94e7ef014eef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/hi-IN/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/hi-IN/firefox-106.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "cd1bf706a138e4ccf2fb3491a67432e258717a06c2bbfb1ed583a80c264ad880";
+      sha256 = "2c1f46a2fdfd3197759b90b2d8c99338222fd58cd6f954c611ec6b134e84b560";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/hr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/hr/firefox-106.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "ee6d2101e9b1b9281fd7fa2bd074cccb657d36acc961c43537206cb838af9c74";
+      sha256 = "a9ec34c078067af32321c0961a0884611f81db6ae5326cfbf43d365971d81907";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/hsb/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/hsb/firefox-106.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "31a1bd9112c514739e98d110453a1b9fc7c4c097e9d22498f21242cafb3e0514";
+      sha256 = "7049c623624bd2a77a60a46cc26d03046c10e6b9fa16f0f15c3ccc1280c60a0f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/hu/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/hu/firefox-106.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8fddf8bffa16805c67cf9b72c6b21b0955753209ba23807bfc2de6bef4de0051";
+      sha256 = "3e16bd536849182fa379940fcae415d7f3c4301a6db4a69ae3d18fa577a3efff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/hy-AM/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/hy-AM/firefox-106.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "69fc52e3c2307fb36d6b165a814c5e55898b87026febc759dc6014c9de375962";
+      sha256 = "160a129e8b45fe510e48d5af2d47784918abde95742b2af9e7c07021289afbea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ia/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ia/firefox-106.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "9d7f9a4706ec8180795e2aab4cf5cd82295f138616888ca88ee35d76d7457166";
+      sha256 = "a6a4ad785e368af7297cd81de7b8b84ad71e23fec7dcf29e98dec4c4d6ee0113";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/id/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/id/firefox-106.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "4a888680e35bf060abbe36c5b9955786e162be412282dfbf2e1949003b06ca00";
+      sha256 = "e20fc5d397d6164daea9eb4bd7b0ea867d5e4c92f5214f4f17d974206fb873b1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/is/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/is/firefox-106.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "2ff3a4bc90a77986f8d9b35a216d2abdda2f0e2c61b617a86c24e722a36e68a7";
+      sha256 = "c3702a5614e26c8ed18c16b5da89aef502c4782a9d186c66b7f469a98a979b1a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/it/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/it/firefox-106.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "ee804ceab7b4a42e9e781ea4b2d65d877561bb85bdf1e3079514c973b27106b4";
+      sha256 = "4c46c918b41626b18276d5cc4aff99d5a0c2198e35d914382f9d291d6dc80f87";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ja/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ja/firefox-106.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "6875c91a033986e4600dbe8bdd2326b3d9f1233fd81162860479aeec5eeb67e4";
+      sha256 = "514f482e47b24036797e1d099ee0a74fec299db6cd94e9054876281b3563060d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ka/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ka/firefox-106.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "9e571e902b4925c9294f1093d161607943df0b9797c3e4dae323ad7271258a90";
+      sha256 = "37b633f8ff1c59151de9e19fdd8ba605605ce8cac08ac390252a2d5e6c152ae5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/kab/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/kab/firefox-106.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "31e00fb9ca697f18a1770be7665b981bd8fc5558cf2247f3211056603b396e08";
+      sha256 = "ecf398fffea7aeb1cca615a07b7019a3e6502560f51ad64faa7d605aecd96bf4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/kk/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/kk/firefox-106.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "3d369677b8fe663847e30c0399a2dde9e4692d209aeffb6a2411516bd5607040";
+      sha256 = "2ec26c7b974d7ea99dbee18cebce959c47be50351b381cc4c4d2ae5d2af92fca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/km/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/km/firefox-106.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "654218c82d49aa77e1d2c28892b027944976eed8195de5f674d651b163291fa0";
+      sha256 = "4f3dc1496fb295ea8183dd0a1fae88059a96bf6747c2eef2cdeaaa8eb5b17018";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/kn/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/kn/firefox-106.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "cda09b1ab169473fbc8a201807cbceef4382ab0a346fd428d95ba2754dc776f4";
+      sha256 = "c535f442a0ff34c01644ffeb1e961c1bdd6082c7e95a0e1bb96a11ceb7c59b35";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ko/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ko/firefox-106.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "c94b4936819f53a76cdf9b50077f8ae66c69153ffb3f34b556a9ec2c6f655474";
+      sha256 = "c557a384b02898a2c833141ccd1caf8fdfe9fb6664ebf309d2707d1f6262c0a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/lij/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/lij/firefox-106.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "4930d71723c240f5493bd032d4a578b2dbf87073be4cd3bf3b43674d48c1efca";
+      sha256 = "13a613ae949181b221b82b9fe92e42ff23add007a3440368d8d5300e074abfe7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/lt/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/lt/firefox-106.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "0323e677a9748aa13a282152504751e41e19bc4692e926898a23d70b1bce8240";
+      sha256 = "fc068c98c2afbd044dbbbf39af2d757886d65a6194cab353bb49073e05a82e7e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/lv/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/lv/firefox-106.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "6de336ecdb9ec67d3cd24416fbfa2430b54add6d5e586b672b3cae977a017933";
+      sha256 = "e83039f4b306c38ee2562fb4e2ec74d8d92806b170a70fe61a840a05e0fcb54e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/mk/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/mk/firefox-106.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "5332892231716c401846a780eb18df1f3944f29db61d0f05418a0044a51a36df";
+      sha256 = "7aa2a1d7210d306e848b905a5d44ee0d15bb54e8f12e4ee23a5fc7953404ebbd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/mr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/mr/firefox-106.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "8be7fc6fea188481fc98eb1141afc3f283b716270f8281fa96fff774f2d55070";
+      sha256 = "4566542d424952d3630c410c328cd4c146f840978a5d37f665af3d0ba332f473";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ms/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ms/firefox-106.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "c72395da50fb54753fe2488c0125e0d0b1f1c3e521538ba57f9c47a15c6b9743";
+      sha256 = "a8b25cb78b3493e3c3fdd1af81042aee8b820473bd2301a4f0a4ec38caab1276";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/my/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/my/firefox-106.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "b2f56edaea8f9c4d4928edf913803cd2bd281af82d239b865c80e204ed7f00c2";
+      sha256 = "9e113258a9f0bc79f97db9807de6615a447c35d243db543966eb0e79f6f15932";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/nb-NO/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/nb-NO/firefox-106.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "271e700ad7521a9f7a346b26e0ad80e2e912668eba81a0f16fb596d0a1e660b9";
+      sha256 = "17b2d98d2cb497328106f77be1dbd53912b41c066b1a099f8af64d67f79f13eb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ne-NP/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ne-NP/firefox-106.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "34b974927f7bc142a0cb1bb432e25ac5105ca1c3d56a7673262334cdd0888a8e";
+      sha256 = "fad578cfbd91b14ff66e06570bd07b5f23e7a6e8602cf3677d07272bad4e8c0d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/nl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/nl/firefox-106.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "d10248e4af2639ef157d834a72a5f863171a538454b9b78da42fdebf4c5897b2";
+      sha256 = "64019fb5ac2ca70f32ec28e1a54728890219af74ec2758413edc48d9c187eabf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/nn-NO/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/nn-NO/firefox-106.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "cbe5407ee2f158bf859cb6bdb83dbefc7136aeb2c5aa14df6fb6a4ecd907e9bd";
+      sha256 = "f56012f01809d3b1b5197ebec59d02635bc1e72f3c8dfbe21fe510cf5daa9f4a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/oc/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/oc/firefox-106.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "59f81bf4f2ca3478434e53442ee910875de1b59c4e0efa81e0e57cb908a40ac9";
+      sha256 = "547fbccd4497db9ba216ec93c7944a85496b86f3cad5dbc18de25aa1dd67ca6d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/pa-IN/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/pa-IN/firefox-106.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "cb760a9bde61467ffc3f19401d1b6d20d70ee02cda9c1dc9d63b63dc88a79786";
+      sha256 = "62f35e782ce5bd4a35d9610e0ad1193323f90624216aea86e6cec6aeb1ce7eea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/pl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/pl/firefox-106.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "603606ad44552ddfb930527d8041eddfbb52159ac96914e1ee949594a4bea149";
+      sha256 = "2657ca1eaa03f89eb8e40abb87268fed9189be8a6e8f2926281fa853c762003c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/pt-BR/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/pt-BR/firefox-106.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "a603d3078db5f27db9a6af118001f904912e3a7eccdca862996de5af6d52d72b";
+      sha256 = "3d4ad803deae54f0bba2b6ec94951cdeb2980b7f1c19f57dd9ed4de555d69261";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/pt-PT/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/pt-PT/firefox-106.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "222fa8104474c2cb83b289692e2d32575ad78c7aa3694ac079fbf2499c95d01b";
+      sha256 = "00fde3c6a5f1be11f92d47ba904f990b58e4bb9c46ab4ad8800ed9081e9adbc7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/rm/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/rm/firefox-106.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "76c269dc85488160029d93a0726907e72d08b940b460a845533b969d444521ce";
+      sha256 = "d0ecd24e232b2a68c0da03865ae35cde2855163dc5e71b56cac84319af1e9576";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ro/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ro/firefox-106.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "932691e66c21d0037116b9250e927d51c3f53dbe146b20e6672034cc1f9234cd";
+      sha256 = "5f03a25631b4b7763f7bf2c948c1a610e095f2f87ba8fa217f49baae5802a065";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ru/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ru/firefox-106.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "e12a4565d69e3e34f16f901539c706141f6be02d6d5382bdd49c22543ffc71be";
+      sha256 = "4ba5c10bb06632c63fd42342d6aa3a6171c127431dba6ef878376947ad3eaa91";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/sco/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/sco/firefox-106.0.2.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "9a19c5b3c9decc0d2f08f410b4e65312561878822d6e8cf5f7db0d2c976f2eb4";
+      sha256 = "2bae09ad0120b77c0ecfe8c9f9db2b6b297dd7867a42836ca27124eaaa02bbe7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/si/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/si/firefox-106.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "4030598f2716585c30334151d4147b01b3ddf363c668ae971c52b779e0bf7ffa";
+      sha256 = "3380c01b1ce07b0ad624fe2872ad5cd8053d2b2d51444918bb6455ccc1947bc5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/sk/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/sk/firefox-106.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "c247c6b1657e55c27ba10bd5256eb5d68a0ae51aa0a53c98d5eb03430c9401db";
+      sha256 = "e48a45bee33b8414921dd07380780d8f13ba1e6b923b717659c14c0a4a3da29e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/sl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/sl/firefox-106.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "5c854b94c2c84136ac320787f04702b4334d2d52e95a97bf80fe014a06df0591";
+      sha256 = "519a2735c36d182c4c4ed4103132564feab0bdf8afc55c0454bb93779297aefe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/son/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/son/firefox-106.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "c8ea64963e41d236541ad5e9eaabc6c87e1da684ad211627134b48c193ef9004";
+      sha256 = "704901257ec45996fdfe11ad99eb52eab0573aed1bb0eb560788bd23a6f636f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/sq/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/sq/firefox-106.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "86a58fc53be72682e686d7bd317117b93b1a074df4a2a4eaea781a31f295f246";
+      sha256 = "0040245c995bd9d51775b102c41f714a9ba77cecdf1169de6214f467f3765a4e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/sr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/sr/firefox-106.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "5241ad256931a6a59c40f2bf8478676951b6030ab89965c1085289cfbe85d62f";
+      sha256 = "032848b75d881d223c776c51b080b326b4a09e3d7494ed1a4531ed630eafc293";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/sv-SE/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/sv-SE/firefox-106.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "55ccc7815c95a1f023cc0a0771d9ce8b7f5e309f5ecc5dd56b9a85d2c3b46f18";
+      sha256 = "7ac309cf2e56bbba5146836569687df0dc024eb0c5bcac50cc536fd789b2eec3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/szl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/szl/firefox-106.0.2.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "9125a91d898a510ee268398684de1ff34b49b13e8a7661bc4d90ffdacf3e6252";
+      sha256 = "0d4238828f09d4f2e12083f1ae0a3fd13488d100b0d3660dc8ff480b7a1c4c04";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ta/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ta/firefox-106.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "911c397b47ff1d3ba9e1e990d1c08e9ad6d3a092e09f8cbdca3537c81b386fe7";
+      sha256 = "f5f8373c8588e34cc0fe60abfe44cb6e2cae83826fb59c7e65bd7bc4599d2fee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/te/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/te/firefox-106.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "25627e0fb575426dffda0d3c87e2f444dfff2d0b3cc2219548a033a02e990f1d";
+      sha256 = "e85fa16dd5c780d3ba92d64c75194b8610fa1cb42002a83ccd81ec1b92dd3ed2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/th/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/th/firefox-106.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "d44972ab642179ccfa6de2ec6cc6d6a4332362e23167c4a1de2f2f011ff2448f";
+      sha256 = "8aa714a7ef1b4e884364571e8d54057d33923105e5dff50f90ea965cbfe36a13";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/tl/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/tl/firefox-106.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "9a5775198e4305242211a2e44ff8dbbf3b78b02b227887e3b5704af770641f50";
+      sha256 = "9f3e59cca6c56dafa7682a142630775c2de737491ccc95c6298fe290c06feb44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/tr/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/tr/firefox-106.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "ffabcb2913e2bcc678696d073170377f30f9559c3c8a0d3a7a6b16e74c4c3ac7";
+      sha256 = "c1457d4ea162643ceeaa644bb10098f44069c87b65188073587599e0a0dd1eb7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/trs/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/trs/firefox-106.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "b5d3a5d575c04ae36290a5d5142ef7f993674d2861486bec2fa1bd24520eb5e5";
+      sha256 = "d7e51bae403116e17acd009bd3302d407c1614c453e9bb0bb6886ee60c45da02";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/uk/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/uk/firefox-106.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "3b0b32b94d9e0258c7555b09c38c71b22c6c22ef06dcf005400d0bd6a766d5d9";
+      sha256 = "1c79157df0cd80ec651ab43054ad9064f868d2aeac44e576dd2a08aba083ae50";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/ur/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/ur/firefox-106.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "3915095ea690e0bba685e71da49b689561a122fb3914ee4ed2430d991104f16e";
+      sha256 = "be045e0336cd865c4882040d0badbf0fe53847ff88a32f975790cf3b76347ddd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/uz/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/uz/firefox-106.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "73e9355528be81af00fb55143f6491c798213be197b7fcfe200e80d1075c3282";
+      sha256 = "eeb222a8109f98aee6e6ceb1e0c7ef4a59ea1de6953f1859fff62de45602fc82";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/vi/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/vi/firefox-106.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "0a36154fda9cd6877a2068474da60d859cc1338c38d1897ac1d9085d73bed0df";
+      sha256 = "be0ca0eeb058c1a7b84d49d66efb04d02a6852f0f77e97d01221a87785ad0449";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/xh/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/xh/firefox-106.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "1befeacf0ad002e6cf7cf2ff8d57277eac4d05f2df68dd2f97ac4063cbf5c573";
+      sha256 = "281015f7c01ff64c2dbedc154c401761a9070cd05d4971b1eb22e01edd16db27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/zh-CN/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/zh-CN/firefox-106.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "8c607afb1a79b9e3af94cbd4a1f847c8aef5fb4dbc31157a49ec52b89515d129";
+      sha256 = "6d6640d8bb82f081dbaa0c58b5cc4fe65855d232297c02bd5af1f9712fc2d94e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.1/linux-i686/zh-TW/firefox-106.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/106.0.2/linux-i686/zh-TW/firefox-106.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "a5fc3a0d052781f8511da1ba585d7fa7e0ab0786d8eef596bb1744fdc9600e13";
+      sha256 = "c162cb00ad7133eefd88042568fbe74b628ecf70d11b8f50c5259d81477e78cc";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 rec {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "106.0.1";
+    version = "106.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "15f5a65a69e11dd0c463b358cafb5ad0f31db93619b9ec3f89e8c5e14d4d319d9423fe4dcd0dbbcbedc1ad444dcbd8e5e30e483220277f5b550bff6124b66519";
+      sha512 = "2aad75c05c3398c19842be46dcde275581344b09f0c65b51a630cef201545996ee00f8020f52a0d7b6416d9ad52cbd5c71b8f1cdf47cd18e4abf1ba21f7cdb93";
     };
 
     # This patch could be applied anywhere (just rebuild, no effect)


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/106.0.2/releasenotes/

Backport #197845 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
