### PR TITLE
nanomq: init at 0.13.0

### DIFF
--- a/pkgs/servers/mqtt/nanomq/default.nix
+++ b/pkgs/servers/mqtt/nanomq/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchFromGitHub, cmake, ninja, mbedtls, sqlite }:
+
+stdenv.mkDerivation rec {
+  pname = "nanomq";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "emqx";
+    repo = "nanomq";
+    rev = version;
+    hash = "sha256-fxV/X34yohh/bxOsnoVngBKiwqABQDthLgZxvomC0+g=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "DESTINATION /etc" "DESTINATION $out/etc"
+  '';
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  buildInputs = [ mbedtls sqlite ];
+
+  cmakeFlags = [
+    "-DNNG_ENABLE_TLS=ON"
+    "-DNNG_ENABLE_SQLITE=ON"
+  ];
+
+  meta = with lib; {
+    description = "An ultra-lightweight and blazing-fast MQTT broker for IoT edge";
+    homepage = "https://nanomq.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21167,6 +21167,8 @@ with pkgs;
 
   mosquitto = callPackage ../servers/mqtt/mosquitto { };
 
+  nanomq = callPackage ../servers/mqtt/nanomq { };
+
   mps = callPackage ../development/libraries/mps { stdenv = gcc10StdenvCompat; };
 
   libmpeg2 = callPackage ../development/libraries/libmpeg2 { };


### PR DESCRIPTION
###### Description of changes
**[nanomq](https://nanomq.io/)** - an ultra-lightweight and blazing-fast MQTT broker for IoT edge.
Alternative to [mosquitto](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/mqtt/mosquitto/default.nix).

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
