### PR TITLE
{tree-sitter-grammars,vimPlugins}: update

### DIFF
--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -281,12 +281,12 @@ final: prev:
 
   SchemaStore-nvim = buildVimPluginFrom2Nix {
     pname = "SchemaStore.nvim";
-    version = "2022-10-27";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "b0o";
       repo = "SchemaStore.nvim";
-      rev = "0a4a5da030dc0c4bd69abd846aa87a1a4a30eb2b";
-      sha256 = "1hki2hpagb0jp65a401jh9g7mwqjvs9qgap7dcmplig1414bckrc";
+      rev = "7c53d1a9b5ad03cd9235a529f735a598149db363";
+      sha256 = "0gi5xjjq9k2vy11nr5cjwrrhc9czmdakg80wpmwfdfgbxmb83mhq";
     };
     meta.homepage = "https://github.com/b0o/SchemaStore.nvim/";
   };
@@ -341,12 +341,12 @@ final: prev:
 
   SpaceVim = buildVimPluginFrom2Nix {
     pname = "SpaceVim";
-    version = "2022-10-27";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "SpaceVim";
       repo = "SpaceVim";
-      rev = "e9ecbbc530d24712b9d79c6bc9f558a4964145be";
-      sha256 = "0zyya5622lsn3lrf3aphnp33fwbi42kd09dcgggvhzb4mhs4ngf0";
+      rev = "a23f52bca0c2ae9ff50f8f033b13e8bd82372fc6";
+      sha256 = "0ih3niscacqyk38dbpc19356fzxkfh6zz0rnj3pricbx22skp5nd";
     };
     meta.homepage = "https://github.com/SpaceVim/SpaceVim/";
   };
@@ -486,12 +486,12 @@ final: prev:
 
   aerial-nvim = buildVimPluginFrom2Nix {
     pname = "aerial.nvim";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "stevearc";
       repo = "aerial.nvim";
-      rev = "62b6ebb0d0c557a25c403a5344e090eabcd114dd";
-      sha256 = "0214ck4sw493h536jrqg2b8m4vcv4sma4inmhmvyaiv8rqm2sn1g";
+      rev = "45de4de76f1bb90f956281b4699df9b058417784";
+      sha256 = "0yscgsi38ir8g8sby65v54sj0nhwz5mh3g215rd1hpvb6jcapyqq";
       fetchSubmodules = true;
     };
     meta.homepage = "https://github.com/stevearc/aerial.nvim/";
@@ -535,12 +535,12 @@ final: prev:
 
   ale = buildVimPluginFrom2Nix {
     pname = "ale";
-    version = "2022-10-14";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "dense-analysis";
       repo = "ale";
-      rev = "e4b20544082ba019d8095cbc24ffab43b15e8fc0";
-      sha256 = "0cm259fvym6swcj9q6viap84xg364x05xc8a432a452ca5xrfgp2";
+      rev = "06efbdd25a3a8cccf17692f7bd4eac71ae7d6e05";
+      sha256 = "106qlm0h2rjj7w3zhcilic7jbb276nh5xwvpqgs645dxgd323f9m";
     };
     meta.homepage = "https://github.com/dense-analysis/ale/";
   };
@@ -715,12 +715,12 @@ final: prev:
 
   auto-git-diff = buildVimPluginFrom2Nix {
     pname = "auto-git-diff";
-    version = "2019-09-23";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "hotwatermorning";
       repo = "auto-git-diff";
-      rev = "a14d52b7ed7e7fb69bf1de9d363f3abdd3410b3a";
-      sha256 = "0i0bnlxclh8pzanrxj428728mdx4wdy19fx499kiin87qr4r2hbn";
+      rev = "8d5ba425218912db0d960ba0bd0a1b39d14082b7";
+      sha256 = "0agwvh7gxhw4ys7fr20xzibgc86h4wh16ivzqh1n26r3119gsfy9";
     };
     meta.homepage = "https://github.com/hotwatermorning/auto-git-diff/";
   };
@@ -1363,12 +1363,12 @@ final: prev:
 
   cmp-nvim-lsp = buildVimPluginFrom2Nix {
     pname = "cmp-nvim-lsp";
-    version = "2022-10-15";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "hrsh7th";
       repo = "cmp-nvim-lsp";
-      rev = "3cf38d9c957e95c397b66f91967758b31be4abe6";
-      sha256 = "0l0cqrarrp3rj3pmjivjgh8f1cd3grrkz6pnzpwpwxj9amv6k6p2";
+      rev = "78924d1d677b29b3d1fe429864185341724ee5a2";
+      sha256 = "1gzn4v70wa61yyw9vfxb8m8kkabz0p35nja1l26cfhl71pnkqrka";
     };
     meta.homepage = "https://github.com/hrsh7th/cmp-nvim-lsp/";
   };
@@ -1543,12 +1543,12 @@ final: prev:
 
   cmp-treesitter = buildVimPluginFrom2Nix {
     pname = "cmp-treesitter";
-    version = "2022-10-02";
+    version = "2022-10-28";
     src = fetchFromGitHub {
       owner = "ray-x";
       repo = "cmp-treesitter";
-      rev = "5f695e4173ad74a4c8dbbfd8990286464bf69293";
-      sha256 = "1l32k8fdmpg8lfh1qqmahash957izz9zr6gfjvfs5s4if0fl3f2r";
+      rev = "b40178b780d547bcf131c684bc5fd41af17d05f2";
+      sha256 = "076x4rfcvy81m28dpjaqcxrl3q9mhfz7qbwgkqsyndrasibsmlzr";
     };
     meta.homepage = "https://github.com/ray-x/cmp-treesitter/";
   };
@@ -1723,12 +1723,12 @@ final: prev:
 
   coc-nvim = buildVimPluginFrom2Nix {
     pname = "coc.nvim";
-    version = "2022-10-27";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "neoclide";
       repo = "coc.nvim";
-      rev = "b422537936351881782d28755c97156b046156e4";
-      sha256 = "1kkyx4sxvsxg4f3pijhyvmzbp4yd2n8ay8iq3s6ramml5havjflw";
+      rev = "d0d3d08d4e5ab7eab7139eef6a2377f2debfecf2";
+      sha256 = "1bzf3rgn1m1b499ycqkq82b1bi9s0081mq144pvka71qcfb3xkwy";
     };
     meta.homepage = "https://github.com/neoclide/coc.nvim/";
   };
@@ -2011,24 +2011,24 @@ final: prev:
 
   coq-artifacts = buildVimPluginFrom2Nix {
     pname = "coq.artifacts";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "ms-jpq";
       repo = "coq.artifacts";
-      rev = "ae5449e1cefa352a62e863a5e647de10bfa01145";
-      sha256 = "16g5fz7z7rm0qgk5qlghl969x2q534mv3njl7hsh7g6gwjzr4hv5";
+      rev = "c4dd8b254ea8925d81db5666d5469cdef1e08bb9";
+      sha256 = "07vwls1g4myigd4aypqsiqnd45bsm22jhp7vn1khg170axavp4ki";
     };
     meta.homepage = "https://github.com/ms-jpq/coq.artifacts/";
   };
 
   coq-thirdparty = buildVimPluginFrom2Nix {
     pname = "coq.thirdparty";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "ms-jpq";
       repo = "coq.thirdparty";
-      rev = "7d3d68df15a1123b14af4035a2eafdc41854c2d1";
-      sha256 = "16qhapgkcbpqdxmij49jp12xpkgpgm6kyk9ld8dvrj9vdbjq323n";
+      rev = "6124d83569e863ad10537172ef7988b1f0ed4455";
+      sha256 = "0ricb4wfapwkkw4m1r9wmqgcm65nrxbx6f6nqq3x028zkfccaqmj";
     };
     meta.homepage = "https://github.com/ms-jpq/coq.thirdparty/";
   };
