### PR TITLE
wireshark: 3.6.5 -> 4.0.1

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, buildPackages, fetchurl, pkg-config, pcre, perl, flex, bison, gettext, libpcap, libnl, c-ares
-, gnutls, libgcrypt, libgpg-error, geoip, openssl, lua5, python3, libcap, glib
-, libssh, nghttp2, zlib, cmake, makeWrapper, wrapGAppsHook
+{ lib, stdenv, buildPackages, fetchurl, pkg-config, pcre2, perl, flex, bison
+, gettext, libpcap, libnl, c-ares, gnutls, libgcrypt, libgpg-error, geoip, openssl
+, lua5, python3, libcap, glib, libssh, nghttp2, zlib, cmake, makeWrapper, wrapGAppsHook
 , withQt ? true, qt5 ? null
 , ApplicationServices, SystemConfiguration, gmp
 , asciidoctor
@@ -11,7 +11,7 @@ assert withQt  -> qt5  != null;
 with lib;
 
 let
-  version = "3.6.5";
+  version = "4.0.1";
   variant = if withQt then "qt" else "cli";
 
 in stdenv.mkDerivation {
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "sha256-otdB1g/zUWE31LnzjNwH7uVKVuw2BG9MOv7mv7T26qE=";
+    sha256 = "sha256-s7AC+Z0Tu/R/ntO+frNyywwkVL0PrqKadWgZzgGf/cI=";
   };
 
   cmakeFlags = [
@@ -44,7 +44,7 @@ in stdenv.mkDerivation {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   buildInputs = [
-    gettext pcre libpcap lua5 libssh nghttp2 openssl libgcrypt
+    gettext pcre2 libpcap lua5 libssh nghttp2 openssl libgcrypt
     libgpg-error gnutls geoip c-ares glib zlib
   ] ++ optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
     ++ optionals stdenv.isLinux  [ libcap libnl ]
@@ -73,19 +73,20 @@ in stdenv.mkDerivation {
         done
     done
   '' else optionalString withQt ''
-    install -Dm644 -t $out/share/applications ../org.wireshark.Wireshark.desktop
+    pwd
+    install -Dm644 -t $out/share/applications ../resources/freedesktop/org.wireshark.Wireshark.desktop
 
-    install -Dm644 ../image/wsicon.svg $out/share/icons/wireshark.svg
-    mkdir $dev/include/{epan/{wmem,ftypes,dfilter},wsutil/wmem,wiretap} -pv
+    install -Dm644 ../resources/icons/wsicon.svg $out/share/icons/wireshark.svg
+    mkdir -pv $dev/include/{epan/{wmem,ftypes,dfilter},wsutil/wmem,wiretap}
 
     cp config.h $dev/include/wireshark/
-    cp ../ws_*.h $dev/include
     cp ../epan/*.h $dev/include/epan/
     cp ../epan/ftypes/*.h $dev/include/epan/ftypes/
     cp ../epan/dfilter/*.h $dev/include/epan/dfilter/
+    cp ../include/ws_*.h $dev/include/
+    cp ../wiretap/*.h $dev/include/wiretap/
     cp ../wsutil/*.h $dev/include/wsutil/
     cp ../wsutil/wmem/*.h $dev/include/wsutil/wmem/
-    cp ../wiretap/*.h $dev/include/wiretap
   '');
 
   dontFixCmake = true;

--- a/pkgs/applications/networking/sniffers/wireshark/wireshark-lookup-dumpcap-in-path.patch
+++ b/pkgs/applications/networking/sniffers/wireshark/wireshark-lookup-dumpcap-in-path.patch
@@ -1,6 +1,6 @@
-From 5bef9deeff8a2e4401de0f45c9701cd6f98f29d8 Mon Sep 17 00:00:00 2001
+From 2f0cbc740a0fe050f4de082620296c5eea18eba3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bj=C3=B8rn=20Forsman?= <bjorn.forsman@gmail.com>
-Date: Thu, 26 Nov 2015 21:03:35 +0100
+Date: Thu, 27 Oct 2022 20:56:07 +0200
 Subject: [PATCH] Lookup dumpcap in PATH
 
 NixOS patch: Look for dumpcap in PATH first, because there may be a
@@ -11,22 +11,26 @@ Also change execv() to execvp() because we've set argv[0] to "dumpcap"
 and have to enable PATH lookup. Wireshark is not a setuid program, so
 looking in PATH is not a security issue.
 
+ORIGINALLY by Björn Forsman
+
 EDITED by teto for wireshark 3.6
+
+EDITED by esclear for wireshark 4.0
 
 Signed-off-by: Franz Pletz <fpletz@fnordicwalking.de>
 ---
- capchild/capture_sync.c | 17 ++++++++++++++---
+ capture/capture_sync.c | 17 ++++++++++++++---
  1 file changed, 14 insertions(+), 3 deletions(-)
 
-diff --git a/capchild/capture_sync.c b/capchild/capture_sync.c
-index f31914886a..df29b6f0ab 100644
+diff --git a/capture/capture_sync.c b/capture/capture_sync.c
+index fc5552f02c..a556f109af 100644
 --- a/capture/capture_sync.c
 +++ b/capture/capture_sync.c
-@@ -187,7 +187,18 @@ init_pipe_args(int *argc) {
+@@ -239,7 +239,18 @@ init_pipe_args(int *argc) {
  #ifdef _WIN32
-     exename = g_strdup_printf("%s\\dumpcap.exe", progfile_dir);
+     exename = ws_strdup_printf("%s\\dumpcap.exe", progfile_dir);
  #else
--    exename = g_strdup_printf("%s/dumpcap", progfile_dir);
+-    exename = ws_strdup_printf("%s/dumpcap", progfile_dir);
 +    /*
 +     * NixOS patch: Look for dumpcap in PATH first, because there may be a
 +     * dumpcap wrapper that we want to use instead of the default
@@ -34,29 +38,29 @@ index f31914886a..df29b6f0ab 100644
 +     */
 +    if (system("command -v dumpcap >/dev/null") == 0) {
 +        /* Found working dumpcap */
-+        exename = g_strdup_printf("dumpcap");
++        exename = ws_strdup_printf("dumpcap");
 +    } else {
 +        /* take Wireshark's absolute program path and replace "Wireshark" with "dumpcap" */
-+        exename = g_strdup_printf("%s/dumpcap", progfile_dir);
++        exename = ws_strdup_printf("%s/dumpcap", progfile_dir);
 +    }
  #endif
  
      /* Make that the first argument in the argument list (argv[0]). */
-@@ -572,7 +583,7 @@ sync_pipe_start(capture_options *capture_opts, capture_session *cap_session, inf
+@@ -690,7 +701,7 @@ sync_pipe_start(capture_options *capture_opts, GPtrArray *capture_comments,
           */
          dup2(sync_pipe[PIPE_WRITE], 2);
          ws_close(sync_pipe[PIPE_READ]);
 -        execv(argv[0], argv);
 +        execvp(argv[0], argv);
-         g_snprintf(errmsg, sizeof errmsg, "Couldn't run %s in child process: %s",
+         snprintf(errmsg, sizeof errmsg, "Couldn't run %s in child process: %s",
                     argv[0], g_strerror(errno));
          sync_pipe_errmsg_to_parent(2, errmsg, "");
-@@ -811,7 +822,7 @@ sync_pipe_open_command(char* const argv[], int *data_read_fd,
+@@ -946,7 +957,7 @@ sync_pipe_open_command(char* const argv[], int *data_read_fd,
          dup2(sync_pipe[PIPE_WRITE], 2);
          ws_close(sync_pipe[PIPE_READ]);
          ws_close(sync_pipe[PIPE_WRITE]);
 -        execv(argv[0], argv);
 +        execvp(argv[0], argv);
-         g_snprintf(errmsg, sizeof errmsg, "Couldn't run %s in child process: %s",
+         snprintf(errmsg, sizeof errmsg, "Couldn't run %s in child process: %s",
                     argv[0], g_strerror(errno));
          sync_pipe_errmsg_to_parent(2, errmsg, "");

--- a/pkgs/development/python-modules/pyshark/default.nix
+++ b/pkgs/development/python-modules/pyshark/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , fetchFromGitHub
 , appdirs
 , lxml
@@ -24,34 +25,36 @@ buildPythonPackage rec {
     hash = "sha256-byll2GWY2841AAf8Xh+KfaCOtMGVKabTsLCe3gCdZ1o=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "fix-mapping.patch";
+      url =
+        "https://github.com/KimiNewt/pyshark/pull/608/commits/c2feb17ef621390481d6acc29dbf807d6851ed4c.patch";
+      hash = "sha256-TY09HPxqJP3zI8+ugm518aMuBgog7wrXs5uoReHHaEI=";
+    })
+  ];
+
+  # `stripLen` does not seem to work here
+  patchFlags = "-p2";
+
   sourceRoot = "${src.name}/src";
 
-  propagatedBuildInputs = [
-    appdirs
-    py
-    lxml
-    packaging
-  ];
+  # propagate wireshark, so pyshark can find it when used
+  propagatedBuildInputs = [ appdirs py lxml packaging wireshark-cli ];
 
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
 
-  checkInputs = [
-    pytestCheckHook
-    wireshark-cli
-  ];
+  checkInputs = [ pytestCheckHook wireshark-cli ];
 
-  pythonImportsCheck = [
-    "pyshark"
-  ];
+  pythonImportsCheck = [ "pyshark" ];
 
-  pytestFlagsArray = [
-    "../tests/"
-  ];
+  pytestFlagsArray = [ "../tests/" ];
 
   meta = with lib; {
-    description = "Python wrapper for tshark, allowing Python packet parsing using Wireshark dissectors";
+    description =
+      "Python wrapper for tshark, allowing Python packet parsing using Wireshark dissectors";
     homepage = "https://github.com/KimiNewt/pyshark/";
     license = licenses.mit;
     maintainers = with maintainers; [ ];


### PR DESCRIPTION
###### Description of changes

The release notes for the major update to 4.0.0 are at https://www.wireshark.org/news/20221004.html

The release notes for the 4.0.1 release can be found at https://www.wireshark.org/docs/relnotes/wireshark-4.0.1.html

This is a draft at the moment, as I want to test some more.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
