### PR TITLE
haskellPackages.taffybar: Compilation with newer ghcs is now unbroken…

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5003,7 +5003,6 @@ broken-packages:
   - Tablify
   - tabloid
   - tabs
-  - taffybar
   - tag-bits
   - tagged-exception-core
   - tagged-timers


### PR DESCRIPTION
… in version 4.0.0

@rvl you are listed as a taffybar maintainer in nix I believe. This issue was fixed in https://github.com/taffybar/taffybar/pull/541 , which is now included in the latest official taffybar release. I'm not up to date on how exactly hackage-packages.nix is generated these days. Will this latest change get picked up?

Also cc @cumber 