@@ -2047,12 +2047,12 @@ final: prev:
 
   coq_nvim = buildVimPluginFrom2Nix {
     pname = "coq_nvim";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "ms-jpq";
       repo = "coq_nvim";
-      rev = "fc0081034a90a5e9d901b3269185b9a46b836ed5";
-      sha256 = "1gp25949v6a8zlp10aspv2rh4pizbjxpjyk0j5qvfv88fcv0pmzl";
+      rev = "2fd1e384ee57c2e5de86c3f9ad9ebb71e5249920";
+      sha256 = "153mi9aqnci6z312l7fj0a7ndx29a8p5x9pw7n84wn93qhc3s59v";
     };
     meta.homepage = "https://github.com/ms-jpq/coq_nvim/";
   };
@@ -2191,12 +2191,12 @@ final: prev:
 
   dashboard-nvim = buildVimPluginFrom2Nix {
     pname = "dashboard-nvim";
-    version = "2022-10-08";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "glepnir";
       repo = "dashboard-nvim";
-      rev = "bd7163f56ac715a6d687737ea144731ac6ce8478";
-      sha256 = "0rbxs7bj0vhjrwmjlw74shskgy5igcfyn4iddrk1qc3kryaakdhw";
+      rev = "1aab263f4773106abecae06e684f762d20ef587e";
+      sha256 = "1w7z01r7pakz6jxajp0j3b71dcl2k7sh6g8x07kb0z1ir1lcgfh6";
     };
     meta.homepage = "https://github.com/glepnir/dashboard-nvim/";
   };
@@ -3228,12 +3228,12 @@ final: prev:
 
   gitsigns-nvim = buildNeovimPluginFrom2Nix {
     pname = "gitsigns.nvim";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "lewis6991";
       repo = "gitsigns.nvim";
-      rev = "6321c884b1a462918b1a7c7c016bcc2f0944832c";
-      sha256 = "0s2frxp25pf7fig25g5p99pq4hbhhhqlm7727h3lcwnjy60jfb59";
+      rev = "9110ea15a134b421723cc45c3a8775a6491df39a";
+      sha256 = "16mvlivkcfnvchlw9lqfxhs3bw4nbrv0jmkpqbm4adxz4wmplfna";
     };
     meta.homepage = "https://github.com/lewis6991/gitsigns.nvim/";
   };
@@ -3384,12 +3384,12 @@ final: prev:
 
   gruvbox-nvim = buildVimPluginFrom2Nix {
     pname = "gruvbox.nvim";
-    version = "2022-10-27";
+    version = "2022-10-28";
     src = fetchFromGitHub {
       owner = "ellisonleao";
       repo = "gruvbox.nvim";
-      rev = "2fc4980dfa17e76f7c7e963caa69599051d2e75e";
-      sha256 = "0wk6bdf11lyrmm7z5bidsjphn76qgwdgjdndx802gn1dghjljp0v";
+      rev = "e9992fe5193f0d8d3694cec9171b678f514d0aea";
+      sha256 = "1syjwbpg5x4p1csvyg3qrb82v5zsfxnqmqzh0xqx1i7pa20fxhiq";
     };
     meta.homepage = "https://github.com/ellisonleao/gruvbox.nvim/";
   };
@@ -3984,12 +3984,12 @@ final: prev:
 
   lean-nvim = buildVimPluginFrom2Nix {
     pname = "lean.nvim";
-    version = "2022-10-27";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "Julian";
       repo = "lean.nvim";
-      rev = "44bc45ad6cdf697b6e2f04d844804aed6c133d06";
-      sha256 = "1d1lc7qjz67b6zkamdhbwvd9nc4ycklc743d5r1qhan1994mi61y";
+      rev = "60d71f31b895cc1a1cb319f780df44de7664f0ee";
+      sha256 = "1x1rdcxh2ga35x527f7csp0sfif7zrb8j4q1lsmvvzvi41y6rq70";
     };
     meta.homepage = "https://github.com/Julian/lean.nvim/";
   };
@@ -4391,12 +4391,12 @@ final: prev:
 
   lsp_signature-nvim = buildVimPluginFrom2Nix {
     pname = "lsp_signature.nvim";
-    version = "2022-10-21";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "ray-x";
       repo = "lsp_signature.nvim";
-      rev = "ad1f9b413e27a8cb86893326e7b02982c69fe3f3";
-      sha256 = "0w0pww74n9abxkbqwfcp2fllaixvcw8972van8mcnj3qhmg743yi";
+      rev = "137bfaa7c112cb058f8e999a8fb49363fae3a697";
+      sha256 = "1vzz5indyx56jifcqrk8fhxyy3dbvw1p9w4sxcg9vxjv05a1jpqx";
     };
     meta.homepage = "https://github.com/ray-x/lsp_signature.nvim/";
   };
@@ -4944,12 +4944,12 @@ final: prev:
 
   neodev-nvim = buildVimPluginFrom2Nix {
     pname = "neodev.nvim";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "folke";
       repo = "neodev.nvim";
-      rev = "1d311ffb45779650d03f16d3e5215212a857cbc0";
-      sha256 = "1vzf2jsz1ichi27g0kj2sknsjp9kicc45af36shvwfmcnahl87gd";
+      rev = "1d5b7f0e335c81c5f2549d8d2b234ae7aa6b5a7c";
+      sha256 = "01nc7yr5wpiw3fsk6829riys2n9w9dfd70wjan057j39xqgh2ibf";
     };
     meta.homepage = "https://github.com/folke/neodev.nvim/";
   };
@@ -5148,12 +5148,12 @@ final: prev:
 
   nerdcommenter = buildVimPluginFrom2Nix {
     pname = "nerdcommenter";
-    version = "2022-10-11";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "preservim";
       repo = "nerdcommenter";
-      rev = "fe74a1b890701eb5f196e9639b2147d5f126d9ae";
-      sha256 = "03427xhx5c1ri7b3wrbgkqk3dv31dxnxjvqrg9h698r0lfb844a9";
+      rev = "fd2114b46d648f2f97831cf404f14863428001b8";
+      sha256 = "0352nq8cnx73wv7z878n7r0vqhgyy6l8al66b0cf3v5qw671hdqm";
     };
     meta.homepage = "https://github.com/preservim/nerdcommenter/";
   };
@@ -5220,12 +5220,12 @@ final: prev:
 
   nightfox-nvim = buildVimPluginFrom2Nix {
     pname = "nightfox.nvim";
-    version = "2022-10-27";
+    version = "2022-10-28";
     src = fetchFromGitHub {
       owner = "EdenEast";
       repo = "nightfox.nvim";
-      rev = "9df01a3fb3d41e1e388ded7a34fe97a19146a283";
-      sha256 = "0n995a33riwbp0dfawwrm5xama6iaak1fvnsgqcx2aigdbjzgmh2";
+      rev = "db26a92fc0175c9ffaa27db489308e306823ed3f";
+      sha256 = "09nyfwp8362zlimg1hv5s09w6cxl5gfka5ixcvf0qx193q5i6y7f";
     };
     meta.homepage = "https://github.com/EdenEast/nightfox.nvim/";
   };
