### PR TITLE
git-credential-keepassxc: init at 0.10.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-credential-keepassxc/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-credential-keepassxc/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, DiskArbitration
+, Foundation
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-credential-keepassxc";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "Frederick888";
+    repo = "git-credential-keepassxc";
+    rev = "v${version}";
+    hash = "sha256-zVE3RQlh0SEV4iavz40YhR+MP31oLCvG54H8gqXwL/k=";
+  };
+
+  cargoHash = "sha256-H75SGbT//02I+umttnPM5BwtFkDVNxEYLf84oULEuEk=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ DiskArbitration Foundation ];
+
+  meta = with lib; {
+    description = "Helper that allows Git (and shell scripts) to use KeePassXC as credential store";
+    longDescription = ''
+      git-credential-keepassxc is a Git credential helper that allows Git
+      (and shell scripts) to get/store logins from/to KeePassXC.
+      It communicates with KeePassXC using keepassxc-protocol which is
+      originally designed for browser extensions.
+    '';
+    homepage = "https://github.com/Frederick888/git-credential-keepassxc";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6995,6 +6995,10 @@ with pkgs;
 
   git-credential-1password = callPackage ../applications/version-management/git-and-tools/git-credential-1password { };
 
+  git-credential-keepassxc = callPackage ../applications/version-management/git-and-tools/git-credential-keepassxc {
+    inherit (darwin.apple_sdk.frameworks) DiskArbitration Foundation;
+  };
+
   git-crecord = callPackage ../applications/version-management/git-crecord { };
 
   git-crypt = callPackage ../applications/version-management/git-and-tools/git-crypt { };


### PR DESCRIPTION
###### Description of changes

Helper that allows Git (and shell scripts) to use KeePassXC as credential store 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
