### PR TITLE
fix pkgsMusl.cargo via cargoSetupHook

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -27,7 +27,7 @@ cargoSetupPostUnpackHook() {
     cat ${tmp_config} >> .cargo/config
 
     cat >> .cargo/config <<'EOF'
-    @rustTarget@
+    @cargoConfig@
 EOF
 
     echo "Finished cargoSetupPostUnpackHook"

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -68,15 +68,37 @@ in {
         # The `.nativeDrv` stanza works like nativeBuildInputs and ensures cross-compiling has the right version available.
         diff = "${diffutils.nativeDrv or diffutils}/bin/diff";
 
-        # Target platform
-        rustTarget = ''
-          [target."${rust.toRustTarget stdenv.buildPlatform}"]
+        # We want to specify the correct crt-static flag for both
+        # the build and host platforms. This is important when the wanted
+        # value for crt-static does not match the defaults in the rustc target,
+        # like for pkgsMusl or pkgsCross.musl64; Upstream rustc still assumes
+        # that musl = static[1].
+        #
+        # By default, Cargo doesn't apply RUSTFLAGS when building build.rs
+        # if --target is passed, so the only good way to set crt-static for
+        # build.rs files is to use the unstable -Zhost-config Cargo feature.
+        # This allows us to specify flags that should be passed to rustc
+        # when building for the build platform. We also need to use
+        # -Ztarget-applies-to-host, because using -Zhost-config requires it.
+        #
+        # When doing this, we also have to specify the linker, or cargo
+        # won't pass a -C linker= argument to rustc.  This will make rustc
+        # try to use its default value of "cc", which won't be available
+        # when cross-compiling.
+        #
+        # [1]: https://github.com/rust-lang/compiler-team/issues/422
+        cargoConfig = ''
+          [host]
           "linker" = "${ccForBuild}"
-          ${lib.optionalString (stdenv.buildPlatform.config != stdenv.hostPlatform.config) ''
-            [target."${shortTarget}"]
-            "linker" = "${ccForHost}"
-          ''}
+          "rustflags" = [ "-C", "target-feature=${if stdenv.buildPlatform.isStatic then "+" else "-"}crt-static" ]
+
+          [target."${shortTarget}"]
+          "linker" = "${ccForHost}"
           "rustflags" = [ "-C", "target-feature=${if stdenv.hostPlatform.isStatic then "+" else "-"}crt-static" ]
+
+          [unstable]
+          host-config = true
+          target-applies-to-host = true
         '';
       };
     } ./cargo-setup-hook.sh) {};

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -75,7 +75,5 @@ rustPlatform.buildRustPackage {
     maintainers = with maintainers; [ retrry ];
     license = [ licenses.mit licenses.asl20 ];
     platforms = platforms.unix;
-    # weird segfault in a build script
-    broken = stdenv.targetPlatform.isMusl && !stdenv.targetPlatform.isStatic;
   };
 }


### PR DESCRIPTION
###### Description of changes

This is a variant of #190796, which removes the need for patching rustc by always applying the unstable host-config flag in cargoSetupHook.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
