### PR TITLE
python310Packages.editdistance: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/editdistance/default.nix
+++ b/pkgs/development/python-modules/editdistance/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "editdistance";
-  version = "0.6.0";
+  version = "0.6.1";
 
 
   src = fetchFromGitHub {
     owner = "roy-ht";
     repo = pname;
     rev = "v${version}";
-    sha256 = "17xkndwdyf14nfxk25z1qnhkzm0yxw65fpj78c01haq241zfzjr5";
+    sha256 = "sha256-c0TdH1nJAKrepatCSCTLaKsDv9NKruMQadCjclKGxBw=";
   };
 
   nativeBuildInputs = [ cython ];

--- a/pkgs/development/python-modules/editdistance/default.nix
+++ b/pkgs/development/python-modules/editdistance/default.nix
@@ -3,29 +3,38 @@
 , fetchFromGitHub
 , pytestCheckHook
 , cython
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "editdistance";
   version = "0.6.1";
+  format = "setuptools";
 
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "roy-ht";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-c0TdH1nJAKrepatCSCTLaKsDv9NKruMQadCjclKGxBw=";
+    hash = "sha256-c0TdH1nJAKrepatCSCTLaKsDv9NKruMQadCjclKGxBw=";
   };
 
-  nativeBuildInputs = [ cython ];
+  nativeBuildInputs = [
+    cython
+  ];
 
   preBuild = ''
     cythonize --inplace editdistance/bycython.pyx
   '';
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+   pytestCheckHook
+  ];
 
-  pythonImportsCheck = [ "editdistance" ];
+  pythonImportsCheck = [
+    "editdistance"
+  ];
 
   meta = with lib; {
     description = "Python implementation of the edit distance (Levenshtein distance)";


### PR DESCRIPTION
###### Description of changes
https://github.com/roy-ht/editdistance/releases/tag/v0.6.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
