### PR TITLE
wxGTK30: remove occurrences in all-packages.nix

### DIFF
--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -93,6 +93,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ebruck/radiotray-ng";
     license = licenses.gpl3;
     maintainers = with maintainers; [ dtzWill ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/emulators/bochs/default.nix
+++ b/pkgs/applications/emulators/bochs/default.nix
@@ -1,21 +1,26 @@
 { lib
 , stdenv
 , fetchurl
-, SDL2
-, curl
 , docbook_xml_dtd_45
 , docbook_xsl
-, gtk2
+, libtool
+, pkg-config
+, curl
+, readline
+, wget
+, libobjc
+, enableX11 ? !stdenv.isDarwin
 , libGL
 , libGLU
 , libX11
 , libXpm
-, libtool
+, enableSdl2 ? true
+, SDL2
+, enableTerm ? true
 , ncurses
-, pkg-config
-, readline
-, wget
+, enableWx ? !stdenv.isDarwin
 , wxGTK
+, gtk3
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -35,23 +40,26 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    SDL2
     curl
-    gtk2
+    readline
+    wget
+  ] ++ lib.optionals stdenv.isDarwin [
+    libobjc
+  ] ++ lib.optionals enableX11 [
     libGL
     libGLU
     libX11
     libXpm
+  ] ++ lib.optionals enableSdl2 [
+    SDL2
+  ] ++ lib.optionals enableTerm [
     ncurses
-    readline
-    wget
+  ] ++ lib.optionals enableWx [
     wxGTK
+    gtk3
   ];
 
   configureFlags = [
-    "--with-x=yes"
-    "--with-x11=yes"
-
     "--with-rfb=no"
     "--with-vncsrv=no"
     "--with-nogui"
@@ -84,8 +92,6 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-cpu-level=6" # from 3 to 6
     "--enable-debugger" #conflicts with gdb-stub option
     "--enable-debugger-gui"
-    "--enable-e1000"
-    "--enable-es1370"
     "--enable-evex"
     "--enable-fpu"
     "--enable-gdb-stub=no" # conflicts with debugger option
@@ -94,12 +100,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-iodebug"
     "--enable-large-ramfile"
     "--enable-largefile"
-    "--enable-ne2000"
     "--enable-pci"
-    "--enable-plugins=yes"
-    "--enable-pnic"
     "--enable-repeat-speedups"
-    "--enable-sb16"
     "--enable-show-ips"
     "--enable-smp"
     "--enable-vmx=2"
@@ -112,11 +114,23 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-voodoo"
     "--enable-x86-64"
     "--enable-x86-debugger"
-  ]
-  # Boolean flags
-  ++ lib.optionals (SDL2 != null) [ "--with-sdl2" ]
-  ++ lib.optionals (ncurses != null) [ "--with-term" ]
-  ++ lib.optionals (gtk2 != null && wxGTK != null) [ "--with-wx" ];
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    "--enable-e1000"
+    "--enable-es1370"
+    "--enable-ne2000"
+    "--enable-plugins"
+    "--enable-pnic"
+    "--enable-sb16"
+  ] ++ lib.optionals enableX11 [
+    "--with-x"
+    "--with-x11"
+  ] ++ lib.optionals enableSdl2 [
+    "--with-sdl2"
+  ] ++ lib.optionals enableTerm [
+    "--with-term"
+  ] ++ lib.optionals enableWx [
+    "--with-wx"
+  ];
 
   enableParallelBuilding = true;
 
@@ -131,7 +145,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;
-    broken = stdenv.isDarwin;
   };
 })
 # TODO: a better way to organize the options

