### PR TITLE
mujoco: init at 2.3.0

### DIFF
--- a/pkgs/applications/science/robotics/mujoco/default.nix
+++ b/pkgs/applications/science/robotics/mujoco/default.nix
@@ -1,0 +1,122 @@
+{ cmake
+, fetchFromGitHub
+, fetchFromGitLab
+, git
+, lib
+, libGL
+, stdenv
+, xorg
+}:
+
+let
+  # See https://github.com/deepmind/mujoco/blob/573d331b69845c5d651b70f5d1b0f3a0d2a3a233/cmake/MujocoDependencies.cmake#L21-L59
+  abseil-cpp = fetchFromGitHub {
+    owner = "abseil";
+    repo = "abseil-cpp";
+    rev = "8c0b94e793a66495e0b1f34a5eb26bd7dc672db0";
+    hash = "sha256-Od1FZOOWEXVQsnZBwGjDIExi6LdYtomyL0STR44SsG8=";
+  };
+  benchmark = fetchFromGitHub {
+    owner = "google";
+    repo = "benchmark";
+    rev = "d845b7b3a27d54ad96280a29d61fa8988d4fddcf";
+    hash = "sha256-XTnTM1k6xMGXUws/fKdJUbpCPcc4U0IelL6BPEEnpEQ=";
+  };
+  ccd = fetchFromGitHub {
+    owner = "danfis";
+    repo = "libccd";
+    rev = "7931e764a19ef6b21b443376c699bbc9c6d4fba8";
+    hash = "sha256-TIZkmqQXa0+bSWpqffIgaBela0/INNsX9LPM026x1Wk=";
+  };
+  eigen3 = fetchFromGitLab {
+    owner = "libeigen";
+    repo = "eigen";
+    rev = "3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e";
+    hash = "sha256-k71DoEsx8JpC9AlQ0cCRI0fWMIWFBFL/Yscx+2iBtNM=";
+  };
+  googletest = fetchFromGitHub {
+    owner = "google";
+    repo = "googletest";
+    rev = "58d77fa8070e8cec2dc1ed015d66b454c8d78850";
+    hash = "sha256-W+OxRTVtemt2esw4P7IyGWXOonUN5ZuscjvzqkYvZbM=";
+  };
+  lodepng = fetchFromGitHub {
+    owner = "lvandeve";
+    repo = "lodepng";
+    rev = "b4ed2cd7ecf61d29076169b49199371456d4f90b";
+    hash = "sha256-5cCkdj/izP4e99BKfs/Mnwu9aatYXjlyxzzYiMD/y1M=";
+  };
+  qhull = fetchFromGitHub {
+    owner = "qhull";
+    repo = "qhull";
+    rev = "3df027b91202cf179f3fba3c46eebe65bbac3790";
+    hash = "sha256-aHO5n9Y35C7/zb3surfMyjyMjo109DoZnkozhiAKpYQ=";
+  };
+  tinyobjloader = fetchFromGitHub {
+    owner = "tinyobjloader";
+    repo = "tinyobjloader";
+    rev = "1421a10d6ed9742f5b2c1766d22faa6cfbc56248";
+    hash = "sha256-9z2Ne/WPCiXkQpT8Cun/pSGUwgClYH+kQ6Dx1JvW6w0=";
+  };
+  tinyxml2 = fetchFromGitHub {
+    owner = "leethomason";
+    repo = "tinyxml2";
+    rev = "1dee28e51f9175a31955b9791c74c430fe13dc82";
+    hash = "sha256-AQQOctXi7sWIH/VOeSUClX6hlm1raEQUOp+VoPjLM14=";
+  };
+
+  # See https://github.com/deepmind/mujoco/blob/573d331b69845c5d651b70f5d1b0f3a0d2a3a233/simulate/cmake/SimulateDependencies.cmake#L32-L35
+  glfw = fetchFromGitHub {
+    owner = "glfw";
+    repo = "glfw";
+    rev = "7482de6071d21db77a7236155da44c172a7f6c9e";
+    hash = "sha256-4+H0IXjAwbL5mAWfsIVhW0BSJhcWjkQx4j2TrzZ3aIo=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "mujoco";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "deepmind";
+    repo = pname;
+    rev = version;
+    hash = "sha256-FxMaXl7yfUAyY6LE1sxaw226dBtp1DOCWNnROp0WX2I=";
+  };
+
+  patches = [ ./dependencies.patch ];
+
+  nativeBuildInputs = [ cmake git ];
+
+  buildInputs = [
+    libGL
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXi
+    xorg.libXinerama
+    xorg.libXrandr
+  ];
+
+  # Move things into place so that cmake doesn't try downloading dependencies.
+  preConfigure = ''
+    mkdir -p build/_deps
+    ln -s ${abseil-cpp} build/_deps/abseil-cpp-src
+    ln -s ${benchmark} build/_deps/benchmark-src
+    ln -s ${ccd} build/_deps/ccd-src
+    ln -s ${eigen3} build/_deps/eigen3-src
+    ln -s ${glfw} build/_deps/glfw-src
+    ln -s ${googletest} build/_deps/googletest-src
+    ln -s ${lodepng} build/_deps/lodepng-src
+    ln -s ${qhull} build/_deps/qhull-src
+    ln -s ${tinyobjloader} build/_deps/tinyobjloader-src
+    ln -s ${tinyxml2} build/_deps/tinyxml2-src
+  '';
+
+  meta = {
+    description = "Multi-Joint dynamics with Contact. A general purpose physics simulator.";
+    homepage = "https://mujoco.org/";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.samuela ];
+  };
+}

