### PR TITLE
sauce: init at 1.0.0

### DIFF
--- a/pkgs/tools/graphics/sauce/default.nix
+++ b/pkgs/tools/graphics/sauce/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "sauce";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "cadecuddy";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-DqJirsbNl8bJuuYZN9nKHMDCgs6agkdx7s0o7h90So8=";
+  };
+
+  vendorHash = "sha256-E7fMnrMtOrPPkWwUZ30MvwSmAKxgSb4MpEcqP4zFEck=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd sauce \
+      --bash <($out/bin/sauce completion bash) \
+      --fish <($out/bin/sauce completion fish) \
+      --zsh <($out/bin/sauce completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "A CLI tool that identifies anime from an image";
+    homepage = "https://github.com/cadecuddy/sauce";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36992,6 +36992,8 @@ with pkgs;
 
   satysfi = callPackage ../tools/typesetting/satysfi { };
 
+  sauce = callPackage ../tools/graphics/sauce { };
+
   sc-controller = python3Packages.callPackage ../misc/drivers/sc-controller {
     inherit libusb1; # Shadow python.pkgs.libusb1.
   };


### PR DESCRIPTION
###### Description of changes

sauce uses [trace.moe](https://soruly.github.io/trace.moe-api/#/) to identify the anime in an image & serves you its essential details.

https://github.com/cadecuddy/sauce

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