--- a/pkgs/applications/misc/slade/default.nix
+++ b/pkgs/applications/misc/slade/default.nix
@@ -1,24 +1,68 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, wxGTK, gtk2, sfml, fluidsynth, curl, freeimage, ftgl, glew, zip }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, which
+, zip
+, wxGTK
+, gtk3
+, sfml
+, fluidsynth
+, curl
+, freeimage
+, ftgl
+, glew
+, lua
+, mpg123
+}:
 
 stdenv.mkDerivation rec {
   pname = "slade";
-  version = "3.1.1.5";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner = "sirjuddington";
     repo = "SLADE";
     rev = version;
-    sha256 = "0mdn59jm6ab4cdh99bgvadif3wdlqmk5mq635gg7krq35njgw6f6";
+    sha256 = "sha256-KFRX3sfI//Op/h/EfEuAZOY22RO5qNXmvhSksC0aS4U=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config zip ];
-  buildInputs = [ wxGTK gtk2 sfml fluidsynth curl freeimage ftgl glew ];
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isx86) ''
+    sed -i '/-msse/d' src/CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    which
+    zip
+  ];
+
+  buildInputs = [
+    wxGTK
+    gtk3
+    sfml
+    fluidsynth
+    curl
+    freeimage
+    ftgl
+    glew
+    lua
+    mpg123
+  ];
+
+  cmakeFlags = [
+    "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
+  ];
+
+  NIX_CFLAGS_COMPILE = "-Wno-narrowing";
 
   meta = with lib; {
     description = "Doom editor";
     homepage = "http://slade.mancubus.net/";
-    license = licenses.gpl2;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/applications/misc/slade/git.nix
+++ b/pkgs/applications/misc/slade/git.nix
@@ -3,43 +3,66 @@
 , fetchFromGitHub
 , cmake
 , pkg-config
+, which
+, zip
 , wxGTK
+, gtk3
 , sfml
 , fluidsynth
 , curl
 , freeimage
 , ftgl
 , glew
-, zip
 , lua
-, fmt
 , mpg123
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "slade";
-  version = "unstable-2021-05-13";
+  version = "unstable-2022-08-15";
 
   src = fetchFromGitHub {
     owner = "sirjuddington";
     repo = "SLADE";
-    rev = "d2e249c89062a44c912a9b86951526edc8735ba0";
-    sha256 = "08dsvx7m7c97jm8fxzivmi1fr47hj53y0lv57clqc35bh2gi62dg";
+    rev = "1a0d25eec54f9ca2eb3667676d93fb0b6b6aea26";
+    sha256 = "sha256-mtaJr4HJbp2UnzwaLq12V69DqPYDmSNqMGiuPpMlznI=";
   };
 
-  cmakeFlags = [
-    "-DwxWidgets_CONFIG_EXECUTABLE=${wxGTK}/bin/wx-config"
-    "-DWX_GTK3=OFF"
-    "-DNO_WEBVIEW=1"
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isx86) ''
+    sed -i '/-msse/d' src/CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    which
+    zip
   ];
-  nativeBuildInputs = [ cmake pkg-config zip ];
-  buildInputs = [ wxGTK wxGTK.gtk sfml fluidsynth curl freeimage ftgl glew lua fmt mpg123 ];
+
+  buildInputs = [
+    wxGTK
+    gtk3
+    sfml
+    fluidsynth
+    curl
+    freeimage
+    ftgl
+    glew
+    lua
+    mpg123
+  ];
+
+  cmakeFlags = [
+    "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
+  ];
+
+  NIX_CFLAGS_COMPILE = "-Wno-narrowing";
 
   meta = with lib; {
     description = "Doom editor";
     homepage = "http://slade.mancubus.net/";
     license = licenses.gpl2Plus;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = platforms.linux;
     maintainers = with maintainers; [ ertes ];
   };
 }

--- a/pkgs/applications/office/mmex/default.nix
+++ b/pkgs/applications/office/mmex/default.nix
@@ -1,33 +1,73 @@
-{ lib, stdenv, fetchFromGitHub, sqlite, wxGTK30, gettext, wrapGAppsHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gettext
+, git
+, makeWrapper
+, lsb-release
+, pkg-config
+, wrapGAppsHook
+, curl
+, sqlite
+, wxGTK
+, gtk3
+, libobjc
+}:
 
 stdenv.mkDerivation rec {
   pname = "money-manager-ex";
-  version = "1.3.3";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "moneymanagerex";
     repo = "moneymanagerex";
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-5NgkP9gY4eDBoKSC/IaXiHoiz+ZdU4c/iGAzPf5IlmQ=";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-ADhTz6OMntgDg3TcAlf3lGBFb+fdZ0Lw7+UYYY1RD8M=";
   };
 
