### PR TITLE
arrow-cpp: 9.0.0 -> 10.0.1

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -52,27 +52,29 @@ assert lib.asserts.assertMsg
 
 let
   arrow-testing = fetchFromGitHub {
+    name = "arrow-testing";
     owner = "apache";
     repo = "arrow-testing";
-    rev = "5bab2f264a23f5af68f69ea93d24ef1e8e77fc88";
-    hash = "sha256-Pxx8ohUpXb5u1995IvXmxQMqWiDJ+7LAll/AjQP7ph8=";
+    rev = "00c483283433b4c02cb811f260dbe35414c806a4";
+    hash = "sha256-x645DFowLk0e4JN2hI6asWlJlhN36vg5/eC3wTbFI2k=";
   };
 
   parquet-testing = fetchFromGitHub {
+    name = "parquet-testing";
     owner = "apache";
     repo = "parquet-testing";
-    rev = "aafd3fc9df431c2625a514fb46626e5614f1d199";
-    hash = "sha256-cO5t/mgsbBhbSefx8EMGTyxmgTjhZ8mFujkFQ3p/JS0=";
+    rev = "e13af117de7c4f0a4d9908ae3827b3ab119868f3";
+    hash = "sha256-rVI9zyk9IRDlKv4u8BeMb0HRdWLfCpqOlYCeUdA7BB8=";
   };
 
 in
 stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "9.0.0";
+  version = "10.0.1";
 
   src = fetchurl {
     url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    hash = "sha256-qaAz8KNJAomZj0WGgNGVec8HkRcXumWv3my4AHD3qbU=";
+    hash = "sha256-yBTgZwESoiwabsA6tCClKuI2qaQunkOMPL03835lj7M=";
   };
   sourceRoot = "apache-arrow-${version}/cpp";
 
