### PR TITLE
waybar: 0.9.13 -> 0.9.14

### DIFF
--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -14,30 +14,33 @@
 , spdlog
 , gtk-layer-shell
 , howard-hinnant-date
+, libinotify-kqueue
 , libxkbcommon
-, runTests        ? true,  catch2
-, traySupport     ? true,  libdbusmenu-gtk3
-, pulseSupport    ? true,  libpulseaudio
-, sndioSupport    ? true,  sndio
-, nlSupport       ? true,  libnl
-, udevSupport     ? true,  udev
 , evdevSupport    ? true,  libevdev
-, swaySupport     ? true,  sway
+, inputSupport    ? true,  libinput
+, jackSupport     ? true,  libjack2
 , mpdSupport      ? true,  libmpdclient
+, nlSupport       ? true,  libnl
+, pulseSupport    ? true,  libpulseaudio
 , rfkillSupport   ? true
-, upowerSupport   ? true, upower
+, runTests        ? true,  catch2_3
+, sndioSupport    ? true,  sndio
+, swaySupport     ? true,  sway
+, traySupport     ? true,  libdbusmenu-gtk3
+, udevSupport     ? true,  udev
+, upowerSupport   ? true,  upower
 , withMediaPlayer ? false, glib, gobject-introspection, python3, python38Packages, playerctl
 }:
 
 stdenv.mkDerivation rec {
   pname = "waybar";
-  version = "0.9.13";
+  version = "0.9.14";
 
   src = fetchFromGitHub {
     owner = "Alexays";
     repo = "Waybar";
     rev = version;
-    sha256 = "sha256-Uzg2IrCDD8uUdGAveA8IjvonJnnnobOrAgjGG1kQ3pU=";
+    sha256 = "sha256-1tnFBUB7/MjnrCkfKOR2SZ/GB5Ik115zsnwjkNMB05E=";
   };
 
   nativeBuildInputs = [
@@ -53,31 +56,36 @@ stdenv.mkDerivation rec {
 
   buildInputs = with lib;
     [ wayland wlroots gtkmm3 libsigcxx jsoncpp spdlog gtk-layer-shell howard-hinnant-date libxkbcommon ]
-    ++ optional  traySupport   libdbusmenu-gtk3
+    ++ optional  (!stdenv.isLinux) libinotify-kqueue
+    ++ optional  evdevSupport  libevdev
+    ++ optional  inputSupport  libinput
+    ++ optional  jackSupport   libjack2
+    ++ optional  mpdSupport    libmpdclient
+    ++ optional  nlSupport     libnl
     ++ optional  pulseSupport  libpulseaudio
     ++ optional  sndioSupport  sndio
-    ++ optional  nlSupport     libnl
-    ++ optional  udevSupport   udev
-    ++ optional  evdevSupport  libevdev
     ++ optional  swaySupport   sway
-    ++ optional  mpdSupport    libmpdclient
+    ++ optional  traySupport   libdbusmenu-gtk3
+    ++ optional  udevSupport   udev
     ++ optional  upowerSupport upower;
 
-  checkInputs = [ catch2 ];
+  checkInputs = [ catch2_3 ];
   doCheck = runTests;
 
   mesonFlags = (lib.mapAttrsToList
     (option: enable: "-D${option}=${if enable then "enabled" else "disabled"}")
     {
       dbusmenu-gtk = traySupport;
-      pulseaudio = pulseSupport;
-      sndio = sndioSupport;
+      jack = jackSupport;
+      libinput = inputSupport;
       libnl = nlSupport;
       libudev = udevSupport;
       mpd = mpdSupport;
+      pulseaudio = pulseSupport;
       rfkill = rfkillSupport;
-      upower_glib = upowerSupport;
+      sndio = sndioSupport;
       tests = runTests;
+      upower_glib = upowerSupport;
     }
   ) ++ [
     "-Dsystemd=disabled"


### PR DESCRIPTION
###### Description of changes
- https://github.com/Alexays/Waybar/releases/tag/0.9.14
- https://github.com/Alexays/Waybar/compare/0.9.13...0.9.14#diff-30d8f6be6320feeacf686be94f48c70869b52630e01ea625f0f15adc0d57c3e4
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
