### PR TITLE
miniupnpc_2: 2.1.20190625 -> 2.2.4 + miniupnpd: 2.1.20190502 -> 2.3.1

### DIFF
--- a/pkgs/tools/networking/miniupnpc/default.nix
+++ b/pkgs/tools/networking/miniupnpc/default.nix
@@ -6,8 +6,7 @@ let
       pname = "miniupnpc";
       inherit version;
       src = fetchurl {
-        name = "${pname}-${version}.tar.gz";
-        url = "http://miniupnp.free.fr/files/download.php?file=${pname}-${version}.tar.gz";
+        url = "https://miniupnp.tuxfamily.org/files/${pname}-${version}.tar.gz";
         inherit sha256;
       };
 
@@ -24,7 +23,7 @@ let
       '';
 
       meta = with lib; {
-        homepage = "http://miniupnp.free.fr/";
+        homepage = "https://miniupnp.tuxfamily.org/";
         description = "A client that implements the UPnP Internet Gateway Device (IGD) specification";
         platforms = with platforms; linux ++ freebsd ++ darwin;
         license = licenses.bsd3;
@@ -32,8 +31,8 @@ let
     };
 in {
   miniupnpc_2 = generic {
-    version = "2.1.20190625";
-    sha256 = "1yqp0d8x5ldjfma5x2vhpg1aaafdg0470ismccixww3rzpbza8w7";
+    version = "2.2.4";
+    sha256 = "0jrc84lkc7xb53rb8dbswxrxj21ndj1iiclmk3r9wkp6xm55w6j8";
   };
   miniupnpc_1 = generic {
     version = "1.9.20160209";

--- a/pkgs/tools/networking/miniupnpd/default.nix
+++ b/pkgs/tools/networking/miniupnpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, iptables, libuuid, pkg-config
+{ stdenv, lib, fetchurl, iptables, libuuid, openssl, pkg-config
 , which, iproute2, gnused, coreutils, gawk, makeWrapper
 , nixosTests
 }:
@@ -8,20 +8,20 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "miniupnpd";
-  version = "2.1.20190502";
+  version = "2.3.1";
 
   src = fetchurl {
-    url = "http://miniupnp.free.fr/files/download.php?file=miniupnpd-${version}.tar.gz";
-    sha256 = "1m8d0g9b0bjwsnqccw1yapp6n0jghmgzwixwjflwmvi2fi6hdp4b";
-    name = "miniupnpd-${version}.tar.gz";
+    url = "https://miniupnp.tuxfamily.org/files/miniupnpd-${version}.tar.gz";
+    sha256 = "0crv975qqppnj27jba96yysq2911y49vjd74sp9vnjb54z0d9pyi";
   };
 
-  buildInputs = [ iptables libuuid ];
+  buildInputs = [ iptables libuuid openssl ];
   nativeBuildInputs= [ pkg-config makeWrapper ];
 
-  makefile = "Makefile.linux";
 
-  buildFlags = [ "miniupnpd" "genuuid" ];
+  # ./configure is not a standard configure file, errors with:
+  # Option not recognized : --prefix=
+  dontAddPrefix = true;
 
   installFlags = [ "PREFIX=$(out)" "INSTALLPREFIX=$(out)" ];
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://miniupnp.free.fr/";
+    homepage = "https://miniupnp.tuxfamily.org/";
     description = "A daemon that implements the UPnP Internet Gateway Device (IGD) specification";
     platforms = platforms.linux;
     license = licenses.bsd3;


### PR DESCRIPTION
###### Description of changes

- new stable releases of miniupnpc_2 and miniupnpd
- change mirror to https one

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
