### PR TITLE
python3Packages.pdoc3: patch failing test

### DIFF
--- a/pkgs/development/python-modules/pdoc3/default.nix
+++ b/pkgs/development/python-modules/pdoc3/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5f22e7bcb969006738e1aa4219c75a32f34c2d62d46dc9d2fb2d3e0b0287e4b7";
+    hash = "sha256-XyLnvLlpAGc44apCGcdaMvNMLWLUbcnS+y0+CwKH5Lc=";
   };
 
   patches = [
@@ -25,7 +25,14 @@ buildPythonPackage rec {
       # test_Class_params fails in 0.10.0
       # https://github.com/pdoc3/pdoc/issues/355
       url = "https://github.com/pdoc3/pdoc/commit/4aa70de2221a34a3003a7e5f52a9b91965f0e359.patch";
-      sha256 = "07sbf7bh09vgd5z1lbay604rz7rhg88414whs6iy60wwbvkz5c2v";
+      hash = "sha256-W7Dy516cA+Oj0ZCTQBB6MJ+fCTBeLRp+aW8nANdxSx8=";
+    })
+    # https://github.com/pdoc3/pdoc/issues/400
+    (fetchpatch {
+      name = "fix-test-for-python310.patch";
+      url = "https://github.com/pdoc3/pdoc/commit/80af5d40d3ca39e2701c44941c1003ae6a280799.patch";
+      hash = "sha256-69Cn+BY7feisSHugONIF/PRgEDEfnvnS/RBHWv1P8/w=";
+      excludes = [".github/workflows/ci.yml"];
     })
   ];
 
@@ -40,7 +47,6 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "Auto-generate API documentation for Python projects.";
     homepage = "https://pdoc3.github.io/pdoc/";
     license = with licenses; [ agpl3Plus ];


### PR DESCRIPTION
###### Description of changes

Pull in https://github.com/pdoc3/pdoc/pull/414, which fixes https://github.com/pdoc3/pdoc/issues/400.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
