### PR TITLE
nixos/vdirsyncer: fix description

### DIFF
--- a/nixos/modules/services/networking/vdirsyncer.nix
+++ b/nixos/modules/services/networking/vdirsyncer.nix
@@ -106,7 +106,7 @@ in
             forceDiscover = mkOption {
               type = types.bool;
               default = false;
-              description = literalMD ''
+              description = mdDoc ''
                 Run `yes | vdirsyncer discover` prior to `vdirsyncer sync`
               '';
             };


### PR DESCRIPTION
The nixos-search import is currently [failing](https://github.com/NixOS/nixos-search/actions/runs/3344181785/jobs/5538245834) because of this, please merge ASAP.

ping @schnusch @SuperSandro2000

(One might also wonder if there's any sense in having two markers with the same semantics ("this is a MarkDown string") and whether we should merge them... cc @pennae)