### PR TITLE
tor-browser-bundle-bin: 11.5.4 -> 11.5.5

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -87,7 +87,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "11.5.4";
+  version = "11.5.5";
 
   lang = "en-US";
 
@@ -99,7 +99,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "sha256-23P8Ew0asOptDYVJ0xA+ATOOT92nz/I2F2+CsAejfKo=";
+      sha256 = "sha256-AOt0PFot6Qh9voqvi5bagW0HLk2kP8b6A2c8Jdv5vkQ=";
     };
 
     i686-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "sha256-ye4qq+zH1AlDItP8lKfA9YIJ7AMg1Roc4itpr0kWNtY=";
+      sha256 = "sha256-MQrJgdAsNvG+WCx4eeb2UHZp/0LoOIhZZQUKESNIGZY=";
     };
   };
 in


### PR DESCRIPTION


###### Description of changes

Update with security fixes: https://blog.torproject.org/new-release-tor-browser-1155/

> Tor Browser 11.5.5 backports the following security updates from Firefox ESR 102.4 to to Firefox ESR 91.13 on Windows, macOS and Linux:
>
> -  [CVE-2022-40674: libexpat before 2.4.9 has a use-after-free in the doContent function in xmlparse.c](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40674)
>  - [CVE-2022-42927: Same-origin policy violation could have leaked cross-origin URLs](https://www.mozilla.org/en-US/security/advisories/mfsa2022-45/#CVE-2022-42927)
>  - [CVE-2022-42928: Memory Corruption in JS Engine](https://www.mozilla.org/en-US/security/advisories/mfsa2022-45/#CVE-2022-42928)
>  - [CVE-2022-42929: Denial of Service via window.print](https://www.mozilla.org/en-US/security/advisories/mfsa2022-45/#CVE-2022-42929)
>  - [CVE-2022-42932: Memory safety bugs fixed in Firefox 106 and Firefox ESR 102.4](https://www.mozilla.org/en-US/security/advisories/mfsa2022-45/#CVE-2022-42932)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Pings: @lourkeur