### PR TITLE
MythTV: 31.0 -> 32.0

### DIFF
--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -1,18 +1,18 @@
 { lib, mkDerivation, fetchFromGitHub, which, qtbase, qtwebkit, qtscript, xlibsWrapper
 , libpulseaudio, fftwSinglePrec , lame, zlib, libGLU, libGL, alsa-lib, freetype
 , perl, pkg-config , libsamplerate, libbluray, lzo, libX11, libXv, libXrandr, libXvMC, libXinerama, libXxf86vm
-, libXmu , yasm, libuuid, taglib, libtool, autoconf, automake, file, exiv2, linuxHeaders
+, libXmu , yasm, libuuid, taglib, libtool, autoconf, automake, file, exiv2, linuxHeaders, soundtouch, libzip
 }:
 
 mkDerivation rec {
   pname = "mythtv";
-  version = "31.0";
+  version = "32.0";
 
   src = fetchFromGitHub {
     owner = "MythTV";
     repo = "mythtv";
     rev = "v${version}";
-    sha256 = "092w5kvc1gjz6jd2lk2jhcazasz2h3xh0i5iq80k8x3znyp4i6v5";
+    sha256 = "0i4fs3rbk1jggh62wflpa2l03na9i1ihpz2vsdic9vfahqqjxff1";
   };
 
   patches = [
@@ -25,7 +25,7 @@ mkDerivation rec {
   buildInputs = [
     freetype qtbase qtwebkit qtscript lame zlib xlibsWrapper libGLU libGL
     perl libsamplerate libbluray lzo alsa-lib libpulseaudio fftwSinglePrec libX11 libXv libXrandr libXvMC
-    libXmu libXinerama libXxf86vm libXmu libuuid taglib exiv2
+    libXmu libXinerama libXxf86vm libXmu libuuid taglib exiv2 soundtouch libzip
   ];
   nativeBuildInputs = [ pkg-config which yasm libtool autoconf automake file ];
 

--- a/pkgs/applications/video/mythtv/disable-os-detection.patch
+++ b/pkgs/applications/video/mythtv/disable-os-detection.patch
@@ -1,31 +1,15 @@
---- a/configure	2020-07-21 20:50:58.653989766 +0200
-+++ b/configure	2020-07-21 20:52:21.236610586 +0200
-@@ -6537,17 +6537,17 @@
-                 }
+--- a/configure
++++ b/configure
+@@ -5894,9 +5894,9 @@ else
+     die "ERROR: cannot find soundtouch 1.8.0 or later."
+ fi
  
- enable enforce_wshadow
--case $target_os in
--    android)
--        disable enforce_wshadow
--        ;;
--    linux)
--        . /etc/os-release
--        if test $ID = "centos"; then
--            disable enforce_wshadow
--        fi
--        ;;
--esac
-+#case $target_os in
-+#    android)
-+#        disable enforce_wshadow
-+#        ;;
-+#    linux)
-+#        . /etc/os-release
-+#        if test $ID = "centos"; then
-+#            disable enforce_wshadow
-+#        fi
-+#        ;;
-+#esac
+-if [ $target_os = "linux" ] ; then
+-    . /etc/os-release
+-fi
++# if [ $target_os = "linux" ] ; then
++#     . /etc/os-release
++# fi
  
- if $(pkg-config --exists Qt5WebKit) || $(pkg-config --exists QtWebKit) ; then
-     enable qtwebkit
+ # libudfread
+ if enabled system_libudfread ; then

--- a/pkgs/applications/video/mythtv/fix-qmake-var-syntax.patch
+++ b/pkgs/applications/video/mythtv/fix-qmake-var-syntax.patch
@@ -1,0 +1,12 @@
+diff -Naur b/configure c/configure
+--- b/configure	2022-04-22 14:39:29.998895626 -0400
++++ c/configure	2022-04-22 14:38:36.688266601 -0400
+@@ -6296,7 +6296,7 @@
+ 
+ # add some linker flags
+ check_ldflags -Wl,--warn-common
+-check_ldflags '-Wl,-rpath-link,\${SRC_PATH_BARE}/external/FFmpeg/libpostproc:\${SRC_PATH_BARE}/external/FFmpeg/libswresample:\${SRC_PATH_BARE}/external/FFmpeg/libswscale:\${SRC_PATH_BARE}/external/FFmpeg/libavfilter:\${SRC_PATH_BARE}/external/FFmpeg/libavdevice:\${SRC_PATH_BARE}/external/FFmpeg/libavformat:\${SRC_PATH_BARE}/external/FFmpeg/libavcodec:\${SRC_PATH_BARE}/external/FFmpeg/libavutil:\${SRC_PATH_BARE}/external/FFmpeg/libavresample'
++check_ldflags '-Wl,-rpath-link,\$\${SRC_PATH_BARE}/external/FFmpeg/libpostproc:\$\${SRC_PATH_BARE}/external/FFmpeg/libswresample:\$\${SRC_PATH_BARE}/external/FFmpeg/libswscale:\$\${SRC_PATH_BARE}/external/FFmpeg/libavfilter:\$\${SRC_PATH_BARE}/external/FFmpeg/libavdevice:\$\${SRC_PATH_BARE}/external/FFmpeg/libavformat:\$\${SRC_PATH_BARE}/external/FFmpeg/libavcodec:\$\${SRC_PATH_BARE}/external/FFmpeg/libavutil:\$\${SRC_PATH_BARE}/external/FFmpeg/libavresample'
+ enabled rpath && add_ldexeflags -Wl,-rpath,$libdir
+ enabled rpath && add_ldlibflags -Wl,-rpath,$libdir
+ test_ldflags -Wl,-Bsymbolic && append SHFLAGS -Wl,-Bsymbolic


### PR DESCRIPTION
###### Description of changes

MythTV version bump as discussed in [issue 190082](https://github.com/NixOS/nixpkgs/issues/190082).

###### Things done

Version bump and disable-os-detection patch update by @zero-one01, [fix-qmake-var-syntax patch](https://github.com/MythTV/mythtv/issues/549) by @acarrico applied here and [merged](https://github.com/MythTV/mythtv/pull/550) upstream.

@zero-one01, did you build on x86_64-linux?

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
