### PR TITLE
jekyll-favicon: Add to full Jekyll setup

### DIFF
--- a/pkgs/applications/misc/jekyll/basic/Gemfile.lock
+++ b/pkgs/applications/misc/jekyll/basic/Gemfile.lock
@@ -101,4 +101,4 @@ DEPENDENCIES
   jemoji
 
 BUNDLED WITH
-   2.3.25
+   2.3.9

--- a/pkgs/applications/misc/jekyll/full/Gemfile
+++ b/pkgs/applications/misc/jekyll/full/Gemfile
@@ -11,6 +11,7 @@ gem "jemoji"
 # Optional dependencies:
 gem "jekyll-coffeescript"
 #gem "jekyll-docs"
+gem "jekyll-favicon"
 gem "jekyll-feed", "~> 0.9"
 gem "jekyll-gist"
 gem "jekyll-paginate"

--- a/pkgs/applications/misc/jekyll/full/Gemfile.lock
+++ b/pkgs/applications/misc/jekyll/full/Gemfile.lock
@@ -58,6 +58,10 @@ GEM
     jekyll-coffeescript (2.0.0)
       coffee-script (~> 2.2)
       coffee-script-source (~> 1.12)
+    jekyll-favicon (1.1.0)
+      jekyll (>= 3.0, < 5.0)
+      mini_magick (~> 4.11)
+      rexml (~> 3.2, >= 3.2.5)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-gist (1.5.0)
@@ -100,6 +104,7 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
+    mini_magick (4.11.0)
     mini_portile2 (2.8.0)
     minitest (5.16.3)
     nokogiri (1.13.9)
@@ -146,6 +151,7 @@ DEPENDENCIES
   jekyll
   jekyll-avatar
   jekyll-coffeescript
+  jekyll-favicon
   jekyll-feed (~> 0.9)
   jekyll-gist
   jekyll-mentions
@@ -163,4 +169,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.4)
 
 BUNDLED WITH
-   2.3.25
+   2.3.9

--- a/pkgs/applications/misc/jekyll/full/gemset.nix
+++ b/pkgs/applications/misc/jekyll/full/gemset.nix
@@ -264,6 +264,17 @@
     };
     version = "2.0.0";
   };
+  jekyll-favicon = {
+    dependencies = ["jekyll" "mini_magick" "rexml"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dyksm4i11n0qshd7wh6dvk8d0fc70dd32ir2dxs6igxq0gd6hi1";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
   jekyll-feed = {
     dependencies = ["jekyll"];
     groups = ["default"];
@@ -525,6 +536,16 @@
       type = "gem";
     };
     version = "3.2022.0105";
+  };
+  mini_magick = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1aj604x11d9pksbljh0l38f70b558rhdgji1s9i763hiagvvx2hs";
+      type = "gem";
+    };
+    version = "4.11.0";
   };
   mini_portile2 = {
     groups = ["default"];


### PR DESCRIPTION
###### Description of changes

Include jekyll-favicon when `withOptionalDependencies` is set.

At-ing other gemset.nix contributors @primeos @raboof @grahamc @anthonyroussel since there's [no official maintainer](https://github.com/NixOS/nixpkgs/blob/f4c278ca0e7969356df58d84a949f78dbe84c505/pkgs/applications/misc/jekyll/default.nix#L54).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).