### PR TITLE
cemu: init at 2.0-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1481,6 +1481,12 @@
     githubId = 35324;
     name = "Badi' Abdul-Wahid";
   };
+  baduhai = {
+    email = "baduhai@pm.me";
+    github = "baduhai";
+    githubId = 31864305;
+    name = "William";
+  };
   baitinq = {
     email = "manuelpalenzuelamerino@gmail.com";
     name = "Baitinq";

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -716,6 +716,16 @@
       </listitem>
       <listitem>
         <para>
+          The
+          <link xlink:href="https://ce-programming.github.io/CEmu">CEmu
+          TI-84 Plus CE emulator</link> package has been renamed to
+          <literal>cemu-ti</literal>. The
+          <link xlink:href="https://cemu.info">Cemu Wii U
+          emulator</link> is now packaged as <literal>cemu</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>systemd-networkd</literal> v250 deprecated, renamed,
           and moved some sections and settings which leads to the
           following breaking module changes:

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -233,6 +233,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - The `aws` package has been removed due to being abandoned by the upstream. It is recommended to use `awscli` or `awscli2` instead.
 
+- The [CEmu TI-84 Plus CE emulator](https://ce-programming.github.io/CEmu) package has been renamed to `cemu-ti`. The [Cemu Wii U emulator](https://cemu.info) is now packaged as `cemu`.
+
 - `systemd-networkd` v250 deprecated, renamed, and moved some sections and settings which leads to the following breaking module changes:
 
    * `systemd.network.networks.<name>.dhcpV6PrefixDelegationConfig` is renamed to `systemd.network.networks.<name>.dhcpPrefixDelegationConfig`.

--- a/pkgs/applications/emulators/cemu/cmakelists.patch
+++ b/pkgs/applications/emulators/cemu/cmakelists.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4b2b789..48d9be0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,6 +92,7 @@ find_package(pugixml REQUIRED)
+ find_package(RapidJSON REQUIRED)
+ find_package(Boost COMPONENTS program_options filesystem nowide REQUIRED)
+ find_package(libzip REQUIRED)
++find_package(SPIRV-Tools-opt REQUIRED)
+ find_package(glslang REQUIRED)
+ find_package(ZLIB REQUIRED)
+ find_package(zstd MODULE REQUIRED) # MODULE so that zstd::zstd is available

--- a/pkgs/applications/emulators/cemu/default.nix
+++ b/pkgs/applications/emulators/cemu/default.nix
@@ -1,0 +1,119 @@
+{ lib, stdenv, fetchFromGitHub
+, addOpenGLRunpath
+, wrapGAppsHook
+, cmake
+, glslang
+, nasm
+, pkg-config
+
+, SDL2
+, boost
+, cubeb
+, curl
+, fmt_9
+, glm
+, gtk3
+, imgui
+, libpng
+, libzip
+, libXrender
+, pugixml
+, rapidjson
+, vulkan-headers
+, wxGTK32
+, zarchive
+
+, vulkan-loader
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cemu";
+  version = "2.0-10";
+
+  src = fetchFromGitHub {
+    owner = "cemu-project";
+    repo = "Cemu";
+    rev = "v${version}";
+    hash = "sha256-GJA/lJJqShuHeYirBW1kyVsU44kMpmAn916PSGOnKkY=";
+  };
+
+  patches = [
+    # glslangTargets want SPIRV-Tools-opt to be defined:
+    # > The following imported targets are referenced, but are missing:
+    # > SPIRV-Tools-opt
+    ./cmakelists.patch
+  ];
+
+  nativeBuildInputs = [
+    addOpenGLRunpath
+    wrapGAppsHook
+    cmake
+    glslang
+    nasm
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    boost
+    cubeb
+    curl
+    fmt_9
+    glm
+    gtk3
+    imgui
+    libpng
+    libzip
+    libXrender
+    pugixml
+    rapidjson
+    vulkan-headers
+    wxGTK32
+    zarchive
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_C_FLAGS_RELEASE=-DNDEBUG"
+    "-DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG"
+    "-DENABLE_VCPKG=OFF"
+
+    # PORTABLE:
+    # "All data created and maintained by Cemu will be in the directory where the executable file is located"
+    "-DPORTABLE=OFF"
+  ];
+
+  preConfigure = ''
+    rm -rf dependencies/imgui
+    ln -s ${imgui}/include/imgui dependencies/imgui
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ../bin/Cemu_release $out/bin/Cemu
+    ln -s $out/bin/Cemu $out/bin/cemu
+
+    mkdir -p $out/share/applications
+    substitute ../dist/linux/info.cemu.Cemu.desktop $out/share/applications/info.cemu.Cemu.desktop \
+      --replace "Exec=Cemu" "Exec=$out/bin/Cemu"
+
+    install -Dm644 ../dist/linux/info.cemu.Cemu.metainfo.xml -t $out/share/metainfo
+    install -Dm644 ../src/resource/logo_icon.png $out/share/icons/hicolor/128x128/apps/info.cemu.Cemu.png
+
+    runHook postInstall
+  '';
+
+  preFixup = let
+    libs = [ vulkan-loader ] ++ cubeb.passthru.backendLibs;
+  in ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libs}")
+  '';
+
+  meta = with lib; {
+    description = "Cemu is a Wii U emulator";
+    homepage = "https://cemu.info";
+    license = licenses.mpl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ zhaofengli baduhai ];
+  };
+}

