### PR TITLE
freedv: 1.8.3.1 -> 1.8.4

### DIFF
--- a/pkgs/applications/radio/freedv/default.nix
+++ b/pkgs/applications/radio/freedv/default.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "freedv";
-  version = "1.8.3.1";
+  version = "1.8.4";
 
   src = fetchFromGitHub {
     owner = "drowe67";
     repo = "freedv-gui";
     rev = "v${version}";
-    hash = "sha256-LPCY5gPinxJkfPfumKggI/JQorcW+Qw/ZAP6XQmPkeA=";
+    hash = "sha256-X/jL6q2yLNtRq7Xg9JeXu1zXD0KCs59D1poA9hM3Ndo=";
   };
 
   postPatch = lib.optionalString stdenv.isDarwin ''
@@ -58,11 +58,14 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DUSE_INTERNAL_CODEC2:BOOL=FALSE"
     "-DUSE_STATIC_DEPS:BOOL=FALSE"
+    "-DUNITTEST=ON"
   ] ++ lib.optionals pulseSupport [ "-DUSE_PULSEAUDIO:BOOL=TRUE" ];
 
   NIX_CFLAGS_COMPILE = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
     "-DAPPLE_OLD_XCODE"
   ];
+
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://freedv.org/";

--- a/pkgs/development/libraries/codec2/default.nix
+++ b/pkgs/development/libraries/codec2/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, freedvSupport ? false
+, lpcnetfreedv
+, codec2
+}:
 
 stdenv.mkDerivation rec {
   pname = "codec2";
@@ -13,6 +20,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  buildInputs = lib.optionals freedvSupport [
+    lpcnetfreedv
+  ];
+
   # Install a binary that is used by openwebrx
   postInstall = ''
     install -Dm0755 src/freedv_rx -t $out/bin/
@@ -26,6 +37,8 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     # RPATH of binary /nix/store/.../bin/freedv_rx contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
+  ] ++ lib.optionals freedvSupport [
+    "-DLPCNET=ON"
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/lpcnetfreedv/default.nix
+++ b/pkgs/development/libraries/lpcnetfreedv/default.nix
@@ -4,21 +4,21 @@ let
   dataVersion = "191005_v1.0";
   data = fetchurl {
     url = "http://rowetel.com/downloads/deep/lpcnet_${dataVersion}.tgz";
-    sha256 = "1j1695hm2pg6ri611f9kr3spm4yxvpikws55z9zxizai8y94152h";
+    sha256 = "sha256-UJRAkkdR/dh/+qVoPuPd3ZN69cgzuRBMzOZdUWFJJsg=";
   };
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "lpcnetfreedv";
-  version = "unstable-2021-06-29";
+  version = "unstable-2022-08-22";
 
   src = fetchFromGitHub {
     owner = "drowe67";
     repo = "LPCNet";
-    rev = "0dc5935bbf49ff3ba3c9654cc2f802838ebbaead";
-    sha256 = "0r6488z40fkar11ync8achpg5l6qz7y7cbh7cs3b3w4fsxn58q9i";
+    rev = "67a6eb74d0c07faddcdce199856862cc45779d25";
+    sha256 = "sha256-eHYZoDgoZBuuLvQn9X7H/zmK5onOAniOgY1/8RVn8gk=";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ codec2 ];
 
   postPatch = ''
     mkdir build

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28614,6 +28614,9 @@ with pkgs;
 
   freedv = callPackage ../applications/radio/freedv {
     inherit (darwin.apple_sdk.frameworks) AppKit AVFoundation Cocoa CoreMedia;
+    codec2 = codec2.override {
+      freedvSupport = true;
+    };
   };
 
   freemind = callPackage ../applications/misc/freemind {


### PR DESCRIPTION
###### Description of changes

Supersedes #198804.

https://github.com/drowe67/freedv-gui/releases/tag/v1.8.4
https://github.com/drowe67/LPCNet/releases/tag/v0.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
