### PR TITLE
screenkey: 1.4 -> 1.5

### DIFF
--- a/pkgs/applications/video/screenkey/default.nix
+++ b/pkgs/applications/video/screenkey/default.nix
@@ -1,23 +1,23 @@
 { lib
 , fetchFromGitLab
-# native
 , wrapGAppsHook
-# not native
 , xorg
 , gobject-introspection
 , gtk3
+, libappindicator-gtk3
+, slop
 , python3
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "screenkey";
-  version = "1.4";
+  version = "1.5";
 
   src = fetchFromGitLab {
-    owner = "screenkey";
-    repo = "screenkey";
+    owner = pname;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1rfngmkh01g5192pi04r1fm7vsz6hg9k3qd313sn9rl9xkjgp11l";
+    hash = "sha256-kWktKzRyWHGd1lmdKhPwrJoSzAIN2E5TKyg30uhM4Ug=";
   };
 
   nativeBuildInputs = [
@@ -28,20 +28,24 @@ python3.pkgs.buildPythonApplication rec {
 
   buildInputs = [
     gtk3
+    libappindicator-gtk3
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
     babel
     pycairo
     pygobject3
+    dbus-python
   ];
 
   # Prevent double wrapping because of wrapGAppsHook
   dontWrapGApps = true;
-  # https://github.com/NixOS/nixpkgs/issues/56943
-  strictDeps = false;
+
   preFixup = ''
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    makeWrapperArgs+=(
+      --prefix PATH ":" "${lib.makeBinPath [ slop ]}"
+      "''${gappsWrapperArgs[@]}"
+      )
   '';
 
   # screenkey does not have any tests


### PR DESCRIPTION
###### Description of changes

https://gitlab.com/screenkey/screenkey/-/releases/v1.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
