### PR TITLE
crosstool-ng: init at 1.25.0

### DIFF
--- a/pkgs/development/compilers/crosstool-ng/configs.nix
+++ b/pkgs/development/compilers/crosstool-ng/configs.nix
@@ -1,0 +1,30 @@
+{
+  aarch64-unknown-linux-gnu = {
+    configFromSample = "aarch64-unknown-linux-gnu";
+    sourceSha256 = "sha256-+3PKqAkkeHcxQgylTWq3JuxuyjuvSuaG4XvoqaUA2aM=";
+  };
+  arm-unknown-linux-gnueabi = {
+    configFromSample = "arm-unknown-linux-gnueabi";
+    sourceSha256 = "sha256-mG0fY8tALheUwwBhYIP322nMwbzgatKo/Ph+1CblHM4";
+  };
+  mips-unknown-linux-gnu = {
+    configFromSample = "mips-unknown-linux-gnu";
+    sourceSha256 = "sha256-BG2KZEcCoi4NlbU1zlBUxdjjcOxLfCD7Jq5t8gMExfY=";
+  };
+  mips64-unknown-linux-gnu = {
+    configFromSample = "mips64-unknown-linux-gnu";
+    sourceSha256 = "sha256-2VRfA1/7SjO6hRnZZwZ3CgxlWKWcbYhMVr9WU8wh8AY=";
+  };
+  powerpc64le-unknown-linux-gnu = {
+    configFromSample = "powerpc64le-unknown-linux-gnu";
+    sourceSha256 = "sha256-rDsBUeBZII/oUFxLOVrEXuPAhMJlFEkX2dd/aN+JYk8=";
+  };
+  riscv64-unknown-elf = {
+    configFromSample = "riscv64-unknown-elf";
+    sourceSha256 = "sha256-mFFJj+HR8vBKr2Wnm56nYZZDyfpy56t2qB76yr36RMw=";
+  };
+  riscv64-unknown-linux-gnu = {
+    configFromSample = "riscv64-unknown-linux-gnu";
+    sourceSha256 = "sha256-z17r1FbCBxJDYnmntDg2ZN9Tmke6QlJQ2DvzmdRp/fQ=";
+  };
+}

