### PR TITLE
ruby: refactor extract patches out of the generic builder

### DIFF
--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,20 +1,20 @@
-{ patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
+{ rvmPatchsets }:
 
 {
-  "2.7.6" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-with-openssl-dir-option.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/04-more-detailed-stacktrace.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/05-malloc-trim.patch"
+  "2.7.6" = [
+    "${rvmPatchsets}/patches/ruby/2.7/head/railsexpress/01-fix-with-openssl-dir-option.patch"
+    "${rvmPatchsets}/patches/ruby/2.7/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch"
+    "${rvmPatchsets}/patches/ruby/2.7/head/railsexpress/03-improve-gc-stats.patch"
+    "${rvmPatchsets}/patches/ruby/2.7/head/railsexpress/04-more-detailed-stacktrace.patch"
+    "${rvmPatchsets}/patches/ruby/2.7/head/railsexpress/05-malloc-trim.patch"
   ];
-  "3.0.4" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/03-malloc-trim.patch"
+  "3.0.4" = [
+    "${rvmPatchsets}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"
+    "${rvmPatchsets}/patches/ruby/3.0/head/railsexpress/02-improve-gc-stats.patch"
+    "${rvmPatchsets}/patches/ruby/3.0/head/railsexpress/03-malloc-trim.patch"
   ];
-  "3.1.2" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/3.1/head/railsexpress/02-malloc-trim.patch"
+  "3.1.2" = [
+    "${rvmPatchsets}/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch"
+    "${rvmPatchsets}/patches/ruby/3.1/head/railsexpress/02-malloc-trim.patch"
   ];
 }


### PR DESCRIPTION
###### Description of changes

This change moves the calculation of patches out of the generic builder,
which allows external callers of `mkRuby` to specify patches for any
ruby versions.

The compiled ruby artifacts maintain the same checksums as before.

Alternative to https://github.com/NixOS/nixpkgs/pull/198249, which
causes an import from derivation problem because of `readDir`.

And here's a possible usage: https://github.com/juanibiapina/nixpkgs-ruby/pull/1 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).