@@ -5268,12 +5268,12 @@ final: prev:
 
   noice-nvim = buildVimPluginFrom2Nix {
     pname = "noice.nvim";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "folke";
       repo = "noice.nvim";
-      rev = "36f1a5628c84b145bdf16e6d2aeea7d43fd7ade5";
-      sha256 = "1p3b5c54jpvnv98i609gfq1ajfp55vhhfrmdx5hcdq9q9ai6b314";
+      rev = "7b62ccfc236e51e78e5b2fc7d3068eacd65e4590";
+      sha256 = "152y0i8csv6fhy5ddbav8v55xpm2f32zqsmi0cbk59ila2xyrfv0";
     };
     meta.homepage = "https://github.com/folke/noice.nvim/";
   };
@@ -5424,12 +5424,12 @@ final: prev:
 
   nvim-bqf = buildVimPluginFrom2Nix {
     pname = "nvim-bqf";
-    version = "2022-10-06";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "kevinhwang91";
       repo = "nvim-bqf";
-      rev = "c33b5c57ff82d71f8004b37c8c17a7928da76d08";
-      sha256 = "019lhnwaiz0drdqx6vj56hgjqklfjf48vsx1fk35j5b97nh0sbnh";
+      rev = "6ed03197868e30a6c6e99b1e7ea8a2ef66e06ace";
+      sha256 = "1ayjymqy8qj2lbkjggg2xamjrw4rzdqa005rbs6xy5m86q5rjj25";
     };
     meta.homepage = "https://github.com/kevinhwang91/nvim-bqf/";
   };
@@ -5460,12 +5460,12 @@ final: prev:
 
   nvim-cmp = buildNeovimPluginFrom2Nix {
     pname = "nvim-cmp";
-    version = "2022-10-22";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "hrsh7th";
       repo = "nvim-cmp";
-      rev = "cdb77665bbf23bd2717d424ddf4bf98057c30bb3";
-      sha256 = "1yyg4ja7vsf1wwjydq6hx6zdgq1pdbklagzh09nh14p98kw4rdqj";
+      rev = "9bb8ee6e2d6ab3c8cc53323b79f05886bc722faa";
+      sha256 = "1z7b53yxamph255rvrs5a4pq5hbqa0nbwpdh1xy8fvfc71gap80n";
     };
     meta.homepage = "https://github.com/hrsh7th/nvim-cmp/";
   };
@@ -5496,12 +5496,12 @@ final: prev:
 
   nvim-colorizer-lua = buildVimPluginFrom2Nix {
     pname = "nvim-colorizer.lua";
-    version = "2022-09-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "nvchad";
       repo = "nvim-colorizer.lua";
-      rev = "9dd7ecde55b06b5114e1fa67c522433e7e59db8b";
-      sha256 = "1lmvxz8k680yfjhadkh0km2v16vhg8p07xbkkvc0jhkp6hg4sxx4";
+      rev = "760e27df4dd966607e8fb7fd8b6b93e3c7d2e193";
+      sha256 = "0zqwdj7qk8sldz99c3f5m2xmvl2kj7n18f9jr9q17nb70rz490xn";
     };
     meta.homepage = "https://github.com/nvchad/nvim-colorizer.lua/";
   };
@@ -5652,12 +5652,12 @@ final: prev:
 
   nvim-gdb = buildVimPluginFrom2Nix {
     pname = "nvim-gdb";
-    version = "2022-10-27";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "sakhnik";
       repo = "nvim-gdb";
-      rev = "127087ec368212d4d763aeb58fdf585abc6a8a0e";
-      sha256 = "15f1crn83yf5amdv0m9cc54znq1w3m2x5nywh70bsz753a37a4ys";
+      rev = "044fc1ef23f485b4fde75b838f0fa27490377854";
+      sha256 = "0qag2blr9zc3dl1gw1606gqrc1c03k0c5vg0dflkg31vpdgiqvv4";
     };
     meta.homepage = "https://github.com/sakhnik/nvim-gdb/";
   };
@@ -5868,12 +5868,12 @@ final: prev:
 
   nvim-navic = buildVimPluginFrom2Nix {
     pname = "nvim-navic";
-    version = "2022-10-25";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "smiteshp";
       repo = "nvim-navic";
-      rev = "9f7f0b797096ee852106c4fd47b6b13d0ebb364e";
-      sha256 = "1zqbs170ppmjh3njsg24z5ic965ga0plrbjam88qys1ap0gdph2v";
+      rev = "eebc4f15132c587c52fcd2ce2f0da78fc19a16c0";
+      sha256 = "1pwshw6r90ycc315f0savp2iid4rchqplphq9ms36nb4x36894mq";
     };
     meta.homepage = "https://github.com/smiteshp/nvim-navic/";
   };
@@ -5904,12 +5904,12 @@ final: prev:
 
   nvim-notify = buildVimPluginFrom2Nix {
     pname = "nvim-notify";
-    version = "2022-10-17";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "rcarriga";
       repo = "nvim-notify";
-      rev = "5e8d4942976bbc45e3adb8f4beb81964a79cfd02";
-      sha256 = "1rxpgx52714sf01kwps9ii0if1q6b32hbc80yzwwpbjs8snmkj58";
+      rev = "354e0ebb269d9e4feca073372431e8453f5f262a";
+      sha256 = "1s0jb61hq14hh71saimj8llqqcxibg8bi8gd38l4yrz0c1cqc61l";
     };
     meta.homepage = "https://github.com/rcarriga/nvim-notify/";
   };
@@ -6024,24 +6024,24 @@ final: prev:
 
   nvim-tree-lua = buildVimPluginFrom2Nix {
     pname = "nvim-tree.lua";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "nvim-tree";
       repo = "nvim-tree.lua";
-      rev = "65c2ba895213c3641fc58dd33bc7a44423a6cdbe";
-      sha256 = "1j5g0d4sw5ngzpf77vbgf4mac0dr9y4db8dc951d9m4sg7q1hhjq";
+      rev = "3845039c1a47ad0759a1ec7deb6f2ffb4421d175";
+      sha256 = "0gdjqax9pqic56q3hjm0nk2izc72c8f8njb27cd0jsj03nnpbm1f";
     };
     meta.homepage = "https://github.com/nvim-tree/nvim-tree.lua/";
   };
 
   nvim-treesitter = buildVimPluginFrom2Nix {
     pname = "nvim-treesitter";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "nvim-treesitter";
-      rev = "287ffdccc1dd7ed017d844a4fad069fd3340fa94";
-      sha256 = "1xhizc124dqgxvqyin42sk9kcm5rg2rwi2g94sm9mir8x326nibi";
+      rev = "9ada5f70f98d51e9e3e76018e783b39fd1cd28f7";
+      sha256 = "0rcd6ssh556mna72kak325k5bi6nl91lnbhckypssaycplxdcz4w";
     };
     meta.homepage = "https://github.com/nvim-treesitter/nvim-treesitter/";
   };
@@ -6108,12 +6108,12 @@ final: prev:
 
   nvim-ts-context-commentstring = buildVimPluginFrom2Nix {
     pname = "nvim-ts-context-commentstring";
-    version = "2022-10-14";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "joosepalviste";
       repo = "nvim-ts-context-commentstring";
-      rev = "2941f0064874b33e93d3a794a8a4e99f5f6ece56";
-      sha256 = "1hq2cv39wmpaak9c0gkjif4xp6sz21k5fygkk5lpxxbsdbm74v1g";
+      rev = "32d9627123321db65a4f158b72b757bcaef1a3f4";
+      sha256 = "176dqn0kxdcsjfxh3nhlkiwh7nrj9792rzbmmrkgghjjw87zrd4p";
     };
     meta.homepage = "https://github.com/joosepalviste/nvim-ts-context-commentstring/";
   };