--- a/pkgs/applications/science/robotics/mujoco/default.nix
+++ b/pkgs/applications/science/robotics/mujoco/default.nix
@@ -113,10 +113,10 @@ stdenv.mkDerivation rec {
     ln -s ${tinyxml2} build/_deps/tinyxml2-src
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Multi-Joint dynamics with Contact. A general purpose physics simulator.";
     homepage = "https://mujoco.org/";
-    license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.samuela ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
   };
 }

--- a/pkgs/applications/science/robotics/mujoco/dependencies.patch
+++ b/pkgs/applications/science/robotics/mujoco/dependencies.patch
@@ -1,0 +1,114 @@
+diff --git a/cmake/MujocoDependencies.cmake b/cmake/MujocoDependencies.cmake
+index 99e4a7a..cf9a901 100644
+--- a/cmake/MujocoDependencies.cmake
++++ b/cmake/MujocoDependencies.cmake
+@@ -82,8 +82,6 @@ set(BUILD_SHARED_LIBS
+ if(NOT TARGET lodepng)
+   FetchContent_Declare(
+     lodepng
+-    GIT_REPOSITORY https://github.com/lvandeve/lodepng.git
+-    GIT_TAG ${MUJOCO_DEP_VERSION_lodepng}
+   )
+ 
+   FetchContent_GetProperties(lodepng)
+@@ -111,10 +109,6 @@ findorfetch(
+   qhull
+   LIBRARY_NAME
+   qhull
+-  GIT_REPO
+-  https://github.com/qhull/qhull.git
+-  GIT_TAG
+-  ${MUJOCO_DEP_VERSION_qhull}
+   TARGETS
+   qhull
+   # TODO(fraromano) Remove when https://github.com/qhull/qhull/pull/112 is merged.
+@@ -146,10 +140,6 @@ findorfetch(
+   tinyxml2
+   LIBRARY_NAME
+   tinyxml2
+-  GIT_REPO
+-  https://github.com/leethomason/tinyxml2.git
+-  GIT_TAG
+-  ${MUJOCO_DEP_VERSION_tinyxml2}
+   TARGETS
+   tinyxml2
+   EXCLUDE_FROM_ALL
+@@ -164,10 +154,6 @@ findorfetch(
+   tinyobjloader
+   LIBRARY_NAME
+   tinyobjloader
+-  GIT_REPO
+-  https://github.com/tinyobjloader/tinyobjloader.git
+-  GIT_TAG
+-  ${MUJOCO_DEP_VERSION_tinyobjloader}
+   TARGETS
+   tinyobjloader
+   EXCLUDE_FROM_ALL
+@@ -182,10 +168,6 @@ findorfetch(
+   ccd
+   LIBRARY_NAME
+   ccd
+-  GIT_REPO
+-  https://github.com/danfis/libccd.git
+-  GIT_TAG
+-  ${MUJOCO_DEP_VERSION_ccd}
+   TARGETS
+   ccd
+   EXCLUDE_FROM_ALL
+@@ -222,10 +204,6 @@ if(MUJOCO_BUILD_TESTS)
+     absl
+     LIBRARY_NAME
+     abseil-cpp
+-    GIT_REPO
+-    https://github.com/abseil/abseil-cpp.git
+-    GIT_TAG
+-    ${MUJOCO_DEP_VERSION_abseil}
+     TARGETS
+     absl::core_headers
+     EXCLUDE_FROM_ALL
+@@ -249,10 +227,6 @@ if(MUJOCO_BUILD_TESTS)
+     GTest
+     LIBRARY_NAME
+     googletest
+-    GIT_REPO
+-    https://github.com/google/googletest.git
+-    GIT_TAG
+-    ${MUJOCO_DEP_VERSION_gtest}
+     TARGETS
+     gtest
+     gmock
+@@ -283,10 +257,6 @@ if(MUJOCO_BUILD_TESTS)
+     benchmark
+     LIBRARY_NAME
+     benchmark
+-    GIT_REPO
+-    https://github.com/google/benchmark.git
+-    GIT_TAG
+-    ${MUJOCO_DEP_VERSION_benchmark}
+     TARGETS
+     benchmark::benchmark
+     benchmark::benchmark_main
+@@ -303,8 +273,6 @@ if(MUJOCO_TEST_PYTHON_UTIL)
+ 
+     FetchContent_Declare(
+       Eigen3
+-      GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+-      GIT_TAG ${MUJOCO_DEP_VERSION_Eigen3}
+     )
+ 
+     FetchContent_GetProperties(Eigen3)
+diff --git a/simulate/cmake/SimulateDependencies.cmake b/simulate/cmake/SimulateDependencies.cmake
+index 6616d6f..5d5a889 100644
+--- a/simulate/cmake/SimulateDependencies.cmake
++++ b/simulate/cmake/SimulateDependencies.cmake
+@@ -81,10 +81,6 @@ findorfetch(
+   glfw
+   LIBRARY_NAME
+   glfw
+-  GIT_REPO
+-  https://github.com/glfw/glfw.git
+-  GIT_TAG
+-  ${MUJOCO_DEP_VERSION_glfw}
+   TARGETS
+   glfw
+   EXCLUDE_FROM_ALL

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21208,6 +21208,8 @@ with pkgs;
 
   mueval = callPackage ../development/tools/haskell/mueval { };
 
+  mujoco = callPackage ../applications/science/robotics/mujoco { };
+
   muparser = callPackage ../development/libraries/muparser {
     inherit (darwin.stubs) setfile;
   };


### PR DESCRIPTION
###### Description of changes

MuJoCo (https://mujoco.org/) is a physics simulator, widely used in the reinforcement learning and robotics communities. It has recently been [acquired and open sourced by DeepMind](https://twitter.com/DeepMind/status/1450118090143014913).

Still remaining to be packaged are the Python bindings. I'll save those for a future PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
