### PR TITLE
hivelytracker: unstable-2020-08-19 -> 1.9

### DIFF
--- a/pkgs/applications/audio/hivelytracker/default.nix
+++ b/pkgs/applications/audio/hivelytracker/default.nix
@@ -2,36 +2,32 @@
 , stdenv
 , fetchFromGitHub
 , pkg-config
-, makeWrapper
 , SDL
 , SDL_image
 , SDL_ttf
-, gtk2
-, glib
+, gtk3
 }:
 
 stdenv.mkDerivation rec {
   pname = "hivelytracker";
-  version = "unstable-2020-08-19";
+  version = "1.9";
 
   src = fetchFromGitHub {
     owner = "pete-gordon";
     repo = "hivelytracker";
-    rev = "c8e3c7a5ee9f4a07cb4a941caecf7e4c4f4d40e0";
-    sha256 = "1nqianlf1msir6wqwapi7ys1vbmf6aik58wa54b6cn5v6kwxh75a";
+    rev = "V${lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "148p320sd8phcpmj4m85ns5zly2dawbp8kgx9ryjfdk24pa88xg6";
   };
 
   nativeBuildInputs = [
     pkg-config
-    makeWrapper
   ];
 
   buildInputs = [
     SDL
     SDL_image
     SDL_ttf
-    gtk2
-    glib
+    gtk3
   ];
 
   makeFlags = [
@@ -40,28 +36,12 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
   ];
 
-  # TODO: try to exclude gtk and glib from darwin builds
-  NIX_CFLAGS_COMPILE = [
-    "-I${SDL}/include/SDL"
-    "-I${SDL_image}/include/SDL"
-    "-I${SDL_ttf}/include/SDL"
-    "-I${gtk2.dev}/include/gtk-2.0"
-    "-I${glib.dev}/include/glib-2.0"
-  ];
-
   # Also build the hvl2wav tool
   postBuild = ''
     make -C hvl2wav
   '';
 
   postInstall = ''
-    # https://github.com/pete-gordon/hivelytracker/issues/43
-    # Ideally we should patch the sources, but the program can't open
-    # files passed as arguments anyway, so this works well enough until the
-    # issue is fixed.
-    wrapProgram $out/bin/hivelytracker \
-      --chdir "$out/share/hivelytracker"
-
     # Also install the hvl2wav tool
     install -Dm755 hvl2wav/hvl2wav $out/bin/hvl2wav
   '';
@@ -86,4 +66,3 @@ stdenv.mkDerivation rec {
     broken = stdenv.isDarwin; # TODO: try to use xcbuild
   };
 }
-


### PR DESCRIPTION
###### Description of changes

notable change: gtk2 -> gtk3 (#39976)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