+  postPatch = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
+    substituteInPlace src/platfdep_mac.mm \
+      --replace "appearance.name == NSAppearanceNameDarkAqua" "NO"
+  '';
+
   nativeBuildInputs = [
+    cmake
+    gettext
+    git
+    makeWrapper
+    pkg-config
     wrapGAppsHook
+  ] ++ lib.optionals stdenv.isLinux [
+    lsb-release
   ];
 
   buildInputs = [
-    gettext
+    curl
     sqlite
-    wxGTK30
-    wxGTK30.gtk
+    wxGTK
+    gtk3
+  ] ++ lib.optionals stdenv.isDarwin [
+    libobjc
   ];
+
+  NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.cc.isClang [
+    "-Wno-old-style-cast"
+  ]);
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/{Applications,bin}
+    mv $out/mmex.app $out/Applications
+    makeWrapper $out/{Applications/mmex.app/Contents/MacOS,bin}/mmex
+  '';
 
   meta = {
     description = "Easy-to-use personal finance software";
     homepage = "https://www.moneymanagerex.org/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [viric];
-    platforms = with lib.platforms; linux;
-    broken = true; # at 2022-11-23
+    maintainers = with lib.maintainers; [ viric ];
+    platforms = with lib.platforms; unix;
+    mainProgram = "mmex";
   };
 }

--- a/pkgs/development/libraries/wxsqliteplus/default.nix
+++ b/pkgs/development/libraries/wxsqliteplus/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0mgfq813pli56mar7pdxlhwjf5k10j196rs3jd0nc8b6dkzkzlnf";
   };
 
+  postPatch = ''
+    sed -i '/WX_CLEAR_ARRAY/s/$/;/' src/{createtable,sqlite3table}.cpp
+  '';
+
   buildInputs = [ wxGTK wxsqlite3 sqlite ] ++ lib.optional stdenv.isDarwin Cocoa;
 
   makeFlags = [
@@ -22,7 +26,7 @@ stdenv.mkDerivation rec {
   preBuild = ''
     sed -ie 's|all: $(LIBPREFIX)wxsqlite$(LIBEXT)|all: |g' Makefile
     sed -ie 's|wxsqliteplus$(EXEEXT): $(WXSQLITEPLUS_OBJECTS) $(LIBPREFIX)wxsqlite$(LIBEXT)|wxsqliteplus$(EXEEXT):  $(WXSQLITEPLUS_OBJECTS) |g' Makefile
-    sed -ie 's|-lwxsqlite |-lwxcode_${if stdenv.isDarwin then "osx_cocoau_wxsqlite3-3.0.0" else "gtk2u_wxsqlite3-3.0"} |g' Makefile
+    sed -ie 's|-lwxsqlite |-lwxcode_${if stdenv.isDarwin then "osx_cocoau_wxsqlite3-3.2.0" else "gtk3u_wxsqlite3-3.2"} |g' Makefile
   '';
 
   installPhase = ''
@@ -35,7 +39,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A simple SQLite database browser built with wxWidgets";
     homepage = "https://github.com/guanlisheng/wxsqliteplus";
-    license = licenses.gpl2;
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.vrthra ];
     platforms = platforms.unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1489,7 +1489,8 @@ with pkgs;
   basiliskii = callPackage ../applications/emulators/basiliskii { };
 
   bochs = callPackage ../applications/emulators/bochs {
-    wxGTK = wxGTK30;
+    inherit (darwin) libobjc;
+    wxGTK = wxGTK32;
   };
 
   box64 = callPackage ../applications/emulators/box64 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12764,7 +12764,7 @@ with pkgs;
   hitch = callPackage ../servers/hitch { };
 
   veracrypt = callPackage ../applications/misc/veracrypt {
-    wxGTK = wxGTK30;
+    wxGTK = wxGTK32;
   };
 
   vlan = callPackage ../tools/networking/vlan { };
@@ -16348,7 +16348,7 @@ with pkgs;
   bloop = callPackage ../development/tools/build-managers/bloop { };
 
   bossa = callPackage ../development/embedded/bossa {
-    wxGTK = wxGTK30;
+    wxGTK = wxGTK30-gtk3;
   };
 
   bossa-arduino = callPackage ../development/embedded/bossa/arduino.nix { };
@@ -29024,7 +29024,7 @@ with pkgs;
   inherit (nodePackages) hueadm;
 
   hugin = callPackage ../applications/graphics/hugin {
-    wxGTK = wxGTK30;
+    wxGTK = wxGTK32;
   };
 
   haunt = callPackage ../applications/misc/haunt { };
@@ -35901,7 +35901,9 @@ with pkgs;
     inherit (linuxPackages) nvidia_x11;
   };
 
