### PR TITLE
oni2: python2 -> python3Minimal

### DIFF
--- a/pkgs/applications/editors/oni2/common.nix
+++ b/pkgs/applications/editors/oni2/common.nix
@@ -4,8 +4,8 @@
 , ripgrep, fontconfig, libGL, libGLU, ncurses, acl, harfbuzz, libjpeg, expat
 , icu58, libpng
 # Build
-, jq, perl, makeWrapper, bash, which, nasm, python2, gn, ninja, cmake, clang
-, fixup_yarn_lock, callPackage }:
+, jq, perl, makeWrapper, bash, which, nasm, python3Minimal, gn, ninja, cmake
+, clang, fixup_yarn_lock, callPackage }:
 
 { variant, version, rev, sha256, fetchDepsSha256, license }:
 
@@ -31,7 +31,7 @@ let
       gitMinimal
       curlMinimal
       cacert
-      python2
+      python3Minimal
       perl
       unzip
       yarn
@@ -98,7 +98,7 @@ in stdenv.mkDerivation (rec {
     perl
     which
     nasm
-    python2
+    python3Minimal
     gn
     ninja
     cmake


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fetchDeps was failing because node-gyp requires at least python3.7.

The build is still failing after this due to a C error, but the dependencies at least install successfully now.

Since oni2 doesn't mention python2 as a build dependency, i updated the version in both places, to minimize the dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
