### PR TITLE
cargo-c: fix cross and static

### DIFF
--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -3,6 +3,7 @@
 
 { stdenvNoCC
 , lib
+, rust
 , buildPackages
 , pkg-config
 , baseBinName ? "pkg-config"
@@ -39,6 +40,7 @@ stdenv.mkDerivation {
   shell = getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";
 
   inherit targetPrefix suffixSalt baseBinName;
+  rustTarget = replaceStrings ["-"] ["_"] (rust.toRustTarget targetPlatform);
 
   outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (pkg-config ? doc) "doc");
 

--- a/pkgs/build-support/pkg-config-wrapper/setup-hook.sh
+++ b/pkgs/build-support/pkg-config-wrapper/setup-hook.sh
@@ -25,5 +25,11 @@ addEnvHooks "$targetOffset" pkgConfigWrapper_addPkgConfigPath
 
 export PKG_CONFIG${role_post}=@targetPrefix@@baseBinName@
 
+# The Rust pkg-config crate does not support prefixed pkg-config executables[1],
+# but it does support checking these idiosyncratic PKG_CONFIG_${TRIPLE}
+# environment variables.
+# [1]: https://github.com/rust-lang/pkg-config-rs/issues/53
+export PKG_CONFIG_@rustTarget@=@targetPrefix@@baseBinName@
+
 # No local scope in sourced file
 unset -v role_post

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -70,13 +70,17 @@ in {
 
         # Target platform
         rustTarget = ''
-          [target."${rust.toRustTarget stdenv.buildPlatform}"]
+          [host."${rust.toRustTarget stdenv.buildPlatform}"]
           "linker" = "${ccForBuild}"
-          ${lib.optionalString (stdenv.buildPlatform.config != stdenv.hostPlatform.config) ''
-            [target."${shortTarget}"]
-            "linker" = "${ccForHost}"
-          ''}
+          "rustflags" = [ "-C", "target-feature=${if stdenv.buildPlatform.isStatic then "+" else "-"}crt-static" ]
+
+          [target."${rust.toRustTarget stdenv.hostPlatform}"]
+          "linker" = "${ccForHost}"
           "rustflags" = [ "-C", "target-feature=${if stdenv.hostPlatform.isStatic then "+" else "-"}crt-static" ]
+
+          [unstable]
+          host-config = true
+          target-applies-to-host = true
         '';
       };
     } ./cargo-setup-hook.sh) {};

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -75,7 +75,5 @@ rustPlatform.buildRustPackage {
     maintainers = with maintainers; [ retrry ];
     license = [ licenses.mit licenses.asl20 ];
     platforms = platforms.unix;
-    # weird segfault in a build script
-    broken = stdenv.targetPlatform.isMusl && !stdenv.targetPlatform.isStatic;
   };
 }

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -41,13 +41,6 @@ in stdenv.mkDerivation rec {
   # See: https://github.com/NixOS/nixpkgs/pull/56540#issuecomment-471624656
   stripDebugList = [ "bin" ];
 
-  # The Rust pkg-config crate does not support prefixed pkg-config executables[1],
-  # but it does support checking these idiosyncratic PKG_CONFIG_${TRIPLE}
-  # environment variables.
-  # [1]: https://github.com/rust-lang/pkg-config-rs/issues/53
-  "PKG_CONFIG_${builtins.replaceStrings ["-"] ["_"] (rust.toRustTarget stdenv.buildPlatform)}" =
-    "${pkgsBuildHost.stdenv.cc.targetPrefix}pkg-config";
-
   NIX_LDFLAGS = toString (
        # when linking stage1 libstd: cc: undefined reference to `__cxa_begin_catch'
        optional (stdenv.isLinux && !withBundledLLVM) "--push-state --as-needed -lstdc++ --pop-state"

--- a/pkgs/development/tools/rust/cargo-c/default.nix
+++ b/pkgs/development/tools/rust/cargo-c/default.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-c";
-  version = "0.9.2";
+  version = "0.9.13";
 
   src = fetchCrate {
     inherit pname;
     # this version may need to be updated along with package version
-    version = "${version}+cargo-0.55";
-    sha256 = "sha256-yh5vAtKlBvoSlJBsW2RSduSK6T8aOssM84WQMNjLZqA=";
+    version = "${version}+cargo-0.65";
+    sha256 = "sha256-f/p+ZIvDe9JQ8GM82SEud7sRTlimNs/ADPevfdkhsfg=";
   };
 
-  cargoSha256 = "sha256-YikTjAeroaHyNe3ygUWRHSXJwdm2BSBV7RgIDN4suZ4=";
+  cargoSha256 = "sha256-JrlEWgKbTqQG/JYFqBR53eB58fa29c/+vIdSNGoS5Y0=";
 
   nativeBuildInputs = [ pkg-config (lib.getDev curl) ];
   buildInputs = [ openssl curl ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/development/tools/rust/cargo-c/default.nix
+++ b/pkgs/development/tools/rust/cargo-c/default.nix
@@ -2,7 +2,9 @@
 , rustPlatform
 , fetchCrate
 , pkg-config
+, zlib
 , curl
+, libssh2
 , openssl
 , stdenv
 , CoreFoundation
@@ -23,12 +25,16 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-JrlEWgKbTqQG/JYFqBR53eB58fa29c/+vIdSNGoS5Y0=";
 
-  nativeBuildInputs = [ pkg-config (lib.getDev curl) ];
-  buildInputs = [ openssl curl ] ++ lib.optionals stdenv.isDarwin [
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [ pkg-config (lib.getDev curl) (lib.getDev libssh2) zlib ];
+  buildInputs = [ openssl curl libssh2 stdenv.cc.cc.lib ] ++ lib.optionals stdenv.isDarwin [
     CoreFoundation
     libiconv
     Security
   ];
+  NIX_LDFLAGS = "-lc -lm -lgcc ";
+  LIBSSH2_SYS_USE_PKG_CONFIG = "1";
 
   # Ensure that we are avoiding build of the curl vendored in curl-sys
   doInstallCheck = stdenv.hostPlatform.libc == "glibc";

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.hostPlatform.isWindows libgnurx;
 
   # https://bugs.astron.com/view.php?id=382
-  doCheck = !stdenv.hostPlatform.isMusl;
+  doCheck = !stdenv.buildPlatform.isMusl;
 
   makeFlags = lib.optional stdenv.hostPlatform.isWindows "FILE_COMPILE=file";
 


### PR DESCRIPTION
###### Description of changes

This depends on several PRs, and is also useful for testing the changes made in those:

#198309
#198311 
https://github.com/NixOS/nixpkgs/pull/198409

With this branch, I successfully built the following derivations:

```
-A fd \
-A cargo-c \
-A pkgsMusl.fd \
-A pkgsMusl.cargo-c \
-A pkgsStatic.fd \
-A pkgsStatic.cargo-c \
-A pkgsCross.musl64.fd \
-A pkgsCross.musl64.cargo \
-A pkgsCross.musl64.cargo-c \
-A pkgsCross.aarch64-multiplatform.fd \
-A pkgsCross.aarch64-multiplatform.cargo \
-A pkgsCross.aarch64-multiplatform.cargo-c \
-A pkgsCross.aarch64-multiplatform.pkgsStatic.fd \
-A pkgsCross.aarch64-multiplatform.pkgsStatic.cargo-c \
-A pkgsMusl.pkgsCross.gnu64.fd \
-A pkgsMusl.pkgsCross.gnu64.cargo \
-A pkgsMusl.pkgsCross.gnu64.cargo-c \
-A pkgsMusl.pkgsCross.aarch64-multiplatform.fd \
-A pkgsMusl.pkgsCross.aarch64-multiplatform.cargo \
-A pkgsMusl.pkgsCross.aarch64-multiplatform.cargo-c \
-A pkgsMusl.pkgsCross.aarch64-multiplatform.pkgsStatic.fd \
-A pkgsMusl.pkgsCross.aarch64-multiplatform.pkgsStatic.cargo-c
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
