### PR TITLE
wasabiwallet: 2.0.1.3 -> 2.0.2

### DIFF
--- a/pkgs/applications/blockchains/wasabiwallet/default.nix
+++ b/pkgs/applications/blockchains/wasabiwallet/default.nix
@@ -8,6 +8,8 @@
 , openssl
 , xorg
 , zlib
+, libICE
+, libSM
 }:
 
 let
@@ -21,15 +23,17 @@ let
     stdenv.cc.cc.lib
     xorg.libX11
     zlib
+    libICE
+    libSM
   ];
 in
 stdenv.mkDerivation rec {
   pname = "wasabiwallet";
-  version = "2.0.1.3";
+  version = "2.0.2";
 
   src = fetchurl {
     url = "https://github.com/zkSNACKs/WalletWasabi/releases/download/v${version}/Wasabi-${version}.tar.gz";
-    sha256 = "sha256-cATqg/n4/BDQtuCVjHAx3EfMLmlX5EjeQ01gavy/L8o=";
+    sha256 = "sha256-0DFl+UFxQckRM2qXFqDpKaRQ5sIMUbNj7l3zKPKAOnQ=";
   };
 
   dontBuild = true;
@@ -48,11 +52,15 @@ stdenv.mkDerivation rec {
     mkdir -p $out/opt/${pname} $out/bin $out/share/applications
     cp -Rv . $out/opt/${pname}
     cd $out/opt/${pname}
-    for i in $(find . -type f -name '*.so') wassabee
+    BINARIES="wassabee \
+              Microservices/Binaries/lin64/Tor/tor \
+              Microservices/Binaries/lin64/bitcoind \
+              Microservices/Binaries/lin64/hwi"
+    for i in $(find . -type f -name '*.so') $BINARIES
       do
         patchelf --set-rpath ${libPath} $i
       done
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" wassabee
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $BINARIES
     ln -s $out/opt/${pname}/wassabee $out/bin/${pname}
     cp -v $desktopItem/share/applications/* $out/share/applications
   '';


### PR DESCRIPTION
###### Description of changes

Fixed version of automatic update (https://github.com/NixOS/nixpkgs/pull/186155)
CC @mmahut
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
