### PR TITLE
plasma-active-window-control: init at 1.1.0

### DIFF
--- a/pkgs/applications/misc/plasma-active-window-control/default.nix
+++ b/pkgs/applications/misc/plasma-active-window-control/default.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, extra-cmake-modules, plasma-framework, qtx11extras, fetchFromGitLab, lib, cmake, qtbase, libSM }:
+
+mkDerivation rec {
+  version = "1.1.0";
+  pname = "plasma-active-window-control";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "plasma";
+    repo = pname;
+    rev = "c36e51c0e3a809ab166b619f130dcf20c8d5f61c";
+    sha256 = "sha256-6hF7ppY9LyLsborsC3iBCmhE/EucGG7en2TeomjdVkQ=";
+  };
+
+  buildInputs = [
+    plasma-framework
+    qtbase
+    qtx11extras
+    libSM
+  ];
+
+  nativeBuildInputs = [cmake extra-cmake-modules];
+
+  meta = with lib; {
+    description = "Active Window Control applet for the Plasma Desktop ";
+    homepage = "https://invent.kde.org/plasma/plasma-active-window-control";
+    license = licenses.gpl2Only or licenses.gpl3Only;
+    maintainers = with maintainers; [ icewind1991 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34849,6 +34849,8 @@ with pkgs;
 
   xfce = recurseIntoAttrs (callPackage ../desktops/xfce { });
 
+  plasma-active-window-control = libsForQt5.callPackage ../applications/misc/plasma-active-window-control { };
+
   plasma-applet-volumewin7mixer = libsForQt5.callPackage ../applications/misc/plasma-applet-volumewin7mixer { };
 
   plasma-theme-switcher = libsForQt5.callPackage ../applications/misc/plasma-theme-switcher {};


### PR DESCRIPTION
###### Description of changes

Add the [plasma-active-window-control](https://invent.kde.org/plasma/plasma-active-window-control) widget

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
