### PR TITLE
rgbds: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/applications/emulators/sameboy/default.nix
+++ b/pkgs/applications/emulators/sameboy/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, rgbds, SDL2, wrapGAppsHook, glib }:
+{ lib, stdenv, fetchpatch, fetchFromGitHub, gtk3, rgbds, SDL2, wrapGAppsHook, glib }:
 
 stdenv.mkDerivation rec {
   pname = "sameboy";
@@ -15,6 +15,13 @@ stdenv.mkDerivation rec {
   # glib and wrapGAppsHook are needed to make the Open ROM menu work.
   nativeBuildInputs = [ rgbds glib wrapGAppsHook ];
   buildInputs = [ SDL2 ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/LIJI32/SameBoy/commit/c0966ceebaf1cf2518427ffa3c0189d8f96ab5aa.patch";
+      hash = "sha256-2o/aWimtAKqay7SGq5Q9vLDcQKqV6Bn2xJtnjACrLUw=";
+    })
+  ];
 
   makeFlags = [
     "CONF=release"

--- a/pkgs/development/compilers/rgbds/default.nix
+++ b/pkgs/development/compilers/rgbds/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "rgbds";
-  version = "0.5.2";
+  version = "0.6.0";
   src = fetchFromGitHub {
     owner = "gbdev";
     repo = "rgbds";
     rev = "v${version}";
-    sha256 = "sha256-/GjxdB3Nt+XuKKQWjU12mS91U4FFoeP+9t0L+HsB/o8=";
+    sha256 = "sha256-2nyjI6z6W959/Yc8EwdQVmGnG0PKwsndPLmeDlNpj18=";
   };
   nativeBuildInputs = [ bison flex pkg-config ];
   buildInputs = [ libpng ];


### PR DESCRIPTION
###### Description of changes

**Motivation**: rgbds 0.6.0 is required to build pokeyellow.

https://github.com/NixOS/nixpkgs/pull/194446 breaks sameboy. I propose to add a patch to sameboy to fix this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
