### PR TITLE
prom2json: 1.3.0 to 1.3.2

### DIFF
--- a/pkgs/servers/monitoring/prometheus/prom2json.nix
+++ b/pkgs/servers/monitoring/prometheus/prom2json.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "prom2json";
-  version = "1.3.0";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "prometheus";
     repo = "prom2json";
-    sha256 = "09glf7br1a9k6j2hs94l2k4mlmlckdz5c9v6qg618c2nd4rk1mz6";
+    sha256 = "sha256-5RPpgUEFLecu0qRg7KSNLwdUEiXeebrGdP/udCtq4z0=";
   };
 
-  vendorSha256 = null;
+  vendorSha256 = "sha256-fPGkqrnl21as1xiT279qPzkz01tDNOSMcsm/DSNHDU0=";
 
   meta = with lib; {
     description = "Tool to scrape a Prometheus client and dump the result as JSON";


### PR DESCRIPTION
This also builds successfully on Mac (Darwin) now, whereas previously it was failing during go compilation due to an old version of transitive dependency `golang.org/x/sys`.

###### Description of changes

https://github.com/prometheus/prom2json/releases/tag/v1.3.1:
> There are no code changes in this release. It merely comes with updated
dependencies, and the pre-built binaries are using Go1.18.1., both to avoid potential security issues. (Note that this is just precaution. We do not know of any relevant vulnerabilities in v1.3.0.)

https://github.com/prometheus/prom2json/releases/tag/v1.3.2:
> There are no code changes in this release. It merely comes with updated
dependencies, and the pre-built binaries are using Go1.19.2., both to avoid potential security issues. (Note that this is just precaution. We do not know of any relevant vulnerabilities in v1.3.1.)

###### Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

`nixpkgs-review` output:

```
> nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
this path will be fetched (0.04 MiB download, 0.13 MiB unpacked):
  /nix/store/rwycdglbh7hcw72ywb63407nxr2wh6z7-nixpkgs-review-2.7.0
copying path '/nix/store/rwycdglbh7hcw72ywb63407nxr2wh6z7-nixpkgs-review-2.7.0' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   9d0f7e2a819..07912c408a2  master     -> refs/nixpkgs-review/0
$ git worktree add /home/caleb/.cache/nixpkgs-review/rev-d2cb74254c9f27ff3d597bdd89a0071a6af6a915/nixpkgs 07912c408a223a18475e767dcf04fea8f5f1e140
Preparing worktree (detached HEAD 07912c408a2)
Updating files: 100% (32529/32529), done.
HEAD is now at 07912c408a2 lutris: set unshareIpc and unsharePid to false
$ nix-env --option system x86_64-linux -f /home/caleb/.cache/nixpkgs-review/rev-d2cb74254c9f27ff3d597bdd89a0071a6af6a915/nixpkgs -qaP --xml --out-path --show
trace
$ git merge --no-commit --no-ff d2cb74254c9f27ff3d597bdd89a0071a6af6a915
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/caleb/.cache/nixpkgs-review/rev-d2cb74254c9f27ff3d597bdd89a0071a6af6a915/nixpkgs -qaP --xml --out-path --show
trace --meta
1 package updated:
prom2json (1.3.0 → 1.3.2)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/caleb/.cache/nixpkgs-review/rev-d2cb74254c9f27ff3d597bdd89a0071a6af6a915/build.nix
1 package built:
prom2json

$ /nix/store/3qilwj844f5wz18mh0lc6ffzj4gcca02-nix-2.11.0/bin/nix-shell /home/caleb/.cache/nixpkgs-review/rev-d2cb74254c9f27ff3d597bdd89a0071a6af6a915/shell.nix
[nix-shell:~/.cache/nixpkgs-review/rev-d2cb74254c9f27ff3d597bdd89a0071a6af6a915]$ cat report.json
{
    "blacklisted": [],
    "broken": [],
    "built": [
        "prom2json"
    ],
    "failed": [],
    "non-existant": [],
    "pr": null,
    "system": "x86_64-linux",
    "tests": []
}
```