### PR TITLE
clightd: Add Yoctolight option

### DIFF
--- a/pkgs/applications/misc/clight/clightd.nix
+++ b/pkgs/applications/misc/clight/clightd.nix
@@ -5,7 +5,8 @@
 , enableDdc ? true, ddcutil
 , enableDpms ? true, libXext
 , enableGamma ? true, libdrm, libXrandr, wayland
-, enableScreen ? true }:
+, enableScreen ? true
+, enableYoctolight ? true }:
 
 stdenv.mkDerivation rec {
   pname = "clightd";
@@ -33,10 +34,11 @@ stdenv.mkDerivation rec {
       "-DDBUS_CONFIG_DIR=${placeholder "out"}/etc/dbus-1/system.d"
       # systemd.pc has prefix=${systemd.out}
       "-DMODULE_LOAD_DIR=${placeholder "out"}/lib/modules-load.d"
-    ] ++ optional enableDdc    "-DENABLE_DDC=1"
-      ++ optional enableDpms   "-DENABLE_DPMS=1"
-      ++ optional enableGamma  "-DENABLE_GAMMA=1"
-      ++ optional enableScreen "-DENABLE_SCREEN=1";
+    ] ++ optional enableDdc        "-DENABLE_DDC=1"
+      ++ optional enableDpms       "-DENABLE_DPMS=1"
+      ++ optional enableGamma      "-DENABLE_GAMMA=1"
+      ++ optional enableScreen     "-DENABLE_SCREEN=1"
+      ++ optional enableYoctolight "-DENABLE_YOCTOLIGHT=1";
 
   nativeBuildInputs = [
     dbus


### PR DESCRIPTION
###### Description of changes

The clightd package supports/enables all the available build options except for Yoctolight support. Yoctolight support requires no additional dependencies as libusb is already a dep. This enables Yoctolight support so that the package can be used on desktop systems with a Yoctolight module as the ALS.

See https://github.com/FedeDP/Clightd/wiki/Build

I have tested it and its working with my Yocto-light-v3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
