### PR TITLE
python310Packages.{fsspec,gcsfs,s3fs}: 2022.8.2 -> 2022.10.0

### DIFF
--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -17,16 +17,16 @@
 
 buildPythonPackage rec {
   pname = "fsspec";
-  version = "2022.8.2";
+  version = "2022.10.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = "intake";
+    owner = "fsspec";
     repo = "filesystem_spec";
     rev = version;
-    hash = "sha256-eT1zqTbU5kfQ7bvzigT9579HfXU6VaOEjRg8VG/DHMI=";
+    hash = "sha256-+lPt/zqI3Mkt+QRNXq+Dxm3h/ryZJsfrmayVi/BTtbg=";
   };
 
   propagatedBuildInputs = [
@@ -68,7 +68,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A specification that Python filesystems should adhere to";
-    homepage = "https://github.com/intake/filesystem_spec";
+    homepage = "https://github.com/fsspec/filesystem_spec";
     changelog = "https://github.com/fsspec/filesystem_spec/raw/${version}/docs/source/changelog.rst";
     license = licenses.bsd3;
     maintainers = with maintainers; [ costrouc ];

--- a/pkgs/development/python-modules/gcsfs/default.nix
+++ b/pkgs/development/python-modules/gcsfs/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "gcsfs";
-  version = "2022.8.2";
+  version = "2022.10.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "fsspec";
     repo = pname;
     rev = version;
-    hash = "sha256-BnnKFrWz47izKc7nS8NR1Vze1x9kJdYBsQT2KEY9ghM=";
+    hash = "sha256-+S4AziibYWos/hZ1v3883b1Vv3y4xjIDUrQ8c2XJ1MQ=";
   };
 
   propagatedBuildInputs = [
@@ -66,6 +66,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Convenient Filesystem interface over GCS";
     homepage = "https://github.com/fsspec/gcsfs";
+    changelog = "https://github.com/fsspec/gcsfs/raw/${version}/docs/source/changelog.rst";
     license = licenses.bsd3;
     maintainers = with maintainers; [ nbren12 ];
   };

--- a/pkgs/development/python-modules/s3fs/default.nix
+++ b/pkgs/development/python-modules/s3fs/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "s3fs";
-  version = "2022.8.2";
+  version = "2022.10.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-PKBwGomp4SWijekIKdGflvQd2x2LQ3kHbCntgsSvhs0=";
+    hash = "sha256-6N64DyC9CyBZFBuHT9udauuMzjUxLqXywCsiWnigBAY=";
   };
 
   buildInputs = [
@@ -42,8 +42,9 @@ buildPythonPackage rec {
 
   meta = with lib; {
     broken = stdenv.isDarwin;
-    homepage = "https://github.com/dask/s3fs/";
     description = "A Pythonic file interface for S3";
+    homepage = "https://github.com/fsspec/s3fs";
+    changelog = "https://github.com/fsspec/s3fs/raw/${version}/docs/source/changelog.rst";
     license = licenses.bsd3;
     maintainers = with maintainers; [ teh ];
   };


### PR DESCRIPTION
###### Description of changes

* Upgrade python310Packages.fsspec from 2022.8.2 to 2022.10.0
  * See https://github.com/fsspec/filesystem_spec/blob/master/docs/source/changelog.rst#2022100

* Upgrade python310Packages.gcsfs from 2022.8.2 to 2022.10.0
  * See https://github.com/fsspec/gcsfs/blob/2022.10.0/docs/source/changelog.rst

* Upgrade python310Packages.s3fs from 2022.8.2 to 2022.10.0
  * See https://github.com/fsspec/s3fs/blob/2022.10.0/docs/source/changelog.rst

* Fixed renamed Github repository URL
* Fixed failing auto-upgrade by adding updateScript
  * See https://r.ryantm.com/log/python310Packages.fsspec/2022-11-01.log

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
