### PR TITLE
thunderbird, thunderbird-bin: fix desktop item

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -166,38 +166,64 @@ let
     in stdenv.mkDerivation {
       inherit pname version;
 
-      desktopItem = makeDesktopItem {
+      desktopItem = makeDesktopItem ({
         name = applicationName;
         exec = "${launcherName} %U";
         inherit icon;
         desktopName = "${desktopName}${nameSuffix}${lib.optionalString forceWayland " (Wayland)"}";
-        genericName = "Web Browser";
-        categories = [ "Network" "WebBrowser" ];
-        mimeTypes = [
-          "text/html"
-          "text/xml"
-          "application/xhtml+xml"
-          "application/vnd.mozilla.xul+xml"
-          "x-scheme-handler/http"
-          "x-scheme-handler/https"
-          "x-scheme-handler/ftp"
-        ];
+        startupNotify = true;
         startupWMClass = wmClass;
-        actions = {
-          new-window = {
-            name = "New Window";
-            exec = "${launcherName} --new-window %U";
-          };
-          new-private-window = {
-            name = "New Private Window";
-            exec = "${launcherName} --private-window %U";
-          };
-          profile-manager-window = {
-            name = "Profile Manager";
-            exec = "${launcherName} --ProfileManger";
-          };
-        };
-      };
+        terminal = false;
+      } // (if libName == "thunderbird"
+            then {
+              genericName = "Email Client";
+              comment = "Read and write e-mails or RSS feeds, or manage tasks on calendars.";
+              categories = [
+                "Network" "Chat" "Email" "Feed" "GTK" "News"
+              ];
+              keywords = [
+                "mail" "email" "e-mail" "messages" "rss" "calendar"
+                "address book" "addressbook" "chat"
+              ];
+              mimeTypes = [
+                "message/rfc822"
+                "x-scheme-handler/mailto"
+                "text/calendar"
+                "text/x-vcard"
+              ];
+              actions = {
+                profile-manager-window = {
+                  name = "Profile Manager";
+                  exec = "${launcherName} --ProfileManger";
+                };
+              };
+            }
+            else {
+              genericName = "Web Browser";
+              categories = [ "Network" "WebBrowser" ];
+              mimeTypes = [
+                "text/html"
+                "text/xml"
+                "application/xhtml+xml"
+                "application/vnd.mozilla.xul+xml"
+                "x-scheme-handler/http"
+                "x-scheme-handler/https"
+              ];
+              actions = {
+                new-window = {
+                  name = "New Window";
+                  exec = "${launcherName} --new-window %U";
+                };
+                new-private-window = {
+                  name = "New Private Window";
+                  exec = "${launcherName} --private-window %U";
+                };
+                profile-manager-window = {
+                  name = "Profile Manager";
+                  exec = "${launcherName} --ProfileManger";
+                };
+              };
+            }));
 
       nativeBuildInputs = [ makeWrapper lndir jq ];
       buildInputs = [ browser.gtk3 ];


### PR DESCRIPTION
Generate appropriate desktop item for Thunderbird.

Fixes #194851.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

My KDE environment somehow shows Thunderbird as a default mail reader without this PR. `xdg-open mailto:text@example.org` also starts Thunderbird without this PR. So I could not test this. Just checked generated desktop files for `thunderbird-bin` and `firefox-bin`. 