### PR TITLE
ptouch-print: 1.4.3 -> 1.5

### DIFF
--- a/pkgs/misc/ptouch-print/default.nix
+++ b/pkgs/misc/ptouch-print/default.nix
@@ -1,33 +1,47 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchgit
-, autoreconfHook
+, cmake
+, gettext
 , gd
 , libusb1
+, pkg-config
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "ptouch-print";
-  version = "1.4.3";
+  version = "1.5";
 
   src = fetchgit {
-    url = "https://mockmoon-cybernetics.ch/cgi/cgit/linux/ptouch-print.git";
-    rev = "v${version}";
-    sha256 = "0i57asg2hj1nfwy5lcb0vhrpvb9dqfhf81vh4i929h1kiqhlw2hx";
+    url = "https://git.familie-radermacher.ch/linux/ptouch-print.git";
+    rev = "e3c0073466ed99dbde9bbbcceea1c54f64967fc8";
+    sha256 = "sha256-Tn7sODj0NqLUAIHYwcR8BK63/EHMwwR5M9EkFHur0gY=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
+    cmake
+    pkg-config
   ];
 
   buildInputs = [
     gd
+    gettext
     libusb1
   ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv ptouch-print $out/bin
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Command line tool to print labels on Brother P-Touch printers on Linux";
     license = licenses.gpl3Plus;
-    homepage = "https://mockmoon-cybernetics.ch/computer/p-touch2430pc/";
+    homepage = "https://dominic.familie-radermacher.ch/projekte/ptouch-print/";
     maintainers = with maintainers; [ shamilton ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Description of changes

Version update. The old repo/homepage domain is dead, see https://github.com/clarkewd/ptouch-print/issues/15 .

The build process has been overhauled to use CMake. Seems like the gettext catalogs are not built automatically anymore, not sure how to fix that.

I am unable to test thoroughly as I do not currently own a compatible printer.

/cc @SCOTT-HAMILTON 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).