### PR TITLE
ica-securestore: init at 6.3.3

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -174,6 +174,7 @@
   ./programs/haguichi.nix
   ./programs/hamster.nix
   ./programs/htop.nix
+  ./programs/ica-securestore.nix
   ./programs/iftop.nix
   ./programs/iotop.nix
   ./programs/java.nix

--- a/nixos/modules/programs/ica-securestore.nix
+++ b/nixos/modules/programs/ica-securestore.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+{
+  meta.maintainers = with lib.maintainers; [ jtojnar ];
+
+  options = {
+    programs.ica-securestore = {
+      enable = lib.mkEnableOption (lib.mdDoc "I.CA SecureStore smart card manager");
+    };
+  };
+
+  config = lib.mkIf config.programs.ica-securestore.enable {
+    environment.systemPackages = [
+      pkgs.ica-securestore
+    ];
+    environment.etc."ICA/cz.ica.SecureStore.ini".source = "${pkgs.ica-securestore}/etc/ICA/cz.ica.SecureStore.ini";
+  };
+}

--- a/pkgs/tools/security/ica-securestore/default.nix
+++ b/pkgs/tools/security/ica-securestore/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, fetchurl
+, lib
+, dpkg
+, makeWrapper
+, autoPatchelfHook
+, ica-securestore-pkcs11
+, libsForQt5
+, curl
+, pcsclite
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ica-securestore";
+  version = "6.3.3";
+
+  src = fetchurl {
+    url = "http://ca.ica.cz/pub/SecureStore/linux/ica-securestore_${finalAttrs.version}-1_amd64.deb";
+    sha256 = "m/pP6J2OrPPnm0C4hsUZnA+FDYFO+c7LAjbddRAt6zE=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.qtgraphicaleffects
+    libsForQt5.wrapQtAppsHook
+    curl
+    pcsclite
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg-deb -x "$src" .
+
+    runHook postUnpack
+  '';
+
+  postPatch = ''
+    substituteInPlace etc/ICA/cz.ica.SecureStore.ini \
+      --replace "/usr/lib/pkcs11/libICASecureStorePkcs11.so" "${ica-securestore-pkcs11}/lib/pkcs11/libICASecureStorePkcs11.so"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp -ar usr/share "$out/share"
+    cp -ar etc "$out/etc"
+    cp opt/ICASecureStore/bin/SecureStore "$out/bin/ICASecureStore"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Manager for I.CA Starcos smart cards";
+    homepage = "https://ica.cz";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ jtojnar ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/tools/security/ica-securestore/pkcs11.nix
+++ b/pkgs/tools/security/ica-securestore/pkcs11.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchurl
+, lib
+, dpkg
+, autoPatchelfHook
+, pcsclite
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ica-securestore-pkcs11";
+  version = "5.1.8";
+
+  src = fetchurl {
+    url = "http://ca.ica.cz/pub/SecureStore/linux/ica-securestore-pkcs11_${finalAttrs.version}-1_amd64.deb";
+    sha256 = "4kKsP7IkHnjUQVRHZSJ135OqJ4FIKfshPVFpWkIoyQY=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    pcsclite
+    stdenv.cc.cc.lib
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg-deb -x "$src" .
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/pkcs11"
+    cp -ar usr/lib/pkcs11/libICASecureStorePkcs11.so "$out/lib/pkcs11"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "ICA SecureStore Pkcs11 module";
+    homepage = "https://ica.cz";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ jtojnar ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7838,6 +7838,8 @@ with pkgs;
 
   ibniz = callPackage ../tools/graphics/ibniz { };
 
+  ica-securestore = callPackage ../tools/security/ica-securestore { };
+
   ica-securestore-pkcs11 = callPackage ../tools/security/ica-securestore/pkcs11.nix { };
 
   icecast = callPackage ../servers/icecast { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7838,6 +7838,8 @@ with pkgs;
 
   ibniz = callPackage ../tools/graphics/ibniz { };
 
+  ica-securestore-pkcs11 = callPackage ../tools/security/ica-securestore/pkcs11.nix { };
+
   icecast = callPackage ../servers/icecast { };
 
   icemon = libsForQt5.callPackage ../applications/networking/icemon { };


### PR DESCRIPTION
###### Description of changes

Starts in a VM, did not test a smart card yet.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
