### PR TITLE
Alkalami, Ruwudu: init at 2.000

### DIFF
--- a/pkgs/data/fonts/alkalami/default.nix
+++ b/pkgs/data/fonts/alkalami/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchzip }:
+
+fetchzip rec {
+  pname = "alkalami";
+  version = "2.000";
+
+  url = "https://software.sil.org/downloads/r/alkalami/Alkalami-${version}.zip";
+
+  postFetch = ''
+    rm -rf $out/web $out/manifest.json
+    mkdir -p $out/share/{doc/${pname},fonts/truetype}
+    mv $out/*.ttf $out/share/fonts/truetype/
+    mv $out/*.txt $out/documentation $out/share/doc/${pname}/
+  '';
+
+  sha256 = "sha256-GjX3YOItLKSMlRjUbBgGp2D7QS/pOJQYuQJzW+iqBNo=";
+
+  meta = with lib; {
+    homepage = "https://software.sil.org/alkalami/";
+    description = "A font for Arabic-based writing systems in the Kano region of Nigeria and in Niger";
+    license = licenses.ofl;
+    maintainers = [ maintainers.vbgl ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/ruwudu/default.nix
+++ b/pkgs/data/fonts/ruwudu/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchzip }:
+
+fetchzip rec {
+  pname = "ruwudu";
+  version = "2.000";
+
+  url = "https://software.sil.org/downloads/r/ruwudu/Ruwudu-${version}.zip";
+
+  postFetch = ''
+    rm -rf $out/web $out/manifest.json
+    mkdir -p $out/share/{doc/${pname},fonts/truetype}
+    mv $out/*.ttf $out/share/fonts/truetype/
+    mv $out/*.txt $out/documentation $out/share/doc/${pname}/
+  '';
+
+  sha256 = "sha256-JCvVPbAFBWHL2eEnEUSgdTZ+Vkw3wkS3aS85xQZKNQs=";
+
+  meta = with lib; {
+    homepage = "https://software.sil.org/ruwudu/";
+    description = "Arabic script font for a style of writing used in Niger, West Africa";
+    license = licenses.ofl;
+    maintainers = [ maintainers.vbgl ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25866,6 +25866,8 @@ with pkgs;
 
   alegreya-sans = callPackage ../data/fonts/alegreya-sans { };
 
+  alkalami = callPackage ../data/fonts/alkalami { };
+
   amber-theme = callPackage ../data/themes/amber { };
 
   amiri = callPackage ../data/fonts/amiri { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26625,6 +26625,8 @@ with pkgs;
 
   route159 = callPackage ../data/fonts/route159 { };
 
+  ruwudu = callPackage ../data/fonts/ruwudu { };
+
   sampradaya = callPackage ../data/fonts/sampradaya { };
 
   sarasa-gothic = callPackage ../data/fonts/sarasa-gothic { };


### PR DESCRIPTION
###### Description of changes

SIL Fonts: https://software.sil.org/alkalami/ https://software.sil.org/ruwudu/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
