### PR TITLE
python37Packages.setuptools-scm: fix in python 3.7

### DIFF
--- a/pkgs/development/python-modules/setuptools-scm/default.nix
+++ b/pkgs/development/python-modules/setuptools-scm/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , callPackage
 , fetchPypi
+, pythonOlder
 , packaging
 , typing-extensions
 , tomli
@@ -15,12 +16,25 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "setuptools_scm";
     inherit version;
-    sha256 = "sha256-Ax4Tr3cdb4krlBrbbqBFRbv5Hrxc5ox4qvP/9uH7SEQ=";
+    hash = "sha256-Ax4Tr3cdb4krlBrbbqBFRbv5Hrxc5ox4qvP/9uH7SEQ=";
   };
+
+  # We need to remove importlib-metadata as a dependency when using Python 3.7
+  # because it depends on setuptools_scm, and we build both from source.
+  #
+  # This still bootstraps because of:
+  #
+  #   https://github.com/pypa/setuptools_scm/pull/724
+  #
+  postPatch = lib.optionalString (pythonOlder "3.8") ''
+    substituteInPlace setup.cfg --replace "importlib-metadata;python_version < '3.8'" ""
+  '';
 
   propagatedBuildInputs = [
     packaging
     typing-extensions
+    # Once 7.0.6+ of setuptools_scm is released, make tomli only a dependency
+    # when Python < 3.11. See https://github.com/pypa/setuptools_scm/pull/748.
     tomli
     setuptools
   ];


### PR DESCRIPTION
###### Description of changes

We need to remove the dependency on importlib-metadata specified within setup.cfg, since importlib-metadata depends on setuptools-scm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
