### PR TITLE
ruby: refactor fetching patches

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -91,10 +91,12 @@ let
         enableParallelBuilding = true;
 
         patches =
-          (import ./patchsets.nix {
-            inherit patchSet useRailsExpress ops fetchpatch;
-            patchLevel = ver.patchLevel;
-          }).${ver.majMinTiny}
+          (ops useRailsExpress
+            (import ./patchsets.nix {
+              inherit patchSet;
+              version = ver.majMinTiny;
+            })
+          )
           ++ op (lib.versionOlder ver.majMin "3.1") ./do-not-regenerate-revision.h.patch
           ++ op (atLeast30 && useBaseRuby) ./do-not-update-gems-baseruby.patch
           ++ ops (!atLeast30 && rubygemsSupport) [

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -94,7 +94,7 @@ let
           (ops useRailsExpress
             (import ./patchsets.nix {
               inherit patchSet;
-              version = ver.majMinTiny;
+              version = ver.majMin;
             })
           )
           ++ op (lib.versionOlder ver.majMin "3.1") ./do-not-regenerate-revision.h.patch

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -93,7 +93,7 @@ let
           (ops useRailsExpress
             (import ./patchsets.nix {
               inherit fetchFromGitHub;
-              version = ver.majMin;
+              version = ver.majMinTiny;
             })
           )
           ++ op (lib.versionOlder ver.majMin "3.1") ./do-not-regenerate-revision.h.patch

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -11,7 +11,6 @@ let
   op = lib.optional;
   ops = lib.optionals;
   opString = lib.optionalString;
-  patchSet = import ./rvm-patchsets.nix { inherit fetchFromGitHub; };
   config = import ./config.nix { inherit fetchFromSavannah; };
   rubygems = import ./rubygems { inherit stdenv lib fetchurl; };
 
@@ -93,7 +92,7 @@ let
         patches =
           (ops useRailsExpress
             (import ./patchsets.nix {
-              inherit patchSet;
+              inherit fetchFromGitHub;
               version = ver.majMin;
             })
           )

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,20 +1,20 @@
-{ patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
+{ patchSet, version }:
 
 {
-  "2.7.6" = ops useRailsExpress [
+  "2.7.6" = [
     "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-with-openssl-dir-option.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/03-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/04-more-detailed-stacktrace.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/05-malloc-trim.patch"
   ];
-  "3.0.4" = ops useRailsExpress [
+  "3.0.4" = [
     "${patchSet}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"
     "${patchSet}/patches/ruby/3.0/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/3.0/head/railsexpress/03-malloc-trim.patch"
   ];
-  "3.1.2" = ops useRailsExpress [
+  "3.1.2" = [
     "${patchSet}/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/3.1/head/railsexpress/02-malloc-trim.patch"
   ];
-}
+}.${version}

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,6 +1,12 @@
-{ patchSet, version }:
+{ version, fetchFromGitHub }:
 
 let
+  patchSet = fetchFromGitHub {
+    owner  = "skaes";
+    repo   = "rvm-patchsets";
+    rev    = "a6429bb1a7fb9b5798c22f43338739a6c192b42d";
+    sha256 = "sha256-NpSa+uGQA1rfHNcLzPNTK65J+Wk9ZlzhHFePDA4uuo0=";
+  };
   directory = "${patchSet}/patches/ruby/${version}/head/railsexpress";
   files = builtins.attrNames (builtins.readDir directory);
   patches = map (file: "${directory}/${file}") files;

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,20 +1,8 @@
 { patchSet, version }:
 
-{
-  "2.7.6" = [
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-with-openssl-dir-option.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/04-more-detailed-stacktrace.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/05-malloc-trim.patch"
-  ];
-  "3.0.4" = [
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/03-malloc-trim.patch"
-  ];
-  "3.1.2" = [
-    "${patchSet}/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/3.1/head/railsexpress/02-malloc-trim.patch"
-  ];
-}.${version}
+let
+  directory = "${patchSet}/patches/ruby/${version}/head/railsexpress";
+  files = builtins.attrNames (builtins.readDir directory);
+  patches = map (file: "${directory}/${file}") files;
+in
+  patches

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -7,7 +7,7 @@ let
     rev    = "a6429bb1a7fb9b5798c22f43338739a6c192b42d";
     sha256 = "sha256-NpSa+uGQA1rfHNcLzPNTK65J+Wk9ZlzhHFePDA4uuo0=";
   };
-  directory = "${patchSet}/patches/ruby/${version}/head/railsexpress";
+  directory = "${patchSet}/patches/ruby/${version}/railsexpress";
   files = builtins.attrNames (builtins.readDir directory);
   patches = map (file: "${directory}/${file}") files;
 in

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -1,8 +1,0 @@
-{ fetchFromGitHub }:
-
-fetchFromGitHub {
-  owner  = "skaes";
-  repo   = "rvm-patchsets";
-  rev    = "a6429bb1a7fb9b5798c22f43338739a6c192b42d";
-  sha256 = "sha256-NpSa+uGQA1rfHNcLzPNTK65J+Wk9ZlzhHFePDA4uuo0=";
-}


### PR DESCRIPTION
TLDR: It seems like `readDir` causes the `rvm-patchsets` derivation to be
built during evaluation time. Here's an alternative without this problem https://github.com/NixOS/nixpkgs/pull/198898

Here's a proposal to allow `mkRuby` to build more versions of ruby instead
of only the latest patch. Feedback is appreciated :heart: 

###### Description of changes

This changes how patches are determined for ruby versions. Instead of
fetching the `head` patches for a `majMin` version, we fetch patches
specific to a `majMinTiny` version. At the current commit of
`rvm-patchsets` and current ruby versions, these are exactly the same
patches.

This doesn't change any behavior (same list of patches, same content),
but the checksum for the ruby artifacts changes. I think it's because
the patch files timestamps are different. The commit that actually changes
the checksum is 15e7e5f8cfa8eb043d727a2232b7f5616331e892.

Commit 6bdffe34fb17121ab2007b0ff4adebb42d75ffa3 breaks the build, even
though the final artifacts are exactly the same. It seems related to the
use of `readDir`, but I still don't understand the problem. I found some
more info in the wiki: https://nixos.wiki/wiki/Import_From_Derivation
which may be related.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all ruby packages (and older versions)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).