### PR TITLE
arangodb_3_3: drop, arangodb_3_4, arangodb_3_5: mark vulnerable to CVE-2021-25938

### DIFF
--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -50,13 +50,10 @@ let
       license = licenses.asl20;
       platforms = platforms.linux;
       maintainers = [ maintainers.flosse ];
+      
     };
   };
 in {
-  arangodb_3_3 = common {
-    version = "3.3.24";
-    sha256 = "18175789j4y586qvpcsaqxmw7d6vc3s29qm1fja5c7wzimx6ilyp";
-  };
   arangodb_3_4 = common {
     version = "3.4.8";
     sha256 = "0vm94lf1i1vvs04vy68bkkv9q43rsaf1y3kfs6s3jcrs3ay0h0jn";

--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, openssl, zlib, cmake, python2, perl, snappy, lzo, which, catch2, catch }:
 
 let
-  common = { version, sha256 }: stdenv.mkDerivation {
+  common = { version, sha256, knownVulnerabilities ? [] }: stdenv.mkDerivation {
     pname = "arangodb";
     inherit version;
 
@@ -50,16 +50,18 @@ let
       license = licenses.asl20;
       platforms = platforms.linux;
       maintainers = [ maintainers.flosse ];
-      
+      inherit knownVulnerabilities;
     };
   };
 in {
   arangodb_3_4 = common {
     version = "3.4.8";
     sha256 = "0vm94lf1i1vvs04vy68bkkv9q43rsaf1y3kfs6s3jcrs3ay0h0jn";
+    knownVulnerabilities = [ "CVE-2021-25938" "Upstream support ended on 2020-12-31" ];
   };
   arangodb_3_5 = common {
     version = "3.5.1";
     sha256 = "1jw3j7vaq3xgkxiqg0bafn4b2169jq7f3y0l7mrpnrpijn77rkrv";
+    knownVulnerabilities = [ "CVE-2021-25938" "Upstream support ended on 2020-06-21" ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -83,6 +83,7 @@ mapAliases ({
   antimicro = throw "antimicro has been removed as it was broken, see antimicrox instead"; # Added 2020-08-06
   antimicroX = antimicrox; # Added 2021-10-31
   apple-music-electron = throw "'apple-music-electron' is end of life and has been removed, you can use 'cider' instead"; # Added 2022-10-02
+  arangodb_3_3 = throw "arangodb_3_3 has been removed as it was broken and not supported upstream since 2020-02-29"; # Added 2022-10-30
   ardour_5 = throw "ardour_5 has been removed. see https://github.com/NixOS/nixpkgs/issues/139549"; # Added 2021-09-28
   arduino_core = throw "'arduino_core' has been renamed to/replaced by 'arduino-core'"; # Converted to throw 2022-02-22
   arora = throw "arora has been removed"; # Added 2020-09-09

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2088,7 +2088,7 @@ with pkgs;
 
   inherit (callPackages ../servers/nosql/arangodb {
     stdenv = gcc8Stdenv;
-  }) arangodb_3_3 arangodb_3_4 arangodb_3_5;
+  }) arangodb_3_4 arangodb_3_5;
   arangodb = arangodb_3_4;
 
   # arcanist currently crashes with some workflows on php8.1, use 8.0


### PR DESCRIPTION
###### Description of changes

ArangoDB 3.3 is broken and not supported upstream anymore.
3.4 and 3.5 are also not supported anymore but at least they build.
Upgrading to 3.10 seems to require some additional work so for the time being the contribution removes the broken package and mark the remaining as vulnerable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
