### PR TITLE
nixos/mattermost: huge rewrite/refactor

### DIFF
--- a/nixos/tests/mattermost.nix
+++ b/nixos/tests/mattermost.nix
@@ -1,124 +1,117 @@
 import ./make-test-python.nix ({ pkgs, lib, ... }:
-let
-  host = "smoke.test";
-  port = "8065";
-  url = "http://${host}:${port}";
-  siteName = "NixOS Smoke Tests, Inc.";
+  let
+    host = "smoke.test";
+    port = 8065;
+    url = "http://${host}:${toString port}";
+    siteName = "NixOS Smoke Tests, Inc.";
 
-  makeMattermost = mattermostConfig:
-    { config, ... }: {
-      environment.systemPackages = [
-        pkgs.mattermost
-        pkgs.curl
-        pkgs.jq
-      ];
-      networking.hosts = {
-        "127.0.0.1" = [ host ];
+    makeMattermost = mattermostConfig:
+      { config, ... }: {
+        environment.systemPackages = [
+          pkgs.mattermost
+          pkgs.curl
+          pkgs.jq
+        ];
+        networking.hosts = {
+          "127.0.0.1" = [ host ];
+        };
+        services.mattermost = lib.recursiveUpdate
+          {
+            enable = true;
+            inherit siteName;
+            listenAddress = "0.0.0.0";
+            inherit port;
+            siteUrl = url;
+            settings.SupportSettings.AboutLink = "https://nixos.org";
+          }
+          mattermostConfig;
       };
-      services.mattermost = lib.recursiveUpdate {
-        enable = true;
-        inherit siteName;
-        listenAddress = "0.0.0.0:${port}";
-        siteUrl = url;
-        extraConfig = {
-          SupportSettings.AboutLink = "https://nixos.org";
-        };
-      } mattermostConfig;
-    };
-in
-{
-  name = "mattermost";
-
-  nodes = {
-    mutable = makeMattermost {
-      mutableConfig = true;
-      extraConfig.SupportSettings.HelpLink = "https://search.nixos.org";
-    };
-    mostlyMutable = makeMattermost {
-      mutableConfig = true;
-      preferNixConfig = true;
-      plugins = let
-        mattermostDemoPlugin = pkgs.fetchurl {
-          url = "https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.9.0/com.mattermost.demo-plugin-0.9.0.tar.gz";
-          sha256 = "1h4qi34gcxcx63z8wiqcf2aaywmvv8lys5g8gvsk13kkqhlmag25";
-        };
-      in [
-        mattermostDemoPlugin
-      ];
-    };
-    immutable = makeMattermost {
-      mutableConfig = false;
-      extraConfig.SupportSettings.HelpLink = "https://search.nixos.org";
-    };
-  };
-
-  testScript = let
-    expectConfig = jqExpression: pkgs.writeShellScript "expect-config" ''
-      set -euo pipefail
-      echo "Expecting config to match: "${lib.escapeShellArg jqExpression} >&2
-      curl ${lib.escapeShellArg url} >/dev/null
-      config="$(curl ${lib.escapeShellArg "${url}/api/v4/config/client?format=old"})"
-      echo "Config: $(echo "$config" | ${pkgs.jq}/bin/jq)" >&2
-      [[ "$(echo "$config" | ${pkgs.jq}/bin/jq -r ${lib.escapeShellArg ".SiteName == $siteName and .Version == ($mattermostName / $sep)[-1] and (${jqExpression})"} --arg siteName ${lib.escapeShellArg siteName} --arg mattermostName ${lib.escapeShellArg pkgs.mattermost.name} --arg sep '-')" = "true" ]]
-    '';
-
-    setConfig = jqExpression: pkgs.writeShellScript "set-config" ''
-      set -euo pipefail
-      mattermostConfig=/var/lib/mattermost/config/config.json
-      newConfig="$(${pkgs.jq}/bin/jq -r ${lib.escapeShellArg jqExpression} $mattermostConfig)"
-      rm -f $mattermostConfig
-      echo "$newConfig" > "$mattermostConfig"
-    '';
   in
-  ''
-    start_all()
+  {
+    name = "mattermost";
 
-    ## Mutable node tests ##
-    mutable.wait_for_unit("mattermost.service")
-    mutable.wait_for_open_port(8065)
+    nodes = {
+      mutable = makeMattermost {
+        mutableConfig = true;
+        settings.SupportSettings.HelpLink = "https://search.nixos.org";
+      };
+      mostlyMutable = makeMattermost {
+        mutableConfig = true;
+        preferNixConfig = true;
+      };
+      immutable = makeMattermost {
+        mutableConfig = false;
+        settings.SupportSettings.HelpLink = "https://search.nixos.org";
+      };
+    };
 
-    # Get the initial config
-    mutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
+    testScript =
+      let
+        expectConfig = jqExpression: pkgs.writeShellScript "expect-config" ''
+          set -euo pipefail
+          echo "Expecting config to match: "${lib.escapeShellArg jqExpression} >&2
+          curl ${lib.escapeShellArg url} >/dev/null
+          config="$(curl ${lib.escapeShellArg "${url}/api/v4/config/client?format=old"})"
+          echo "Config: $(echo "$config" | ${pkgs.jq}/bin/jq)" >&2
+          [[ "$(echo "$config" | ${pkgs.jq}/bin/jq -r ${lib.escapeShellArg ".SiteName == $siteName and .Version == ($mattermostName / $sep)[-1] and (${jqExpression})"} --arg siteName ${lib.escapeShellArg siteName} --arg mattermostName ${lib.escapeShellArg pkgs.mattermost.name} --arg sep '-')" = "true" ]]
+        '';
 
-    # Edit the config
-    mutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
-    mutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
-    mutable.systemctl("restart mattermost.service")
-    mutable.wait_for_open_port(8065)
+        setConfig = jqExpression: pkgs.writeShellScript "set-config" ''
+          set -euo pipefail
+          mattermostConfig=/etc/mattermost/config.json
+          newConfig="$(${pkgs.jq}/bin/jq -r ${lib.escapeShellArg jqExpression} $mattermostConfig)"
+          sudo -u mattermost echo "$newConfig" > "$mattermostConfig"
+        '';
+      in
+      ''
+        start_all()
 
-    # AboutLink and HelpLink should be changed
-    mutable.succeed("${expectConfig ''.AboutLink == "https://mattermost.com" and .HelpLink == "https://nixos.org/nixos/manual"''}")
+        ## Mutable node tests ##
+        mutable.wait_for_unit("mattermost.service")
+        mutable.wait_for_open_port(8065)
 
-    ## Mostly mutable node tests ##
-    mostlyMutable.wait_for_unit("mattermost.service")
-    mostlyMutable.wait_for_open_port(8065)
+        # Get the initial config
+        mutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
 
-    # Get the initial config
-    mostlyMutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org"''}")
+        # Edit the config
+        mutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
+        mutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
+        mutable.systemctl("restart mattermost.service")
+        mutable.wait_for_open_port(8065)
 
-    # Edit the config
-    mostlyMutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
-    mostlyMutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
-    mostlyMutable.systemctl("restart mattermost.service")
-    mostlyMutable.wait_for_open_port(8065)
+        # AboutLink and HelpLink should be changed
+        mutable.succeed("${expectConfig ''.AboutLink == "https://mattermost.com" and .HelpLink == "https://nixos.org/nixos/manual"''}")
 
-    # AboutLink should be overridden by NixOS configuration; HelpLink should be what we set above
-    mostlyMutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://nixos.org/nixos/manual"''}")
+        ## Mostly mutable node tests ##
+        mostlyMutable.wait_for_unit("mattermost.service")
+        mostlyMutable.wait_for_open_port(8065)
 
-    ## Immutable node tests ##
-    immutable.wait_for_unit("mattermost.service")
-    immutable.wait_for_open_port(8065)
+        # Get the initial config
+        mostlyMutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org"''}")
 
-    # Get the initial config
-    immutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
+        # Edit the config
+        mostlyMutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
+        mostlyMutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
+        mostlyMutable.systemctl("restart mattermost.service")
+        mostlyMutable.wait_for_open_port(8065)
 
-    # Edit the config
-    immutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
-    immutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
-    immutable.systemctl("restart mattermost.service")
-    immutable.wait_for_open_port(8065)
+        # AboutLink should be overridden by NixOS configuration; HelpLink should be what we set above
+        mostlyMutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://nixos.org/nixos/manual"''}")
 
-    # Our edits should be ignored on restart
-    immutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
-  '';
-})
+        ## Immutable node tests ##
+        immutable.wait_for_unit("mattermost.service")
+        immutable.wait_for_open_port(8065)
+
+        # Get the initial config
+        immutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
+
+        # Edit the config
+        immutable.succeed("${setConfig ''.SupportSettings.AboutLink = "https://mattermost.com"''}")
+        immutable.succeed("${setConfig ''.SupportSettings.HelpLink = "https://nixos.org/nixos/manual"''}")
+        immutable.systemctl("restart mattermost.service")
+        immutable.wait_for_open_port(8065)
+
+        # Our edits should be ignored on restart
+        immutable.succeed("${expectConfig ''.AboutLink == "https://nixos.org" and .HelpLink == "https://search.nixos.org"''}")
+      '';
+  })

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -39,7 +39,7 @@ buildGoModule rec {
     find $out/{client,i18n,fonts,templates,config} -type f -exec chmod -x {} \;
   '';
 
-  passthru.tests.mattermost = nixosTests.mattermost;
+  passthru.test = nixosTests.mattermost;
 
   meta = with lib; {
     description = "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle";


### PR DESCRIPTION
###### Description of changes
For a couple of months/weeks now I've been working on a (sort-of) rewrite of the mattermost module to make it use better practices. The biggest change in this PR is the removal of the plugins option which doesn't work as expected anyway as it requires the user to manually install the plugins via `mmctl` which defeats its purpose. I decided to just remove it for now and later on use the binary inside an FHS env or patch the Go code to support plugins directly from the nix store. I don't think that functionality should delay this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
