### PR TITLE
hydrus: 503 -> 519, switch to qt6

### DIFF
--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "508";
+  version = "509";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-8t7xW8mAmHb/VNuxhgOUNAcDH6UD8SSTEo2Pk5oosro=";
+    hash = "sha256-5dHP9+leymD6fLjT96CR4DwAILR7jRspAo2an4fnBbw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "511";
+  version = "512";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-/3bGh1qFBEzVoObLMn3g6jdqujnCBI8ZUQMTM0YeeLQ=";
+    hash = "sha256-XP9xeJLCwct5q1+3R5xlx4RXAwZe3TY/XkcSjhuK99U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "504";
+  version = "505b";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-d9GxAUbdtKzyQI7ow8Cx0e0TCDchasSZL450+9GhJAU=";
+    hash = "sha256-mnZ5dz8E3wtuXtGgoCKE2YkwrCiLNPaTROCqaiRGFNY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -6,6 +6,8 @@
 , enableSwftools ? false
 , swftools
 , python3Packages
+, qtbase
+, qtcharts
 }:
 
 python3Packages.buildPythonPackage rec {
@@ -25,6 +27,11 @@ python3Packages.buildPythonPackage rec {
     python3Packages.mkdocs-material
   ];
 
+  buildInputs = [
+    qtbase
+    qtcharts
+  ];
+
   propagatedBuildInputs = with python3Packages; [
     beautifulsoup4
     cbor2
@@ -38,7 +45,8 @@ python3Packages.buildPythonPackage rec {
     pillow
     psutil
     pyopenssl
-    pyside2
+    pyqt6
+    pyqt6-charts
     pysocks
     python-dateutil
     python3Packages.mpv

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "505b";
+  version = "507";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-mnZ5dz8E3wtuXtGgoCKE2YkwrCiLNPaTROCqaiRGFNY=";
+    hash = "sha256-0WFvW9euafDMnS3vwUSMmJcaaAXIIgQZ4H/VdqCao+E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "510a";
+  version = "511";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-nOxOeuIVGkqnfkGe/SFQEhEk6VJ392VqdC9gH/9Ff3Q=";
+    hash = "sha256-/3bGh1qFBEzVoObLMn3g6jdqujnCBI8ZUQMTM0YeeLQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "509";
+  version = "510";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-5dHP9+leymD6fLjT96CR4DwAILR7jRspAo2an4fnBbw=";
+    hash = "sha256-g5bVsc0c9CqIHzIW6oFjmp8bvZ5b9Ng55cAo3sjzw3k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "507";
+  version = "508";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-0WFvW9euafDMnS3vwUSMmJcaaAXIIgQZ4H/VdqCao+E=";
+    hash = "sha256-8t7xW8mAmHb/VNuxhgOUNAcDH6UD8SSTEo2Pk5oosro=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "510";
+  version = "510a";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-g5bVsc0c9CqIHzIW6oFjmp8bvZ5b9Ng55cAo3sjzw3k=";
+    hash = "sha256-nOxOeuIVGkqnfkGe/SFQEhEk6VJ392VqdC9gH/9Ff3Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "512";
+  version = "513";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-XP9xeJLCwct5q1+3R5xlx4RXAwZe3TY/XkcSjhuK99U=";
+    hash = "sha256-SY+IjK05DLThU2nNJ6Hp6DjmAFEjguxbYcxkWpmHi7w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "503";
+  version = "504";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-nJn5EphbmVYAAOisV3fym/nHlJl/aPZ2Iyp+Z2/N3Jc=";
+    hash = "sha256-d9GxAUbdtKzyQI7ow8Cx0e0TCDchasSZL450+9GhJAU=";
   };
 
   nativeBuildInputs = [
@@ -82,6 +82,7 @@ python3Packages.buildPythonPackage rec {
     -e TestHydrusServer \
     -e TestHydrusSessions \
     -e TestServer \
+    -e TestClientMetadataMigration \
   '';
 
   outputs = [ "out" "doc" ];

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "514";
+  version = "515";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-7Ialm8+yHz51+E8td0xwhcq+woF8uxroa9QUHg3HALc=";
+    hash = "sha256-2V9FGwq7mkr3N4Fghq8JI2WvDKQeadVU1C8ggXzyEQM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "515";
+  version = "516";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-2V9FGwq7mkr3N4Fghq8JI2WvDKQeadVU1C8ggXzyEQM=";
+    hash = "sha256-1sjHPOkbfvmtDSSyv04S47LsQZ/fcJoGuK8c64RZy8Y=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "513";
+  version = "514";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-SY+IjK05DLThU2nNJ6Hp6DjmAFEjguxbYcxkWpmHi7w=";
+    hash = "sha256-7Ialm8+yHz51+E8td0xwhcq+woF8uxroa9QUHg3HALc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "518";
+  version = "519";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-DdzRi2Yw5epblN5oLpuwuvmidrbr2EBm1ocsWrNiDRk=";
+    hash = "sha256-q5pPRMBuB6hqDGuOl0kMyXjMKze5dw+3kdmA2FPJTPU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "516";
+  version = "517";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-1sjHPOkbfvmtDSSyv04S47LsQZ/fcJoGuK8c64RZy8Y=";
+    hash = "sha256-YTphPBwOVnCkCxrUe7ISZryVjbbZbBe7IFkrMij1s1w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "517";
+  version = "518";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-YTphPBwOVnCkCxrUe7ISZryVjbbZbBe7IFkrMij1s1w=";
+    hash = "sha256-DdzRi2Yw5epblN5oLpuwuvmidrbr2EBm1ocsWrNiDRk=";
   };
 
   nativeBuildInputs = [
@@ -44,6 +44,7 @@ python3Packages.buildPythonPackage rec {
     opencv4
     pillow
     psutil
+    pympler
     pyopenssl
     pyqt6
     pyqt6-charts

--- a/pkgs/development/python-modules/pyqt6-charts.nix
+++ b/pkgs/development/python-modules/pyqt6-charts.nix
@@ -1,0 +1,77 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, sip
+, pyqt-builder
+, qt6Packages
+, pythonOlder
+, pyqt6
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "PyQt6_Charts";
+  version = "6.4.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-tG6xKEBRagOcNvcLs/hCMzf5j94ma1gs6tQEm3e0P2Q=";
+  };
+
+  # fix include path and increase verbosity
+  postPatch = ''
+    sed -i \
+      '/\[tool.sip.project\]/a\
+      verbose = true\
+      sip-include-dirs = [\"${pyqt6}/${python.sitePackages}/PyQt6/bindings\"]' \
+      pyproject.toml
+  '';
+
+  enableParallelBuilding = true;
+  # HACK: paralellize compilation of make calls within pyqt's setup.py
+  # pkgs/stdenv/generic/setup.sh doesn't set this for us because
+  # make gets called by python code and not its build phase
+  # format=pyproject means the pip-build-hook hook gets used to build this project
+  # pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+  # does not use the enableParallelBuilding flag
+  preBuild = ''
+    export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
+  '';
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = with qt6Packages; [
+    qtcharts
+    sip
+    qmake
+    pyqt-builder
+  ];
+
+  buildInputs = with qt6Packages; [
+    qtcharts
+  ];
+
+  propagatedBuildInputs = [
+    pyqt6
+  ];
+
+  dontConfigure = true;
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "PyQt6.QtCharts"
+  ];
+
+  meta = with lib; {
+    description = "Python bindings for Qt6 QtCharts";
+    homepage = "https://riverbankcomputing.com/";
+    license = licenses.gpl3Only;
+    platforms = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29446,7 +29446,7 @@ with pkgs;
 
   hydrus = python3Packages.callPackage ../applications/graphics/hydrus {
     inherit miniupnpc swftools;
-    inherit (qt5) wrapQtAppsHook;
+    inherit (qt6) wrapQtAppsHook qtbase qtcharts;
   };
 
   jetbrains = (recurseIntoAttrs (callPackages ../applications/editors/jetbrains {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8545,6 +8545,8 @@ self: super: with self; {
 
   pyqt6 = callPackage ../development/python-modules/pyqt/6.x.nix { };
 
+  pyqt6-charts = callPackage ../development/python-modules/pyqt6-charts.nix { };
+
   pyqt6-sip = callPackage ../development/python-modules/pyqt/pyqt6-sip.nix { };
 
   pyqt6-webengine = callPackage ../development/python-modules/pyqt6-webengine.nix { };


### PR DESCRIPTION
###### Description of changes

https://github.com/hydrusnetwork/hydrus/releases/tag/v504
https://github.com/hydrusnetwork/hydrus/releases/tag/v505a
https://github.com/hydrusnetwork/hydrus/releases/tag/v506
https://github.com/hydrusnetwork/hydrus/releases/tag/v507
https://github.com/hydrusnetwork/hydrus/releases/tag/v508
https://github.com/hydrusnetwork/hydrus/releases/tag/v509
https://github.com/hydrusnetwork/hydrus/releases/tag/v510
https://github.com/hydrusnetwork/hydrus/releases/tag/v510a
https://github.com/hydrusnetwork/hydrus/releases/tag/v511
https://github.com/hydrusnetwork/hydrus/releases/tag/v512
https://github.com/hydrusnetwork/hydrus/releases/tag/v513
https://github.com/hydrusnetwork/hydrus/releases/tag/v514
https://github.com/hydrusnetwork/hydrus/releases/tag/v515
https://github.com/hydrusnetwork/hydrus/releases/tag/v516
https://github.com/hydrusnetwork/hydrus/releases/tag/v517
https://github.com/hydrusnetwork/hydrus/releases/tag/v518
https://github.com/hydrusnetwork/hydrus/releases/tag/v519

official builds now switched to only qt6 so I also switched to qt6 for nixpkgs

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
