### PR TITLE
bpftools: fix build on ppc64le

### DIFF
--- a/pkgs/os-specific/linux/bpftools/default.nix
+++ b/pkgs/os-specific/linux/bpftools/default.nix
@@ -15,7 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xDalSMcxLOb8WjRyy+rYle749ShB++fHH9jki9/isLo=";
   };
 
-  patches = [ ./strip-binary-name.patch ];
+  patches = [
+    ./strip-binary-name.patch
+    # fix unknown type name '__vector128' on ppc64le
+    ./include-asm-types-for-ppc64le.patch
+  ];
 
   nativeBuildInputs = [ python3 bison flex ];
   buildInputs = (if (lib.versionAtLeast version "5.20")

--- a/pkgs/os-specific/linux/bpftools/include-asm-types-for-ppc64le.patch
+++ b/pkgs/os-specific/linux/bpftools/include-asm-types-for-ppc64le.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/include/uapi/linux/types.h b/tools/include/uapi/linux/types.h
+index 91fa51a9c31d..bfbd9b47277f 100644
+--- a/tools/include/uapi/linux/types.h
++++ b/tools/include/uapi/linux/types.h
+@@ -2,7 +2,7 @@
+ #ifndef _UAPI_LINUX_TYPES_H
+ #define _UAPI_LINUX_TYPES_H
+ 
+-#include <asm-generic/int-ll64.h>
++#include <asm/types.h>
+ 
+ /* copied from linux:include/uapi/linux/types.h */
+ #define __bitwise


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pr fixes compilation of bpftools on ppc64le. Related pr: #192670. The fix is learned from https://www.spinics.net/lists/netdev/msg694314.html.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] powerpc64le-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