--- a/pkgs/development/compilers/crosstool-ng/default.nix
+++ b/pkgs/development/compilers/crosstool-ng/default.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, autoconf
+, automake
+, binutils
+, bison
+, flex
+, gnum4
+, help2man
+, libtool
+, makeWrapper
+, ncurses
+, perl
+, python3
+, texinfo
+, unzip
+, wget
+, which
+}:
+
+stdenv.mkDerivation rec {
+  pname = "crosstool-ng";
+  version = "1.25.0";
+
+  src = fetchurl {
+    url = "http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-${version}.tar.xz";
+    sha256 = "sha256-aBYvNCJDzUGJ7XwfTjuxMCyqPyy7+DMYeb0B/gbGDNM=";
+  };
+
+  patches = [
+    # fix zlib download error
+    # remove in next release
+    (
+      fetchpatch {
+        name = "fix-zlib-download.patch";
+        url = "https://github.com/crosstool-ng/crosstool-ng/commit/878a16a13af1024356f2aa623ef7419ec82d4d76.patch";
+        sha256 = "sha256-yiui/i4JSEnR8G4fBydTpdI5yw8f6G6XiwuA3Axy4c4=";
+      }
+    )
+  ];
+
+  nativeBuildInputs = [
+    # remove in next release
+    autoconf
+    automake
+
+    binutils
+    bison
+    flex
+    help2man
+    libtool
+    makeWrapper
+    ncurses
+    python3
+    texinfo
+    unzip
+    wget
+    which
+  ];
+
+  preConfigure = ''
+    # let crosstool-ng find zlib 1.2.13
+    # remove in next release
+    patchShebangs .
+    touch packages/zlib/1.2.13/version.desc
+    ./bootstrap
+  '';
+
+  postInstall = ''
+    # add runtime dependencies to build toolchain
+    wrapProgram "$out/bin/ct-ng" \
+      --prefix PATH : ${lib.makeBinPath [ wget gnum4 which perl autoconf automake python3 binutils ]}
+  '';
+
+  # binutils interfere with code signing on darwin
+  dontStrip = stdenv.isDarwin;
+
+  meta = with lib; {
+    homepage = "https://crosstool-ng.github.io/";
+    description = "A versatile (cross-)toolchain generator";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ jiegec ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/development/compilers/crosstool-ng/fetcher.nix
+++ b/pkgs/development/compilers/crosstool-ng/fetcher.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, crosstool-ng
+, cacert
+, writeShellScript
+, preferLocalBuild ? true
+}:
+
+{ name
+, sha256
+  # use config from samples
+, configFromSample ? ""
+  # provide config content
+, configContent ? ""
+}:
+
+stdenv.mkDerivation {
+  pname = "crosstool-ng-src-${name}";
+  version = crosstool-ng.version;
+
+  unpackPhase = ''
+    if [ ! -z "${configFromSample}" ]
+    then
+      ct-ng ${configFromSample}
+    else
+      echo "${configContent}" > .config
+    fi
+
+    # override folders in config
+    mkdir -p tarballs
+    echo CT_LOCAL_TARBALLS_DIR=$PWD/tarballs >> .config
+    echo CT_PREFIX_DIR=$PWD/prefix >> .config
+  '';
+
+  buildPhase = ''
+    unset CC CXX
+    ct-ng source
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r tarballs $out/
+    cp .config $out/
+  '';
+
+  nativeBuildInputs = [ crosstool-ng cacert ];
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = sha256;
+
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
+  inherit preferLocalBuild;
+}
+

--- a/pkgs/development/compilers/crosstool-ng/toolchains.nix
+++ b/pkgs/development/compilers/crosstool-ng/toolchains.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, crosstool-ng
+, crosstool-ng-fetcher
+, cacert
+, python3
+, writeShellScript
+}:
+
+let toolchains = import ./configs.nix;
+in
+(builtins.mapAttrs
+  (name: { configFromSample, sourceSha256 }: stdenv.mkDerivation {
+    pname = "crosstool-ng-toolchain-${name}";
+    version = crosstool-ng.version;
+    src = crosstool-ng-fetcher {
+      inherit name;
+      sha256 = sourceSha256;
+      inherit configFromSample;
+    };
+
+    unpackPhase = ''
+      cp -r $src/.config .
+      chmod +w .config
+      echo CT_LOCAL_TARBALLS_DIR=$src/tarballs >> .config
+      echo CT_PREFIX_DIR=$PWD/prefix >> .config
+    '';
+
+    buildPhase = ''
+      unset CC CXX
+      ct-ng build
+    '';
+
+    installPhase = ''
+      cp -r prefix $out
+      rm -f $out/build.log.gz
+    '';
+
+    nativeBuildInputs = [ crosstool-ng python3 ];
+
+    # Fix error: '-Wformat-security' when building gcc
+    hardeningDisable = [ "format" ];
+
+    # patchelf complains wrong ELF type
+    dontPatchELF = true;
+
+    meta = with lib; {
+      homepage = "https://crosstool-ng.github.io/";
+      description = "toolchain built by crosstool-ng";
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ jiegec ];
+      platforms = platforms.unix;
+    };
+  })
+  toolchains)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13587,6 +13587,22 @@ with pkgs;
 
   cotton = callPackage ../development/tools/cotton { };
 
+  crosstool-ng = callPackage ../development/compilers/crosstool-ng { };
+
+  crosstool-ng-fetcher = callPackage ../development/compilers/crosstool-ng/fetcher.nix { };
+
+  crosstoolNgToolchains = callPackage ../development/compilers/crosstool-ng/toolchains.nix { };
+
+  crosstoolNgGcc = builtins.mapAttrs (name: value: wrapCCWith {
+    cc = value;
+    libc = value;
+    bintools = bintools.override {
+      libc = value;
+      # do not override dynamic linker
+      sharedLibraryLoader = null;
+    };
+  }) crosstoolNgToolchains;
+
   inherit (callPackages ../development/compilers/crystal {
     llvmPackages = if stdenv.system == "aarch64-darwin" then llvmPackages_11 else llvmPackages_10;
   })


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Crosstool-NG is a versatile (cross) toolchain generator. It supports many architectures and components and has a simple yet powerful menuconfig-style interface.

Homepage: https://crosstool-ng.github.io/

Provides cross compiling toolchains under crosstoolNgToolchains. You can
use pkgsCrosstoolNg to build packages using the toolchains.

For example, cross compile `hello` to ppc64le using `nix build
.#pkgsCrosstoolNg.powerpc64le-unknown-linux-gnu.hello`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
