### PR TITLE
flashrom: Drop unneeded dependencies

### DIFF
--- a/pkgs/tools/misc/flashrom/default.nix
+++ b/pkgs/tools/misc/flashrom/default.nix
@@ -21,8 +21,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config installShellFiles ];
-  buildInputs = [ libftdi1 libusb1 pciutils ]
-    ++ lib.optional jlinkSupport libjaylink;
+  buildInputs = [
+    libftdi1
+    libusb1
+    pciutils
+  ]
+  ++ lib.optional jlinkSupport libjaylink;
 
   patches = [
     # remove when updating from 1.2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6660,7 +6660,14 @@ with pkgs;
 
   flamerobin = callPackage ../applications/misc/flamerobin { };
 
-  flashrom = callPackage ../tools/misc/flashrom { };
+  flashrom = callPackage ../tools/misc/flashrom {
+    # Disable dependencies that are not needed
+    libftdi1 = libftdi1.override {
+      cppSupport = false;
+      pythonSupport = false;
+      docSupport = false;
+    };
+  };
 
   flent = python3Packages.callPackage ../applications/networking/flent { };
 


### PR DESCRIPTION
###### Description of changes

libftdi comes with various options enabled bringing in buildtime- and runtime dependencies that are not needed by flashrom. Thus disable them to minimize its dependencies.

Unneeded dependencies are:

  * boost. Required for CPP support.
  * Python 3. Required for scripting support.
  * Doxygen and Graphviz. Required for generating documentation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
