### PR TITLE
extra-container: 0.10 -> 0.11

### DIFF
--- a/pkgs/tools/virtualization/extra-container/default.nix
+++ b/pkgs/tools/virtualization/extra-container/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "extra-container";
-  version = "0.10";
+  version = "0.11";
 
   src = fetchFromGitHub {
     owner = "erikarvstedt";


### PR DESCRIPTION
[Release notes](https://github.com/erikarvstedt/extra-container/blob/master/CHANGELOG.md#011-2022-10-22).

- [x] Tested on x86_64-linux

cc @Lassulus