@@ -6276,12 +6276,12 @@ final: prev:
 
   onedarkpro-nvim = buildVimPluginFrom2Nix {
     pname = "onedarkpro.nvim";
-    version = "2022-10-25";
+    version = "2022-10-28";
     src = fetchFromGitHub {
       owner = "olimorris";
       repo = "onedarkpro.nvim";
-      rev = "05219bc43981109105329428a03fe0ae254e8a12";
-      sha256 = "16il2l4270jlxf59d7h1d2m5h90jw9dkihnmym3lbj8rysk9m4xc";
+      rev = "62b12ba06cb617fdccfd1553f864e6492dcff2fa";
+      sha256 = "1kvnycwid2s7iabaql3iwlin4n88czm56d0qd12hhz2sa6jrriy9";
     };
     meta.homepage = "https://github.com/olimorris/onedarkpro.nvim/";
   };
@@ -6770,12 +6770,12 @@ final: prev:
 
   registers-nvim = buildVimPluginFrom2Nix {
     pname = "registers.nvim";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "tversteeg";
       repo = "registers.nvim";
-      rev = "6671ecda17977a65c1dd251463cd1289deecf87d";
-      sha256 = "10h0m1vz765grjdsvjhawmw3dsa98zldndpqlrnim2ih2g9cdgaw";
+      rev = "15261a88fbbe0081db0d25655c8514234dcace11";
+      sha256 = "0hwkvw164wk32vw1xb6dsp0a2w2c1i2zddi5l622jb81xsl2sw6m";
     };
     meta.homepage = "https://github.com/tversteeg/registers.nvim/";
   };
@@ -8084,12 +8084,12 @@ final: prev:
 
   tokyonight-nvim = buildVimPluginFrom2Nix {
     pname = "tokyonight.nvim";
-    version = "2022-10-27";
+    version = "2022-10-28";
     src = fetchFromGitHub {
       owner = "folke";
       repo = "tokyonight.nvim";
-      rev = "8756c99d08f3605534600e70f9fae64035a287dc";
-      sha256 = "1g7j3fzvs94bi67h277xmjd6rafsqbs58fsgrc0jlhi1zhbablr3";
+      rev = "29e2c689c10679f723ae1deadf7f0067d394a545";
+      sha256 = "06c1zav7w3izc543iwp0q02zy8qdajx34ifrwqb8ih6mvs0zbav6";
     };
     meta.homepage = "https://github.com/folke/tokyonight.nvim/";
   };
@@ -9284,12 +9284,12 @@ final: prev:
 
   vim-css-color = buildVimPluginFrom2Nix {
     pname = "vim-css-color";
-    version = "2021-12-29";
+    version = "2022-10-28";
     src = fetchFromGitHub {
       owner = "ap";
       repo = "vim-css-color";
-      rev = "8bf943681f92c81a8cca19762a1ccec8bc29098a";
-      sha256 = "061x58afpl7f17ixp3sal54aymhsn0kyygdbvaqxzanzmrsgp8m7";
+      rev = "1c4b78f5512980227ca747e76f1f6c904f2eb3dc";
+      sha256 = "03r3sllai2nn3zhyc2v3cyxmpxw6incv9jfy74nr2p94yz9yasqh";
     };
     meta.homepage = "https://github.com/ap/vim-css-color/";
   };
@@ -9332,12 +9332,12 @@ final: prev:
 
   vim-dadbod = buildVimPluginFrom2Nix {
     pname = "vim-dadbod";
-    version = "2022-10-13";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "tpope";
       repo = "vim-dadbod";
-      rev = "69c419194ee708a58a297d567bdcfd3dcf606574";
-      sha256 = "0qng34n5sm01qs4pyfsx1nl7lhjhxkzcz7bx5747c041hb1ia3jm";
+      rev = "87785156a7919f51409f3e6656ea2b3a9e0e8e97";
+      sha256 = "0rbrp8cnkngfnvfvrfv2nfs3c7ryyv9zs738xay15nmcgif4by1s";
     };
     meta.homepage = "https://github.com/tpope/vim-dadbod/";
   };
@@ -10726,12 +10726,12 @@ final: prev:
 
   vim-lsp = buildVimPluginFrom2Nix {
     pname = "vim-lsp";
-    version = "2022-10-25";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "prabirshrestha";
       repo = "vim-lsp";
-      rev = "9d4dbf7e689af58b1289cb1be9d755dc96b0de04";
-      sha256 = "1xv236fyj6nxvn5afs18yxpkx38h9cfvl21rn81ikjvvim1vz9h7";
+      rev = "0c8fda792177375ee90c03598adb1783c05bed83";
+      sha256 = "0lvh0g8bqnyxpqk51iwbdqayy4dmh6hbfg7ha23mslhscl1b3zga";
     };
     meta.homepage = "https://github.com/prabirshrestha/vim-lsp/";
   };
@@ -10859,12 +10859,12 @@ final: prev:
 
   vim-merginal = buildVimPluginFrom2Nix {
     pname = "vim-merginal";
-    version = "2022-10-04";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "idanarye";
       repo = "vim-merginal";
-      rev = "e8740401cdec9199f4676c5a640a785ec094258b";
-      sha256 = "09rmmqq9a3xjcplw69kxsqbv3bpdkw1zvdiiihl499vafwrhky6w";
+      rev = "8ec5976aa4bd647c64504ff535eb06a8b709b051";
+      sha256 = "0z43gdgm3vjbq4whwj6dm218fldkjlhp5kwks79w6x6rx84nnj6v";
     };
     meta.homepage = "https://github.com/idanarye/vim-merginal/";
   };
@@ -12948,12 +12948,12 @@ final: prev:
 
   vimspector = buildVimPluginFrom2Nix {
     pname = "vimspector";
-    version = "2022-10-27";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "puremourning";
       repo = "vimspector";
-      rev = "82b47b18262d70de140221f69279d80a2f096221";
-      sha256 = "05h67zk7lj52ry0clb0dqqiniscmyb49x46ss8zgi0dmfnp3avav";
+      rev = "5c328b513485675c061558d2f25a98ee503cb243";
+      sha256 = "0wwkz7prh7zabvna0imbx24byx3ky2hzia5jg03na0z8g1djm3vv";
       fetchSubmodules = true;
     };
     meta.homepage = "https://github.com/puremourning/vimspector/";
@@ -12961,12 +12961,12 @@ final: prev:
 
   vimtex = buildVimPluginFrom2Nix {
     pname = "vimtex";
-    version = "2022-10-27";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "lervag";
       repo = "vimtex";
-      rev = "2f799f47a85bca75deaec4e2c6a51cde9341ae01";
-      sha256 = "0m1j5xl994g5bxv5jnzk3a2sfga96b2k0kznwj8a6xqilk8gq798";
+      rev = "151a59eff61a1f3ca11110dd7872a04c714038c6";
+      sha256 = "1db5ldsai5szp011v8z65z4hbri807fpkb45g2f5gigw9js5xzly";
     };
     meta.homepage = "https://github.com/lervag/vimtex/";
   };
@@ -13214,12 +13214,12 @@ final: prev:
 
   yuck-vim = buildVimPluginFrom2Nix {
     pname = "yuck.vim";
-    version = "2021-08-09";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "elkowar";
       repo = "yuck.vim";
-      rev = "6dc3da77c53820c32648cf67cbdbdfb6994f4e08";
-      sha256 = "0890cyxnnvbbhv1irm0nxl5x7a49h1327cmhl1gmayigd4jym7ln";
+      rev = "9b5e0370f70cc30383e1dabd6c215475915fe5c3";
+      sha256 = "1mkf0vd8vvw1njlczlgai80djw1n1a7dl1k940l089d3vvqr5dhp";
     };
     meta.homepage = "https://github.com/elkowar/yuck.vim/";
   };
