### PR TITLE
paper-note: init at 22.11

### DIFF
--- a/pkgs/applications/office/paper-note/default.nix
+++ b/pkgs/applications/office/paper-note/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, vala
+, meson
+, ninja
+, pkg-config
+, glib
+, gtk4
+, dbus
+, libgee
+, librsvg
+, libadwaita
+, gtksourceview5
+, blueprint-compiler
+, wrapGAppsHook4
+, appstream-glib
+, desktop-file-utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "paper-note";
+  version = "22.11";
+
+  src = fetchFromGitLab {
+    owner = "posidon_software";
+    repo = "paper";
+    rev = version;
+    hash = "sha256-o5MYagflHE8Aup8CbqauRBrdt3TrSlffs35psYT7hyE=";
+  };
+
+  nativeBuildInputs = [
+    vala
+    meson
+    ninja
+    pkg-config
+    blueprint-compiler
+    wrapGAppsHook4
+    appstream-glib
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    dbus
+    libgee
+    librsvg
+    libadwaita
+    gtksourceview5
+  ];
+
+  meta = with lib; {
+    description = "A pretty markdown note-taking app for Gnome";
+    homepage = "https://posidon.io/paper";
+    mainProgram = "io.posidon.Paper";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10069,6 +10069,8 @@ with pkgs;
 
   paperless-ngx = callPackage ../applications/office/paperless-ngx { };
 
+  paper-note = callPackage ../applications/office/paper-note { };
+
   paperoni = callPackage ../tools/text/paperoni {
     inherit (darwin.apple_sdk.frameworks) Security;
     openssl = openssl_1_1;


### PR DESCRIPTION
###### Description of changes

A pretty markdown note-taking app for Gnome.

https://gitlab.com/posidon_software/paper

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
