### PR TITLE
miniupnpc_1: drop

### DIFF
--- a/nixos/tests/upnp.nix
+++ b/nixos/tests/upnp.nix
@@ -47,7 +47,7 @@ in
 
       client1 =
         { pkgs, nodes, ... }:
-        { environment.systemPackages = [ pkgs.miniupnpc_2 pkgs.netcat ];
+        { environment.systemPackages = [ pkgs.miniupnpc pkgs.netcat ];
           virtualisation.vlans = [ 2 ];
           networking.defaultGateway = internalRouterAddress;
           networking.interfaces.eth1.ipv4.addresses = [
@@ -65,7 +65,7 @@ in
 
       client2 =
         { pkgs, ... }:
-        { environment.systemPackages = [ pkgs.miniupnpc_2 ];
+        { environment.systemPackages = [ pkgs.miniupnpc ];
           virtualisation.vlans = [ 1 ];
           networking.interfaces.eth1.ipv4.addresses = [
             { address = externalClient2Address; prefixLength = 24; }

--- a/pkgs/applications/blockchains/groestlcoin/default.nix
+++ b/pkgs/applications/blockchains/groestlcoin/default.nix
@@ -10,7 +10,7 @@
 , wrapQtAppsHook ? null
 , boost
 , libevent
-, miniupnpc_2
+, miniupnpc
 , zeromq
 , zlib
 , db53
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
     ++ lib.optionals withGui [ wrapQtAppsHook ];
 
-  buildInputs = [ boost libevent miniupnpc_2 zeromq zlib ]
+  buildInputs = [ boost libevent miniupnpc zeromq zlib ]
     ++ lib.optionals withWallet [ db53 sqlite ]
     ++ lib.optionals withGui [ qrencode qtbase qttools ];
 

--- a/pkgs/applications/blockchains/wownero/default.nix
+++ b/pkgs/applications/blockchains/wownero/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitea, cmake, boost, miniupnpc_2, openssl, unbound
+{ lib, stdenv, fetchFromGitea, cmake, boost, miniupnpc, openssl, unbound
 , readline, libsodium, rapidjson
 }:
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
-    boost miniupnpc_2 openssl unbound rapidjson readline libsodium
+    boost miniupnpc openssl unbound rapidjson readline libsodium
   ];
 
   postUnpack = ''

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , wrapQtAppsHook
-, miniupnpc_2
+, miniupnpc
 , ffmpeg
 , enableSwftools ? false
 , swftools
@@ -108,7 +108,7 @@ python3Packages.buildPythonPackage rec {
   dontWrapQtApps = true;
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
-    makeWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ffmpeg miniupnpc_2 ]})
+    makeWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ffmpeg miniupnpc ]})
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/miniupnpc/default.nix
+++ b/pkgs/tools/networking/miniupnpc/default.nix
@@ -1,41 +1,35 @@
-{ lib, stdenv, fetchurl, which, cctools }:
+{ lib
+, stdenv
+, fetchurl
+, which
+, cctools
+}:
 
