### PR TITLE
dropbear: 2020.81 -> 2022.82

### DIFF
--- a/pkgs/tools/networking/dropbear/default.nix
+++ b/pkgs/tools/networking/dropbear/default.nix
@@ -16,11 +16,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "dropbear";
-  version = "2020.81";
+  version = "2022.82";
 
   src = fetchurl {
     url = "https://matt.ucc.asn.au/dropbear/releases/dropbear-${version}.tar.bz2";
-    sha256 = "0fy5ma4cfc2pk25mcccc67b2mf1rnb2c06ilb7ddnxbpnc85s8s8";
+    sha256 = "sha256-OgONK7wCvyi73SDAEgkfdBo+xcvkYGkYEdcUh2qtddE=";
   };
 
   dontDisableStatic = enableStatic;

--- a/pkgs/tools/networking/dropbear/pass-path.patch
+++ b/pkgs/tools/networking/dropbear/pass-path.patch
@@ -1,36 +1,39 @@
 diff --git a/svr-chansession.c b/svr-chansession.c
-index e44299e..7ef750a 100644
+index 9ae2e60..2db7598 100644
 --- a/svr-chansession.c
 +++ b/svr-chansession.c
-@@ -893,6 +893,8 @@ static void addchildpid(struct ChanSess *chansess, pid_t pid) {
- static void execchild(void *user_data) {
- 	struct ChanSess *chansess = user_data;
+@@ -948,6 +948,8 @@ static void addchildpid(struct ChanSess *chansess, pid_t pid) {
+ static void execchild(const void *user_data) {
+ 	const struct ChanSess *chansess = user_data;
  	char *usershell = NULL;
-+	const char *path = DEFAULT_PATH;
++	const char *path = (getuid() == 0) ? DEFAULT_ROOT_PATH : DEFAULT_PATH;
 +	const char *ldpath = NULL;
- 
- 	/* with uClinux we'll have vfork()ed, so don't want to overwrite the
- 	 * hostkey. can't think of a workaround to clear it */
-@@ -905,6 +907,10 @@ static void execchild(void *user_data) {
+ 	char *cp = NULL;
+ 	char *envcp = getenv("LANG");
+ 	if (envcp != NULL) {
+@@ -965,6 +967,11 @@ static void execchild(const void *user_data) {
  	seedrandom();
  #endif
  
-+	if (getenv("PATH"))
++	if (getenv("PATH")) {
 +		path = getenv("PATH");
++	}
 +	ldpath = getenv("LD_LIBRARY_PATH");
 +
- 	/* clear environment */
+ 	/* clear environment if -e was not set */
  	/* if we're debugging using valgrind etc, we need to keep the LD_PRELOAD
  	 * etc. This is hazardous, so should only be used for debugging. */
-@@ -948,7 +954,10 @@ static void execchild(void *user_data) {
+@@ -1012,10 +1019,9 @@ static void execchild(const void *user_data) {
  	addnewvar("LOGNAME", ses.authstate.pw_name);
  	addnewvar("HOME", ses.authstate.pw_dir);
  	addnewvar("SHELL", get_user_shell());
--	addnewvar("PATH", DEFAULT_PATH);
+-	if (getuid() == 0) {
+-		addnewvar("PATH", DEFAULT_ROOT_PATH);
+-	} else {
+-		addnewvar("PATH", DEFAULT_PATH);
 +	addnewvar("PATH", path);
 +	if (ldpath != NULL) {
 +		addnewvar("LD_LIBRARY_PATH", ldpath);
-+	}
- 	if (chansess->term != NULL) {
- 		addnewvar("TERM", chansess->term);
  	}
+ 	if (cp != NULL) {
+ 		addnewvar("LANG", cp);


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2021-36369
https://github.com/mkj/dropbear/releases/tag/DROPBEAR_2022.82
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>dropbear</li>
  </ul>
</details>

