### PR TITLE
ocamlPackages.eqaf: 0.8 → 0.9

### DIFF
--- a/pkgs/development/ocaml-modules/eqaf/default.nix
+++ b/pkgs/development/ocaml-modules/eqaf/default.nix
@@ -1,17 +1,16 @@
-{ lib, fetchurl, buildDunePackage, cstruct, bigarray-compat }:
+{ lib, fetchurl, buildDunePackage, cstruct }:
 
 buildDunePackage rec {
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.07";
   pname = "eqaf";
-  version = "0.8";
-  useDune2 = true;
+  version = "0.9";
 
   src = fetchurl {
-    url = "https://github.com/mirage/eqaf/releases/download/v${version}/eqaf-v${version}.tbz";
-    sha256 = "sha256-EUWhYBB0N9eUPgLkht9r0jPTk37BpZfX+jntuUcc+HU=";
+    url = "https://github.com/mirage/eqaf/releases/download/v${version}/eqaf-${version}.tbz";
+    sha256 = "sha256-7A4oqUasaBf5XVhU8FqZYa46hAi7YQ55z60BubJV3+A=";
   };
 
-  propagatedBuildInputs = [ cstruct bigarray-compat ];
+  propagatedBuildInputs = [ cstruct ];
 
   meta = {
     description = "Constant time equal function to avoid timing attacks in OCaml";


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5: https://github.com/mirage/eqaf/blob/v0.9/CHANGES.md#v09-2022-07-24-paris-france

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
