### PR TITLE
pgsync: 0.6.8 → 0.7.2

### DIFF
--- a/pkgs/development/tools/database/pgsync/Gemfile.lock
+++ b/pkgs/development/tools/database/pgsync/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    parallel (1.21.0)
-    pg (1.2.3)
-    pgsync (0.6.8)
+    parallel (1.22.1)
+    pg (1.4.4)
+    pgsync (0.7.2)
       parallel
       pg (>= 0.18.2)
       slop (>= 4.8.2)
       tty-spinner
-    slop (4.9.1)
+    slop (4.9.3)
     tty-cursor (0.7.1)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
@@ -20,4 +20,4 @@ DEPENDENCIES
   pgsync
 
 BUNDLED WITH
-   2.2.24
+   2.3.7

--- a/pkgs/development/tools/database/pgsync/gemset.nix
+++ b/pkgs/development/tools/database/pgsync/gemset.nix
@@ -4,20 +4,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1hkfpm78c2vs1qblnva3k1grijvxh87iixcnyd83s3lxrxsjvag4";
+      sha256 = "07vnk6bb54k4yc06xnwck7php50l09vvlw1ga8wdz0pia461zpzb";
       type = "gem";
     };
-    version = "1.21.0";
+    version = "1.22.1";
   };
   pg = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "13mfrysrdrh8cka1d96zm0lnfs59i5x2g6ps49r2kz5p3q81xrzj";
+      sha256 = "09a5z9qhxnybahx162q2q1cygdhxfp6cihdivvzh32jlwc37z1x3";
       type = "gem";
     };
-    version = "1.2.3";
+    version = "1.4.4";
   };
   pgsync = {
     dependencies = ["parallel" "pg" "slop" "tty-spinner"];
@@ -25,20 +25,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1rsm1irmz97v1kxhnq4lbwwiapqa2zkx0n0xlcf68ca8sfcfql1z";
+      sha256 = "009xrrxqwcrcackw2w86xamkb1clb70ghcr8g8n8w9h13qaa0j78";
       type = "gem";
     };
-    version = "0.6.8";
+    version = "0.7.2";
   };
   slop = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "067bvjmjdjs19bvy138hkqqvw8li3732radcd4x5f5dbf30yk3a9";
+      sha256 = "0cz9fpr7zya6d44070ya0ik4pwv7c8dlqgw4bxgxficzakdxy9kf";
       type = "gem";
     };
-    version = "4.9.1";
+    version = "4.9.3";
   };
   tty-cursor = {
     groups = ["default"];


### PR DESCRIPTION
###### Description of changes

0.7.2 (2022-09-19)

    Improved error message when a primary key is required
    Switched to monotonic time
    Fixed schema sync with Homebrew Postgres 14.5

0.7.1 (2022-07-06)

    Fixed random letter data rule generating non-letter

0.7.0 (2022-03-10)

    Changed --defer-constraints to --defer-constraints-v1
    Changed --defer-constraints-v2 to --defer-constraints
    Fixed unknown alias error with Ruby 3.1
    Dropped support for Ruby < 2.5

From: https://github.com/ankane/pgsync/blob/master/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
