### PR TITLE
factorio: better mod support

### DIFF
--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -39,7 +39,7 @@ let
   } // cfg.extraSettings;
   serverSettingsFile = pkgs.writeText "server-settings.json" (builtins.toJSON (filterAttrsRecursive (n: v: v != null) serverSettings));
   serverAdminsFile = pkgs.writeText "server-adminlist.json" (builtins.toJSON cfg.admins);
-  modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods;
+  modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods cfg.mods-dat;
 in
 {
   options = {
@@ -134,6 +134,13 @@ in
           the .zip, named correctly, into the output directory. Eventually,
           there will be a way to pull in the most up-to-date list of
           derivations via nixos-channel. Until then, this is for experts only.
+        '';
+      };
+      mods-dat = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = lib.mdDoc ''
+        Mods settings can be changed by specifying a dat file.
         '';
       };
       game-name = mkOption {

--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -140,7 +140,9 @@ in
         type = types.nullOr types.path;
         default = null;
         description = lib.mdDoc ''
-        Mods settings can be changed by specifying a dat file.
+          Mods settings can be changed by specifying a dat file, in the [mod
+          settings file
+          format](https://wiki.factorio.com/Mod_settings_file_format).
         '';
       };
       game-name = mkOption {

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -3,6 +3,7 @@
 , libSM, libICE, libXext, factorio-utils
 , releaseType
 , mods ? []
+, versionsJson ? ./versions.json
 , username ? "", token ? "" # get/reset token at https://factorio.com/profile
 , experimental ? false # true means to always use the latest branch
 }:
@@ -60,7 +61,7 @@ let
 
   # NB `experimental` directs us to take the latest build, regardless of its branch;
   # hence the (stable, experimental) pairs may sometimes refer to the same distributable.
-  versions = importJSON ./versions.json;
+  versions = importJSON versionsJson;
   binDists = makeBinDists versions;
 
   actual = binDists.${stdenv.hostPlatform.system}.${releaseType}.${branch} or (throw "Factorio ${releaseType}-${branch} binaries for ${stdenv.hostPlatform.system} are not available for download.");

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -3,6 +3,7 @@
 , libSM, libICE, libXext, factorio-utils
 , releaseType
 , mods ? []
+, mods-dat ? null
 , versionsJson ? ./versions.json
 , username ? "", token ? "" # get/reset token at https://factorio.com/profile
 , experimental ? false # true means to always use the latest branch
@@ -130,7 +131,7 @@ let
     fi
   '';
 
-  modDir = factorio-utils.mkModDirDrv mods;
+  modDir = factorio-utils.mkModDirDrv mods mods-dat;
 
   base = with actual; {
     pname = "factorio-${releaseType}";

--- a/pkgs/games/factorio/utils.nix
+++ b/pkgs/games/factorio/utils.nix
@@ -3,7 +3,7 @@
 { lib, stdenv }:
 with lib;
 {
-  mkModDirDrv = mods: # a list of mod derivations
+  mkModDirDrv = mods: modsDatFile: # a list of mod derivations
     let
       recursiveDeps = modDrv: [modDrv] ++ map recursiveDeps modDrv.deps;
       modDrvs = unique (flatten (map recursiveDeps mods));
@@ -18,7 +18,9 @@ with lib;
           # NB: there will only ever be a single zip file in each mod derivation's output dir
           ln -s $modDrv/*.zip $out
         done
-      '';
+      '' + (if modsDatFile != null then ''
+       cp ${modsDatFile} $out/mod-settings.dat
+      '' else "");
     };
 
     modDrv = { allRecommendedMods, allOptionalMods }:

--- a/pkgs/games/factorio/utils.nix
+++ b/pkgs/games/factorio/utils.nix
@@ -18,9 +18,9 @@ with lib;
           # NB: there will only ever be a single zip file in each mod derivation's output dir
           ln -s $modDrv/*.zip $out
         done
-      '' + (if modsDatFile != null then ''
+      '' + (lib.optionalString (modsDatFile != null) ''
        cp ${modsDatFile} $out/mod-settings.dat
-      '' else "");
+      '');
     };
 
     modDrv = { allRecommendedMods, allOptionalMods }:


### PR DESCRIPTION
###### Description of changes

1. Allow us to provide updated versions via a customJson file.
2. Factorio fires an error message about unwritable mod settings as it's in the nix-store, this tweak lets us provide a dat file to allow custom settings.

I also have an ugly script for building a mod listed here: https://github.com/YellowOnion/factorio-mods that I tested it against: https://github.com/YellowOnion/nixos-config/blob/factorio-testing/selene.nix

@Baughn @elitak @erictapen @priegger @lukegb @leifhelm
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [] (Package updates) Added a release notes entry if the change is major or breaking
  - [] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
