### PR TITLE
inetutils: 2.3 -> 2.4

### DIFF
--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -1,14 +1,14 @@
 { stdenv, lib, fetchurl, ncurses, perl, help2man
-, apparmorRulesFromClosure, fetchpatch
+, apparmorRulesFromClosure
 }:
 
 stdenv.mkDerivation rec {
   pname = "inetutils";
-  version = "2.3";
+  version = "2.4";
 
   src = fetchurl {
     url = "mirror://gnu/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-CwG7COKWI8TjuUDyM8lhRR2a+MUGYwGt12pSqV1Rdyw=";
+    sha256 = "sha256-F4nWsbGlff4qere1M+6fXf2cv1tZuxuzwmEu0I0PaLI=";
   };
 
   outputs = ["out" "apparmor"];
@@ -16,11 +16,6 @@ stdenv.mkDerivation rec {
   patches = [
     # https://git.congatec.com/yocto/meta-openembedded/commit/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3
     ./inetutils-1_9-PATH_PROCNET_DEV.patch
-    (fetchpatch {
-      name = "CVE-2022-39028.patch";
-      url = "https://sources.debian.org/data/main/i/inetutils/2%3A2.3-5/debian/patches/inetutils-telnetd-EC_EL_null_deref.patch";
-      sha256 = "sha256-NYNDbEk3q3EhQdJaR12JBbnjJIRRpOcKLBF/EJJPiGU=";
-    })
   ];
 
   nativeBuildInputs = [ help2man perl /* for `whois' */ ];


### PR DESCRIPTION
###### Description of changes

```
GNU inetutils NEWS -- history of user-visible changes.

* Noteworthy changes in release 2.4 (2022-10-25) [stable]

** ifconfig

*** Support specifying prefix netmask lengths in -A.
Patch by Samuel Thibault <samuel.thibault@gnu.org>.

** Hurd: tell pfinet translator interfaces to configure
Patch by Samuel Thibault <samuel.thibault@gnu.org>.

** ftp

*** Avoid crash caused by signed integer overflow resulting in
out-of-bounds buffer access.  Reported by AiDai in
<https://lists.gnu.org/archive/html/bug-inetutils/2021-12/msg00003.html>.

*** Avoid crash caused by heap buffer overflow.  Reported by ZFeiXQ in
<https://lists.gnu.org/archive/html/bug-inetutils/2021-12/msg00016.html>.

*** Avoid crash caused by NULL pointer dereference.  Reported by AiDai in
<https://lists.gnu.org/archive/html/bug-inetutils/2021-12/msg00004.html>.

*** Avoid crash caused by infinite macro recursion.  Reported by AiDai in
<https://lists.gnu.org/archive/html/bug-inetutils/2021-12/msg00005.html>.

** telnetd

*** Avoid crash on 0xff 0xf7 (IAC EC) or 0xff 0xf8 (IAC EL).  CVE-2022-39028
https://pierrekim.github.io/blog/2022-08-24-2-byte-dos-freebsd-netbsd-telnetd-netkit-telnetd-inetutils-telnetd-kerberos-telnetd.html

** telnet

*** Fix a buffer overflow problem.  CVE-2019-0053
https://cgit.freebsd.org/src/commit/?id=14aab889f4e50072a6b914eb95ebbfa939539dad

** tftp

*** Avoid crashing when given unexpected or invalid commands from tty.
Reported by AiDai in
<https://lists.gnu.org/archive/html/bug-inetutils/2021-12/msg00018.html>.

** Various bugs fixes, internal improvements and clean ups.
Update of gnulib and build fixes for C23.
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
