### PR TITLE
Sqlboiler

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3372,6 +3372,12 @@
     githubId = 33262214;
     name = "Dawid Gliwka";
   };
+  dgollings = {
+    email = "daniel.gollings+nixpkgs@gmail.com";
+    github = "dgollings";
+    githubId = 2032823;
+    name = "Daniel Gollings";
+  };
   dgonyeo = {
     email = "derek@gonyeo.com";
     github = "dgonyeo";

--- a/pkgs/development/tools/database/sqlboiler/default.nix
+++ b/pkgs/development/tools/database/sqlboiler/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "sqlboiler";
+  version = "4.13.0";
+
+  src = fetchFromGitHub {
+    owner = "volatiletech";
+    repo = "sqlboiler";
+    rev = "v${version}";
+    sha256 = "sha256-vSHr6c06d0b6ZF0YlBAIE7NvBqvcn+phoRlFvP5nlUM=";
+  };
+
+  vendorSha256 = "sha256-r8lvsmzo0uiPqSPq2WX7ZMMrl+zYj+c6bta4CGgnUG8";
+
+  preCheck = ''
+     # attempts to run go mod tidy
+    rm -v boilingcore/boilingcore_test.go || true
+
+    # attempts to access a running testdb which does not exist
+    rm -v drivers/sqlboiler-mssql/driver/mssql_test.go \
+    drivers/sqlboiler-mysql/driver/mysql_test.go \
+    drivers/sqlboiler-sqlite3/driver/sqlite3_test.go \
+    drivers/sqlboiler-psql/driver/psql_test.go || true
+  '';
+
+  meta = with lib; {
+    description = "SQLBoiler is a tool to generate a Go ORM tailored to your database schema.";
+    homepage = https://github.com/volatiletech/sqlboiler;
+    changelog = "https://github.com/volatiletech/sqlboiler/blob/v${version}/CHANGELOG.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ dgollings ];
+    platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "sqlboiler";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17628,6 +17628,8 @@ with pkgs;
 
   spruce = callPackage ../development/tools/misc/spruce {};
 
+  sqlboiler = callPackage ../development/tools/database/sqlboiler { };
+
   sqlc = callPackage ../development/tools/database/sqlc { };
 
   sqlcheck = callPackage ../development/tools/database/sqlcheck { };


### PR DESCRIPTION
###### Description of changes

Added [SQLBoiler](https://github.com/volatiletech/sqlboiler) for generating ORMs in Go. I've been using this exact code for weeks so consider it stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
