### PR TITLE
Add a couple new Jane Street ocaml packages at 0.15

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -338,6 +338,23 @@ with self;
     propagatedBuildInputs = [ base ];
   };
 
+  file_path = janePackage {
+    pname = "file_path";
+    minimumOCamlVersion = "4.11";
+    hash = "0vjvxviryywwwfdazcijwhpajp2d4mavlki7lj4qaafjrw62x14k";
+    meta.description =
+      "A library for typed manipulation of UNIX-style file paths";
+    propagatedBuildInputs = [
+      async
+      core
+      core_kernel
+      core_unix
+      expect_test_helpers_async
+      expect_test_helpers_core
+      ppx_jane
+    ];
+  };
+
   fuzzy_match = janePackage {
     pname = "fuzzy_match";
     hash = "0s5w81698b07l5m11nwx8xbjcpmp54dnf5fcrnlva22jrlsf14h4";

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -656,6 +656,16 @@ with self;
     propagatedBuildInputs = [ base_quickcheck ppx_bin_prot ppx_disable_unused_warnings ppx_expect ppx_fixed_literal ppx_ignore_instrumentation ppx_log ppx_module_timer ppx_optcomp ppx_optional ppx_pipebang ppx_stable ppx_string ppx_typerep_conv ppx_variants_conv ];
   };
 
+  ppx_jsonaf_conv = janePackage {
+    pname = "ppx_jsonaf_conv";
+    version = "0.15.1";
+    hash = "0wprs7qmscklyskj4famhaqqisi6jypy414aqba14qdyi43w0cv3";
+    minimumOCamlVersion = "4.08";
+    meta.description =
+      "[@@deriving] plugin to generate Jsonaf conversion functions";
+    propagatedBuildInputs = [ base jsonaf ppx_jane ppxlib ];
+  };
+
   ppx_js_style = janePackage {
     pname = "ppx_js_style";
     hash = "0q2p9pvmlncgv0hprph95xiv7s6q44ynvp4yl4dckf1qx68rb3ba";

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -849,6 +849,13 @@ with self;
     propagatedBuildInputs = [ base ppx_jane ];
   };
 
+  redis-async = janePackage {
+    pname = "redis-async";
+    hash = "0pccf4gkm880yyk8x4kgy5rwblkbscxav2sbis13abpms9vr7jfn";
+    meta.description = "Redis client for Async applications";
+    propagatedBuildInputs = [ async bignum core core_kernel ppx_jane ];
+  };
+
   resource_cache = janePackage {
     pname = "resource_cache";
     hash = "13wzx8ixgbb7jj5yrps890irw2wvkchnihsn7rfrcvnvrjzzjshm";

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -362,6 +362,14 @@ with self;
     propagatedBuildInputs = [ core ppx_jane ];
   };
 
+  fzf = janePackage {
+    pname = "fzf";
+    minimumOCamlVersion = "4.08";
+    hash = "1ha0i6dx5bgwzbdi4rn98wjwi2imv5p2i7qs7hy0c6cmg88xbdry";
+    meta.description = "A library for running the fzf command line tool";
+    propagatedBuildInputs = [ async core_kernel ppx_jane ];
+  };
+
   higher_kinded = janePackage {
     pname = "higher_kinded";
     minimumOCamlVersion = "4.09";


### PR DESCRIPTION
###### Description of changes

This adds the following Jane Street opam packages, which were introduced in 0.15:

- file_path
- fzf
- ppx_jsonaf_conv
- redis-async

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).