### PR TITLE
palapeli: init at 22.08.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5289,6 +5289,12 @@
       fingerprint = "3F35 E4CA CBF4 2DE1 2E90  53E5 03A6 E6F7 8693 6619";
     }];
   };
+  harrisonthorne = {
+    email = "harrisonthorne@proton.me";
+    github = "harrisonthorne";
+    githubId = 33523827;
+    name = "Harrison Thorne";
+  };
   harvidsen = {
     email = "harvidsen@gmail.com";
     github = "harvidsen";

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -222,6 +222,7 @@ let
       messagelib = callPackage ./messagelib.nix {};
       minuet = callPackage ./minuet.nix {};
       okular = callPackage ./okular.nix {};
+      palapeli = callPackage ./palapeli.nix {};
       picmi = callPackage ./picmi.nix {};
       pim-data-exporter = callPackage ./pim-data-exporter.nix {};
       pim-sieve-editor = callPackage ./pim-sieve-editor.nix {};

--- a/pkgs/applications/kde/palapeli.nix
+++ b/pkgs/applications/kde/palapeli.nix
@@ -1,0 +1,22 @@
+{ lib
+, mkDerivation
+, extra-cmake-modules
+, shared-mime-info
+, kconfig
+, kdoctools
+, kio
+, ktextwidgets
+, libkdegames
+}:
+
+mkDerivation {
+  pname = "palapeli";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools shared-mime-info ];
+  buildInputs = [ libkdegames kio ktextwidgets ];
+  meta = {
+    homepage = "https://apps.kde.org/palapeli/";
+    description = "A single-player jigsaw puzzle game";
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ harrisonthorne ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Hello! For my first package contribution to nixpkgs, I'm adding [palapeli](https://apps.kde.org/palapeli/), KDE's single-player jigsaw puzzle game. I was surprised to find that a simple jigsaw game seemed to be missing from nixpkgs, so I had to jump on this one.

~~**I faced a bug** where the dropdown menus (File, View, Move) weren't appearing when clicked on. i've also tried right-clicking on things that would supposedly be right-clickable (i.e. the puzzle list entries on the main Collections screen) but couldn't get a context menu to appear. I'm not sure if this is because of the way the package was built or if this is a known bug with KDE/Qt apps on swaywm.~~ edit: i'm finding this is an issue with all of my Qt apps.

The list in #62168 should be updated after merging :)

Thank you for reviewing!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
