### PR TITLE
krunner-translator: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10950,6 +10950,12 @@
     githubId = 138074;
     name = "Pedro Pombeiro";
   };
+  pongo1231 = {
+    email = "pongo1999712@gmail.com";
+    github = "pongo1231";
+    githubId = 4201956;
+    name = "pongo1231";
+  };
   poscat = {
     email = "poscat@mail.poscat.moe";
     github = "poscat0x04";

--- a/pkgs/tools/misc/krunner-translator/default.nix
+++ b/pkgs/tools/misc/krunner-translator/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, krunner
+, kconfigwidgets
+, ktextwidgets
+, kservice
+, ki18n
+, translate-shell
+, qtbase
+, qtdeclarative
+, qtlocation
+}:
+
+stdenv.mkDerivation rec {
+  pname = "krunner-translator";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "naraesk";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "8MusGvNhTxa8Sm8WiSwRaVIfZOeXmgcO4T6H9LqFGLs=";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+
+  dontWrapQtApps = true;
+
+  buildInputs = [
+    krunner
+    kconfigwidgets
+    ktextwidgets
+    kservice
+    ki18n
+    qtbase
+    qtdeclarative
+    qtlocation
+  ];
+
+  postPatch = ''
+    substituteInPlace src/translateShellProcess.cpp --replace "start(\"trans\", arguments);" "start(\"${translate-shell}/bin/trans\", arguments);"
+  '';
+
+  meta = with lib; {
+    description = "A plugin for KRunner which integrates a translator, supports Google Translate, Bing Translator, youdao and Baidu Fanyi";
+    homepage = "https://github.com/naraesk/krunner-translator";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ pongo1231 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8358,6 +8358,8 @@ with pkgs;
 
   krunner-pass = libsForQt5.callPackage ../tools/security/krunner-pass { };
 
+  krunner-translator = libsForQt5.callPackage ../tools/misc/krunner-translator { };
+
   krunvm = callPackage ../applications/virtualization/krunvm {
     inherit (darwin) sigtool;
   };


### PR DESCRIPTION
###### Description of changes

A translator plugin for KRunner, supporting Google Translate, Bing Translator, youdao and Baidu Fanyi.

Repository: https://github.com/naraesk/krunner-translator

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).