### PR TITLE
func: init at 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8787,6 +8787,12 @@
     githubId = 4141584;
     name = "Maxime Daniel";
   };
+  maxwell-lt = {
+    email = "maxwell.lt@live.com";
+    github = "maxwell-lt";
+    githubId = 17859747;
+    name = "Maxwell L-T";
+  };
   maxxk = {
     email = "maxim.krivchikov@gmail.com";
     github = "maxxk";

--- a/pkgs/applications/networking/cluster/func/default.nix
+++ b/pkgs/applications/networking/cluster/func/default.nix
@@ -1,0 +1,46 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, func }:
+
+buildGoModule rec {
+  pname = "func";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "knative";
+    repo = "func";
+    rev = "knative-v${version}";
+    sha256 = "sha256-LrWRY22deh+YL/cLb+ZwK93okVPgysBoMCmo2MrbqIs=";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "cmd/func" ];
+
+  ldflags = [
+    "-X main.vers=v${version}"
+    "-X main.date=19700101T000000Z"
+    "-X main.hash=${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+
+  postInstall = ''
+    installShellCompletion --cmd func \
+      --bash <($out/bin/func completion bash) \
+      --zsh <($out/bin/func completion zsh)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = func;
+    command = "func version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    description = "The Knative client library and CLI for creating, building, and deploying Knative Functions";
+    homepage = "https://github.com/knative/func";
+    changelog = "https://github.com/knative/func/releases/tag/knative-v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ maxwell-lt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17015,6 +17015,8 @@ with pkgs;
 
   explain = callPackage ../development/tools/explain { };
 
+  func = callPackage ../applications/networking/cluster/func { };
+
   funnelweb = callPackage ../development/tools/literate-programming/funnelweb { };
 
   license_finder = callPackage ../development/tools/license_finder { };


### PR DESCRIPTION
###### Description of changes

`func` is the CLI tool for building and deploying Knative functions, and works side-by-side with the main `kn` Knative CLI tool.

I'm not all that familiar with using this tool, but I was able to adapt the `kn` derivation to build it, and it seems to work. I've had some problems getting it to actually build and deploy images, but I'm assuming that's down to my configuration of podman. Additional testing might be useful.

I initialized this at the 1.7.0 version to match the current version of `kn` in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
