### PR TITLE
debian-devscripts: 2.16.8 -> 2.22.2, fix debchange editor

### DIFF
--- a/pkgs/tools/misc/debian-devscripts/default.nix
+++ b/pkgs/tools/misc/debian-devscripts/default.nix
@@ -1,7 +1,7 @@
 {lib, stdenv, fetchurl, xz, dpkg
 , libxslt, docbook_xsl, makeWrapper, writeScript
 , python3Packages
-, perlPackages, curl, gnupg, diffutils, nano
+, perlPackages, curl, gnupg, diffutils, nano, pkg-config, bash-completion, help2man
 , sendmailPath ? "/run/wrappers/bin/sendmail"
 }:
 
@@ -12,17 +12,23 @@ let
     exec ''${EDITOR-${nano}/bin/nano} "$@"
   '';
 in stdenv.mkDerivation rec {
-  version = "2.16.8";
+  version = "2.22.2";
   pname = "debian-devscripts";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/d/devscripts/devscripts_${version}.tar.xz";
-    sha256 = "0xy1nvqrnifx46g8ch69pk31by0va6hn10wpi1fkrsrgncanjjh1";
+    hash = "sha256-Fflalt2JxqLS0gq0wy88pXCqiNvHj7sfP7fLwdSmUCs=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ xz dpkg libxslt python setuptools curl gnupg diffutils ] ++
+  buildInputs = [ xz dpkg libxslt python setuptools curl gnupg diffutils pkg-config bash-completion help2man ] ++
     (with perlPackages; [ perl CryptSSLeay LWP TimeDate DBFile FileDesktopEntry ParseDebControl LWPProtocolHttps ]);
+
+  postPatch = ''
+    substituteInPlace scripts/Makefile --replace /usr/share/dpkg ${dpkg}/share/dpkg
+    substituteInPlace scripts/debrebuild.pl --replace /usr/bin/perl ${perlPackages.perl}/bin/perl
+    patchShebangs scripts
+  '';
 
   preConfigure = ''
     export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${dpkg}";

--- a/pkgs/tools/misc/debian-devscripts/default.nix
+++ b/pkgs/tools/misc/debian-devscripts/default.nix
@@ -7,8 +7,7 @@
 
 let
   inherit (python3Packages) python setuptools;
-  sensible-editor = writeScript "sensible-editor" ''
-    #!/bin/sh
+  sensible-editor = writeShellScript "sensible-editor" ''
     exec ''${EDITOR-${nano}/bin/nano} "$@"
   '';
 in stdenv.mkDerivation rec {
@@ -20,15 +19,15 @@ in stdenv.mkDerivation rec {
     hash = "sha256-Fflalt2JxqLS0gq0wy88pXCqiNvHj7sfP7fLwdSmUCs=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ xz dpkg libxslt python setuptools curl gnupg diffutils pkg-config bash-completion help2man ] ++
-    (with perlPackages; [ perl CryptSSLeay LWP TimeDate DBFile FileDesktopEntry ParseDebControl LWPProtocolHttps ]);
-
   postPatch = ''
     substituteInPlace scripts/Makefile --replace /usr/share/dpkg ${dpkg}/share/dpkg
     substituteInPlace scripts/debrebuild.pl --replace /usr/bin/perl ${perlPackages.perl}/bin/perl
     patchShebangs scripts
   '';
+
+  nativeBuildInputs = [ makeWrapper pkg-config ];
+  buildInputs = [ xz dpkg libxslt python setuptools curl gnupg diffutils bash-completion help2man ] ++
+    (with perlPackages; [ perl CryptSSLeay LWP TimeDate DBFile FileDesktopEntry ParseDebControl LWPProtocolHttps ]);
 
   preConfigure = ''
     export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${dpkg}";
@@ -64,7 +63,7 @@ in stdenv.mkDerivation rec {
       wrapProgram "$i" \
         --prefix PERL5LIB : "$PERL5LIB" \
         --prefix PERL5LIB : "$out/share/devscripts" \
-        --prefix PYTHONPATH : "$out/lib/${python.libPrefix}/site-packages" \
+        --prefix PYTHONPATH : "$out/${python.sitePackages}" \
         --prefix PATH : "${dpkg}/bin"
     done
   '';

--- a/pkgs/tools/misc/debian-devscripts/default.nix
+++ b/pkgs/tools/misc/debian-devscripts/default.nix
@@ -1,5 +1,5 @@
 {lib, stdenv, fetchurl, xz, dpkg
-, libxslt, docbook_xsl, makeWrapper, writeScript
+, libxslt, docbook_xsl, makeWrapper, writeShellScript
 , python3Packages
 , perlPackages, curl, gnupg, diffutils, nano, pkg-config, bash-completion, help2man
 , sendmailPath ? "/run/wrappers/bin/sendmail"


### PR DESCRIPTION
###### Description of changes

Makes `debchange` work by supplying an implementation of `sensible-editor`. I was surprised to not see something already existing for this in nixpkgs, but a small wrapper achieves the same effect:

```
nix build github:mikepurvis/nixpkgs/fix-debian-devscripts-debchange#debian-devscripts

# Opens nano by default
result/bin/debchange

# Opens vim as expected
EDITOR=vim result/bin/debchange
```

~~I looked at bumping forward the version as well, since `2.16.8` is from 2016, but it looked like it was going to be a non-trivial effort to do so, so I've left that for a separate PR.~~ Never mind, PR is updated to bump the version as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).