-  wxmaxima = callPackage ../applications/science/math/wxmaxima { wxGTK = wxGTK30; };
+  wxmaxima = callPackage ../applications/science/math/wxmaxima {
+    wxGTK = wxGTK32;
+  };
 
   pari = callPackage ../applications/science/math/pari { tex = texlive.combined.scheme-basic; };
   gp2c = callPackage ../applications/science/math/pari/gp2c.nix { };
@@ -35987,7 +35989,9 @@ with pkgs;
 
   gravit = callPackage ../applications/science/astronomy/gravit { };
 
-  golly = callPackage ../applications/science/misc/golly { wxGTK = wxGTK30; };
+  golly = callPackage ../applications/science/misc/golly {
+    wxGTK = wxGTK32;
+  };
 
   megam = callPackage ../applications/science/misc/megam {
     inherit (ocaml-ng.ocamlPackages_4_07) ocaml;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31394,7 +31394,7 @@ with pkgs;
   radioboat = callPackage ../applications/audio/radioboat { };
 
   radiotray-ng = callPackage ../applications/audio/radiotray-ng {
-    wxGTK = wxGTK30;
+    wxGTK = wxGTK30-gtk3;
   };
 
   raiseorlaunch = callPackage ../applications/misc/raiseorlaunch {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5934,7 +5934,9 @@ with pkgs;
   sl1-to-photon = python3Packages.callPackage ../applications/misc/sl1-to-photon { };
 
   slade = callPackage ../applications/misc/slade {
-    wxGTK = wxGTK30;
+    wxGTK = wxGTK32.override {
+      withWebKit = true;
+    };
   };
 
   sladeUnstable = callPackage ../applications/misc/slade/git.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5940,7 +5940,9 @@ with pkgs;
   };
 
   sladeUnstable = callPackage ../applications/misc/slade/git.nix {
-    wxGTK = wxGTK30;
+    wxGTK = wxGTK32.override {
+      withWebKit = true;
+    };
   };
 
   drive = callPackage ../applications/networking/drive { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37326,7 +37326,7 @@ with pkgs;
   };
 
   wxsqliteplus = callPackage ../development/libraries/wxsqliteplus {
-    wxGTK = wxGTK30;
+    wxGTK = wxGTK32;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
     inherit (darwin.stubs) setfile;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30154,9 +30154,9 @@ with pkgs;
   MMA = callPackage ../applications/audio/MMA { };
 
   mmex = callPackage ../applications/office/mmex {
-    wxGTK30 = wxGTK30.override {
+    inherit (darwin) libobjc;
+    wxGTK = wxGTK32.override {
       withWebKit = true;
-      withGtk2 = false;
     };
   };
 


### PR DESCRIPTION
###### Description of changes

... so that no package has overrides like `wxGTK = wxGTK30;`.

This PR contains the following non-trivial parts:

- slade: 3.1.1.5 -> 3.2.1 (also #193973)
- bochs: cleanup, unbreak on darwin
- mmex: 1.3.3 -> 1.6.0, unbreak, add darwin support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
