### PR TITLE
openiscsi: 2.1.7 -> 2.1.8

### DIFF
--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -1,54 +1,59 @@
-{ lib, stdenv, fetchFromGitHub, automake, autoconf, libtool, gettext
-, util-linux, open-isns, openssl, kmod, perl, systemd, pkgconf, nixosTests
-}:
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, pkg-config
+, ninja
+, perl
+, util-linux
+, open-isns
+, openssl
+, kmod
+, systemd
+, runtimeShell
+, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "open-iscsi";
-  version = "2.1.7";
-
-  nativeBuildInputs = [ autoconf automake gettext libtool perl pkgconf ];
-  buildInputs = [ kmod open-isns.lib openssl systemd util-linux ];
+  version = "2.1.8";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo = "open-iscsi";
     rev = version;
-    sha256 = "sha256-R1ttHHxVSQ5TGtWVy4I9BAmEJfcRhKRD5jThoeddjUw=";
+    hash = "sha256-JzSyX9zvUkhCEpNwTMneTZpCRgaYxHZ1wP215YnMI78=";
   };
 
-  DESTDIR = "$(out)";
-
-  NIX_LDFLAGS = "-lkmod -lsystemd";
-  NIX_CFLAGS_COMPILE = "-DUSE_KMOD";
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+    perl
+  ];
+  buildInputs = [
+    kmod
+    (lib.getLib open-isns)
+    openssl
+    systemd
+    util-linux
+  ];
 
   preConfigure = ''
-    # Remove blanket -Werror. Fails for minor error on gcc-11.
-    substituteInPlace usr/Makefile --replace ' -Werror ' ' '
+    patchShebangs .
   '';
 
-  # avoid /usr/bin/install
-  makeFlags = [
-    "INSTALL=install"
-    "SED=sed"
-    "prefix=/"
-    "manprefix=/share"
+  prePatch = ''
+    substituteInPlace etc/systemd/iscsi-init.service.template \
+      --replace /usr/bin/sh ${runtimeShell}
+    sed -i '/install_dir: db_root/d' meson.build
+  '';
+
+  mesonFlags = [
+    "-Discsi_sbindir=${placeholder "out"}/sbin"
+    "-Drulesdir=${placeholder "out"}/etc/udev/rules.d"
+    "-Dsystemddir=${placeholder "out"}/lib/systemd"
+    "-Ddbroot=/etc/iscsi"
   ];
-
-  installFlags = [
-    "install"
-  ];
-
-  postInstall = ''
-    cp usr/iscsistart $out/sbin/
-    for f in $out/lib/systemd/system/*; do
-      substituteInPlace $f --replace /sbin $out/bin
-    done
-    $out/sbin/iscsistart -v
-  '';
-
-  postFixup = ''
-    sed -i "s|/sbin/iscsiadm|$out/bin/iscsiadm|" $out/bin/iscsi_fw_login
-  '';
 
   passthru.tests = { inherit (nixosTests) iscsi-root iscsi-multipath-root; };
 


### PR DESCRIPTION
###### Description of changes
autotools -> meson
> support for make/autoconf is still in place but is deprecated
- https://github.com/open-iscsi/open-iscsi/releases/tag/2.1.8

Replaces/Closes #193104

Draft, because it breaks the `passthru.tests`

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).