### PR TITLE
python310Packages.aiosmtplib: 1.1.7 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/aiosmtplib/default.nix
+++ b/pkgs/development/python-modules/aiosmtplib/default.nix
@@ -7,11 +7,12 @@
 , pytest-asyncio
 , pytestCheckHook
 , pythonOlder
+, trustme
 }:
 
 buildPythonPackage rec {
   pname = "aiosmtplib";
-  version = "1.1.7";
+  version = "2.0.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -20,7 +21,7 @@ buildPythonPackage rec {
     owner = "cole";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ZVNYMVg2qeMoSojmPllvJLv2Xm5IYN9h5N13oHPFXSk=";
+    hash = "sha256-NdGap6sl+3tqr/8jhDSDsun/4SiuznfqLf1banIp9EQ=";
   };
 
   nativeBuildInputs = [
@@ -32,6 +33,7 @@ buildPythonPackage rec {
     hypothesis
     pytest-asyncio
     pytestCheckHook
+    trustme
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/fastapi-mail/default.nix
+++ b/pkgs/development/python-modules/fastapi-mail/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "fastapi-mail";
-  version = "1.2.2";
+  version = "1.2.4";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -28,12 +28,16 @@ buildPythonPackage rec {
     owner = "sabuhish";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-+i/p4KVppsOkj2TEoZKmjrlnkhk2wxPg2enh2QCXiQI=";
+    hash = "sha256-6Iwgl15adc6wK7i8sFLeSf2HSvMo/Sx/BI44qboNnRM=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'starlette = "^0.21.0"' 'starlette = "*"'
+      --replace 'version = "1.2.2"' 'version = "${version}"' \
+      --replace 'aiosmtplib = "^2.0"' 'aiosmtplib = "*"' \
+      --replace 'pydantic = "^1.8"' 'pydantic = "*"' \
+      --replace 'starlette = "^0.22.0"' 'starlette = "*"' \
+      --replace 'black = "^22.12.0"' ""
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes
https://github.com/cole/aiosmtplib/releases/tag/v2.0.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
