### PR TITLE
signald: 0.19.1 -> 0.23.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signald/0001-Fetch-buildconfig-during-gradle-build-inside-Nix-FOD.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/0001-Fetch-buildconfig-during-gradle-build-inside-Nix-FOD.patch
@@ -1,4 +1,4 @@
-From 8ed5f3c9117e08f7c2e4e1e01c2eee501675049b Mon Sep 17 00:00:00 2001
+From 2c126682aaabd7f486dfb2ff75fe29b5d8697060 Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
 Date: Sat, 26 Feb 2022 12:33:13 +0100
 Subject: [PATCH] Fetch buildconfig during gradle build inside Nix FOD
@@ -8,7 +8,7 @@ Subject: [PATCH] Fetch buildconfig during gradle build inside Nix FOD
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/build.gradle b/build.gradle
-index eaa6e0e..63c2947 100644
+index 799e782..caceaac 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -83,6 +83,9 @@ static String getVersion() {
@@ -22,11 +22,11 @@ index eaa6e0e..63c2947 100644
  }
  
 @@ -104,6 +107,8 @@ dependencies {
-     implementation 'io.prometheus:simpleclient_httpserver:0.15.0'
+     implementation 'io.prometheus:simpleclient_httpserver:0.16.0'
      implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
-     implementation 'io.sentry:sentry:5.7.3'
-+    implementation 'com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:3.0.3'
-+    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.4.31'
+     implementation 'io.sentry:sentry:6.4.0'
++    implementation 'com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:3.1.0'
++    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.7.10'
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
  }
  
@@ -38,5 +38,5 @@ index eaa6e0e..63c2947 100644
 \ No newline at end of file
 +}
 -- 
-2.36.0
+2.36.2
 

--- a/pkgs/applications/networking/instant-messengers/signald/0002-buildconfig-local-deps-fixes.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/0002-buildconfig-local-deps-fixes.patch
@@ -1,4 +1,4 @@
-From f319e1db47ae1eeddb6021cafe7b4f8551a702d7 Mon Sep 17 00:00:00 2001
+From b068af1f3e49dedfb489e3ed957934ff651e98ee Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
 Date: Sat, 26 Feb 2022 12:36:15 +0100
 Subject: [PATCH 2/2] buildconfig/local deps fixes
@@ -8,7 +8,7 @@ Subject: [PATCH 2/2] buildconfig/local deps fixes
  1 file changed, 18 insertions(+), 8 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index eaa6e0e..9a2f4e2 100644
+index 799e782..6ecef3e 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -10,11 +10,21 @@ import org.gradle.nativeplatform.platform.internal.ArchitectureInternal
@@ -48,11 +48,11 @@ index eaa6e0e..9a2f4e2 100644
  
  dependencies {
 @@ -104,6 +117,8 @@ dependencies {
-     implementation 'io.prometheus:simpleclient_httpserver:0.15.0'
+     implementation 'io.prometheus:simpleclient_httpserver:0.16.0'
      implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
-     implementation 'io.sentry:sentry:5.7.3'
-+    implementation 'com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:3.0.3'
-+    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.4.31'
+     implementation 'io.sentry:sentry:6.4.0'
++    implementation 'com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin:3.1.0'
++    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.7.10'
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
  }
  
@@ -67,5 +67,5 @@ index eaa6e0e..9a2f4e2 100644
 -}
 \ No newline at end of file
 -- 
-2.36.0
+2.36.2
 

--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -4,18 +4,18 @@
 
 let
   pname = "signald";
-  version = "0.19.1";
+  version = "0.23.0";
 
   src = fetchFromGitLab {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-Ma6kIKRVM8UUU/TvfVp2RVl/FLxFgBQU3mEypnujJ+c=";
+    sha256 = "sha256-RN0OYjOmVtHKeFkviep952uf3qWuBj8lhcaP1Lk/gDo=";
   };
 
   jre' = jre_minimal.override {
     jdk = jdk17_headless;
-    # from https://gitlab.com/signald/signald/-/blob/0.19.1/build.gradle#L173
+    # from https://gitlab.com/signald/signald/-/blob/0.23.0/build.gradle#L173
     modules = [
       "java.base"
       "java.management"
@@ -54,8 +54,8 @@ let
     outputHashMode = "recursive";
     # Downloaded jars differ by platform
     outputHash = {
-      x86_64-linux = "sha256-q1gzauIL7aKalvPSfiK5IvkNkidCh+6jp5bpwxR+PZ0=";
-      aarch64-linux = "sha256-cM+7MaV0/4yAzobXX9FSdl/ZfLddwySayao96UdDgzk=";
+      x86_64-linux = "sha256-ANiNDdTuCuDEH5zUPsrVF6Uegdq3zVsMv+uMtYRX0jE=";
+      aarch64-linux = "sha256-V9zn4v/ZeLELAwFJ5y7OVAeJwZp4DmHm4KWxE6KpwGs=";
     }.${stdenv.system} or (throw "Unsupported platform");
   };
 


### PR DESCRIPTION


###### Description of changes
__Note:__ I guess it'd make sense to backport, but perhaps we should do it in a less invasive way, i.e. without having to migrate all your data. OTOH I'm not sure if it's a good idea to cherry-pick db migrations from later versions as it'd perhaps cause issues on later upgrades, so I'm open for suggestions.

Replaces/Closes #174256

Needed because the CA of a signal server seems to have changed[1] which has caused the following errors to appear while trying to send messages from Matrix (via `mautrix-signal` and subsequently `signald`):

    ⚠ Your message was not bridged:
    org.whispersystems.signalservice.api.push.exceptions.PushNetworkException,
    javax.net.ssl.SSLHandshakeException,
    sun.security.validator.ValidatorException,
    sun.security.provider.certpath.SunCertPathBuilderException:
    org.whispersystems.signalservice.api.push.exceptions.PushNetworkException:
    javax.net.ssl.SSLHandshakeException:
    PKIX path building failed:
    sun.security.provider.certpath.SunCertPathBuilderException:
    unable to find valid certification path to requested target

Migration can be performed by running a command like

    $ signald \
        -d /var/lib/signald/data \
        --database sqlite:/var/lib/signald/db \
        -s /run/signald/signald.sock \
        --migrate-data

before starting signald itself.

ChangeLogs:

* https://gitlab.com/signald/signald/-/blob/main/releases/0.20.0.md
* https://gitlab.com/signald/signald/-/blob/main/releases/0.21.0.md
* https://gitlab.com/signald/signald/-/blob/main/releases/0.22.0.md
* https://gitlab.com/signald/signald/-/blob/main/releases/0.22.1.md
* https://gitlab.com/signald/signald/-/blob/main/releases/0.22.2.md
* https://gitlab.com/signald/signald/-/blob/main/releases/0.23.0.md

[1] https://gitlab.com/signald/signald/-/blob/main/releases/0.23.0.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
