### PR TITLE
verovio: init at 4.2.0

### DIFF
--- a/pkgs/by-name/ve/verovio/package.nix
+++ b/pkgs/by-name/ve/verovio/package.nix
@@ -1,0 +1,67 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  git,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "verovio";
+  version = "4.2.0";
+
+  src = fetchFromGitHub {
+    owner = "rism-digital";
+    repo = "verovio";
+    rev = "version-${finalAttrs.version}";
+    hash = "sha256-PjBtnt46pHV3rDlwltVxfUMlgNoZGnI9CfnFtk2/j3s=";
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    git
+    makeWrapper
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd tools
+    patchShebangs .
+    cmake ../cmake
+    make -j 8
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/
+
+    mv verovio $out/bin
+    cp -R $src/data $out/share/verovio
+
+    wrapProgram $out/bin/verovio \
+      --add-flags "-r $out/share/verovio"
+
+    runHook postInstall
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = ''
+      A fast, portable and lightweight library for engraving Music Encoding Initiative (MEI) digital scores into SVG images.
+    '';
+    homepage = "https://www.verovio.org/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ tshaynik ];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
Add verovio tool for engraving MEI music notation as SVG

###### Description of changes


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a package for the [verovio](https://www.verovio.org) command line tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
