### PR TITLE
sage: fix aarch64 crashes and skip problematic test

### DIFF
--- a/pkgs/applications/science/math/sage/patches/disable-slow-glpk-test.patch
+++ b/pkgs/applications/science/math/sage/patches/disable-slow-glpk-test.patch
@@ -1,0 +1,17 @@
+diff --git a/src/sage/graphs/generic_graph.py b/src/sage/graphs/generic_graph.py
+index 0070705f78..ac19818f1b 100644
+--- a/src/sage/graphs/generic_graph.py
++++ b/src/sage/graphs/generic_graph.py
+@@ -6699,12 +6699,6 @@ class GenericGraph(GenericGraph_pyx):
+             sage: G = DiGraph(d6, format='dig6')
+             sage: G.edge_connectivity()
+             5
+-            sage: G.edge_disjoint_spanning_trees(5)  # long time
+-            [Digraph on 28 vertices,
+-             Digraph on 28 vertices,
+-             Digraph on 28 vertices,
+-             Digraph on 28 vertices,
+-             Digraph on 28 vertices]
+ 
+         Small cases::
+ 

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -138,6 +138,22 @@ stdenv.mkDerivation rec {
       rev = "eb8cd42feb58963adba67599bf6e311e03424328";
       sha256 = "sha256-0dKewOZe2n3PqSdxCJt18FkqwTdrD0VA5MXAMiTW8Tw=";
     })
+
+    # https://trac.sagemath.org/ticket/34701
+    (fetchSageDiff {
+      name = "libgap-fix-gc-crashes-on-aarch64.patch";
+      base = "eb8cd42feb58963adba67599bf6e311e03424328"; # TODO: update when #34391 lands
+      rev = "90acc7f1c13a80b8aa673469a2668feb9cd4207f";
+      sha256 = "sha256-9BhQLFB3wUhiXRQsK9L+I62lSjvTfrqMNi7QUIQvH4U=";
+    })
+
+    # Sage uses mixed integer programs (MIPs) to find edge disjoint
+    # spanning trees. For some reason, aarch64 glpk takes much longer
+    # than x86_64 glpk to solve such MIPs. Since the MIP formulation
+    # has "numerous problems" and will be replaced by a polynomial
+    # algorithm soon, disable this test for now.
+    # https://trac.sagemath.org/ticket/34575
+    ./patches/disable-slow-glpk-test.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION
###### Description of changes

After the GAP update in #192548, fixing Sage tests on aarch64 is now doable. I've submitted https://trac.sagemath.org/ticket/34701 upstream, and this PR will apply the upstream change to fix some GC crashes. Moreover, we disable a GLPK-using test which is known to be slow (https://trac.sagemath.org/ticket/34575).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