-let
-  generic = { version, sha256 }:
-    stdenv.mkDerivation rec {
-      pname = "miniupnpc";
-      inherit version;
-      src = fetchurl {
-        url = "https://miniupnp.tuxfamily.org/files/${pname}-${version}.tar.gz";
-        inherit sha256;
-      };
+stdenv.mkDerivation rec {
+  pname = "miniupnpc";
+  version = "2.2.4";
 
-      nativeBuildInputs = lib.optionals stdenv.isDarwin [ which cctools ];
-
-      patches = lib.optional stdenv.isFreeBSD ./freebsd.patch;
-
-      doCheck = !stdenv.isFreeBSD;
-
-      makeFlags = [ "PREFIX=$(out)" "INSTALLPREFIX=$(out)" ];
-
-      postInstall = ''
-        chmod +x "$out"/lib/libminiupnpc${stdenv.hostPlatform.extensions.sharedLibrary}
-      '';
-
-      meta = with lib; {
-        homepage = "https://miniupnp.tuxfamily.org/";
-        description = "A client that implements the UPnP Internet Gateway Device (IGD) specification";
-        platforms = with platforms; linux ++ freebsd ++ darwin;
-        license = licenses.bsd3;
-      };
-    };
-in {
-  miniupnpc_2 = generic {
-    version = "2.2.4";
+  src = fetchurl {
+    url = "https://miniupnp.tuxfamily.org/files/${pname}-${version}.tar.gz";
     sha256 = "0jrc84lkc7xb53rb8dbswxrxj21ndj1iiclmk3r9wkp6xm55w6j8";
   };
-  miniupnpc_1 = generic {
-    version = "1.9.20160209";
-    sha256 = "0vsbv6a8by67alx4rxfsrxxsnmq74rqlavvvwiy56whxrkm728ap";
+
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ which cctools ];
+
+  patches = lib.optional stdenv.isFreeBSD ./freebsd.patch;
+
+  doCheck = !stdenv.isFreeBSD;
+
+  makeFlags = [ "PREFIX=$(out)" "INSTALLPREFIX=$(out)" ];
+
+  postInstall = ''
+    chmod +x "$out"/lib/libminiupnpc${stdenv.hostPlatform.extensions.sharedLibrary}
+  '';
+
+  meta = with lib; {
+    homepage = "https://miniupnp.tuxfamily.org/";
+    description = "A client that implements the UPnP Internet Gateway Device (IGD) specification";
+    platforms = with platforms; linux ++ freebsd ++ darwin;
+    license = licenses.bsd3;
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -912,6 +912,7 @@ mapAliases ({
   minetestclient_4 = throw "minetestclient_4 has been removed from Nixpkgs; current version is available at minetest or minetestclient"; # added 2022-02-01
   minetestserver_4 = throw "minetestserver_4 has been removed from Nixpkgs; current version is available at minetestserver"; # added 2022-02-01
   minetime = throw "minetime has been removed from nixpkgs, because it was discontinued 2021-06-22"; # Added 2021-10-14
+  miniupnpc_1 = throw "miniupnpc_1 has been removed; current version is available at miniupnpc"; # Added 2022-10-30
   mist = throw "mist has been removed as the upstream project has been abandoned, see https://github.com/ethereum/mist#mist-browser-deprecated"; # Added 2020-08-15
   mlt-qt5 = throw "'mlt-qt5' has been renamed to/replaced by 'libsForQt5.mlt'"; # Converted to throw 2022-02-22
   mobile_broadband_provider_info = throw "'mobile_broadband_provider_info' has been renamed to/replaced by 'mobile-broadband-provider-info'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9239,10 +9239,9 @@ with pkgs;
 
   minissdpd = callPackage ../tools/networking/minissdpd { };
 
-  inherit (callPackage ../tools/networking/miniupnpc
-            { inherit (darwin) cctools; })
-    miniupnpc_1 miniupnpc_2;
-  miniupnpc = miniupnpc_1;
+  miniupnpc = callPackage ../tools/networking/miniupnpc {
+    inherit (darwin) cctools;
+  };
 
   miniupnpd = callPackage ../tools/networking/miniupnpd { };
 
@@ -28775,7 +28774,7 @@ with pkgs;
   gum = callPackage ../applications/misc/gum { };
 
   hydrus = python3Packages.callPackage ../applications/graphics/hydrus {
-    inherit miniupnpc_2 swftools;
+    inherit miniupnpc swftools;
     inherit (qt5) wrapQtAppsHook;
   };
 
@@ -33284,21 +33283,18 @@ with pkgs;
 
   bitcoin  = libsForQt5.callPackage ../applications/blockchains/bitcoin {
     boost = boost17x;
-    miniupnpc = miniupnpc_2;
     withGui = true;
     inherit (darwin) autoSignDarwinBinariesHook;
   };
 
   bitcoind = callPackage ../applications/blockchains/bitcoin {
     boost = boost17x;
-    miniupnpc = miniupnpc_2;
     withGui = false;
     inherit (darwin) autoSignDarwinBinariesHook;
   };
 
   bitcoind-knots = callPackage ../applications/blockchains/bitcoin-knots {
     boost = boost17x;
-    miniupnpc = miniupnpc_2;
     withGui = false;
     inherit (darwin) autoSignDarwinBinariesHook;
   };
@@ -33386,13 +33382,11 @@ with pkgs;
   };
 
   elements  = libsForQt5.callPackage ../applications/blockchains/elements {
-    miniupnpc = miniupnpc_2;
     withGui = true;
     boost = boost175;
     inherit (darwin) autoSignDarwinBinariesHook;
   };
   elementsd = callPackage ../applications/blockchains/elements {
-    miniupnpc = miniupnpc_2;
     withGui = false;
     boost = boost175;
     inherit (darwin) autoSignDarwinBinariesHook;
@@ -33551,7 +33545,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  particl-core = callPackage ../applications/blockchains/particl-core { miniupnpc = miniupnpc_2; };
+  particl-core = callPackage ../applications/blockchains/particl-core { };
 
   quorum = callPackage ../applications/blockchains/quorum { };
 


### PR DESCRIPTION
###### Description of changes

- it is time to drop 6 years old version
- no package really requires miniupnpc 1.x
- no distributions ship miniupnpc 1.x these days
- miniupnpc package now defaults to 2.x
- rebuilt all packages which depend on miniupnpc locally on x86_64-linux and found no new build failures

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
