### PR TITLE
chart-testing: add runtimeInputs

### DIFF
--- a/pkgs/applications/networking/cluster/helm/chart-testing/default.nix
+++ b/pkgs/applications/networking/cluster/helm/chart-testing/default.nix
@@ -1,4 +1,15 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+{ buildGoModule
+, coreutils
+, fetchFromGitHub
+, git
+, installShellFiles
+, kubectl
+, kubernetes-helm
+, lib
+, makeWrapper
+, yamale
+, yamllint
+}:
 
 buildGoModule rec {
   pname = "chart-testing";
@@ -8,10 +19,10 @@ buildGoModule rec {
     owner = "helm";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-b8U7zVvzewSxqX7RG7+FMAVytW4s2apNxR3krNJuiro=";
+    hash = "sha256-b8U7zVvzewSxqX7RG7+FMAVytW4s2apNxR3krNJuiro=";
   };
 
-  vendorSha256 = "sha256-z4hNGswxRMU40qkgwY3n516FiyaoeDaAE+CCla3TMkk=";
+  vendorHash = "sha256-z4hNGswxRMU40qkgwY3n516FiyaoeDaAE+CCla3TMkk=";
 
   postPatch = ''
     substituteInPlace pkg/config/config.go \
@@ -26,7 +37,7 @@ buildGoModule rec {
     "-X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=19700101-00:00:00"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   postInstall = ''
     install -Dm644 -t $out/etc/ct etc/chart_schema.yaml
@@ -36,6 +47,15 @@ buildGoModule rec {
       --bash <($out/bin/ct completion bash) \
       --zsh <($out/bin/ct completion zsh) \
       --fish <($out/bin/ct completion fish) \
+
+    wrapProgram $out/bin/ct --prefix PATH : ${lib.makeBinPath [
+      coreutils
+      git
+      kubectl
+      kubernetes-helm
+      yamale
+      yamllint
+    ]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Turns out that chart-testing execs a few other binaries at runtime, so they do not get automatically detected by nix.

###### Things done

 The primary ones are listed upstream, https://github.com/helm/chart-testing#prerequisites, however they also callout to echo, so we have tacked on coreutils for good measure.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
