### PR TITLE
jami: 20220726.1515.da8d1da -> 20220825.0828.c10f01f

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jami/client-qt.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/client-qt.nix
@@ -21,7 +21,7 @@
 , qtsvg
 , qtwebengine
 , qtwebchannel
-, withWebengine ? false
+, withWebengine ? true
 }:
 
 stdenv.mkDerivation {
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     python gen-resources.py
-    echo 'const char VERSION_STRING[] = "${version}";' > src/version.h
+    echo 'const char VERSION_STRING[] = "${version}";' > src/app/version.h
   '';
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/instant-messengers/jami/update.sh
+++ b/pkgs/applications/networking/instant-messengers/jami/update.sh
@@ -13,7 +13,7 @@ echo "Latest version: ${version}"
 
 update-source-version jami-daemon "$version" --file=$jami_dir/default.nix
 
-src=$(nix-build --no-out-link -A jami-libclient.src)
+src=$(nix-build --no-out-link -A jami-daemon.src)
 
 config_dir="$jami_dir/config"
 mkdir -p $config_dir
@@ -47,7 +47,7 @@ echo "${pjsip_patches}" > "$config_dir/pjsip_patches"
 
 # Update pjsip version
 pjsip_version=$(sed -n -E 's/.*PJPROJECT_VERSION := ([0-9a-f]+).*/\1/p' ${src}/daemon/contrib/src/pjproject/rules.mak)
-update-source-version jami-daemon.pjsip "$pjsip_version" --file=pkgs/applications/networking/instant-messengers/jami/daemon.nix
+update-source-version jami.pjsip-jami "$pjsip_version" --file=$jami_dir/default.nix
 
 pjsip_rules="${src}/daemon/contrib/src/pjproject/rules.mak"
 


### PR DESCRIPTION
###### Description of changes
The pjsip patches are appiled upstream.
The ffmpeg tests fail but I don't know why. The related functions still work.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
