### PR TITLE
grype: 0.49.0 -> 0.51.0

### DIFF
--- a/pkgs/tools/security/grype/default.nix
+++ b/pkgs/tools/security/grype/default.nix
@@ -1,19 +1,20 @@
 { lib
-, stdenv
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
+
+, openssl
 }:
 
 buildGoModule rec {
   pname = "grype";
-  version = "0.49.0";
+  version = "0.51.0";
 
   src = fetchFromGitHub {
     owner = "anchore";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-MShlKtrorqXRInQ01dEzVeLDRDua9PISkficF02PrBI=";
+    sha256 = "sha256-WTDUkC+TFVkT/D36hDusqxwidy6O+iMInBpTumdCaw4=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -25,12 +26,14 @@ buildGoModule rec {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-
-  vendorSha256 = "sha256-MusEvYNaMM0kqHSDdenPKo4IrIFmvPHSCRzciKMFiew=";
+  vendorSha256 = "sha256-bpWUo6YA0TkIyDg27mv88X1fh+1Wal362Sqi7loo/Zs=";
 
   nativeBuildInputs = [
     installShellFiles
   ];
+
+  subPackages = [ "." ];
+  excludedPackages = "test/integration";
 
   ldflags = [
     "-s"
@@ -49,8 +52,44 @@ buildGoModule rec {
     ldflags+=" -X github.com/anchore/grype/internal/version.buildDate=$(cat SOURCE_DATE_EPOCH)"
   '';
 
-  # Tests require a running Docker instance
-  doCheck = false;
+  checkInputs = [ openssl ];
+  preCheck = ''
+    # test all dirs (except excluded)
+    unset subPackages
+    # test goldenfiles expect no version
+    unset ldflags
+
+    # patch utility script
+    patchShebangs grype/db/test-fixtures/tls/generate-x509-cert-pair.sh
+
+    # remove tests that depend on docker
+    substituteInPlace test/cli/cmd_test.go \
+      --replace "TestCmd" "SkipCmd"
+    substituteInPlace grype/pkg/provider_test.go \
+      --replace "TestSyftLocationExcludes" "SkipSyftLocationExcludes"
+    substituteInPlace grype/presenter/cyclonedx/presenter_test.go \
+      --replace "TestCycloneDxPresenterImage" "SkipCycloneDxPresenterImage"
+    substituteInPlace grype/presenter/cyclonedxvex/presenter_test.go \
+      --replace "TestCycloneDxPresenterImage" "SkipCycloneDxPresenterImage"
+    substituteInPlace grype/presenter/sarif/presenter_test.go \
+      --replace "Test_imageToSarifReport" "Skip_imageToSarifReport" \
+      --replace "TestSarifPresenterImage" "SkipSarifPresenterImage"
+
+    # remove tests that depend on git
+    substituteInPlace test/cli/db_validations_test.go \
+      --replace "TestDBValidations" "SkipDBValidations"
+    substituteInPlace test/cli/registry_auth_test.go \
+      --replace "TestRegistryAuth" "SkipRegistryAuth"
+    substituteInPlace test/cli/sbom_input_test.go \
+      --replace "TestSBOMInput_FromStdin" "SkipSBOMInput_FromStdin" \
+      --replace "TestSBOMInput_AsArgument" "SkipSBOMInput_AsArgument" \
+      --replace "TestAttestationInput_AsArgument" "SkipAttestationInput_AsArgument"
+    substituteInPlace test/cli/subprocess_test.go \
+      --replace "TestSubprocessStdin" "SkipSubprocessStdin"
+
+    # segfault
+    rm grype/db/v5/namespace/cpe/namespace_test.go
+  '';
 
   postInstall = ''
     installShellCompletion --cmd grype \


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated & added the tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
