### PR TITLE
cc-wrapper: adding a cc-wrapper-hook to the cc-wrapper

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1140,6 +1140,13 @@ Here are some more packages that provide a setup hook. Since the list of hooks i
 Many other packages provide hooks, that are not part of `stdenv`. You can find
 these in the [Hooks Reference](#chap-hooks).
 
+### Compiler and Linker wrapper hooks {#compiler-linker-wrapper-hooks}
+
+If the file `${cc}/nix-support/cc-wrapper-hook` exists, it will be run at the end of the [compiler wrapper](#cc-wrapper).
+If the file `${binutils}/nix-support/post-link-hook` exists, it will be run at the end of the linker wrapper.
+These hooks allow a user to inject code into the wrappers.
+As an example, these hooks can be used to extract `extraBefore`, `params` and `extraAfter` which store all the command line arguments passed to the compiler and linker respectively.
+
 ## Purity in Nixpkgs {#sec-purity-in-nixpkgs}
 
 *Measures taken to prevent dependencies on packages outside the store, and what you can do to prevent them.*

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -219,6 +219,12 @@ fi
 PATH="$path_backup"
 # Old bash workaround, see above.
 
+# if a cc-wrapper-hook exists, run it.
+if [[ -e @out@/nix-support/cc-wrapper-hook ]]; then
+    compiler=@prog@
+    source @out@/nix-support/cc-wrapper-hook
+fi
+
 if (( "${NIX_CC_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
     exec @prog@ @<(printf "%q\n" \
        ${extraBefore+"${extraBefore[@]}"} \


### PR DESCRIPTION
###### Description of changes

Adding a `cc-wrapper-hook` to the `cc-wrapper`. The `ld-wrapper` already has a `post-link-hook`. My main motivation for adding this is it will allow us to reliably generate `compile_commands.json` files which are required for LSP servers to function for C/C++ projects. Existing tools for generating `compile_commands.json` are unreliable on nixos because they struggle to distinguish between the compiler wrappers and the compilers themselves.

See my earlier PR for an example of how this could be used: https://github.com/NixOS/nixpkgs/pull/192694. This PR is just the infrastructure part of my earlier PR. Also see the discussion on discourse: https://discourse.nixos.org/t/using-nix-infrastructure-to-reliably-generate-compile-commands-json/21961/20

I am hoping that this smaller PR will be easier to merge! 

###### Things done

- add `cc-wrapper-hook` to `cc-wrapper.sh`.
- document both `cc-wrapper-hook` and `post-link-hook`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

