### PR TITLE
python3Packages:mdformat-frontmatter: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/mdformat-frontmatter/default.nix
+++ b/pkgs/development/python-modules/mdformat-frontmatter/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  flit-core,
+  mdformat,
+  mdit-py-plugins,
+  ruamel-yaml,
+  coverage,
+  pytest,
+  pytest-cov,
+}:
+buildPythonPackage rec {
+  pname = "mdformat-frontmatter";
+  version = "0.4.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "butler54";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-gaaWPwtnlSPUv8ai2RJsAcwxCZaHtqPlkjAlauQrr78=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    mdformat
+    mdit-py-plugins
+    ruamel-yaml
+  ];
+
+  checkInputs = [
+    coverage
+    pytest
+    pytest-cov
+  ];
+
+  checkPhase = "pytest";
+
+  meta = with lib; {
+    description = "An mdformat plugin for ensuring that yaml front-matter is respected";
+    homepage = "https://github.com/butler54/mdformat-frontmatter";
+    license = with licenses; [mit];
+    maintainers = with maintainers; [djacu];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5567,6 +5567,8 @@ self: super: with self; {
 
   mdformat = callPackage ../development/python-modules/mdformat { };
 
+  mdformat-frontmatter = callPackage ../development/python-modules/mdformat-frontmatter { };
+
   mdit-py-plugins = callPackage ../development/python-modules/mdit-py-plugins { };
 
   mdurl = callPackage ../development/python-modules/mdurl { };


### PR DESCRIPTION
###### Description of changes

Add python package mdformat-frontmatter.
Depends on https://github.com/NixOS/nixpkgs/pull/197551.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
