### PR TITLE
efivar: 37 -> 38, efibootmgr: 17 -> 18

### DIFF
--- a/pkgs/tools/system/efibootmgr/default.nix
+++ b/pkgs/tools/system/efibootmgr/default.nix
@@ -1,36 +1,31 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, pkg-config, efivar, popt }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, efivar, popt }:
 
 stdenv.mkDerivation rec {
   pname = "efibootmgr";
-  version = "17";
-
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ efivar popt ];
+  version = "18";
 
   src = fetchFromGitHub {
     owner = "rhboot";
     repo = "efibootmgr";
     rev = version;
-    sha256 = "1niicijxg59rsmiw3rsjwy4bvi1n42dynvm01lnp9haixdzdpq03";
+    hash = "sha256-DYYQGALEn2+mRHgqCJsA7OQCF7xirIgQlWexZ9uoKcg=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "remove-extra-decl.patch";
-      url = "https://github.com/rhboot/efibootmgr/commit/99b578501643377e0b1994b2a068b790d189d5ad.patch";
-      sha256 = "1sbijvlpv4khkix3vix9mbhzffj8lp8zpnbxm9gnzjz8yssz9p5h";
-    })
-  ];
+  nativeBuildInputs = [ pkg-config ];
 
-  makeFlags = [ "EFIDIR=nixos" "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config" ];
+  buildInputs = [ efivar popt ];
+
+  makeFlags = [
+    "EFIDIR=nixos"
+    "PKG_CONFIG=${stdenv.cc.targetPrefix}pkg-config"
+  ];
 
   installFlags = [ "prefix=$(out)" ];
 
   meta = with lib; {
     description = "A Linux user-space application to modify the Intel Extensible Firmware Interface (EFI) Boot Manager";
     homepage = "https://github.com/rhboot/efibootmgr";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/system/efivar/default.nix
+++ b/pkgs/tools/system/efivar/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, buildPackages, fetchFromGitHub, fetchurl, pkg-config, popt }:
+{ lib, stdenv, buildPackages, fetchFromGitHub, pkg-config, popt, mandoc }:
 
 stdenv.mkDerivation rec {
   pname = "efivar";
-  version = "37";
+  version = "38";
 
   outputs = [ "bin" "out" "dev" "man" ];
 
@@ -10,42 +10,10 @@ stdenv.mkDerivation rec {
     owner = "rhinstaller";
     repo = "efivar";
     rev = version;
-    sha256 = "1z2dw5x74wgvqgd8jvibfff0qhwkc53kxg54v12pzymyibagwf09";
+    hash = "sha256-A38BKGMK3Vo+85wzgxmzTjzZXtpcY9OpbZaONWnMYNk=";
   };
-  patches = [
-    (fetchurl {
-      name = "r13y.patch";
-      url = "https://patch-diff.githubusercontent.com/raw/rhboot/efivar/pull/133.patch";
-      sha256 = "038cwldb8sqnal5l6mhys92cqv8x7j8rgsl8i4fiv9ih9znw26i6";
-    })
-    (fetchurl {
-      name = "fix-misaligned-pointer.patch";
-      url = "https://github.com/rhboot/efivar/commit/b98ba8921010d03f46704a476c69861515deb1ca.patch";
-      sha256 = "0ni9mz7y40a2wf1d1q5n9y5dhcbydxvfdhqic7zsmgnaxs3a0p27";
-    })
-    (fetchurl {
-      name = "fix-gcc9-error.patch";
-      url = "https://github.com/rhboot/efivar/commit/c3c553db85ff10890209d0fe48fb4856ad68e4e0.patch";
-      sha256 = "0lc38npydp069nlcga25wzzm204ww9l6mpjfn6wmhdfhn0pgjwky";
-    })
-    (fetchurl {
-      name = "remove_unused_variable.patch";
-      url = "https://github.com/rhboot/efivar/commit/fdb803402fb32fa6d020bac57a40c7efe4aabb7d.patch";
-      sha256 = "1xhy8v8ff9lyxb830n9hci2fbh7rfps6rwsqrjh4lw7316gwllsd";
-    })
-    (fetchurl {
-      name = "check_string_termination.patch";
-      url = "https://github.com/rhboot/efivar/commit/4e04afc2df9bbc26e5ab524b53a6f4f1e61d7c9e.patch";
-      sha256 = "1ajj11wwsvamfspq4naanvw08h63gr0g71q0dfbrrywrhc0jlmdw";
-    })
-  ];
 
-  NIX_CFLAGS_COMPILE = [
-    "-Wno-error=stringop-truncation"
-    "-flto-partition=none"
-  ];
-
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config mandoc ];
   buildInputs = [ popt ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
@@ -62,6 +30,6 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     description = "Tools and library to manipulate EFI variables";
     platforms = platforms.linux;
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
   };
 }


### PR DESCRIPTION
###### Description of changes

* https://github.com/rhboot/efibootmgr/releases/tag/18
* https://github.com/rhboot/efivar/releases/tag/38
  * Had to upgrade efivar from 37 -> 38 to fix efibootmgr build warning treated as error (Wno-pointer-sign)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
