### PR TITLE
vhs: init at 0.1.1

### DIFF
--- a/pkgs/applications/misc/vhs/default.nix
+++ b/pkgs/applications/misc/vhs/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildGoModule, installShellFiles, fetchFromGitHub, ffmpeg, ttyd, makeWrapper }:
+
+buildGoModule rec {
+  pname = "vhs";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "charmbracelet";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-wcOLUA/U+xRwo7slnACCURQO7D0F3pFP2/SHDfEHeTA=";
+  };
+
+  vendorHash = "sha256-f8EHDxu+NWAFJx9ujzsiDhNymdEzExmdreP11gV56AI=";
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+  buildInputs = [ ttyd ffmpeg ];
+
+  ldflags = [ "-s" "-w" "-X=main.Version=${version}" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/vhs --prefix PATH : ${lib.makeBinPath [ ffmpeg ttyd ]}
+    $out/bin/vhs man > vhs.1
+    installManPage vhs.1
+    installShellCompletion --cmd vhs \
+      --bash <($out/bin/vhs completion bash) \
+      --fish <($out/bin/vhs completion fish) \
+      --zsh <($out/bin/vhs completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "A tool for generating terminal GIFs with code";
+    homepage = "https://github.com/charmbracelet/vhs";
+    changelog = "https://github.com/charmbracelet/vhs/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ maaslalani ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37201,6 +37201,8 @@ with pkgs;
 
   vazir-fonts = callPackage ../data/fonts/vazir-fonts { };
 
+  vhs = callPackage ../applications/misc/vhs { };
+
   vgmstream = callPackage ../applications/audio/vgmstream { };
 
   viddy = callPackage ../tools/misc/viddy { };


### PR DESCRIPTION
###### Description of changes

Init VHS at `v0.1.1`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
