### PR TITLE
python311Packages.cffi: patch failing test

### DIFF
--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, buildPythonPackage, isPyPy, fetchPypi, pytestCheckHook,
-  libffi, pkg-config, pycparser
+  libffi, pkg-config, pycparser, python, fetchpatch
 }:
 
 if isPyPy then null else buildPythonPackage rec {
@@ -16,6 +16,17 @@ if isPyPy then null else buildPythonPackage rec {
   nativeBuildInputs = [ pkg-config ];
 
   propagatedBuildInputs = [ pycparser ];
+
+  patches =
+    # Fix test that failed because python seems to have changed the exception format in the
+    # final release. This patch should be included in the next version and can be removed when
+    # it is released.
+    lib.optionals (python.pythonVersion == "3.11") [
+      (fetchpatch {
+        url = "https://foss.heptapod.net/pypy/cffi/-/commit/8a3c2c816d789639b49d3ae867213393ed7abdff.diff";
+        sha256 = "sha256-3wpZeBqN4D8IP+47QDGK7qh/9Z0Ag4lAe+H0R5xCb1E=";
+      })
+    ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     # Remove setup.py impurities


### PR DESCRIPTION
### Steps To Reproduce
Steps to reproduce the behavior:
`nix build nixpkgs#python311Packages.cffi`

### Build log
https://gist.github.com/voidus/90ea9dbfb3cbf08c026d866ca6acb8c8

### Additional context
I debugged the issue and fixed the test, but upstream gitlab is down: https://foss.heptapod.net/pypy/cffi
Not sure how to best proceed, we could keep this open, I can submit it upstream in the next days and then remove the patch maybe?

### Notify maintainers
@domenkozar @LnL7

###### Description of changes

Added a patch to fix the failing tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
   - I didn't do that because a) no idea how to find the presumably huge number of affected packages and b) it doesn't build at all right now 
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Metadata
Please run `nix-shell -p nix-info --run "nix-info -m"` and paste the result.

```console
> nix-shell -p nix-info --run "nix-info -m"
this path will be fetched (0.00 MiB download, 0.00 MiB unpacked):
  /nix/store/q1drpnp5qifc38akiv4r169ll7cizisp-nix-info
copying path '/nix/store/q1drpnp5qifc38akiv4r169ll7cizisp-nix-info' from 'https://cache.nixos.org'...
 - system: `"x86_64-linux"`
 - host os: `Linux 6.0.2-arch1-1, Arch Linux, noversion, rolling`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.11.1`
 - channels(root): `""`
 - channels(voyd): `"home-manager, nixpkgs"`
 - channels(testie): `"nixpkgs"`
 - nixpkgs: `/home/voyd/.nix-defexpr/channels/nixpkgs`
```