### PR TITLE
lib.modules.doRename: Don't define warning, even as undefined, if not warning.

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1135,10 +1135,10 @@ rec {
         type = toType;
       });
       config = mkMerge [
-        {
+        (optionalAttrs (options ? warnings) {
           warnings = optional (warn && fromOpt.isDefined)
             "The option `${showOption from}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption to}'.";
-        }
+        })
         (if withPriority
           then mkAliasAndWrapDefsWithPriority (setAttrByPath to) fromOpt
           else mkAliasAndWrapDefinitions (setAttrByPath to) fromOpt)

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -348,6 +348,13 @@ checkConfigOutput 'ok' config.freeformItems.foo.bar ./adhoc-freeformType-survive
 # because of an `extendModules` bug, issue 168767.
 checkConfigOutput '^1$' config.sub.specialisation.value ./extendModules-168767-imports.nix
 
+# doRename works when `warnings` does not exist.
+checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix
+# doRename adds a warning.
+checkConfigOutput '^"The option `a\.b. defined in `.*/doRename-warnings\.nix. has been renamed to `c\.d\.e.\."$' \
+  config.result \
+  ./doRename-warnings.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/doRename-basic.nix
+++ b/lib/tests/modules/doRename-basic.nix
@@ -1,0 +1,11 @@
+{ lib, ... }: {
+  imports = [
+    (lib.doRename { from = ["a" "b"]; to = ["c" "d" "e"]; warn = true; use = x: x; visible = true; })
+  ];
+  options = {
+    c.d.e = lib.mkOption {};
+  };
+  config = {
+    a.b = 1234;
+  };
+}

--- a/lib/tests/modules/doRename-warnings.nix
+++ b/lib/tests/modules/doRename-warnings.nix
@@ -1,0 +1,14 @@
+{ lib, config, ... }: {
+  imports = [
+    (lib.doRename { from = ["a" "b"]; to = ["c" "d" "e"]; warn = true; use = x: x; visible = true; })
+  ];
+  options = {
+    warnings = lib.mkOption { type = lib.types.listOf lib.types.str; };
+    c.d.e = lib.mkOption {};
+    result = lib.mkOption {};
+  };
+  config = {
+    a.b = 1234;
+    result = lib.concatStringsSep "%" config.warnings;
+  };
+}


### PR DESCRIPTION
This fixes mkAliasOptionModule in systems with no warning option.