### PR TITLE
element-{web,desktop}: 1.11.10 -> 1.11.12

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-web.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-web.nix
@@ -9,6 +9,7 @@
 , fixup_yarn_lock
 , nodejs
 , jitsi-meet
+, applyPatches
 , conf ? { }
 }:
 
@@ -24,11 +25,14 @@ in stdenv.mkDerivation rec {
   pname = "element-web";
   inherit (pinData) version;
 
-  src = fetchFromGitHub {
-    owner = "vector-im";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = pinData.webSrcHash;
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "vector-im";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = pinData.webSrcHash;
+    };
+    patches = [ ./regenerate-element-web-yarn.lock.diff ];
   };
 
   offlineCache = fetchYarnDeps {

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.11.10",
-  "desktopSrcHash": "cywTZ5OgKaFkHh3i3KLfb8HH8ZlIAOY3Xn2WHyY0fNM=",
-  "desktopYarnHash": "1xwnw9hbbrr72xs2d43qwhbmhfk3w4z80cipyrmdj5y248y8sz84",
-  "webSrcHash": "r7WZUWgPDEBS9xpc1YmmPVGch7B2ouJOFAoKdcC/55Q=",
-  "webYarnHash": "0s8wxf13jc9x4zykhm4abgq3a38mjya7z43kjsags1fxhilf09bc"
+  "version": "1.11.12",
+  "desktopSrcHash": "85mH9y3/IlThrdZY4Nv6iZQ8SxVGoYcZ1bbkCuAAroU=",
+  "desktopYarnHash": "1scp9y2lmah3n20f1kpc9paspd3qgslg129diis7g11cz4h0wyi5",
+  "webSrcHash": "MfiPrTw7BFLFPbm6xR5QbQHNPYpaJBtZES6KjISMTeE=",
+  "webYarnHash": "sha256-KZNBocVEs3wD5020h6C4n2jgp4shv4IgFENSi87rUFM="
 }

--- a/pkgs/applications/networking/instant-messengers/element/regenerate-element-web-yarn.lock.diff
+++ b/pkgs/applications/networking/instant-messengers/element/regenerate-element-web-yarn.lock.diff
@@ -1,0 +1,32 @@
+diff --git a/yarn.lock b/yarn.lock
+index 1581f599f..910764c86 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -3150,6 +3150,11 @@ brorand@^1.0.1, brorand@^1.1.0:
+   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
+ 
++browser-request@^0.3.3:
++  version "0.3.3"
++  resolved "https://registry.yarnpkg.com/browser-request/-/browser-request-0.3.3.tgz#9ece5b5aca89a29932242e18bf933def9876cc17"
++  integrity sha512-YyNI4qJJ+piQG6MMEuo7J3Bzaqssufx04zpEKYfSrl/1Op59HWali9zMtBpXnkmqMcOuWJPZvudrm9wISmnCbg==
++
+ browserify-aes@^1.0.0, browserify-aes@^1.0.4:
+   version "1.2.0"
+   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+@@ -8177,7 +8182,6 @@ matrix-js-sdk@21.0.0:
+   dependencies:
+     "@babel/runtime" "^7.12.5"
+     another-json "^0.2.0"
+-    browser-request "^0.3.3"
+     bs58 "^5.0.0"
+     content-type "^1.0.4"
+     loglevel "^1.7.1"
+@@ -8208,7 +8212,6 @@ matrix-react-sdk@3.59.0:
+     "@types/ua-parser-js" "^0.7.36"
+     await-lock "^2.1.0"
+     blurhash "^1.1.3"
+-    browser-request "^0.3.3"
+     cheerio "^1.0.0-rc.9"
+     classnames "^2.2.6"
+     commonmark "^0.29.3"

--- a/pkgs/applications/networking/instant-messengers/element/update.sh
+++ b/pkgs/applications/networking/instant-messengers/element/update.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -I nixpkgs=../../../../../ -i bash -p nix wget prefetch-yarn-deps nix-prefetch-github
 
+# FIXME should fix itself on the next release -> remove the warning if that's the case
+echo "WARNING: on the last update, the yarn.lock had to be patched. Please be careful when updating the hashes!"
+
 if [ "$#" -gt 1 ] || [[ "$1" == -* ]]; then
   echo "Regenerates packaging data for the element packages."
   echo "Usage: $0 [git release tag]"


### PR DESCRIPTION

###### Description of changes
ChangeLogs:
* https://github.com/vector-im/element-web/releases/tag/v1.11.11
* https://github.com/vector-im/element-web/releases/tag/v1.11.12

Also, it has apparently been forgotten to regenerate `yarn.lock` on the release, `element-web` failed to build like this initially:

    yarn install v1.22.19
    [1/4] Resolving packages...
    error Couldn't find any versions for "browser-request" that matches "^0.3.3" in our cache (possible versions are ""). This is usually caused by a missing entry in the lockfile, running Yarn without the --offline flag may help fix this issue.
    info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

To fix this, I decided to apply a patch with the proper `yarn.lock` and the problem is gone now. We should be careful however on the next update, so I added a warning to the `update.sh`-script to remind myself (or whoever will do the next update).

I'll leave it as-is now assuming that the issue fixes itself at the next time, a developer runs `yarn`. Also, I'm tired of having to chase dependency errors whenever I touch this package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
