### PR TITLE
spark2014: init at unstable-2022-05-25

### DIFF
--- a/pkgs/development/libraries/ada/spark2014/default.nix
+++ b/pkgs/development/libraries/ada/spark2014/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gnat12
+, gnatcoll-core
+, gprbuild
+, python3
+, why3
+, ocaml
+, ocamlPackages
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "spark2014";
+  version = "unstable-2022-05-25";
+
+  src = fetchFromGitHub {
+    owner = "AdaCore";
+    repo = "spark2014";
+    # commit on fsf-12 branch
+    rev = "ab34e07080a769b63beacc141707b5885c49d375";
+    sha256 = "sha256-7pe3eWitpxmqzjW6qEIEuN0qr2IR+kJ7Ssc9pTBcCD8=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    gnat12
+    gprbuild
+    python3
+    ocaml
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gnatcoll-core
+    ocamlPackages.camlzip
+    ocamlPackages.findlib
+    ocamlPackages.menhir
+    ocamlPackages.menhirLib
+    ocamlPackages.num
+    ocamlPackages.yojson
+    ocamlPackages.zarith
+  ];
+
+  postPatch = ''
+    # gnat2why/gnat_src points to the GNAT sources
+    tar xf ${gnat12.cc.src} gcc-12.2.0/gcc/ada
+    mv gcc-12.2.0/gcc/ada gnat2why/gnat_src
+  '';
+
+  configurePhase = ''
+    make setup
+  '';
+
+  postInstall = ''
+    cp -a ./install/. $out
+    # help gnatprove to locate why3server
+    wrapProgram "$out/bin/gnatprove" \
+        --prefix PATH : "${why3}/lib/why3"
+  '';
+
+  meta = with lib; {
+    description = "a software development technology specifically designed for engineering high-reliability applications";
+    homepage = "https://github.com/AdaCore/spark2014";
+    maintainers = [ maintainers.jiegec ];
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15850,6 +15850,8 @@ with pkgs;
 
   sparkleshare = callPackage ../applications/version-management/sparkleshare { };
 
+  spark2014 = callPackage ../development/libraries/ada/spark2014 { };
+
   spidermonkey_78 = callPackage ../development/interpreters/spidermonkey/78.nix {
     inherit (darwin) libobjc;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This revives #138932 based on work by @fluffynukeit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
