### PR TITLE
mindustry: 126.2 → 139

### DIFF
--- a/pkgs/games/mindustry/0001-fix-include-path-for-SDL2-on-linux.patch
+++ b/pkgs/games/mindustry/0001-fix-include-path-for-SDL2-on-linux.patch
@@ -4,13 +4,13 @@ Date: Fri, 8 Jan 2021 04:49:14 +0100
 Subject: [PATCH] fix include path for SDL2 on linux
 
 ---
- .../src/main/java/arc/backend/sdl/jni/SDL.java            | 8 --------
+ .../src/arc/backend/sdl/jni/SDL.java            | 8 --------
  1 file changed, 8 deletions(-)
 
-diff --git a/backends/backend-sdl/src/main/java/arc/backend/sdl/jni/SDL.java b/backends/backend-sdl/src/main/java/arc/backend/sdl/jni/SDL.java
+diff --git a/backends/backend-sdl/src/arc/backend/sdl/jni/SDL.java b/backends/backend-sdl/src/arc/backend/sdl/jni/SDL.java
 index 62d9286a..2853119d 100644
---- a/Arc/backends/backend-sdl/src/main/java/arc/backend/sdl/jni/SDL.java
-+++ b/Arc/backends/backend-sdl/src/main/java/arc/backend/sdl/jni/SDL.java
+--- a/Arc/backends/backend-sdl/src/arc/backend/sdl/jni/SDL.java
++++ b/Arc/backends/backend-sdl/src/arc/backend/sdl/jni/SDL.java
 @@ -8,16 +8,8 @@ import java.nio.*;
  public class SDL{
      /*JNI

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -83,14 +83,14 @@ let
   };
 
   cleanupMindustrySrc = ''
-    pushd Mindustry
+    # Ensure the prebuilt shared objects don't accidentally get shipped
+    rm -r Arc/natives/natives-*/libs/*
+    rm -r Arc/backends/backend-*/libs/*
 
     # Remove unbuildable iOS stuff
-    sed -i '/^project(":ios"){/,/^}/d' build.gradle
-    sed -i '/robo(vm|VM)/d' build.gradle
-    rm ios/build.gradle
-
-    popd
+    sed -i '/^project(":ios"){/,/^}/d' Mindustry/build.gradle
+    sed -i '/robo(vm|VM)/d' Mindustry/build.gradle
+    rm Mindustry/ios/build.gradle
   '';
 
   # fake build to pre-download deps into fixed-output derivation
@@ -126,11 +126,7 @@ assert lib.assertMsg (enableClient || enableServer)
 stdenv.mkDerivation rec {
   inherit pname version unpackPhase patches;
 
-  postPatch = ''
-    # ensure the prebuilt shared objects don't accidentally get shipped
-    rm -r Arc/natives/natives-*/libs/*
-    rm -r Arc/backends/backend-*/libs/*
-  '' + cleanupMindustrySrc;
+  postPatch = cleanupMindustrySrc;
 
   buildInputs = lib.optionals enableClient [
     SDL2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34150,16 +34150,12 @@ with pkgs;
 
   methane = callPackage ../games/methane { };
 
-  mindustry = callPackage ../games/mindustry {
-    jdk = adoptopenjdk-hotspot-bin-15;
-  };
+  mindustry = callPackage ../games/mindustry { };
   mindustry-wayland = callPackage ../games/mindustry {
-    jdk = adoptopenjdk-hotspot-bin-15;
     glew = glew-egl;
   };
 
   mindustry-server = callPackage ../games/mindustry {
-    jdk = adoptopenjdk-hotspot-bin-15;
     enableClient = false;
     enableServer = true;
   };


### PR DESCRIPTION
###### Description of changes

* Bump mindustry version to current.
* Get back to using the latest Java and gradle versions (as enabled and required by https://github.com/Anuken/Mindustry/issues/5114 )
* Eliminate more (maybe the last of?) uses of binaries-not-built-here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


###### FYI
Mindustry maintainer @fgaz
Author of #108274 that fixed Arc to build from source (thanks!) @ghost
Other folks that have done mindustry version bumps @maxhbr @Mindavi