### PR TITLE
flare-signal: init at 0.5.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/flare-signal/default.nix
+++ b/pkgs/applications/networking/instant-messengers/flare-signal/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, gtk4
+, protobuf
+, libsecret
+, libadwaita
+, rustPlatform
+, desktop-file-utils
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "flare";
+  version = "0.5.3";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "Schmiddiii";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "sha256-gco8cqlO5t5ugbIaPWBbDpbp0E9j6rvTDRp4NQkUIl0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "sha256-y1CHCSGHJlqMwogqWmpYAVkgUP2xGDS4xs99I1X81s4=";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils # for update-desktop-database
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    libsecret
+    protobuf
+  ];
+
+  meta = with lib; {
+    description = "A unofficial Signal GTK client.";
+    homepage = "https://gitlab.com/Schmiddiii/flare";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -735,6 +735,8 @@ with pkgs;
 
   flare-floss = callPackage ../tools/security/flare-floss { };
 
+  flare-signal = callPackage ../applications/networking/instant-messengers/flare-signal { };
+
   prefer-remote-fetch = import ../build-support/prefer-remote-fetch;
 
   global-platform-pro = callPackage ../development/tools/global-platform-pro { };


### PR DESCRIPTION
###### Description of changes

Packaging of [Flare](https://gitlab.com/Schmiddiii/flare), an unofficial GTK Signal client, recently featured in https://thisweek.gnome.org/posts/2022/10/twig-67/

`pkgs.flare` would be a preferred name, but this is already taken. `flare-signal` seems okay.

Tested by linking my Signal account, and sending/receiving messages to individuals/groups.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
