### PR TITLE
netatalk: patch afpd segfault

### DIFF
--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
         "https://github.com/Netatalk/Netatalk/commit/916b515705cf7ba28dc53d13202811c6e1fe6a9e.patch";
       sha256 = "sha256-DAABpYjQPJLsQBhmtP30gA357w0Qn+AsnFgAeyDC/Rg=";
     })
+    (fetchpatch {
+      name = "fix-afpd-segfault.patch";
+      url = "https://github.com/Netatalk/Netatalk/commit/9d0c21298363e8174cdfca657e66c4d10819507b.patch";
+      sha256 = "sha256-a6kKUSOyMEz7gFg1KSeGnL1znu4TQx86tdn4DYH5r+E=";
+    })
   ];
 
   freeBSDPatches = [


### PR DESCRIPTION
###### Description of changes

Apply a patch that fixes a segfault in afpd that happens on user log-in.
The segfault is reliably reproducible on my aarch64 (Raspberry Pi 4) nixos-22.05 and a macOS client.

The upstream PR: https://github.com/Netatalk/Netatalk/pull/174

The upstream issue: https://github.com/Netatalk/Netatalk/issues/175

<details>

<summary>
An excerpt from journalctl -u netatalk.service
</summary>

```
Oct 28 22:25:29 pi4 afpd[1908122]: pam_unix(netatalk:session): session opened for user raindev(uid=1000) by (uid=0)
Oct 28 22:25:29 pi4 afpd[1908122]: Login by raindev (AFP3.4)
Oct 28 22:25:29 pi4 afpd[1908122]: ===============================================================
Oct 28 22:25:29 pi4 afpd[1908122]: INTERNAL ERROR: Signal 11 in pid 1908122 (3.1.13)
Oct 28 22:25:29 pi4 afpd[1908122]: ===============================================================
Oct 28 22:25:29 pi4 afpd[1908122]: PANIC: internal error
Oct 28 22:25:29 pi4 afpd[1908122]: BACKTRACE: 13 stack frames:
Oct 28 22:25:29 pi4 afpd[1908122]:  #0 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/lib/libatalk.so.18(netatalk_panic+0x44) [0xffffacf3e584]
Oct 28 22:25:29 pi4 afpd[1908122]:  #1 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/lib/libatalk.so.18(+0x366f8) [0xffffacf3e6f8]
Oct 28 22:25:29 pi4 afpd[1908122]:  #2 linux-vdso.so.1(__kernel_rt_sigreturn+0) [0xffffad00f7cc]
Oct 28 22:25:29 pi4 afpd[1908122]:  #3 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/lib/libatalk.so.18(+0x17930) [0xffffacf1f930]
Oct 28 22:25:29 pi4 afpd[1908122]:  #4 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/lib/libatalk.so.18(ad_open+0x390) [0xffffacf20548]
Oct 28 22:25:29 pi4 afpd[1908122]:  #5 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/sbin/afpd() [0x42cebc]
Oct 28 22:25:29 pi4 afpd[1908122]:  #6 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/sbin/afpd() [0x42dab4]
Oct 28 22:25:29 pi4 afpd[1908122]:  #7 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/sbin/afpd(afp_openvol+0x2d0) [0x42e150]
Oct 28 22:25:29 pi4 afpd[1908122]:  #8 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/sbin/afpd(afp_over_dsi+0x36c) [0x40d164]
Oct 28 22:25:29 pi4 afpd[1908122]:  #9 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/sbin/afpd(main+0x9b4) [0x40b1b4]
Oct 28 22:25:29 pi4 afpd[1908122]:  #10 /nix/store/lcbf6jjzbv0kpcrlm75b1lg8d4h1vkxa-glibc-2.34-210/lib/libc.so.6(+0x27260) [0xffffacc4f260]
Oct 28 22:25:29 pi4 afpd[1908122]:  #11 /nix/store/lcbf6jjzbv0kpcrlm75b1lg8d4h1vkxa-glibc-2.34-210/lib/libc.so.6(__libc_start_main+0x98) [0xffffacc4f340]
Oct 28 22:25:29 pi4 afpd[1908122]:  #12 /nix/store/y9kk54jx5a3d20gr35dmkcn6dgkkzprf-netatalk-3.1.13/sbin/afpd(_start+0x30) [0x40b5f0]
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
