### PR TITLE
tt-rss: 2021-06-21 -> 2022-10-15

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1131,6 +1131,13 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>tt-rss</literal> service performs two database
+          migrations when you first use its web UI after upgrade.
+          Consider backing up its database before updating.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>pass-secret-service</literal> package now
           includes systemd units from upstream, so adding it to the
           NixOS <literal>services.dbus.packages</literal> option will

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -346,6 +346,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
   [systemd.oomd.enableRootSlice](options.html#opt-systemd.oomd.enableRootSlice),
   [systemd.oomd.enableSystemSlice](options.html#opt-systemd.oomd.enableSystemSlice),
   and [systemd.oomd.enableUserServices](options.html#opt-systemd.oomd.enableUserServices).
+  
+- The `tt-rss` service performs two database migrations when you first use its web UI after upgrade. Consider backing up its database before updating.
 
 - The `pass-secret-service` package now includes systemd units from upstream, so adding it to the NixOS `services.dbus.packages` option will make it start automatically as a systemd user service when an application tries to talk to the libsecret D-Bus API.
 

--- a/pkgs/servers/tt-rss/default.nix
+++ b/pkgs/servers/tt-rss/default.nix
@@ -2,13 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "tt-rss";
-  version = "unstable-2022-08-01";
-  rev = "cd26dbe64c9b14418f0b2d826a38a35c6bf8a270";
+  version = "unstable-2022-10-15";
 
   src = fetchgit {
     url = "https://git.tt-rss.org/fox/tt-rss.git";
-    rev = "ed2cbeffcc456a86726b52d37c977a35b895968c";
-    sha256 = "0ab1q316y4f432z2kwn86kc144awk529cild7b4jbffh2ydlj3r4";
+    rev = "602e8684258062937d7f554ab7889e8e02318c96";
+    sha256 = "sha256-vgRaxo998Gx9rVeZZl52jppK1v11jpEK0J0NoDMT44I=";
   };
 
   installPhase = ''
@@ -19,7 +18,7 @@ stdenv.mkDerivation rec {
 
     # see the code of Config::get_version(). you can check that the version in
     # the footer of the preferences pages is not UNKNOWN
-    echo "22.08" > $out/version_static.txt
+    echo "22.10" > $out/version_static.txt
 
     runHook postInstall
   '';

--- a/pkgs/servers/tt-rss/default.nix
+++ b/pkgs/servers/tt-rss/default.nix
@@ -1,16 +1,14 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
   pname = "tt-rss";
-  year = "21";
-  month = "06";
-  day = "21";
-  version = "20${year}-${month}-${day}";
+  version = "unstable-2022-08-01";
   rev = "cd26dbe64c9b14418f0b2d826a38a35c6bf8a270";
 
-  src = fetchurl {
-    url = "https://git.tt-rss.org/fox/tt-rss/archive/${rev}.tar.gz";
-    sha256 = "1dpmzi7hknv5rk2g1iw13r8zcxcwrhkd5hhf292ml0dw3cwki0gm";
+  src = fetchgit {
+    url = "https://git.tt-rss.org/fox/tt-rss.git";
+    rev = "ed2cbeffcc456a86726b52d37c977a35b895968c";
+    sha256 = "0ab1q316y4f432z2kwn86kc144awk529cild7b4jbffh2ydlj3r4";
   };
 
   installPhase = ''
@@ -21,7 +19,7 @@ stdenv.mkDerivation rec {
 
     # see the code of Config::get_version(). you can check that the version in
     # the footer of the preferences pages is not UNKNOWN
-    echo "${year}.${month}" > $out/version_static.txt
+    echo "22.08" > $out/version_static.txt
 
     runHook postInstall
   '';

--- a/pkgs/servers/tt-rss/plugin-auth-ldap/default.nix
+++ b/pkgs/servers/tt-rss/plugin-auth-ldap/default.nix
@@ -2,19 +2,20 @@
 
 stdenv.mkDerivation rec {
   pname = "tt-rss-plugin-auth-ldap";
-  version = "2.0.0";
+  version = "unstable-2022-10-31";
 
   src = fetchFromGitHub {
     owner = "hydrian";
     repo = "TTRSS-Auth-LDAP";
-    rev = version;
-    sha256 = "1mg9jff2m0ajxql1vd1g7hsxfbv9smhrmjg4j2gvvjbii45ry0jh";
+    rev = "0cc2a21441f99eef8368cfe0fbdbb78126e28d61";
+    sha256 = "sha256-pJWyvRnC38Ov1awVLgFZfp8+haADPniP+/P/C74qpcA=";
   };
 
   patches = [
+    # https://github.com/hydrian/TTRSS-Auth-LDAP/pull/47
     (fetchpatch {
-      url = "https://github.com/Mic92/TTRSS-Auth-LDAP/commit/7534fa54babc377a070e05e326a46a252b5e3884.patch";
-      sha256 = "1p7zas0n627z0g226dp5m5dg1ai2z3vi69n3xivp517iv3lch70l";
+      url = "https://github.com/hydrian/TTRSS-Auth-LDAP/commit/003ca55bbd6e0a87fb729383e51eb269d918313d.patch";
+      sha256 = "sha256-0YD33JPNOOPH2dpGwA/RbV3Kg4i2oKazBjP3hBcUIes=";
     })
     # https://github.com/hydrian/TTRSS-Auth-LDAP/pull/40
     (fetchpatch {


### PR DESCRIPTION
###### Description of changes

based on https://github.com/NixOS/nixpkgs/pull/184496

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
