### PR TITLE
python310Packages.dill: 0.3.5.1 -> 0.3.6

### DIFF
--- a/pkgs/development/python-modules/dill/default.nix
+++ b/pkgs/development/python-modules/dill/default.nix
@@ -1,41 +1,31 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
+, python
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "dill";
-  version = "0.3.5.1";
+  version = "0.3.6";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "uqfoundation";
     repo = pname;
     rev = "refs/tags/dill-${version}";
-    sha256 = "sha256-gWE7aQodblgHjUqGAzOJGgxJ4qx9wHo/DU4KRE6JMWo=";
+    hash = "sha256-lh1o/TqnqtYN9xTZom33y1/7ZhMEAFpheLdtalwgObQ=";
   };
 
-  checkInputs = [
-    pytestCheckHook
+  nativeBuildInputs = [
+    setuptools
   ];
 
-  # Tests seem to fail because of import pathing and referencing items/classes in modules.
-  # Seems to be a Nix/pathing related issue, not the codebase, so disabling failing tests.
-  disabledTestPaths = [
-    "tests/test_diff.py"
-    "tests/test_module.py"
-    "tests/test_objects.py"
-    "tests/test_session.py"
-  ];
-
-  disabledTests = [
-    "test_class_objects"
-    "test_importable"
-    "test_method_decorator"
-    "test_the_rest"
-    # test exception catching needs updating, can probably be removed with next update
-    "test_recursive_function"
-  ];
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} dill/tests/__main__.py
+    runHook postCheck
+  '';
 
   pythonImportsCheck = [ "dill" ];
 
@@ -43,6 +33,6 @@ buildPythonPackage rec {
     description = "Serialize all of python (almost)";
     homepage = "https://github.com/uqfoundation/dill/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ tjni ];
   };
 }


### PR DESCRIPTION
1. Update version so that it is compatible with Python 3.11.
2. Run tests the same way that dill does.
3. Add myself to the maintainer list.

I also tried to fix the tests using pytest and pytestCheckHook, but I could not do it. I found https://github.com/uqfoundation/dill/issues/460, which has more information about this difficulty. In the meantime, I feel it is better to run all the tests in a custom way than stick to pytest and skip many of them.

I found that this is needed also by https://github.com/NixOS/nixpkgs/issues/198533.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
