### PR TITLE
nextcloud25: use openssl 1.1 as a PHP extension to fix RC4 encryption

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -609,6 +609,22 @@
       </listitem>
       <listitem>
         <para>
+          The NextCloud NixOS module uses OpenSSL 3.x for its PHP’s
+          openssl extension, this breaks RC4-based server-side
+          encryption in NextCloud, making all your files unreadable upon
+          upgrade. Upon testing, we could not trigger any cases of
+          <emphasis role="strong">data loss</emphasis>, but we
+          <emphasis role="strong">cannot guarantee</emphasis> that for
+          every accidental OpenSSL upgrade. To restore functionality,
+          <link linkend="opt-services.nextcloud.enableBrokenCiphersForSSE"><literal>services.nextcloud.enableBrokenCiphersForSSE</literal></link>
+          has to be set to <literal>true</literal>. NextCloud is
+          planning to implement AES-256-GCM server-side encryption in
+          the future through
+          <link xlink:href="https://github.com/nextcloud/server/pull/25551">https://github.com/nextcloud/server/pull/25551</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>coq</literal> package and versioned variants
           starting at <literal>coq_8_14</literal> no longer include
           CoqIDE, which is now available through

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -609,18 +609,20 @@
       </listitem>
       <listitem>
         <para>
-          The NextCloud NixOS module uses OpenSSL 3.x for its PHP’s
-          openssl extension, this breaks RC4-based server-side
-          encryption in NextCloud, making all your files unreadable upon
-          upgrade. Upon testing, we could not trigger any cases of
-          <emphasis role="strong">data loss</emphasis>, but we
-          <emphasis role="strong">cannot guarantee</emphasis> that for
-          every accidental OpenSSL upgrade. To restore functionality,
-          <link linkend="opt-services.nextcloud.enableBrokenCiphersForSSE"><literal>services.nextcloud.enableBrokenCiphersForSSE</literal></link>
-          has to be set to <literal>true</literal>. NextCloud is
-          planning to implement AES-256-GCM server-side encryption in
-          the future through
-          <link xlink:href="https://github.com/nextcloud/server/pull/25551">https://github.com/nextcloud/server/pull/25551</link>.
+          The <literal>openssl</literal>-extension for the PHP
+          interpreter used by <literal>services.nextcloud</literal> is
+          built against OpenSSL 1.1 if
+          <xref linkend="opt-system.stateVersion" /> is below
+          <literal>22.11</literal>. This is to make sure that people
+          using
+          <link xlink:href="https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html">server-side
+          encryption</link> don’t loose access to their files.
+        </para>
+        <para>
+          In any other case it’s safe to use OpenSSL 3 for PHP’s openssl
+          extension. This can be done by setting
+          <xref linkend="opt-services.nextcloud.enableBrokenCiphersForSSE" />
+          to <literal>false</literal>.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -610,8 +610,7 @@
       <listitem>
         <para>
           The <literal>openssl</literal>-extension for the PHP
-          interpreter used by <literal>services.nextcloud</literal> is
-          built against OpenSSL 1.1 if
+          interpreter used by Nextcloud is built against OpenSSL 1.1 if
           <xref linkend="opt-system.stateVersion" /> is below
           <literal>22.11</literal>. This is to make sure that people
           using

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -196,7 +196,12 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - The `p4` package now only includes the open-source Perforce Helix Core command-line client and APIs. It no longer installs the unfree Helix Core Server binaries `p4d`, `p4broker`, and `p4p`. To install the Helix Core Server binaries, use the `p4d` package instead.
 
