### PR TITLE
[22.05] netatalk: FreeBSD patchset 3.1.13_3, critical fix

### DIFF
--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -4,12 +4,10 @@
 
 stdenv.mkDerivation rec {
   pname = "netatalk";
-  release = "3.1.13";
-  patch = "3";
-  version = "${release}_${patch}";
+  version = "3.1.13";
 
   src = fetchurl {
-    url = "mirror://sourceforge/netatalk/netatalk/netatalk-${release}.tar.bz2";
+    url = "mirror://sourceforge/netatalk/netatalk/netatalk-${version}.tar.bz2";
     sha256 = "0pg0slvvvq3l6f5yjz9ybijg4i6rs5a6c8wcynaasf8vzsyadbc9";
   };
 
@@ -18,8 +16,7 @@ stdenv.mkDerivation rec {
     ./omitLocalstatedirCreation.patch
     (fetchpatch {
       name = "make-afpstats-python3-compatible.patch";
-      url =
-        "https://github.com/Netatalk/Netatalk/commit/916b515705cf7ba28dc53d13202811c6e1fe6a9e.patch";
+      url = "https://github.com/Netatalk/Netatalk/commit/916b515705cf7ba28dc53d13202811c6e1fe6a9e.patch";
       sha256 = "sha256-DAABpYjQPJLsQBhmtP30gA357w0Qn+AsnFgAeyDC/Rg=";
     })
   ];
@@ -28,26 +25,22 @@ stdenv.mkDerivation rec {
     # https://bugs.freebsd.org/263123
     (fetchpatch {
       name = "patch-etc_afpd_directory.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_directory.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_directory.c";
       sha256 = "sha256-07YAJs+EtqGcFXbYHDLbILved1Ebtd8ukQepvzy6et0=";
     })
     (fetchpatch {
       name = "patch-etc_afpd_file.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_file.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_file.c";
       sha256 = "sha256-T1WTNa2G6wxKtvMa/MCX3Vx6XZBHtU6w3enkdGuIWus=";
     })
     (fetchpatch {
       name = "patch-etc_afpd_volume.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_volume.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_volume.c";
       sha256 = "sha256-NOZNZGzA0hxrNkoLTvN64h40yApPbMH4qIfBTpQoI0s=";
     })
     (fetchpatch {
       name = "patch-etc_cnid__dbd_cmd__dbd__scanvol.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_cnid__dbd_cmd__dbd__scanvol.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_cnid__dbd_cmd__dbd__scanvol.c";
       sha256 = "sha256-5QV+tQDo8/XeKwH/e5+Ne+kEOl2uvRDbHMaWysIB6YU=";
     })
     (fetchpatch {
@@ -58,33 +51,28 @@ stdenv.mkDerivation rec {
     })
     (fetchpatch {
       name = "patch-libatalk_adouble_ad__conv.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__conv.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__conv.c";
       sha256 = "sha256-T27WlKVXosv4bX5Gek2bR2cVDYEee5qrH4mnL9ghbP8=";
     })
     (fetchpatch {
       name = "patch-libatalk_adouble_ad__date.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__date.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__date.c";
       sha256 = "sha256-fkW5A+7R5fT3bukRfZaOwFo7AsyPaYajc1hIlDMZMnc=";
     })
     (fetchpatch {
       name = "patch-libatalk_adouble_ad__flush.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__flush.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__flush.c";
       sha256 = "sha256-k2zTx35tAlsFHym83bZGoWXRomwFV9xT3r2fzr3Zvbk=";
     })
     (fetchpatch {
       name = "patch-libatalk_adouble_ad__open.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__open.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__open.c";
       sha256 = "sha256-uV4wwft2IH54+4k5YR+Gz/BpRZBanxX/Ukp8BkohInU=";
     })
     # https://bugs.freebsd.org/251203
     (fetchpatch {
       name = "patch-libatalk_vfs_extattr.c";
-      url =
-        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_vfs_extattr.c";
+      url = "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_vfs_extattr.c";
       sha256 = "sha256-lFWF0Qo8PJv7QKvnMn0Fc9Ruzb+FTEWgOMpxc789jWs=";
     })
   ];
@@ -96,8 +84,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  nativeBuildInputs =
-    [ autoreconfHook pkg-config perl python3 python3.pkgs.wrapPython ];
+  nativeBuildInputs = [ autoreconfHook pkg-config perl python3 python3.pkgs.wrapPython ];
 
   buildInputs = [ db libgcrypt avahi libiconv pam openssl acl libevent ];
 

--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -1,14 +1,15 @@
-{ fetchurl, lib, stdenv, autoreconfHook, pkg-config, perl, python3
-, db, libgcrypt, avahi, libiconv, pam, openssl, acl
-, ed, libtirpc, libevent, fetchpatch
-}:
+{ fetchurl, lib, stdenv, autoreconfHook, pkg-config, perl, python3, db
+, libgcrypt, avahi, libiconv, pam, openssl, acl, ed, libtirpc, libevent
+, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "netatalk";
-  version = "3.1.13";
+  release = "3.1.13";
+  patch = "3";
+  version = "${release}_${patch}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/netatalk/netatalk/netatalk-${version}.tar.bz2";
+    url = "mirror://sourceforge/netatalk/netatalk/netatalk-${release}.tar.bz2";
     sha256 = "0pg0slvvvq3l6f5yjz9ybijg4i6rs5a6c8wcynaasf8vzsyadbc9";
   };
 
@@ -17,12 +18,86 @@ stdenv.mkDerivation rec {
     ./omitLocalstatedirCreation.patch
     (fetchpatch {
       name = "make-afpstats-python3-compatible.patch";
-      url = "https://github.com/Netatalk/Netatalk/commit/916b515705cf7ba28dc53d13202811c6e1fe6a9e.patch";
+      url =
+        "https://github.com/Netatalk/Netatalk/commit/916b515705cf7ba28dc53d13202811c6e1fe6a9e.patch";
       sha256 = "sha256-DAABpYjQPJLsQBhmtP30gA357w0Qn+AsnFgAeyDC/Rg=";
     })
   ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config perl python3 python3.pkgs.wrapPython ];
+  freeBSDPatches = [
+    # https://bugs.freebsd.org/263123
+    (fetchpatch {
+      name = "patch-etc_afpd_directory.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_directory.c";
+      sha256 = "sha256-07YAJs+EtqGcFXbYHDLbILved1Ebtd8ukQepvzy6et0=";
+    })
+    (fetchpatch {
+      name = "patch-etc_afpd_file.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_file.c";
+      sha256 = "sha256-T1WTNa2G6wxKtvMa/MCX3Vx6XZBHtU6w3enkdGuIWus=";
+    })
+    (fetchpatch {
+      name = "patch-etc_afpd_volume.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_afpd_volume.c";
+      sha256 = "sha256-NOZNZGzA0hxrNkoLTvN64h40yApPbMH4qIfBTpQoI0s=";
+    })
+    (fetchpatch {
+      name = "patch-etc_cnid__dbd_cmd__dbd__scanvol.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-etc_cnid__dbd_cmd__dbd__scanvol.c";
+      sha256 = "sha256-5QV+tQDo8/XeKwH/e5+Ne+kEOl2uvRDbHMaWysIB6YU=";
+    })
+    (fetchpatch {
+      name = "patch-libatalk_adouble_ad__attr.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__attr.c";
+      sha256 = "sha256-Ose6BdilwBOmoYpm8Jat1B3biOXJj4y3U4T49zE0G7Y=";
+    })
+    (fetchpatch {
+      name = "patch-libatalk_adouble_ad__conv.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__conv.c";
+      sha256 = "sha256-T27WlKVXosv4bX5Gek2bR2cVDYEee5qrH4mnL9ghbP8=";
+    })
+    (fetchpatch {
+      name = "patch-libatalk_adouble_ad__date.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__date.c";
+      sha256 = "sha256-fkW5A+7R5fT3bukRfZaOwFo7AsyPaYajc1hIlDMZMnc=";
+    })
+    (fetchpatch {
+      name = "patch-libatalk_adouble_ad__flush.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__flush.c";
+      sha256 = "sha256-k2zTx35tAlsFHym83bZGoWXRomwFV9xT3r2fzr3Zvbk=";
+    })
+    (fetchpatch {
+      name = "patch-libatalk_adouble_ad__open.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_adouble_ad__open.c";
+      sha256 = "sha256-uV4wwft2IH54+4k5YR+Gz/BpRZBanxX/Ukp8BkohInU=";
+    })
+    # https://bugs.freebsd.org/251203
+    (fetchpatch {
+      name = "patch-libatalk_vfs_extattr.c";
+      url =
+        "https://cgit.freebsd.org/ports/plain/net/netatalk3/files/patch-libatalk_vfs_extattr.c";
+      sha256 = "sha256-lFWF0Qo8PJv7QKvnMn0Fc9Ruzb+FTEWgOMpxc789jWs=";
+    })
+  ];
+
+  postPatch = ''
+    # freeBSD patches are -p0
+    for i in $freeBSDPatches ; do
+      patch -p0 < $i
+    done
+  '';
+
+  nativeBuildInputs =
+    [ autoreconfHook pkg-config perl python3 python3.pkgs.wrapPython ];
 
   buildInputs = [ db libgcrypt avahi libiconv pam openssl acl libevent ];
 


### PR DESCRIPTION
###### Description of changes

A backport of #196933 and #199056 with a fix for a segmentation fault in afpd.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
