### PR TITLE
vlc: use xorg.libSM packages directly instead of xlibsWrapper indirection

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -64,7 +64,6 @@
 , systemd
 , taglib
 , unzip
-, xlibsWrapper
 , xorg
 , zlib
 , chromecastSupport ? true, libmicrodns, protobuf
@@ -150,10 +149,10 @@ stdenv.mkDerivation rec {
     srt
     systemd
     taglib
-    xlibsWrapper
     zlib
   ]
   ++ (with xorg; [
+    libSM
     libXpm
     libXv
     libXvMC


### PR DESCRIPTION
###### Description of changes

See #194054
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages marked as broken and skipped:</summary>
  <ul>
    <li>elisa</li>
    <li>libsForQt512.elisa</li>
    <li>libsForQt512.phonon-backend-vlc</li>
    <li>libsForQt514.elisa</li>
    <li>libsForQt514.phonon-backend-vlc</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>obs-studio-plugins.obs-ndi</li>
  </ul>
</details>
<details>
  <summary>33 packages built:</summary>
  <ul>
    <li>arcanPackages.all-wrapped</li>
    <li>arcanPackages.arcan</li>
    <li>arcanPackages.arcan-wrapped</li>
    <li>arcanPackages.cat9-wrapped</li>
    <li>arcanPackages.durden-wrapped</li>
    <li>arcanPackages.pipeworld-wrapped</li>
    <li>arcanPackages.prio-wrapped</li>
    <li>arcanPackages.xarcan</li>
    <li>kaffeine</li>
    <li>kphotoalbum</li>
    <li>libsForQt5.elisa</li>
    <li>libsForQt5.phonon-backend-vlc</li>
    <li>libvlc</li>
    <li>megaglest</li>
    <li>minitube</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-backgroundremoval</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>openlpFull</li>
    <li>pympress</li>
    <li>python310Packages.python-vlc</li>
    <li>python39Packages.python-vlc</li>
    <li>reaper</li>
    <li>strawberry</li>
    <li>vlc</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
