### PR TITLE
nixos/dotd: add option to emulate behavior of .d folders

### DIFF
--- a/nixos/modules/config/dotd.nix
+++ b/nixos/modules/config/dotd.nix
@@ -1,0 +1,66 @@
+{ config, pkgs, lib, utils, ... }:
+let
+  inherit (utils) escapeSystemdPath;
+  inherit (lib) mdDoc mkOption mkMerge mkIf mkEnableOption types;
+  cfg = config.environment.dotd;
+in {
+  options = {
+    environment.dotd = mkOption {
+      description = mdDoc "Module to create .d like directories and special files that when read get the contents of the files in the .d folder in sort order";
+      default = {};
+      example = {
+        "nix/machines".enable = true;
+        "i3/config".enable = true;
+      };
+      type = types.attrsOf (types.submodule {
+        options = {
+          enable = mkEnableOption (mdDoc "Create this file, create it's .d folder and the required stuff to make the file get the contents from the files inside the .d folder");
+        };
+      });
+    };
+  };
+  config.systemd = let
+      dotdKeys = builtins.attrNames cfg;
+  in mkMerge  (builtins.map (key: let
+      item = cfg.${key};
+      normalizedKey = escapeSystemdPath key;
+    in {
+      tmpfiles.rules = [
+        "p+ \"${key}\" 0644 root root" # recreate the named pipe
+        "d \"${key}.d\" 0755 root root" # create the .d folder but don't clean it periodically
+      ];
+      paths."dotd-${normalizedKey}-watcher" = {
+        inherit (item) enable;
+        wantedBy = [ "default.target" ];
+        pathConfig = {
+          PathChanged = "${key}.d";
+        };
+      };
+      services = {
+        "dotd-${normalizedKey}-watcher" = {
+          inherit (item) enable;
+          script = ''
+            echo "Reacting to file change..."
+            systemctl restart "dotd-${normalizedKey}"
+          '';
+        };
+        "dotd-${normalizedKey}" = {
+          inherit (item) enable;
+          restartIfChanged = true;
+          wantedBy = [ "default.target" ];
+          environment = {
+            DOTD_FILE = "${key}";
+            DOTD_FOLDER = "${key}.d";
+          };
+          script = ''
+            while true; do
+              echo Someone accessed the named pipe >&2
+              ls -1 "$DOTD_FOLDER" | sort | while read file; do
+                cat "$DOTD_FOLDER/$file"
+              done > "$DOTD_FILE"
+            done
+          '';
+        };
+      };
+    }) dotdKeys);
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1,5 +1,6 @@
 [
   ./config/debug-info.nix
+  ./config/dotd.nix
   ./config/fonts/fontconfig.nix
   ./config/fonts/fontdir.nix
   ./config/fonts/fonts.nix


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

###### Description of changes
Add module that implements the behavior of .d folders. It creates a named pipe on /etc/$name that when read gives the content of all files in /etc/name.d in sort order. It generates two services for each .d, one to do this kind of magic and another to restart the first one if any file in the .d folder changes. I am using rn with Nix to [enable or disable groups of machines to be used as Nix remote builders](https://github.com/lucasew/nixcfg/blob/d819a9d37f8fc71bd6ce554464af16752ddc0997/nodes/riverwood/remote-build.nix#L26). If the folder or the named pipe doesn't exist, it creates at runtime. If the module is disabled, the files and folders are maintained. Works out of the box. Just enable, apply and enjoy.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
