### PR TITLE
nixos/generations-dir: Improve symlinking in `/boot`

### DIFF
--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir-builder.sh
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir-builder.sh
@@ -50,6 +50,7 @@ addEntry() {
     local path="$1"
     local generation="$2"
     local outdir=/boot/system-$generation
+    local defaultdir=/boot/default
 
     if ! test -e $path/kernel -a -e $path/initrd; then
         return
@@ -76,12 +77,13 @@ addEntry() {
       cp "$initrd" /boot/nixos-initrd
       cp "$(readlink -f "$path/init")" /boot/nixos-init
 
-      mkdir -p /boot/default
-      # ln -sfT: overrides target even if it exists.
-      ln -sfT $(readlink -f $path) /boot/default/system
-      ln -sfT $(readlink -f $path/init) /boot/default/init
-      ln -sfT $extraLnArgs $initrd /boot/default/initrd
-      ln -sfT $extraLnArgs $kernel /boot/default/kernel
+      # Clean up the /boot/default directory created by earlier
+      # versions of generations-dir.
+      if test -d $defaultdir -a ! -L $defaultdir; then
+        rm -Rf $defaultdir
+      fi
+
+      ln -sfrT $outdir $defaultdir
     fi
 }
 

--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir-builder.sh
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir-builder.sh
@@ -57,17 +57,19 @@ addEntry() {
 
     local kernel=$(readlink -f $path/kernel)
     local initrd=$(readlink -f $path/initrd)
+    local extraLnArgs=""
 
     if test -n "@copyKernels@"; then
         copyToKernelsDir $kernel; kernel=$result
         copyToKernelsDir $initrd; initrd=$result
+        extraLnArgs="-r"
     fi
 
     mkdir -p $outdir
     ln -sf $(readlink -f $path) $outdir/system
     ln -sf $(readlink -f $path/init) $outdir/init
-    ln -sf $initrd $outdir/initrd
-    ln -sf $kernel $outdir/kernel
+    ln -sf $extraLnArgs $initrd $outdir/initrd
+    ln -sf $extraLnArgs $kernel $outdir/kernel
 
     if test $(readlink -f "$path") = "$default"; then
       cp "$kernel" /boot/nixos-kernel
@@ -78,8 +80,8 @@ addEntry() {
       # ln -sfT: overrides target even if it exists.
       ln -sfT $(readlink -f $path) /boot/default/system
       ln -sfT $(readlink -f $path/init) /boot/default/init
-      ln -sfT $initrd /boot/default/initrd
-      ln -sfT $kernel /boot/default/kernel
+      ln -sfT $extraLnArgs $initrd /boot/default/initrd
+      ln -sfT $extraLnArgs $kernel /boot/default/kernel
     fi
 }
 

--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir-builder.sh
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir-builder.sh
@@ -73,9 +73,11 @@ addEntry() {
     ln -sf $extraLnArgs $kernel $outdir/kernel
 
     if test $(readlink -f "$path") = "$default"; then
-      cp "$kernel" /boot/nixos-kernel
-      cp "$initrd" /boot/nixos-initrd
-      cp "$(readlink -f "$path/init")" /boot/nixos-init
+      if test -n "@copyDefault@"; then
+        cp "$kernel" /boot/nixos-kernel
+        cp "$initrd" /boot/nixos-initrd
+        cp "$(readlink -f "$path/init")" /boot/nixos-init
+      fi
 
       # Clean up the /boot/default directory created by earlier
       # versions of generations-dir.

--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
@@ -19,7 +19,7 @@ let
         pkgs.gnused
         pkgs.gnugrep
       ];
-      inherit (config.boot.loader.generationsDir) copyKernels;
+      inherit (config.boot.loader.generationsDir) copyKernels copyDefault;
     };
   };
 
@@ -55,6 +55,25 @@ in
         description = ''
           Whether to copy the necessary boot files into /boot, so
           /nix/store is not needed by the boot loader.
+        '';
+      };
+
+      copyDefault = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Whether to copy the default system profile boot files to a second set
+          of files in `/boot` (`nixos-kernel`, `nixos-initrd`, `nixos-init`).
+
+          Disable this option to save space on the `/boot` partition if your
+          boot loader can follow the `default` symlink.
+
+          If you previously enabled this option, you need to clean up the old
+          files manually:
+
+          ```
+          rm -vf /boot/nixos-{kernel,initrd,init}
+          ```
         '';
       };
 


### PR DESCRIPTION
###### Description of changes

`boot.loader.generationsDir` is a simple "boot loader" that creates a directory structure in `/boot` with symlinks to kernel, initrd, init, and system. This is ideal for some boot loaders (e.g. old or anemic builds of U-Boot) that don't otherwise support a menu of system profiles at boot.

- f7ccb384323830c3af2b7032b6558a46f4cacc0c fixes an issue where those symlinks are broken when `/boot` has its own partition.
- 15d56abf52a9a404c97744fc25b917f1ce72e243 makes it easier to change the default boot profile by re-pointing the `default` symlink.
- 9ee1a4b60994514fff2538dc8c6840b232835674 adds an option to suppress the redundant copying of `kernel`, `initrd` and `init` files.
- 69cdd9fb5e9632f88a8aff5788b03fb7cccc600a changes the default for that option to `false`.

I tested this on an `armv7l-linux` system which has a U-Boot build from 2011 that lacks support for `extlinux.conf`. In particular, I tested that:

- U-Boot can follow the double symlinks for the `default` profile.
- NixOS cleanly updates `/boot` when upgrading to this branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] armv7l-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
