### PR TITLE
map-machine: init at unstable-2022-10-26

### DIFF
--- a/pkgs/development/python-modules/portolan/default.nix
+++ b/pkgs/development/python-modules/portolan/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "portolan";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fitnr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-zKloFO7uCLkqgayxC11JRfMpNxIR+UkT/Xabb9AH8To=";
+  };
+
+  pythonImportsCheck = [ "portolan" ];
+
+  # has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/fitnr/portolan";
+    license = licenses.gpl3;
+    description = "Convert between compass points and degrees";
+    maintainers = with maintainers; [ kevink ];
+  };
+}

--- a/pkgs/tools/graphics/map-machine/default.nix
+++ b/pkgs/tools/graphics/map-machine/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitHub, python3, pkgs }:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "map-machine";
+  version = "unstable-2022-10-26";
+
+  src = fetchFromGitHub {
+    owner = "enzet";
+    repo = pname;
+    rev = "dcf3ffa00902d7812dd581c959e97d8d33f3a78d";
+    sha512 = "sha512-VtdsI6ATIWoksLzUQGEVlcIjQ9ADrBQwfmUPPHI/DHRcC8yKKiiiKuSxF5mOphKIyWVCL065iMdnzRCccI8QLg==";
+  };
+
+  doCheck = false; # Checks require moire, which is not available
+
+  buildInputs = with python3.pkgs; [ pytest ];
+
+  propagatedBuildInputs = with python3.pkgs; [ cairosvg colour numpy pillow pycairo pyyaml setuptools shapely svgwrite urllib3 portolan ];
+
+  postFixup = ''
+    patchPythonScript "$out/bin/.map-machine-wrapped"
+  '';
+
+  meta = with lib; {
+    description = "Python renderer for OpenStreetMap with custom icons intended to display as many map features as possible";
+    homepage = "https://github.com/enzet/map-machine";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kevink ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3398,6 +3398,8 @@ with pkgs;
 
   map-cmd = callPackage ../tools/misc/map {};
 
+  map-machine = callPackage ../tools/graphics/map-machine {};
+
   clash = callPackage ../tools/networking/clash { };
 
   clash-geoip = callPackage ../data/misc/clash-geoip { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7168,6 +7168,8 @@ self: super: with self; {
 
   portend = callPackage ../development/python-modules/portend { };
 
+  portolan = callPackage ../development/python-modules/portolan { };
+
   portpicker = callPackage ../development/python-modules/portpicker { };
 
   posix_ipc = callPackage ../development/python-modules/posix_ipc { };


### PR DESCRIPTION
###### Description of changes

This PR contains the package [`map-machine`](https://github.com/enzet/map-machine) and the python package [`portolan`](https://github.com/fitnr/portolan) which is required for `map-machine`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
