### PR TITLE
Revert "pahole: 1.23 -> 1.24"

### DIFF
--- a/pkgs/development/tools/misc/pahole/default.nix
+++ b/pkgs/development/tools/misc/pahole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pahole";
-  version = "1.24";
+  version = "1.23";
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git";
     rev = "v${version}";
-    sha256 = "sha256-OPseVKt5kIKgK096+ufKrWMS1E/7Z0uxNqCMN6wKfKg=";
+    sha256 = "sha256-Dt3ZcUfjwdtTTv6qRFRgwK5GFWXdpN7fvb9KhpS1O94=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17299,9 +17299,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  pahole = callPackage ../development/tools/misc/pahole {
-    libbpf = libbpf_1;
-  };
+  pahole = callPackage ../development/tools/misc/pahole {};
 
   panopticon = callPackage ../development/tools/analysis/panopticon {};
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#194551

It broke build of some kernel branches, so let's revert for now.