### PR TITLE
pythonRelaxDepsHook: improve Requires-Dist parsing

### DIFF
--- a/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-relax-deps-hook.sh
@@ -22,6 +22,24 @@
 #     # pythonRemoveDeps = true;
 #     …
 #   }
+#
+# IMPLEMENTATION NOTES:
+#
+# The "Requires-Dist" dependency specification format is described in PEP 508.
+# Examples that the regular expressions in this hook needs to support:
+#
+# Requires-Dist: foo
+#   -> foo
+# Requires-Dist: foo[optional]
+#   -> foo[optional]
+# Requires-Dist: foo[optional]~=1.2.3
+#   -> foo[optional]
+# Requires-Dist: foo[optional, xyz] (~=1.2.3)
+#   -> foo[optional, xyz]
+# Requires-Dist: foo[optional]~=1.2.3 ; os_name = "posix"
+#   -> foo[optional] ; os_name = "posix"
+#
+# Currently unsupported: URL specs (foo @ https://example.com/a.zip).
 
 _pythonRelaxDeps() {
     local -r metadata_file="$1"
@@ -30,11 +48,11 @@ _pythonRelaxDeps() {
         return
     elif [[ "$pythonRelaxDeps" == 1 ]]; then
         sed -i "$metadata_file" -r \
-            -e 's/(Requires-Dist: \S*) \(.*\)/\1/'
+            -e 's/(Requires-Dist: [a-zA-Z0-9_.-]+\s*(\[[^]]+\])?)[^;]*(;.*)?/\1\3/'
     else
         for dep in $pythonRelaxDeps; do
             sed -i "$metadata_file" -r \
-                -e "s/(Requires-Dist: $dep) \(.*\)/\1/"
+                -e "s/(Requires-Dist: $dep\s*(\[[^]]+\])?)[^;]*(;.*)?/\1\3/"
         done
     fi
 }


### PR DESCRIPTION
###### Description of changes

Prior to this commit, pythonRelaxDeps would only support removing version constraints from "Requires-Dist" lines formatted in a particular way ("foo (>= 1.2.3)"). This way is deprecated as per PyPA Core Metadata Specs v2.1 [1]:

> Tools parsing the format should accept optional parentheses around
> this, but tools generating it should not use parentheses.

Additionally, a "Requires-Dist" dependency specification can contain other metadata than just package name and version (extra names, environment marker). These were being silently dropped by the prior version of pythonRelaxDeps, or the version could not be relaxed.

The actual grammar is defined in PEP 508 [2]. Our tool of choice here is sed extended regexps, so there's only so much we can do to be correct with this parser. The regexp implemented in this commit makes an attempt at supporting [extra] names, ; env_markers, as well as version specs without parentheses. There are still unsupported features (URL specs) as well as unhandled edge cases, but at some point trying to make the regexp better is bound to awaken ZALGO [3].

[1] https://packaging.python.org/en/latest/specifications/core-metadata/#requires-dist-multiple-use
[2] https://peps.python.org/pep-0508/#grammar
[3] https://stackoverflow.com/a/1732454/179806
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