--- a/pkgs/development/libraries/audio/cubeb/default.nix
+++ b/pkgs/development/libraries/audio/cubeb/default.nix
@@ -1,0 +1,56 @@
+{ lib, stdenv, fetchFromGitHub
+, cmake
+, pkg-config
+, jack2
+, pulseaudio
+, sndio
+, speexdsp
+, lazyLoad ? true
+}:
+
+stdenv.mkDerivation {
+  pname = "cubeb";
+  version = "unstable-2022-10-18";
+
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "cubeb";
+    rev = "27d2a102b0b75d9e49d43bc1ea516233fb87d778";
+    hash = "sha256-q+uz1dGU4LdlPogL1nwCR/KuOX4Oy3HhMdA6aJylBRk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    jack2
+    pulseaudio
+    sndio
+    speexdsp
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_TESTS=OFF" # tests require an audio server
+    "-DBUNDLE_SPEEX=OFF"
+    "-DUSE_SANITIZERS=OFF"
+
+    # Whether to lazily load libraries with dlopen()
+    "-DLAZY_LOAD_LIBS=${if lazyLoad then "ON" else "OFF"}"
+  ];
+
+  passthru = {
+    # For downstream users when lazyLoad is true
+    backendLibs = [ jack2 pulseaudio sndio speexdsp ];
+  };
+
+  meta = with lib; {
+    description = "Cross platform audio library";
+    homepage = "https://github.com/mozilla/cubeb";
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zhaofengli ];
+  };
+}

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -53,7 +53,7 @@ in
   };
 
   fmt_9 = generic {
-    version = "9.0.0";
-    sha256 = "sha256-nwlAzMkY1JdhLtes48VaNH9LS7GzqtPCwk2dZA/bGmQ=";
+    version = "9.1.0";
+    sha256 = "sha256-rP6ymyRc7LnKxUXwPpzhHOQvpJkpnRFOt2ctvUNlYI0=";
   };
 }

--- a/pkgs/tools/archivers/zarchive/default.nix
+++ b/pkgs/tools/archivers/zarchive/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, cmake, zstd }:
+
+stdenv.mkDerivation rec {
+  pname = "zarchive";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "Exzap";
+    repo = "ZArchive";
+    rev = "v${version}";
+    hash = "sha256-hX637O/mVLTzmG0a9swJu9w+3o26VHo+K/9RhMuf1lI=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zstd ];
+
+  meta = with lib; {
+    description = "File archive format supporting random-access reads";
+    homepage = "https://github.com/Exzap/ZArchive";
+    license = licenses.mit0;
+    maintainers = with maintainers; [ zhaofengli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1503,6 +1503,8 @@ with pkgs;
 
   cdemu-daemon = callPackage ../applications/emulators/cdemu/daemon.nix { };
 
+  cemu = callPackage ../applications/emulators/cemu { };
+
   cen64 = callPackage ../applications/emulators/cen64 { };
 
   citra-canary = callPackage ../applications/emulators/citra {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13057,6 +13057,8 @@ with pkgs;
 
   yj = callPackage ../development/tools/yj { };
 
+  zarchive = callPackage ../tools/archivers/zarchive { };
+
   zprint = callPackage ../development/tools/zprint { };
 
   yle-dl = callPackage ../tools/misc/yle-dl {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18191,6 +18191,8 @@ with pkgs;
   # justStaticExecutables is needed due to https://github.com/NixOS/nix/issues/2990
   cachix = haskell.lib.compose.justStaticExecutables haskellPackages.cachix;
 
+  cubeb = callPackage ../development/libraries/audio/cubeb { };
+
   hercules-ci-agent = callPackage ../development/tools/continuous-integration/hercules-ci-agent { };
 
   hci = callPackage ../development/tools/continuous-integration/hci { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Cemu is a Wii U emulator.

Tested running _Breath of the Wild_ on my Steam Deck. ~~Perhaps we can rename it to `cemu` once #188939 is merged.~~ (done)

Thanks to @romatthe and @baduhai for attempting this first in [this gist](https://gist.github.com/romatthe/81505a322e1afa00f9f0081985ea105b). Things have improved greatly in the meantime, and none of the invasive patches seem to be required anymore. Please comment with your email addresses so I can add you to the maintainer list :heart:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
