### PR TITLE
python3Packages.brian2: init at 2.5.1

### DIFF
--- a/pkgs/development/python-modules/brian2/default.nix
+++ b/pkgs/development/python-modules/brian2/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cython
+, jinja2
+, numpy
+, pyparsing
+, setuptools
+, sympy
+, pytest
+, pytest-xdist
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "brian2";
+  version = "2.5.1";
+
+  src = fetchPypi {
+    pname = "Brian2";
+    inherit version;
+    sha256 = "sha256-x1EcS7PFCsjPYsq3Lt87SJRW4J5DE/OfdFs3NuyHiLw=";
+  };
+
+  propagatedBuildInputs = [
+    cython
+    jinja2
+    numpy
+    pyparsing
+    setuptools
+    sympy
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-xdist
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    # Cython cache lies in home directory
+    export HOME=$(mktemp -d)
+    cd $HOME && ${python.interpreter} -c "import brian2;assert brian2.test()"
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "A clock-driven simulator for spiking neural networks";
+    homepage = "https://briansimulator.org/";
+    license = licenses.cecill21;
+    maintainers = with maintainers; [ jiegec ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1372,6 +1372,8 @@ self: super: with self; {
 
   brelpy = callPackage ../development/python-modules/brelpy { };
 
+  brian2 = callPackage ../development/python-modules/brian2 { };
+
   broadlink = callPackage ../development/python-modules/broadlink { };
 
   brother = callPackage ../development/python-modules/brother { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Brian is a free, open source simulator for spiking neural networks. It is written in the Python programming language and is available on almost all platforms.

Homepage: http://brian2.readthedocs.org/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
