### PR TITLE
pythonPackages.dbus-next: Ignore tcp_connection_with_forwarding test

### DIFF
--- a/pkgs/development/python-modules/dbus-next/default.nix
+++ b/pkgs/development/python-modules/dbus-next/default.nix
@@ -26,10 +26,12 @@ buildPythonPackage rec {
   ];
 
   # test_peer_interface hits a timeout
+  # test_tcp_connection_with_forwarding fails due to dbus
+  # creating unix socket anyway on v1.14.4
   checkPhase = ''
     dbus-run-session --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       ${python.interpreter} -m pytest -sv --cov=dbus_next \
-      -k "not test_peer_interface"
+      -k "not test_peer_interface and not test_tcp_connection_with_forwarding"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Fixes #197408, by removing the offending test until the time comes)

Co-authored-by: @SFrijters

**Note:** I can probably add `optionalString` to `-k` option, but we probably want to delete it anyway if everything ever turns green. 

However if appearing/disappearing test suite problems are expected, maybe that `optionalString` would be for the best, so we don't have to juggle parameters in and out.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
