### PR TITLE
minase: init at unstable-2023-01-15

### DIFF
--- a/pkgs/applications/file-managers/minase/default.nix
+++ b/pkgs/applications/file-managers/minase/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libuchardet
+, libiconv
+, taglib
+, zlib
+# Whether to use nano's syntax highlighting files
+, withNano ? true, nano
+}:
+
+stdenv.mkDerivation {
+  pname = "minase";
+  version = "unstable-2023-01-15";
+
+  src = fetchFromGitHub {
+    owner = "SAT1226";
+    repo = "Minase";
+    rev = "b9135d4d0f51fe27534f9ae0713d0fe952f5dd06"; # master
+    hash = "sha256-Ex44qVJOiLnz+kAqELCjKTTPagG0EpAPkCdv/OI05SM=";
+  };
+
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isx86) ''
+    substituteInPlace CMakeLists.txt --replace " -mfpmath=both" ""
+  '' + lib.optionalString withNano ''
+    substituteInPlace main.cpp --replace "/usr/share/nano" "${nano}/share/nano"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libuchardet
+    libiconv
+    taglib
+    zlib
+  ];
+
+  meta = with lib; {
+    description = "Terminal file manager";
+    homepage = "https://github.com/SAT1226/Minase";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ chuangzhu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2282,6 +2282,8 @@ with pkgs;
     inherit (darwin) autoSignDarwinBinariesHook;
   };
 
+  minase = callPackage ../applications/file-managers/minase { };
+
   mucommander = callPackage ../applications/file-managers/mucommander { };
 
   nimmm = callPackage ../applications/file-managers/nimmm { };


### PR DESCRIPTION
###### Description of changes

Terminal file manager

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

![2022-10-31T17:51:16,608297095+08:00](https://user-images.githubusercontent.com/31200881/198981230-bebc9c3d-1332-4a3e-a0e7-2d315a5c4316.png)