-- The NextCloud NixOS module uses OpenSSL 3.x for its PHP's openssl extension, this breaks RC4-based server-side encryption in NextCloud, making all your files unreadable upon upgrade. Upon testing, we could not trigger any cases of **data loss**, but we **cannot guarantee** that for every accidental OpenSSL upgrade. To restore functionality, [`services.nextcloud.enableBrokenCiphersForSSE`](#opt-services.nextcloud.enableBrokenCiphersForSSE) has to be set to `true`. NextCloud is planning to implement AES-256-GCM server-side encryption in the future through <https://github.com/nextcloud/server/pull/25551>.
+- The `openssl`-extension for the PHP interpreter used by `services.nextcloud` is built against OpenSSL 1.1 if
+  [](#opt-system.stateVersion) is below `22.11`. This is to make sure that people using [server-side encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html)
+  don't loose access to their files.
+
+  In any other case it's safe to use OpenSSL 3 for PHP's openssl extension. This can be done by setting
+  [](#opt-services.nextcloud.enableBrokenCiphersForSSE) to `false`.
 
 - The `coq` package and versioned variants starting at `coq_8_14` no
   longer include CoqIDE, which is now available through

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -196,6 +196,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - The `p4` package now only includes the open-source Perforce Helix Core command-line client and APIs. It no longer installs the unfree Helix Core Server binaries `p4d`, `p4broker`, and `p4p`. To install the Helix Core Server binaries, use the `p4d` package instead.
 
+- The NextCloud NixOS module uses OpenSSL 3.x for its PHP's openssl extension, this breaks RC4-based server-side encryption in NextCloud, making all your files unreadable upon upgrade. Upon testing, we could not trigger any cases of **data loss**, but we **cannot guarantee** that for every accidental OpenSSL upgrade. To restore functionality, [`services.nextcloud.enableBrokenCiphersForSSE`](#opt-services.nextcloud.enableBrokenCiphersForSSE) has to be set to `true`. NextCloud is planning to implement AES-256-GCM server-side encryption in the future through <https://github.com/nextcloud/server/pull/25551>.
+
 - The `coq` package and versioned variants starting at `coq_8_14` no
   longer include CoqIDE, which is now available through
   `coqPackages.coqide`. It is still possible to get CoqIDE as part of

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -196,7 +196,7 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - The `p4` package now only includes the open-source Perforce Helix Core command-line client and APIs. It no longer installs the unfree Helix Core Server binaries `p4d`, `p4broker`, and `p4p`. To install the Helix Core Server binaries, use the `p4d` package instead.
 
-- The `openssl`-extension for the PHP interpreter used by `services.nextcloud` is built against OpenSSL 1.1 if
+- The `openssl`-extension for the PHP interpreter used by Nextcloud is built against OpenSSL 1.1 if
   [](#opt-system.stateVersion) is below `22.11`. This is to make sure that people using [server-side encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html)
   don't loose access to their files.
 

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -88,7 +88,8 @@ in {
 
     enableBrokenCiphersForSSE = mkOption {
       type = types.bool;
-      default = false;
+      # Workaround can be removed at backport-time for 22.11.
+      default = !(versionOlder stateVersion "22.11");
       description = lib.mdDoc ''
         This option uses OpenSSL PHP extension linked against OpenSSL 1.x rather
         than latest OpenSSL (≥ 3), this is not recommended except if you need

--- a/nixos/modules/services/web-apps/nextcloud.xml
+++ b/nixos/modules/services/web-apps/nextcloud.xml
@@ -170,6 +170,20 @@
      </listitem>
     </itemizedlist>
    </listitem>
+   <listitem>
+    <formalpara>
+     <title>Server-side encryption</title>
+     <para>
+      Nextcloud supports <link xlink:href="https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html">server-side encryption (SSE)</link>.
+      This is not an end-to-end encryption, but can be used to encrypt files that will be persisted
+      to external storage such as S3. Please note that this won't work anymore when using OpenSSL 3
+      for PHP's openssl extension because this is implemented using the legacy cipher RC4.
+      If <xref linkend="opt-system.stateVersion" /> is <emphasis>above</emphasis> <literal>22.05</literal>,
+      this is disabled by default. To turn it on again and for further information please refer to
+      <xref linkend="opt-services.nextcloud.enableBrokenCiphersForSSE" />.
+     </para>
+    </formalpara>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -37,13 +37,12 @@ in {
         "d /var/lib/nextcloud-data 0750 nextcloud nginx - -"
       ];
 
-      system.stateVersion = "22.11";
+      system.stateVersion = "22.11"; # stateVersion >=21.11 to make sure that we use OpenSSL3
 
       services.nextcloud = {
         enable = true;
         datadir = "/var/lib/nextcloud-data";
         hostName = "nextcloud";
-        enableBrokenCiphersForSSE = args.enableBrokenCiphersForSSE or false;
         config = {
           # Don't inherit adminuser since "root" is supposed to be the default
           adminpassFile = "${pkgs.writeText "adminpass" adminpass}"; # Don't try this at home!
@@ -102,6 +101,10 @@ in {
     # This is just to ensure the nextcloud-occ program is working
     nextcloud.succeed("nextcloud-occ status")
     nextcloud.succeed("curl -sSf http://nextcloud/login")
+    # Ensure that no OpenSSL 1.1 is used.
+    nextcloud.succeed(
+        "${nodes.nextcloud.services.phpfpm.pools.nextcloud.phpPackage}/bin/php -i | grep 'OpenSSL Library Version' | awk -F'=>' '{ print $2 }' | awk '{ print $2 }' | grep -v 1.1"
+    )
     nextcloud.succeed(
         "${withRcloneEnv} ${copySharedFile}"
     )
@@ -111,5 +114,6 @@ in {
         "${withRcloneEnv} ${diffSharedFile}"
     )
     assert "hi" in client.succeed("cat /mnt/dav/test-shared-file")
+    nextcloud.succeed("grep -vE '^HBEGIN:oc_encryption_module' /var/lib/nextcloud-data/data/root/files/test-shared-file")
   '';
 })) args

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -41,6 +41,7 @@ in {
         enable = true;
         datadir = "/var/lib/nextcloud-data";
         hostName = "nextcloud";
+        enableBrokenCiphersForSSE = args.enableBrokenCiphersForSSE or false;
         config = {
           # Don't inherit adminuser since "root" is supposed to be the default
           adminpassFile = "${pkgs.writeText "adminpass" adminpass}"; # Don't try this at home!

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -37,6 +37,8 @@ in {
         "d /var/lib/nextcloud-data 0750 nextcloud nginx - -"
       ];
 
+      system.stateVersion = "22.11";
+
       services.nextcloud = {
         enable = true;
         datadir = "/var/lib/nextcloud-data";

--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -8,10 +8,9 @@ with pkgs.lib;
 foldl
   (matrix: ver: matrix // {
     "basic${toString ver}" = import ./basic.nix { inherit system pkgs; nextcloudVersion = ver; };
-    "with-legacy-openssl${toString ver}" = import ./basic.nix {
+    "openssl-sse${toString ver}" = import ./openssl-sse.nix {
       inherit system pkgs;
       nextcloudVersion = ver;
-      enableBrokenCiphersForSSE = true;
     };
     "with-postgresql-and-redis${toString ver}" = import ./with-postgresql-and-redis.nix {
       inherit system pkgs;

--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -8,6 +8,11 @@ with pkgs.lib;
 foldl
   (matrix: ver: matrix // {
     "basic${toString ver}" = import ./basic.nix { inherit system pkgs; nextcloudVersion = ver; };
+    "with-legacy-openssl${toString ver}" = import ./basic.nix {
+      inherit system pkgs;
+      nextcloudVersion = ver;
+      enableBrokenCiphersForSSE = true;
+    };
     "with-postgresql-and-redis${toString ver}" = import ./with-postgresql-and-redis.nix {
       inherit system pkgs;
       nextcloudVersion = ver;

--- a/nixos/tests/nextcloud/openssl-sse.nix
+++ b/nixos/tests/nextcloud/openssl-sse.nix
@@ -1,0 +1,105 @@
+args@{ pkgs, nextcloudVersion ? 25, ... }:
+
+(import ../make-test-python.nix ({ pkgs, ...}: let
+  adminuser = "root";
+  adminpass = "notproduction";
+  nextcloudBase = {
+    networking.firewall.allowedTCPPorts = [ 80 ];
+    system.stateVersion = "22.05"; # stateVersions <22.11 use openssl 1.1 by default
+    services.nextcloud = {
+      enable = true;
+      config.adminpassFile = "${pkgs.writeText "adminpass" adminpass}";
+      package = pkgs.${"nextcloud" + (toString nextcloudVersion)};
+    };
+  };
+in {
+  name = "nextcloud-openssl";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ ma27 ];
+  };
+  nodes.nextcloudwithopenssl1 = {
+    imports = [ nextcloudBase ];
+    services.nextcloud.hostName = "nextcloudwithopenssl1";
+  };
+  nodes.nextcloudwithopenssl3 = {
+    imports = [ nextcloudBase ];
+    services.nextcloud = {
+      hostName = "nextcloudwithopenssl3";
+      enableBrokenCiphersForSSE = false;
+    };
+  };
+  testScript = { nodes, ... }: let
+    withRcloneEnv = host: pkgs.writeScript "with-rclone-env" ''
+      #!${pkgs.runtimeShell}
+      export RCLONE_CONFIG_NEXTCLOUD_TYPE=webdav
+      export RCLONE_CONFIG_NEXTCLOUD_URL="http://${host}/remote.php/webdav/"
+      export RCLONE_CONFIG_NEXTCLOUD_VENDOR="nextcloud"
+      export RCLONE_CONFIG_NEXTCLOUD_USER="${adminuser}"
+      export RCLONE_CONFIG_NEXTCLOUD_PASS="$(${pkgs.rclone}/bin/rclone obscure ${adminpass})"
+      "''${@}"
+    '';
+    withRcloneEnv1 = withRcloneEnv "nextcloudwithopenssl1";
+    withRcloneEnv3 = withRcloneEnv "nextcloudwithopenssl3";
+    copySharedFile1 = pkgs.writeScript "copy-shared-file" ''
+      #!${pkgs.runtimeShell}
+      echo 'hi' | ${withRcloneEnv1} ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file
+    '';
+    copySharedFile3 = pkgs.writeScript "copy-shared-file" ''
+      #!${pkgs.runtimeShell}
+      echo 'bye' | ${withRcloneEnv3} ${pkgs.rclone}/bin/rclone rcat nextcloud:test-shared-file2
+    '';
+    openssl1-node = nodes.nextcloudwithopenssl1.config.system.build.toplevel;
+    openssl3-node = nodes.nextcloudwithopenssl3.config.system.build.toplevel;
+  in ''
+    nextcloudwithopenssl1.start()
+    nextcloudwithopenssl1.wait_for_unit("multi-user.target")
+    nextcloudwithopenssl1.succeed("nextcloud-occ status")
+    nextcloudwithopenssl1.succeed("curl -sSf http://nextcloudwithopenssl1/login")
+
+    with subtest("With OpenSSL 1 SSE can be enabled and used"):
+        nextcloudwithopenssl1.succeed("nextcloud-occ app:enable encryption")
+        nextcloudwithopenssl1.succeed("nextcloud-occ encryption:enable")
+
+    with subtest("Upload file and ensure it's encrypted"):
+        nextcloudwithopenssl1.succeed("${copySharedFile1}")
+        nextcloudwithopenssl1.succeed("grep -E '^HBEGIN:oc_encryption_module' /var/lib/nextcloud/data/root/files/test-shared-file")
+        nextcloudwithopenssl1.succeed("${withRcloneEnv1} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file | grep hi")
+
+    with subtest("Switch to OpenSSL 3"):
+        nextcloudwithopenssl1.succeed("${openssl3-node}/bin/switch-to-configuration test")
+        nextcloudwithopenssl1.wait_for_open_port(80)
+        nextcloudwithopenssl1.succeed("nextcloud-occ status")
+
+    with subtest("Existing encrypted files cannot be read, but new files can be added"):
+        nextcloudwithopenssl1.fail("${withRcloneEnv3} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file >&2")
+        nextcloudwithopenssl1.succeed("nextcloud-occ encryption:disable")
+        nextcloudwithopenssl1.succeed("${copySharedFile3}")
+        nextcloudwithopenssl1.succeed("grep bye /var/lib/nextcloud/data/root/files/test-shared-file2")
+        nextcloudwithopenssl1.succeed("${withRcloneEnv3} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file2 | grep bye")
+
+    with subtest("Switch back to OpenSSL 1.1 and ensure that encrypted files are readable again"):
+        nextcloudwithopenssl1.succeed("${openssl1-node}/bin/switch-to-configuration test")
+        nextcloudwithopenssl1.wait_for_open_port(80)
+        nextcloudwithopenssl1.succeed("nextcloud-occ status")
+        nextcloudwithopenssl1.succeed("nextcloud-occ encryption:enable")
+        nextcloudwithopenssl1.succeed("${withRcloneEnv1} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file2 | grep bye")
+        nextcloudwithopenssl1.succeed("${withRcloneEnv1} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file | grep hi")
+        nextcloudwithopenssl1.succeed("grep -E '^HBEGIN:oc_encryption_module' /var/lib/nextcloud/data/root/files/test-shared-file")
+        nextcloudwithopenssl1.succeed("grep bye /var/lib/nextcloud/data/root/files/test-shared-file2")
+
+    with subtest("Ensure that everything can be decrypted"):
+        nextcloudwithopenssl1.succeed("echo y | nextcloud-occ encryption:decrypt-all >&2")
+        nextcloudwithopenssl1.succeed("${withRcloneEnv1} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file2 | grep bye")
+        nextcloudwithopenssl1.succeed("${withRcloneEnv1} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file | grep hi")
+        nextcloudwithopenssl1.succeed("grep -vE '^HBEGIN:oc_encryption_module' /var/lib/nextcloud/data/root/files/test-shared-file")
+
+    with subtest("Switch to OpenSSL 3 ensure that all files are usable now"):
+        nextcloudwithopenssl1.succeed("${openssl3-node}/bin/switch-to-configuration test")
+        nextcloudwithopenssl1.wait_for_open_port(80)
+        nextcloudwithopenssl1.succeed("nextcloud-occ status")
+        nextcloudwithopenssl1.succeed("${withRcloneEnv3} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file2 | grep bye")
+        nextcloudwithopenssl1.succeed("${withRcloneEnv3} ${pkgs.rclone}/bin/rclone cat nextcloud:test-shared-file | grep hi")
+
+    nextcloudwithopenssl1.shutdown()
+  '';
+})) args

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -91,7 +91,7 @@ let
               [ ]
               allExtensionFunctions;
 
-          getExtName = ext: lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
+          getExtName = ext: ext.extensionName;
 
           # Recursively get a list of all internal dependencies
           # for a list of extensions.

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -71,16 +71,17 @@ lib.makeScope pkgs.newScope (self: with self; {
   # will mark the extension as a zend extension or not.
   mkExtension = lib.makeOverridable
     ({ name
-    , configureFlags ? [ "--enable-${name}" ]
+    , configureFlags ? [ "--enable-${extName}" ]
     , internalDeps ? [ ]
     , postPhpize ? ""
     , buildInputs ? [ ]
     , zendExtension ? false
     , doCheck ? true
+    , extName ? name
     , ...
     }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
       pname = "php-${name}";
-      extensionName = name;
+      extensionName = extName;
 
       outputs = [ "out" "dev" ];
 
@@ -103,7 +104,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
       cdToExtensionRootPhase = ''
         # Go to extension source root.
-        cd "ext/${name}"
+        cd "ext/${extName}"
       '';
 
       preConfigure = ''
@@ -139,7 +140,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         runHook preInstall
 
         mkdir -p $out/lib/php/extensions
-        cp modules/${name}.so $out/lib/php/extensions/${name}.so
+        cp modules/${extName}.so $out/lib/php/extensions/${extName}.so
         mkdir -p $dev/include
         ${rsync}/bin/rsync -r --filter="+ */" \
                               --filter="+ *.h" \
@@ -419,6 +420,7 @@ lib.makeScope pkgs.newScope (self: with self; {
         # without a specific openssl.cnf file
         {
           name = "openssl-legacy";
+          extName = "openssl";
           buildInputs = [ openssl_1_1 ];
           configureFlags = [ "--with-openssl" ];
           doCheck = false;

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -414,6 +414,15 @@ lib.makeScope pkgs.newScope (self: with self; {
           configureFlags = [ "--with-openssl" ];
           doCheck = false;
         }
+        # This provides a legacy OpenSSL PHP extension
+        # For situations where OpenSSL 3 do not support a set of features
+        # without a specific openssl.cnf file
+        {
+          name = "openssl-legacy";
+          buildInputs = [ openssl_1_1 ];
+          configureFlags = [ "--with-openssl" ];
+          doCheck = false;
+        }
         { name = "pcntl"; }
         { name = "pdo"; doCheck = false; }
         {


### PR DESCRIPTION
###### Description of changes

NextCloud encryption is RC4-based, when moving to NextCloud 25 and OpenSSL3, NC cannot decrypt the files anymore, see #197726.

This adds a `openssl-legacy` PHP extension that can be used for these scenarios where OpenSSL 1.1 is easier to use.

Another solution is to provide a custom `openssl.cnf` file to re-enable RC4 encryption to OpenSSL 3, I will open such a PR soon, but it will might be a bit uglier than this one.

cc @mweinelt @Ma27 @AkechiShiro

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
