### PR TITLE
ocamlPackages.lablgtk3: 3.1.2 → 3.1.3

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk3/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/default.nix
@@ -1,10 +1,11 @@
-{ lib, fetchFromGitHub, fetchpatch, pkg-config, buildDunePackage, dune-configurator, gtk3, cairo2 }:
+{ lib, fetchFromGitHub, pkg-config, buildDunePackage, dune-configurator
+, gtk3, cairo2
+, camlp-streams
+}:
 
 buildDunePackage rec {
-  version = "3.1.2";
+  version = "3.1.3";
   pname = "lablgtk3";
-
-  useDune2 = true;
 
   minimalOCamlVersion = "4.05";
 
@@ -12,16 +13,11 @@ buildDunePackage rec {
     owner = "garrigue";
     repo = "lablgtk";
     rev = version;
-    sha256 = "sha256:0b17w9qb1f02h3313cm62mrqlhwxficppzm72n7sf8mmwrylxbm7";
+    sha256 = "sha256-1kXJP+tKudP3qfosTgZAQueNK46H9aLevEj6wxPKDWY=";
   };
 
-  patches = [ (fetchpatch {
-    name = "dune-project.patch";
-    url = "https://raw.githubusercontent.com/ocaml/opam-repository/10a48cb9fab88f67f6cb70280e0fec035c32d41c/packages/lablgtk3/lablgtk3.3.1.2/files/dune-project.patch";
-    sha256 = "03jf5hclqdq7iq84djaqcnfnnnd7z3hb48rr8n1gyxzjyx86b3fh";
-  }) ];
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator camlp-streams ];
   propagatedBuildInputs = [ gtk3 cairo2 ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/lablgtk3/gtkspell3.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/gtkspell3.nix
@@ -4,5 +4,5 @@ buildDunePackage {
   pname = "lablgtk3-gtkspell3";
   buildInputs = [ gtkspell3 ] ++ lablgtk3.buildInputs;
   propagatedBuildInputs = [ lablgtk3 ];
-  inherit (lablgtk3) src version useDune2 meta nativeBuildInputs;
+  inherit (lablgtk3) src version meta nativeBuildInputs;
 }

--- a/pkgs/development/ocaml-modules/lablgtk3/sourceview3.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/sourceview3.nix
@@ -4,5 +4,5 @@ buildDunePackage {
   pname = "lablgtk3-sourceview3";
   buildInputs = lablgtk3.buildInputs ++ [ gtksourceview ];
   propagatedBuildInputs = [ lablgtk3 ];
-  inherit (lablgtk3) src version useDune2 meta nativeBuildInputs;
+  inherit (lablgtk3) src version meta nativeBuildInputs;
 }


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
