### PR TITLE
python3Packages.mdformat-tables: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/mdformat-tables/default.nix
+++ b/pkgs/development/python-modules/mdformat-tables/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  flit-core,
+  markdown-it-py,
+  coverage,
+  mdformat,
+  pytest,
+  pytest-cov,
+}:
+buildPythonPackage rec {
+  pname = "mdformat-tables";
+  version = "0.4.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6.1";
+
+  src = fetchFromGitHub {
+    owner = "executablebooks";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Q61GmaRxjxJh9GjyR8QCZOH0njFUtAWihZ9lFQJ2nQQ=";
+  };
+
+  buildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    markdown-it-py
+    mdformat
+  ];
+
+  checkInputs = [
+    coverage
+    pytest
+    pytest-cov
+  ];
+
+  checkPhase = "pytest";
+
+  meta = with lib; {
+    description = "An mdformat plugin for rendering tables";
+    homepage = "https://github.com/executablebooks/mdformat-tables";
+    license = with licenses; [mit];
+    maintainers = with maintainers; [djacu];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5700,6 +5700,8 @@ in {
 
   mdformat = callPackage ../development/python-modules/mdformat { };
 
+  mdformat-tables = callPackage ../development/python-modules/mdformat-tables { };
+
   mdit-py-plugins = callPackage ../development/python-modules/mdit-py-plugins { };
 
   mdurl = callPackage ../development/python-modules/mdurl { };


### PR DESCRIPTION
###### Description of changes

Add python package mdformat-tables.
Depends on #197551.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