@@ -97,8 +99,8 @@ stdenv.mkDerivation rec {
   ARROW_XSIMD_URL = fetchFromGitHub {
     owner = "xtensor-stack";
     repo = "xsimd";
-    rev = "8.1.0";
-    hash = "sha256-Aqs6XJkGjAjGAp0PprabSM4m+32M/UXpSHppCHdzaZk=";
+    rev = "9.0.1";
+    hash = "sha256-onALN6agtrHWigtFlCeefD9CiRZI4Y690XTzy2UDnrk=";
   };
 
   ARROW_SUBSTRAIT_URL = fetchFromGitHub {
@@ -137,18 +139,17 @@ stdenv.mkDerivation rec {
     utf8proc
     zlib
     zstd
-  ] ++ lib.optionals enableShared [
-    python3.pkgs.python
-    python3.pkgs.numpy
   ] ++ lib.optionals enableFlight [
     grpc
     openssl
     protobuf
+    sqlite
   ] ++ lib.optionals enableS3 [ aws-sdk-cpp openssl ]
   ++ lib.optionals enableGcs [
     crc32c
     curl
-    google-cloud-cpp grpc
+    google-cloud-cpp
+    grpc
     nlohmann_json
   ];
 
@@ -172,16 +173,12 @@ stdenv.mkDerivation rec {
     "-DARROW_COMPUTE=ON"
     "-DARROW_CSV=ON"
     "-DARROW_DATASET=ON"
-    "-DARROW_ENGINE=ON"
     "-DARROW_FILESYSTEM=ON"
     "-DARROW_FLIGHT_SQL=${if enableFlight then "ON" else "OFF"}"
     "-DARROW_HDFS=ON"
     "-DARROW_IPC=ON"
     "-DARROW_JEMALLOC=${if enableJemalloc then "ON" else "OFF"}"
     "-DARROW_JSON=ON"
-    "-DARROW_PLASMA=ON"
-    # Disable Python for static mode because openblas is currently broken there.
-    "-DARROW_PYTHON=${if enableShared then "ON" else "OFF"}"
     "-DARROW_USE_GLOG=ON"
     "-DARROW_WITH_BACKTRACE=ON"
     "-DARROW_WITH_BROTLI=ON"
@@ -192,20 +189,21 @@ stdenv.mkDerivation rec {
     "-DARROW_WITH_ZLIB=ON"
     "-DARROW_WITH_ZSTD=ON"
     "-DARROW_MIMALLOC=ON"
-    # Parquet options:
-    "-DARROW_PARQUET=ON"
     "-DARROW_SUBSTRAIT=ON"
-    "-DPARQUET_BUILD_EXECUTABLES=ON"
     "-DARROW_FLIGHT=${if enableFlight then "ON" else "OFF"}"
     "-DARROW_FLIGHT_TESTING=${if enableFlight then "ON" else "OFF"}"
     "-DARROW_S3=${if enableS3 then "ON" else "OFF"}"
     "-DARROW_GCS=${if enableGcs then "ON" else "OFF"}"
+    # Parquet options:
+    "-DARROW_PARQUET=ON"
+    "-DPARQUET_BUILD_EXECUTABLES=ON"
+    "-DPARQUET_REQUIRE_ENCRYPTION=ON"
   ] ++ lib.optionals (!enableShared) [
     "-DARROW_TEST_LINKAGE=static"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DCMAKE_INSTALL_RPATH=@loader_path/../lib" # needed for tools executables
-  ] ++ lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF"
-  ++ lib.optional enableS3 "-DAWSSDK_CORE_HEADER_FILE=${aws-sdk-cpp}/include/aws/core/Aws.h"
+  ] ++ lib.optionals (!stdenv.isx86_64) [ "-DARROW_USE_SIMD=OFF" ]
+  ++ lib.optionals enableS3 [ "-DAWSSDK_CORE_HEADER_FILE=${aws-sdk-cpp}/include/aws/core/Aws.h" ]
   ++ lib.optionals enableGcs [ "-DCMAKE_CXX_STANDARD=${grpc.cxxStandard}" ];
 
   doInstallCheck = true;
@@ -228,26 +226,27 @@ stdenv.mkDerivation rec {
         "TestS3FSGeneric.*"
       ];
     in
-    lib.optionalString doInstallCheck "-${builtins.concatStringsSep ":" filteredTests}";
+    lib.optionalString doInstallCheck "-${lib.concatStringsSep ":" filteredTests}";
+
   __darwinAllowLocalNetworking = true;
-  installCheckInputs = [ perl which sqlite ] ++ lib.optional enableS3 minio;
-  installCheckPhase =
-    let
-      excludedTests = lib.optionals stdenv.isDarwin [
-        # Some plasma tests need to be patched to use a shorter AF_UNIX socket
-        # path on Darwin. See https://github.com/NixOS/nix/pull/1085
-        "plasma-external-store-tests"
-        "plasma-client-tests"
-      ] ++ [ "arrow-gcsfs-test" ];
-    in
-    ''
-      runHook preInstallCheck
 
-      ctest -L unittest \
-        --exclude-regex '^(${builtins.concatStringsSep "|" excludedTests})$'
+  installCheckInputs = [ perl which sqlite ]
+    ++ lib.optionals enableS3 [ minio ]
+    ++ lib.optionals enableFlight [ python3 ];
 
-      runHook postInstallCheck
-    '';
+  disabledTests = [
+    # requires networking
+    "arrow-gcsfs-test"
+    "arrow-flight-integration-test"
+  ];
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    ctest -L unittest --exclude-regex '^(${lib.concatStringsSep "|" disabledTests})$'
+
+    runHook postInstallCheck
+  '';
 
   meta = with lib; {
     description = "A cross-language development platform for in-memory data";

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -120,6 +120,8 @@ buildPythonPackage rec {
     "--deselect=pyarrow/tests/test_flight.py::test_large_descriptor"
     "--deselect=pyarrow/tests/test_flight.py::test_large_metadata_client"
     "--deselect=pyarrow/tests/test_flight.py::test_none_action_side_effect"
+    # fails to compile
+    "--deselect=pyarrow/tests/test_cython.py::test_cython_api"
   ] ++ lib.optionals stdenv.isLinux [
     # this test requires local networking
     "--deselect=pyarrow/tests/test_fs.py::test_filesystem_from_uri_gcs"

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -17,18 +17,15 @@
 , pkg-config
 , scipy
 , setuptools-scm
-, six
 }:
 
 let
   zero_or_one = cond: if cond then 1 else 0;
-
-  _arrow-cpp = arrow-cpp.override { python3 = python; };
 in
 
 buildPythonPackage rec {
   pname = "pyarrow";
-  inherit (_arrow-cpp) version src;
+  inherit (arrow-cpp) version src;
 
   disabled = pythonOlder "3.7";
 
@@ -41,13 +38,14 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  buildInputs = [ arrow-cpp ];
+
   propagatedBuildInputs = [
     cffi
     cloudpickle
     fsspec
     numpy
     scipy
-    six
   ];
 
   checkInputs = [
@@ -60,20 +58,24 @@ buildPythonPackage rec {
   PYARROW_BUILD_TYPE = "release";
 
   PYARROW_WITH_DATASET = zero_or_one true;
-  PYARROW_WITH_FLIGHT = zero_or_one _arrow-cpp.enableFlight;
+  PYARROW_WITH_FLIGHT = zero_or_one arrow-cpp.enableFlight;
   PYARROW_WITH_HDFS = zero_or_one true;
   PYARROW_WITH_PARQUET = zero_or_one true;
-  PYARROW_WITH_PLASMA = zero_or_one (!stdenv.isDarwin);
-  PYARROW_WITH_S3 = zero_or_one _arrow-cpp.enableS3;
+  PYARROW_WITH_PARQUET_ENCRYPTION = zero_or_one true;
+  # Plasma is deprecated since arrow 10.0.0
+  PYARROW_WITH_PLASMA = zero_or_one false;
+  PYARROW_WITH_S3 = zero_or_one arrow-cpp.enableS3;
+  PYARROW_WITH_GCS = zero_or_one arrow-cpp.enableGcs;
+  PYARROW_BUNDLE_ARROW_CPP_HEADERS = zero_or_one false;
 
   PYARROW_CMAKE_OPTIONS = [
     "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib"
   ];
 
-  ARROW_HOME = _arrow-cpp;
-  PARQUET_HOME = _arrow-cpp;
+  ARROW_HOME = arrow-cpp;
+  PARQUET_HOME = arrow-cpp;
 
-  ARROW_TEST_DATA = lib.optionalString doCheck _arrow-cpp.ARROW_TEST_DATA;
+  ARROW_TEST_DATA = lib.optionalString doCheck arrow-cpp.ARROW_TEST_DATA;
 
   doCheck = true;
 
@@ -83,6 +85,13 @@ buildPythonPackage rec {
 
   preBuild = ''
     export PYARROW_PARALLEL=$NIX_BUILD_CORES
+  '';
+
+  postInstall = ''
+    # copy the pyarrow C++ header files to the appropriate location
+    pyarrow_include="$out/${python.sitePackages}/pyarrow/include"
+    mkdir -p "$pyarrow_include/arrow/python"
+    find "$PWD/pyarrow/src/arrow" -type f -name '*.h' -exec cp {} "$pyarrow_include/arrow/python" \;
   '';
 
   pytestFlagsArray = [
@@ -102,6 +111,8 @@ buildPythonPackage rec {
     "--deselect=pyarrow/tests/test_pandas.py::test_threaded_pandas_import"
     # Flaky test, works locally but not on Hydra
     "--deselect=pyarrow/tests/test_csv.py::TestThreadedCSVTableRead::test_cancellation"
+    # expects arrow-cpp headers to be bundled
+    "--deselect=pyarrow/tests/test_misc.py::test_get_include"
   ] ++ lib.optionals stdenv.isDarwin [
     # Requires loopback networking
     "--deselect=pyarrow/tests/test_ipc.py::test_socket_"
@@ -109,7 +120,12 @@ buildPythonPackage rec {
     "--deselect=pyarrow/tests/test_flight.py::test_large_descriptor"
     "--deselect=pyarrow/tests/test_flight.py::test_large_metadata_client"
     "--deselect=pyarrow/tests/test_flight.py::test_none_action_side_effect"
+  ] ++ lib.optionals stdenv.isLinux [
+    # this test requires local networking
+    "--deselect=pyarrow/tests/test_fs.py::test_filesystem_from_uri_gcs"
   ];
+
+  disabledTests = [ "GcsFileSystem" ];
 
   dontUseSetuptoolsCheck = true;
 
@@ -125,7 +141,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "pyarrow"
-  ] ++ map (module: "pyarrow.${module}") ([
+  ] ++ map (module: "pyarrow.${module}") [
     "compute"
     "csv"
     "dataset"
@@ -135,9 +151,7 @@ buildPythonPackage rec {
     "hdfs"
     "json"
     "parquet"
-  ] ++ lib.optionals (!stdenv.isDarwin) [
-    "plasma"
-  ]);
+  ];
 
   meta = with lib; {
     description = "A cross-language development platform for in-memory data";


### PR DESCRIPTION
###### Description of changes

This PR bumps arrow-cpp to version 10.0.0.

Notes:

1. ~This PR currently depends on #198469.~
1. ~To avoid what I believe to be cxx abi issues, I had to set `cxxStandard` to 17
   for abseil-cpp, and `-DCMAKE_CXX_STANDARD=17` for grpc and google-cloud-cpp.~ The default of 17 works!
1. ~Arrow itself now requires `CMAKE_CXX_STANDARD` to be set to 17.~

I'm not sure if this should go to `staging`, but happy to move it there if so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
