### PR TITLE
austin, austin-python, austin-tui: init

### DIFF
--- a/pkgs/development/python-modules/austin-python/default.nix
+++ b/pkgs/development/python-modules/austin-python/default.nix
@@ -2,7 +2,7 @@
 , lib
 , buildPythonPackage
 
-, austin
+, austin ? null  # Avoid circular dependency between austin / austin-python.
 , fetchFromGitHub
 , hatchling
 , hatch-vcs
@@ -33,8 +33,11 @@ buildPythonPackage rec {
     # Fixup paths to dependencies usually found in PATH.
     substituteInPlace austin/tools/resolve.py \
       --replace '"addr2line"' '"${stdenv.cc.bintools}/bin/addr2line"'
-    substituteInPlace austin/__init__.py \
-      --replace 'return self.BINARY' 'return "${austin}/bin/austin"'
+    ${if austin == null then ""
+      else ''
+        substituteInPlace austin/__init__.py \
+          --replace 'return self.BINARY' 'return "${austin}/bin/austin"'
+      ''}
   '';
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -55,6 +58,8 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
   ];
+
+  doCheck = austin != null;
 
   pythonRelaxDeps = [ "protobuf" ];
 

--- a/pkgs/development/python-modules/austin-python/default.nix
+++ b/pkgs/development/python-modules/austin-python/default.nix
@@ -1,0 +1,83 @@
+{ stdenv
+, lib
+, buildPythonPackage
+
+, austin
+, fetchFromGitHub
+, hatchling
+, hatch-vcs
+, poetry-core
+, protobuf
+, psutil
+, pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "austin-python";
+  version = "1.4.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "p403n1x87";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-ddzv17lxj+59NMEe13eUNUmuzezrLY5q08+2Rrocp9E=";
+  };
+
+  postPatch = ''
+    # Fixup paths to dependencies usually found in PATH.
+    substituteInPlace austin/tools/resolve.py \
+      --replace '"addr2line"' '"${stdenv.cc.bintools}/bin/addr2line"'
+    substituteInPlace austin/__init__.py \
+      --replace 'return self.BINARY' 'return "${austin}/bin/austin"'
+  '';
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    hatchling
+    hatch-vcs
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    protobuf
+    psutil
+    toml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonRelaxDeps = [ "protobuf" ];
+
+  disabledTests = [
+    # With the way we patch austin-python to find austin (from the Nix store
+    # instead of $PATH) the tests always find a proper austin binary, causing
+    # them to fail. This is fine, it just means the error condition this is
+    # trying to test cannot happen with Nix.
+    "test_async_invalid_binary"
+    "test_simple_invalid_binary"
+    "test_threaded_invalid_binary"
+
+    # https://github.com/P403n1x87/austin-python/pull/14
+    "test_threaded_bad_options"
+  ];
+
+  pythonImportsCheck = [ "austin" ];
+
+  meta = with lib; {
+    description = "Python wrapper for Austin, the CPython frame stack sampler";
+    homepage = "https://github.com/P403n1x87/austin-python";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/development/python-modules/austin-tui/default.nix
+++ b/pkgs/development/python-modules/austin-tui/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, buildPythonPackage
+
+, austin-python
+, fetchFromGitHub
+, importlib-resources
+, lxml
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+}:
+
+buildPythonPackage rec {
+  pname = "austin-tui";
+  version = "1.2.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "p403n1x87";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-S8K+Ys1PnFs8/7h1Z013xpEUVCEwVhJdZrEk07k56/M=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "poetry.masonry.api" "poetry.core.masonry.api" \
+      --replace 'version = "0.0.0"' 'version = "${version}"' \
+      --replace "^1.1.0*" "^1.1.0"
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    austin-python
+    importlib-resources
+    lxml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonRelaxDeps = [ "importlib-resources" ];
+
+  pythonImportsCheck = [ "austin_tui" ];
+
+  meta = with lib; {
+    description = "The top-like text-based user interface for Austin";
+    homepage = "https://github.com/P403n1x87/austin-tui";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/development/tools/profiling/austin/default.nix
+++ b/pkgs/development/tools/profiling/austin/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, testers
+, autoreconfHook, libbfd, libiberty, libunwind, zlib
+, austin  # For testVersion
+}:
+
+stdenv.mkDerivation rec {
+  pname = "austin";
+  version = "3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "p403n1x87";
+    repo = "austin";
+    rev = "v${version}";
+    hash = "sha256-R/LxGHapPjaaTbJh6/CxT49WvX3zg7u+mATQGZCEXtk=";
+  };
+
+  patches = [
+    # https://github.com/P403n1x87/austin/issues/152
+    (fetchpatch {
+      url = "https://github.com/P403n1x87/austin/commit/1e26986ecd8981460af5b9bd6526d6560f9c16a0.patch";
+      hash = "sha256-c+r1iLMXkPU3Mzn8qyZv0EDnTbrxZQrWGdRkebNTN/4=";
+    })
+  ];
+
+  postPatch = ''
+    # Allow linking with dynamic libraries. Replace "-l:libfoo.a" -> "-lfoo".
+    sed -ri 's/-l:lib([^.]*).a/-l\1/g' configure.ac
+  '';
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [
+    libbfd
+    libiberty
+    libunwind
+    zlib
+  ];
+
+  # TODO: run test suite in checkPhase. This requires currently unavailable
+  # dependencies, and has some slightly annoying circular dependencies
+  # (uses austin-python).
+
+  passthru = {
+    tests.austin-version = testers.testVersion {
+      package = austin;
+    };
+    tests.austinp-version = testers.testVersion {
+      package = austin;
+      command = "austinp --version";
+    };
+  };
+
+  meta = with lib; {
+    description = "Python frame stack sampler for CPython";
+    homepage = "https://github.com/p403n1x87/austin";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16311,6 +16311,8 @@ with pkgs;
 
   austin = callPackage ../development/tools/profiling/austin { };
 
+  austin-tui = with python3Packages; toPythonApplication austin-tui;
+
   automaticcomponenttoolkit = callPackage ../development/tools/misc/automaticcomponenttoolkit { };
 
   aviator = callPackage ../development/tools/misc/aviator { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16309,6 +16309,8 @@ with pkgs;
 
   astyle = callPackage ../development/tools/misc/astyle { };
 
+  austin = callPackage ../development/tools/profiling/austin { };
+
   automaticcomponenttoolkit = callPackage ../development/tools/misc/automaticcomponenttoolkit { };
 
   aviator = callPackage ../development/tools/misc/aviator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -752,6 +752,8 @@ self: super: with self; {
 
   aurorapy = callPackage ../development/python-modules/aurorapy { };
 
+  austin-python = callPackage ../development/python-modules/austin-python { };
+
   autarco = callPackage ../development/python-modules/autarco { };
 
   auth0-python = callPackage ../development/python-modules/auth0-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -754,6 +754,8 @@ self: super: with self; {
 
   austin-python = callPackage ../development/python-modules/austin-python { };
 
+  austin-tui = callPackage ../development/python-modules/austin-tui { };
+
   autarco = callPackage ../development/python-modules/autarco { };
 
   auth0-python = callPackage ../development/python-modules/auth0-python { };


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/issues/198752

Austin is a stack trace sampling profiler for CPython applications.

Submitted as draft for now since it requires #198802 (first commit of this PR).

![out](https://user-images.githubusercontent.com/202798/199077508-940d9e22-4976-4def-8f33-a270d2a0dc0c.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