@@ -13346,24 +13346,24 @@ final: prev:
 
   chad = buildVimPluginFrom2Nix {
     pname = "chad";
-    version = "2022-10-28";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "ms-jpq";
       repo = "chadtree";
-      rev = "671a11051e945b45e3e93c124a65adf84289d830";
-      sha256 = "18408ixpkgwgs9in65qi60lqpy1p40vb5mmmnrlimjncghy05dr5";
+      rev = "15f021a1284b7149f4051c598da27858ae0efe07";
+      sha256 = "09f2dbvbqyvhlvxvrd5s0nljgxg47v9c4hh9864mm5k2wjfksagb";
     };
     meta.homepage = "https://github.com/ms-jpq/chadtree/";
   };
 
   dracula-vim = buildVimPluginFrom2Nix {
     pname = "dracula-vim";
-    version = "2022-10-24";
+    version = "2022-10-29";
     src = fetchFromGitHub {
       owner = "dracula";
       repo = "vim";
-      rev = "7ebadce59c087f441b7baacff68e1667386d119a";
-      sha256 = "1i0gxwih7sc4mkhdg6g7cldx1fgpdy16lnqz2a03d1icfddbyp7n";
+      rev = "834f54c1e09a4ae7115f590ad26d470ccd67c3b4";
+      sha256 = "1m1gzj2npmx31hpmhc05i17lqikbk3v2k3zf10rls6ipgz4lfsz3";
     };
     meta.homepage = "https://github.com/dracula/vim/";
   };

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "ad8e6980e9bf1882a324196229692febf332c4dd",
-  "date": "2022-08-22T14:15:43+01:00",
-  "path": "/nix/store/wl7r0cp4s43ivzxkd9vpvwp08xsl1cb2-tree-sitter-c-sharp",
-  "sha256": "17vn2cy23k1ms8dizyw2gz8gwfghhgd92xfvp9n4vnav9qzah09w",
+  "rev": "7a47daeaf0d410dd1a91c97b274bb7276dd96605",
+  "date": "2022-09-15T09:14:12+01:00",
+  "path": "/nix/store/sscjjlp833rqqvfpgh84wsnq59jmy90c-tree-sitter-c-sharp",
+  "sha256": "0lijbi5q49g50ji00p2lb45rvd76h07sif3xjl9b31yyxwillr6l",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "d5e90fba898f320db48d81ddedd78d52c67c1fed",
-  "date": "2022-10-03T14:48:29-05:00",
-  "path": "/nix/store/c7qvdbkrk0s4rdwhkb8kcfq2w39y1322-tree-sitter-cpp",
-  "sha256": "013b170cxjkjpnqcvv8cc18cn1zxnip602h4x4n0i3hcsa1b50nk",
+  "rev": "5ead1e26c6ab71919db0f1880c46a278a93bc5ea",
+  "date": "2022-10-19T20:38:44-05:00",
+  "path": "/nix/store/0zigaml3k0fk0w9mzsjrhrp1968hd6r7-tree-sitter-cpp",
+  "sha256": "1572qhfw1jjkm1q6c110lnnj2n384a97fgn645c5q9ikciv8kac7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-css",
-  "rev": "a03f1d2d1dfbf6f8e0fdca5f9ff030228241eb57",
-  "date": "2021-09-15T14:32:51-07:00",
-  "path": "/nix/store/zamdl9ixsmgi7rdsb7mx2a1g0i8gfvdy-tree-sitter-css",
-  "sha256": "0i5xf97m6vxgcpa21h2gzlgj9n5rlv9mz3w738bwvcz5k6nbx6np",
+  "rev": "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51",
+  "date": "2022-08-31T10:51:16-07:00",
+  "path": "/nix/store/a91kqixk4gmh40ak98jjnfrlzm3ngvax-tree-sitter-css",
+  "sha256": "05875jmkkklx0b5g1h4qc8cbgcj8mr1n8slw7hsn0wssn7yn42z5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "bc48d8eaf5a145922a1bed0a69dca1342a83c12c",
-  "date": "2022-07-24T11:22:15+02:00",
-  "path": "/nix/store/xjgyflwrn6k3slzjvpy0mi1769z657li-tree-sitter-cuda",
-  "sha256": "0nd1xi5w9wjj4jbwlvwacs6b4q0syb91q06p27nc2ygs3v9wx3l7",
+  "rev": "7f1a79e612160aa02be87f1a24469ae3655fe818",
+  "date": "2022-10-19T23:28:33-07:00",
+  "path": "/nix/store/6sgr13lqfw9s9lzlq4m116kvazzkkbmk-tree-sitter-cuda",
+  "sha256": "1bcci9v61lcgiqq3jqf4gl0kbq89w2h5kjn70g8x2g4lmky6y6fc",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elixir-lang/tree-sitter-elixir",
-  "rev": "05e3631c6a0701c1fa518b0fee7be95a2ceef5e2",
-  "date": "2022-08-04T13:28:43-05:00",
-  "path": "/nix/store/ixqcx5344qr5bzjgyl05zcp2f0gnkbz8-tree-sitter-elixir",
-  "sha256": "0qy4dgs72dyr9cv16q8na7xxkhsqjyk99xnwpgqm1sa8m0yjjyp6",
+  "rev": "b20eaa75565243c50be5e35e253d8beb58f45d56",
+  "date": "2022-10-16T19:20:07+00:00",
+  "path": "/nix/store/424sg83igjqrkl4yzyiqv0byv4hzii0n-tree-sitter-elixir",
+  "sha256": "1i0c0xki3sv24649p0ws7xs2jagbwg7z7baz1960239bj94nl487",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elm-tooling/tree-sitter-elm",
-  "rev": "a9317711507b094b2049b42356646dd5764bca06",
-  "date": "2022-08-28T14:37:52+02:00",
-  "path": "/nix/store/cq018zk73bw5163ch7p52kkxiqd0yz0y-tree-sitter-elm",
-  "sha256": "1ml93yj9ns6pxzhk0l4hiwfp9h9s1ad3cpwdnpmbgyc0fgaqzjf9",
+  "rev": "cce0e5938e7779f86cf8bf445eadf7df4b88229d",
+  "date": "2022-09-03T13:02:26+02:00",
+  "path": "/nix/store/scick955z3qrbxmk1jr8cchwsnx4l814-tree-sitter-elm",
+  "sha256": "0b5jpj8bnil1ylisyc4w48j8a30dyf3zylhidj73mlrb8rf7xm2s",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-erlang.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-erlang.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/abstractmachineslab/tree-sitter-erlang",
-  "rev": "fab680273af1a8f5cc0c3a0c62cbf5b1bea71f39",
-  "date": "2022-03-05T23:18:36+01:00",
-  "path": "/nix/store/vj28kyy3jg21qicwxq2g1ysrwfqd3mz9-tree-sitter-erlang",
-  "sha256": "0shzzik8yxwb76kxs3l0fccjwvkarck1q4wqyv5hdma6hwl52b69",
+  "rev": "3a9c769444f08bbccce03845270efac0c641c5e7",
+  "date": "2022-10-20T12:35:01+02:00",
+  "path": "/nix/store/lcpjcmkb2js7mmvpd9w9c4gql0yqvdaj-tree-sitter-erlang",
+  "sha256": "10hv3brjvrvg81qxi956mrc16riknhaqmxb6vpl46k0zsm6cgj36",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "e594c182d9d55170ba01678e1fc534166a38e171",
-  "date": "2022-08-07T23:31:50-07:00",
-  "path": "/nix/store/cnfwwpml52i755k3k52r9c5sgpw57bmp-tree-sitter-glsl",
-  "sha256": "0pjy6d3fx973qf4waj80lkv03ws0sbmy4vpa9a1s72ws6y6c72in",
+  "rev": "a743ada24fa17da9acc5665133f07d56e03530be",
+  "date": "2022-09-04T21:41:54+02:00",
+  "path": "/nix/store/z4bzmqy26xqwi4lysjicllf2jrk6pvvm-tree-sitter-glsl",
+  "sha256": "04naalz59mczi0dlnjg49z5ygl0f9v1byr2kfclw6q6rhx9pcswp",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "aeb2f33b366fd78d5789ff104956ce23508b85db",
-  "date": "2022-05-30T11:35:02-07:00",
-  "path": "/nix/store/iww8iz50gqp58p89f2rk3y9ck5hannaj-tree-sitter-go",
-  "sha256": "1008r5y8h2vpjjcx4cvi9qa02cmfaskc97y2zahjfrv3lm1gkqp7",
+  "rev": "05900faa3cdb5d2d8c8bd5e77ee698487e0a8611",
+  "date": "2022-10-20T09:01:48+02:00",
+  "path": "/nix/store/p44flk3wlp5n99jc550pkm8rzjqnvy84-tree-sitter-go",
+  "sha256": "1qymkdi4qcnj8ywmsanb6pdl9zd71cbm6kzl87zk241h7dhkkkvz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/omertuc/tree-sitter-go-work",
-  "rev": "6dd9dd79fb51e9f2abc829d5e97b15015b6a8ae2",
-  "date": "2021-12-18T20:13:22+01:00",
-  "path": "/nix/store/7a4raw2gi4xgbg858cs0davbplj7m8rq-tree-sitter-go-work",
-  "sha256": "1kzrs4rpby3b0h87rbr02k55k3mmkmdy7rvl11q95b3ym0smmyqb",
+  "rev": "949a8a470559543857a62102c84700d291fc984c",
+  "date": "2022-10-04T10:19:22+02:00",
+  "path": "/nix/store/v8ny6m450z2g2ijk6gkbc3m1nsxcvck8-tree-sitter-go-work",
+  "sha256": "1nn6nfw24v4m38g9ac528cn608bbxffkll1y525a7i9rdpnmx1sf",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "1c89468614883e951db7d4ac05a56ec864f80bc1",
-  "date": "2022-08-22T12:22:27+02:00",
-  "path": "/nix/store/20yq98my5vdv12f76hyly2cc6b1d2dz3-tree-sitter-haskell",
-  "sha256": "1m94qx0gdcv31mskjxs884153qrz1jicajxph2wlp4wdpchl7gsp",
+  "rev": "bee6b49543e34c2967c6294a4b05e8bd2bf2da59",
+  "date": "2022-09-30T18:11:21+02:00",
+  "path": "/nix/store/d6c30iv724f2kpcb969zskcxbh6fcrdz-tree-sitter-haskell",
+  "sha256": "069pyll6nvzakj5rhpd28md9dfzhcap2jwffqkwjyaavwcwar9gz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-heex",
-  "rev": "961bc4d2937cfd24ceb0a5a6b2da607809f8822e",
-  "date": "2022-06-13T09:15:37-07:00",
-  "path": "/nix/store/5qackjn309ls9qja23wkwhqiid9rc6l3-tree-sitter-heex",
-  "sha256": "1by6c4gcqxy9czvwabbmlfr1hlw8z2w7f623llbag956scp2b9al",
+  "rev": "52b804b1cb2d57e58d90090326d3ef9bd19cf16c",
+  "date": "2022-10-18T07:22:45-07:00",
+  "path": "/nix/store/7f1xgx8l68lz8jwvni65j4kcxpl68b36-tree-sitter-heex",
+  "sha256": "0qiwzkb2ksp2cb87zsda5zwwsbpbqzgvnmysalbm3x0c81gnzv3y",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-json",
-  "rev": "368736a6137770f785e1e7479a6be29417eb13aa",
-  "date": "2022-05-22T14:37:14-07:00",
-  "path": "/nix/store/1hgawfjnlijb9vj0bl4ry05p9cnyhpqq-tree-sitter-json",
-  "sha256": "06gvjpg5z8l9vm8a5di5ziv4z1wx3cah1ng14wa9f8r6zi9gn6an",
+  "rev": "73076754005a460947cafe8e03a8cf5fa4fa2938",
+  "date": "2022-10-03T12:40:23-07:00",
+  "path": "/nix/store/v8s2xfc2jx8wvrfcf0silm5w4gj3m15j-tree-sitter-json",
+  "sha256": "1npf2hrx33jhjpmzcyi7aszg436m4d80sa6h4mhhkmx51q4kpcf1",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-julia",
-  "rev": "fc60b7cce87da7a1b7f8cb0f9371c3dc8b684500",
-  "date": "2022-05-31T14:11:51-07:00",
-  "path": "/nix/store/mmcw5by2scxv3k085qbi0m5qfm7qldmz-tree-sitter-julia",
-  "sha256": "1mkbp0913xi0mccdp4lb3rvcf9h1xljr5mgavs2kmajcabygv46w",
+  "rev": "0572cebf7b8e8ef5990b4d1e7f44f0b36f62922c",
+  "date": "2022-09-01T18:19:12-07:00",
+  "path": "/nix/store/qh31867lp801xzb93n6jdmibp25zzli1-tree-sitter-julia",
+  "sha256": "1vxwwdl98n7ic739hl9mq43di10j6r53fpyjh4a738dvjrjg1pc4",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/latex-lsp/tree-sitter-latex",
-  "rev": "9cbe0c6be9455b6d3be19f51daef6d08732abab1",
-  "date": "2022-06-05T08:50:52+02:00",
-  "path": "/nix/store/63i0iskmn862l0rm8gdkgs1bsxxpxw54-tree-sitter-latex",
-  "sha256": "1ahij4lwg59xvzy2jn8i4rpp6bjz8pl7sqwn6a3rwal3d2x89b3d",
+  "rev": "8c75e93cd08ccb7ce1ccab22c1fbd6360e3bcea6",
+  "date": "2022-10-26T10:55:26+02:00",
+  "path": "/nix/store/zhx1vnr3xdrb0ry6kfjsfrzs6c3nf8i9-tree-sitter-latex",
+  "sha256": "0lc42x604f04x3kkp88vyqa5dx90wqyisiwl7nn861lyxl6phjnf",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "c9ece5b2d348f917052db5a2da9bd4ecff07426c",
-  "date": "2022-07-16T17:09:45+06:00",
-  "path": "/nix/store/88rff0xq0hw7snlcf2kkvvrknnda6sgk-tree-sitter-lua",
-  "sha256": "11jhyll9w6ffd78nnr6d0y79x8r253wvxsflmq3nrhvwqvk2yarm",
+  "rev": "887dfd4e83c469300c279314ff1619b1d0b85b91",
+  "date": "2022-09-16T01:06:50+06:00",
+  "path": "/nix/store/nypzx0f8fdlamiycl1vqrj4ifx0bfgij-tree-sitter-lua",
+  "sha256": "1lv3mp0xm5ac9440gcskcxy0hzsnddvcysix1k5axy1cl4vr8bz6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "e375ba95ff9a12418f9b9e7c190f549d08b5380a",
-  "date": "2022-08-05T11:11:58+02:00",
-  "path": "/nix/store/2mga5flf52j6m8v5gglmnammklyp4qw8-tree-sitter-markdown",
-  "sha256": "0ziciy95wgw8j0dimi79dpqg7ql6m1vzkygffmqqmmvap9zfhggb",
+  "rev": "272e080bca0efd19a06a7f4252d746417224959e",
+  "date": "2022-10-27T17:15:20+02:00",
+  "path": "/nix/store/n8n85lvdf3galrlr5ywjjkpsny6mvg7n-tree-sitter-markdown",
+  "sha256": "1q9s8ln6pag0362ckvzid8jpc2h14pd7kfr1qq4dpirzqq0y79l0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "6b71a810c0acd49b980c50fc79092561f7cee307",
-  "date": "2022-05-19T13:37:55-05:00",
-  "path": "/nix/store/9x9ffq6k7mxpclpfw8g5ynl30a446mnh-tree-sitter-nix",
-  "sha256": "1v1g49g1jg56nifjp3m3ak6ng3hpzkp51ywaq3rnpwgkij7i4f5r",
+  "rev": "1b69cf1fa92366eefbe6863c184e5d2ece5f187d",
+  "date": "2022-09-29T23:30:43-05:00",
+  "path": "/nix/store/m5g4d7vddlwhhbdmzpwdvisqvb1hbh02-tree-sitter-nix",
+  "sha256": "0ls9djhpbbnjvd6b3166zjy92di0927f70720b57j2d3925538i5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-neorg/tree-sitter-norg",
-  "rev": "17d61df817c1e0a9cdef8d915d4e4c556b7cf68c",
-  "date": "2022-03-16T16:23:43+01:00",
-  "path": "/nix/store/xjsyabq06584fnwjvqbyqf6yd19i4gn9-tree-sitter-norg",
-  "sha256": "161pmkpfyfhf4lcgkzcl1wdi4bsmmpwxcz7kjcb0jpjy7bamikch",
+  "rev": "dfac5ad2740a79b18ae849590a924e7bad3f1b23",
+  "date": "2022-10-13T09:07:45+02:00",
+  "path": "/nix/store/9csv2xax6ris1wghj83gdf1sjvbh7jfq-tree-sitter-norg",
+  "sha256": "0jws376b7a2jqr0d32c20qh9v3d0wi8af95dprmfhi8pcvd5hzww",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/milisims/tree-sitter-org",
-  "rev": "698bb1a34331e68f83fc24bdd1b6f97016bb30de",
-  "date": "2022-08-16T11:52:06-04:00",
-  "path": "/nix/store/bixwb7s6ax1wygp2pmg1r4czgail0kq8-tree-sitter-org",
-  "sha256": "0adzb2kw8k3w75p5f3ax9lal64k8n2fwrmrqak2z2w8jl8cgagl6",
+  "rev": "081179c52b3e8175af62b9b91dc099d010c38770",
+  "date": "2022-10-21T23:23:29-04:00",
+  "path": "/nix/store/7jy3jqyd02kryfgz16k3zxg2kmjz0wqf-tree-sitter-org",
+  "sha256": "0h9krbaq9j6ijf86sg0w221s0zbpbx5f7m1l0whzjahbrqpnqgxl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/rolandwalker/tree-sitter-pgn",
-  "rev": "4c372e9e4d69bdc57701201347afe5f6413f2367",
-  "date": "2021-09-14T07:33:59-04:00",
-  "path": "/nix/store/62pvfyg8qlybxmd8kac8fdpycsypga67-tree-sitter-pgn",
-  "sha256": "0c2iqv93fg2pl7ixa7bby0bgnfnd8djjkjcg7d9bn3y7vpswvbvi",
+  "rev": "e26ee30850f0cb81541480cf1e2c70385bdb013a",
+  "date": "2021-08-25T17:57:38-04:00",
+  "path": "/nix/store/fj882ab2hl3qrz45zvq366na6d2gqv8v-tree-sitter-pgn",
+  "sha256": "1c4602jmq3p7p7splzip76863l1z3rgbjlbksqv0diqjxp7c42gq",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "670d1eb6822d8c7ade1c71232e0bef42757b9da7",
-  "date": "2022-07-16T12:25:05+02:00",
-  "path": "/nix/store/swkym10m39vwrhvknv5x2wsx2qml6w13-tree-sitter-php",
-  "sha256": "01kkds6nac4b8xb4y4qsndg2z9y2ikr4j7brrs28aw8rzw0qlqf0",
+  "rev": "ab2e72179ceb8bb0b249c8ac9162a148e911b3dc",
+  "date": "2022-09-24T09:03:15+02:00",
+  "path": "/nix/store/99jwdb92ng3xr6j881aja24dgwra4lvx-tree-sitter-php",
+  "sha256": "0gfjvpa5rfi1lgz30jhmdfr8f09vl34k3xjad8n8l2cv5q9203if",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "de221eccf9a221f5b85474a553474a69b4b5784d",
-  "date": "2022-06-27T15:09:45-07:00",
-  "path": "/nix/store/r8cac3zd9xd3l3knzl6k98zhq0wshv0n-tree-sitter-python",
-  "sha256": "1mp2rqv6p2nla0sh1s5hprq32b9nkwbj2q21dcpvdcg6gack1sdf",
+  "rev": "b14614e2144b8f9ee54deed5a24f3c6f51f9ffa8",
+  "date": "2022-10-24T22:08:56+02:00",
+  "path": "/nix/store/n4jhzd32dykrfxzar6cymx1b8njmmsxs-tree-sitter-python",
+  "sha256": "086v2mrczj8gavl4w8w8m982pg94w8ph5vf5iaksi1pvgcmw8c71",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql-dbscheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql-dbscheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ql-dbscheme",
-  "rev": "ad0c1485aa1e61b727a986d82c7fab4cd21ca723",
-  "date": "2022-07-22T15:14:16+00:00",
-  "path": "/nix/store/13yzcd1k87sfxdac4cdj8pvqv06wal6i-tree-sitter-ql-dbscheme",
-  "sha256": "0glj3j9m4wsmfgahsjzhzp34scxrwpwjqkzgj0i72rn23869xjip",
+  "rev": "6b66b9e6e3d36a49ce4def7abee2a286ac9ca289",
+  "date": "2022-08-29T08:49:16+02:00",
+  "path": "/nix/store/k58fls33kiwgbf8vn4488x5l79c9a18x-tree-sitter-ql-dbscheme",
+  "sha256": "1kpkjg97s5j1dx79r3fk0i2bxhpm9sdawgb1drqnjgz4qsshp7f2",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-treesitter/tree-sitter-query",
-  "rev": "5217c6805c09f8fc00ed13d17d5fcb791437aee6",
-  "date": "2021-12-23T16:48:02-05:00",
-  "path": "/nix/store/b8n553bwlyzi05p8vn08qv6vbzg9875q-tree-sitter-query",
-  "sha256": "00q6cpw5rkb20cypx820glqhfs4vsgqdymj5y0sknd874lq6crfg",
+  "rev": "0695cd0760532de7b54f23c667d459b5d1332b44",
+  "date": "2022-10-14T22:40:48+02:00",
+  "path": "/nix/store/s8jkcp7vk5hpw9qxwkr4xq926na9sxa6-tree-sitter-query",
+  "sha256": "1m8dsni3wzs94yc7y6zydh4l6zgm35wy9r1lcmk17phvylx6y20g",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-r.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-r.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/r-lib/tree-sitter-r",
-  "rev": "205c2877af33a814386ff275031f88400a011397",
-  "date": "2022-05-25T11:21:11-04:00",
-  "path": "/nix/store/5sh3nzb04ldqw9kap7la897jfp3m19ai-tree-sitter-r",
-  "sha256": "0xy6w5zybcb4gl38xz1y0s08x7an1ql57i63gmq3awn2hr6w7380",
+  "rev": "0f4f66e5050037b759ea040dafd596bcdda1de94",
+  "date": "2022-10-12T16:08:16-07:00",
+  "path": "/nix/store/yffaihslg48mx67cy4gw8n8m3wrc9a7h-tree-sitter-r",
+  "sha256": "1qw2ngr9db3nv9bc74y2rlsvbk9np5djj1pxhb3ks5dkk7airf76",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "ad1043283b1f9daf4aad381b6a81f18a5a27fe7e",
-  "date": "2022-08-24T18:08:57+02:00",
-  "path": "/nix/store/mkg79bscx68yirm7avhlspfwqz3snqvl-tree-sitter-ruby",
-  "sha256": "0x4j2z18gf40snhyb416s9l5a2r9jjmki8v57wqldvkm39cvhm4z",
+  "rev": "fe6a2d634da0e16b11b5aa255cc3df568a4572fd",
+  "date": "2021-03-03T16:54:30-08:00",
+  "path": "/nix/store/ragrvqj7hm98r74v5b3fljvc47gd3nhj-tree-sitter-ruby",
+  "sha256": "0m3h4928rbs300wcb6776h9r88hi32rybbhcaf6rdympl5nzi83v",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/6cdh/tree-sitter-scheme",
-  "rev": "5bb5b2de83d548243fbcc77e76224882ffb4ce68",
-  "date": "2022-06-07T22:14:20+08:00",
-  "path": "/nix/store/jy8z2s9zmgxm8ziv39cqkkia52mq7mbx-tree-sitter-scheme",
-  "sha256": "1cdbzmgkz3f1zbhgps9q1zvy1hnwwj5rlr5fp4jbvbnwp13pd04a",
+  "rev": "af0fd1fa452cb2562dc7b5c8a8c55551c39273b9",
+  "date": "2022-09-30T20:37:24+08:00",
+  "path": "/nix/store/gra9hiqd3rqgvvq10m3z6lzjf0y0lfz0-tree-sitter-scheme",
+  "sha256": "1pk1q8lmgj2mh7fmyvsr610qdv1c7nmfqdbr1bln1ar356dv6zrb",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-surface",
-  "rev": "f4586b35ac8548667a9aaa4eae44456c1f43d032",
-  "date": "2022-01-18T18:13:51-08:00",
-  "path": "/nix/store/l1nzhnhw1219140vzwvillawr7m9sz22-tree-sitter-surface",
-  "sha256": "085yvq2m4dbhhn51ndhzvgfmpp3hqiwk1a39xpjy4lxgrhbyjzqn",
+  "rev": "21b7676859c1187645a27ff301f76738af5dfd44",
+  "date": "2021-08-15T10:33:50-07:00",
+  "path": "/nix/store/7i1klj80jbcvwgad7nrbcs7hvn68f125-tree-sitter-surface",
+  "sha256": "122v1d2zb0w2k5h7xqgm1c42rwfrp59dzyb2lly7kxmylyazmshy",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/Himujjal/tree-sitter-svelte",
-  "rev": "52e122ae68b316d3aa960a0a422d3645ba717f42",
-  "date": "2022-07-08T23:25:40+05:30",
-  "path": "/nix/store/lqis7h7db9bq7g063l60q7361h718z56-tree-sitter-svelte",
-  "sha256": "1pbs508ly4dlppnpa5657j0zsi7fdd6azvxjk7dayxznbygnj900",
+  "rev": "84c90ee15f851e1541c25c86e8a4338f5b4d5af2",
+  "date": "2022-04-13T11:35:15+05:30",
+  "path": "/nix/store/2miakcpw7xgg2pcwdbcg0kl2djijcfbj-tree-sitter-svelte",
+  "sha256": "0hidafgzbnksyigksab8731jdnvj1vqn7fv0jxsc1yfrwrmai6ls",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "082da44a5263599186dadafd2c974c19f3a73d28",
-  "date": "2022-08-25T11:07:19-07:00",
-  "path": "/nix/store/b84c7mhjj9dm3ccfwp9h2q1ac9k2axv1-tree-sitter-typescript",
-  "sha256": "0y1c4bldgmhbhll629xks5y3c9l8dq29na75y3n0hfwivrpry8rx",
+  "rev": "0ab9d99867435a7667c5548a6617a6bf73dbd830",
+  "date": "2022-10-10T11:19:39-07:00",
+  "path": "/nix/store/fjbslm2md38afkaxbnc3l537j23z9mvv-tree-sitter-typescript",
+  "sha256": "0kv91f8k7jwzkmkz2zvx9rh0ncgbcys9c37jbj0g4y1zhzn8l7rp",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-verilog",
-  "rev": "6fae7414fa854b5052bee9111b200e9137797f3d",
-  "date": "2021-10-04T10:25:49-07:00",
-  "path": "/nix/store/aklrgpy0si72r8vac5fqjbzvcpqiy5lk-tree-sitter-verilog",
-  "sha256": "0yjhb2rp7drwkwfp35fgwnp6d7qf6k1k6zlf0dfxygjywnjy0bfs",
+  "rev": "4457145e795b363f072463e697dfe2f6973c9a52",
+  "date": "2022-09-07T16:11:11-07:00",
+  "path": "/nix/store/z29mm9c88dd2iybsy648wh4m6z593kvk-tree-sitter-verilog",
+  "sha256": "0lfw8p04c85xyd85jfi3gajzrzsl5xcgc44nwxa43x4g3d7f104p",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "d38ee3b8ea625591a0dc009d6691118517205685",
-  "date": "2022-08-27T12:10:49+02:00",
-  "path": "/nix/store/gl64rifl6x0c0g32fpzwk7kscwbzvxnk-tree-sitter-viml",
-  "sha256": "1mvmg0vssydmgkwgb4blgiwbiqiw5233l58hrqmcgfz4vg4yazr7",
+  "rev": "9736af8ef0a7f20b4c45f6474342c8f5b473e2cc",
+  "date": "2022-10-20T14:10:31+02:00",
+  "path": "/nix/store/ss7h5sjfkfj5ims3q273ric2yljpz3gz-tree-sitter-viml",
+  "sha256": "1li2y1cmvf74xjqhfjzfmr8cy3d6fymz4mbgfpnzjfc41yn556vj",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/maxxnino/tree-sitter-zig",
-  "rev": "8d3224c3bd0890fe08358886ebf54fca2ed448a6",
-  "date": "2022-06-25T10:13:16+07:00",
-  "path": "/nix/store/an534h97z3gi6zk5mzysbx2fp8rvy9c4-tree-sitter-zig",
-  "sha256": "0mw4s92qmxkh9a13h9hg6kv9b704vzx3kr4j6dap0c80dffvfjhk",
+  "rev": "b1803f2a665d228f968a831eac4fcc07a377c7bc",
+  "date": "2022-10-14T15:52:08+07:00",
+  "path": "/nix/store/2sb78vfflr69yj6f2iw3872dvij1vxgf-tree-sitter-zig",
+  "sha256": "0z6y2sazcqbqs6fndszgqblih2syg6g9kpzk41zxh25hz9qxxdsq",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This should fix a couple errors with nvim-treesitter, some are still broken (e.g. bash) since the latest tree-sitter grammar release is different from the pinned version in nvim-treesitter's lock file

I am working on something that fetches grammars from nvim-treesitter's `lockfile.json` into a separate `vimPlugins.nvim-treesitter.grammars` that will hopefully fix the incompatibilities once and for all

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
