### PR TITLE
python310Packages.requests-cache: 0.9.7 -> 0.9.7, python310Packages.cattrs: 22.1.0 -> 22.2.0

### DIFF
--- a/pkgs/development/python-modules/cattrs/default.nix
+++ b/pkgs/development/python-modules/cattrs/default.nix
@@ -2,7 +2,6 @@
 , attrs
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , exceptiongroup
 , hypothesis
 , immutables
@@ -21,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "cattrs";
-  version = "22.1.0";
+  version = "22.2.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -30,16 +29,8 @@ buildPythonPackage rec {
     owner = "python-attrs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-C8uIsewpgJfB1yYckWTwF5K32+2AAOrxFKB9I18RENg=";
+    hash = "sha256-Qnrq/mIA/t0mur6IAen4vTmMIhILWS6v5nuf+Via2hA=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/python-attrs/cattrs/commit/290d162a589acf10ea63b825b7b283e23ca7698a.diff";
-      excludes = [ "poetry.lock" ];
-      hash = "sha256-n6c3qVg9umGKAxeTALq3QTJgO9DIj3SY0ZHhtsDeW94=";
-    })
-  ];
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/exceptiongroup/default.nix
+++ b/pkgs/development/python-modules/exceptiongroup/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "exceptiongroup";
-  version = "1.0.0rc9";
+  version = "1.0.0";
   format = "flit";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-kIakoh75sxxyGBx3wECgdLoIie5Wp7KJ/wr7DZdlX5Y=";
+    hash = "sha256-r/ur8T+26YmIw42cVlDnAVaf48HeMjPPthxfM3dGkK0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/requests-cache/default.nix
+++ b/pkgs/development/python-modules/requests-cache/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "requests-cache";
-  version = "0.9.6";
+  version = "0.9.7";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner = "requests-cache";
     repo = "requests-cache";
     rev = "v${version}";
-    hash = "sha256-oFI5Rv/MAiPHiZts0PrNS+YMDFD/RxnMJ6deTxZNkSM=";
+    hash = "sha256-HSYu4jOEMXI/zGuWI7invYVvVeeM5+dDlc+9h8TOGms=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes
- https://github.com/requests-cache/requests-cache/blob/main/HISTORY.md#097-2022-10-26
- https://github.com/agronholm/exceptiongroup/blob/main/CHANGES.rst
- https://cattrs.readthedocs.io/en/latest/history.html#id1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
