### PR TITLE
kicad: 6.0.8 -> 6.0.9

### DIFF
--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,22 +3,22 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"6.0.8";
+      version =			"6.0.9";
       src = {
-        rev =			"f2edbf62ab6eb123d605d06cffedadc424fed55b";
-        sha256 =		"0f5iriahskzflgfzahbjihiff7m7nbdmp3ip8dx69xa28b9012w9";
+        rev =			"8da3e8f7071484853b31c61cbd5045903b5c6dd3";
+        sha256 =		"1fr02jcy09v14d3k8ril0zhwnzhcqcf77wfj5b3bkrh6r8xraqhs";
       };
     };
     libVersion = {
-      version =			"6.0.8";
+      version =			"6.0.9";
       libSources = {
-        symbols.rev =		"64a2f338f3f994975edfd33bc04f92fd6b9ed1c3";
-        symbols.sha256 =	"1nxz8r3h3j62fs3s77lj27333fsj5c4i01n05lv0gqx36h28hqxk";
-        templates.rev =		"549275966dd4f01ce656cec2b46599d1b7a3ca62";
+        symbols.rev =		"0d9559dfddd51110e5c5223901ada2445285ce80";
+        symbols.sha256 =	"0y5mjjmmln37hkp9wmydinlfgrn8im8rn20145g9xgdpj8j38d48";
+        templates.rev =		"ae2b46f8756d79379b90fec01d4fdde1ccfd73c1";
         templates.sha256 =	"08zxh83fbygh1x2jhca8nrp3f9kihf7kmg65qmyp95wvps4p5h8v";
-        footprints.rev =	"8eedad538f5b8234d3889ad08a3f272832b724b1";
-        footprints.sha256 =	"19di37hi80rzlwd468w3b6bq5kzxbslp3daskv8xb4y4f7pk3n00";
-        packages3d.rev =	"471e36d23c2d4f9971a591e2ab6ce717709438f9";
+        footprints.rev =	"6705da57c29e9896556c7cdbe719ede3f96e9121";
+        footprints.sha256 =	"02j445i0kcf87fhj9y6pwfcwq3arppxbrv77lbizm8kcpkpcfldl";
+        packages3d.rev =	"45df600c5e3dd5113d62e6445115e7c37bdf362f";
         packages3d.sha256 =	"0cnrg7mr3khpglviid1adk2ihs1qwj0r7l32z2vqsl8aidzbg9kr";
       };
     };


### PR DESCRIPTION
###### Description of changes

summary blogpost not posted yet

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).