### PR TITLE
python310Packages.tox: 3.26.0 -> 3.27.0

### DIFF
--- a/pkgs/development/python-modules/tox/default.nix
+++ b/pkgs/development/python-modules/tox/default.nix
@@ -1,29 +1,40 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , packaging
 , pluggy
 , py
 , six
 , virtualenv
 , setuptools-scm
-, toml
+, tomli
 , filelock
 }:
 
 buildPythonPackage rec {
   pname = "tox";
-  version = "3.26.0";
-
-  buildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ packaging pluggy py six virtualenv toml filelock ];
-
-  doCheck = false;
+  version = "3.27.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-RPPDR8aMLGh5nX1E8YCPnTlvyKGlAMvGJCUzdceuEH4=";
+    hash = "sha256-0slF8CoD1FATdKPVQwh3OA3rabIYsd+bfx0vKhC++vk=";
   };
+
+  buildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    packaging
+    pluggy
+    py
+    six
+    virtualenv
+    filelock
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ];
+
+  doCheck = false;
 
   meta = with lib; {
     description = "Virtualenv-based automation of test activities";


### PR DESCRIPTION
###### Description of changes

https://github.com/tox-dev/tox/releases/tag/3.27.0

In addition, this fixes `tox` so that it works again. Since https://github.com/tox-dev/tox/pull/2463 released on 3.26.0, `toml` has been switched to `tomli` for Python versions 3.6 to 3.10.

Older versions still depend on `toml`, but since they are EOLed, I removed that dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
