### PR TITLE
linuxdeployqt: init at 20220821, 5fa79fa1

### DIFF
--- a/pkgs/development/tools/linuxdeployqt/default.nix
+++ b/pkgs/development/tools/linuxdeployqt/default.nix
@@ -1,0 +1,49 @@
+{ lib, stdenv, fetchFromGitHub, cmake, qtbase }:
+
+# WARNING: Supported only for use with glibc version 2.27 or older.
+# In order to use it with newer glibc you can use the following flags:
+# -unsupported-allow-new-glibc and -unsupported-bundle-everything
+# https://github.com/probonopd/linuxdeployqt/issues/340
+stdenv.mkDerivation rec {
+  pname = "linuxdeployqt";
+  version = "20220821";
+  commit = "5fa79fa1df0788b45ed04963d7478d4e68fda2f8c";
+  name = "${pname}-${version}-${lib.substring 0 8 commit}";
+
+  src = fetchFromGitHub {
+    owner = "probonopd";
+    repo = "linuxdeployqt";
+    rev = commit;
+    sha256 = "sha256-HNReONrdDnJf+s48m/vxmrkuba+1KmRwYTjtj+QKioo=";
+  };
+
+  cmakeFlags = [
+    "-DGIT_COMMIT=${commit}"
+    "-DGIT_TAG_NAME=${version}"
+  ];
+
+  TRAVIS_BUILD_NUMBER = version;
+
+  dontWrapQtApps = true;
+
+  buildInputs = [ qtbase ];
+  nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp tools/linuxdeployqt/linuxdeployqt $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Tool for bundling QT AppImages";
+    longDescription = ''
+      Makes Linux applications self-contained by copying in the libraries and
+      plugins that the application uses, and optionally generates an AppImage.
+      Can be used for Qt and other applications.
+    '';
+    homepage = "https://github.com/probonopd/linuxdeployqt";
+    license = with licenses; [ gpl3 lgpl3 ];
+    maintainers = with maintainers; [ jakubgs ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1365,6 +1365,8 @@ with pkgs;
 
   license-generator = callPackage ../tools/misc/license-generator { };
 
+  linuxdeployqt = libsForQt5.callPackage ../development/tools/linuxdeployqt { };
+
   linux-router = callPackage ../tools/networking/linux-router { };
 
   linux-router-without-wifi = linux-router.override { useWifiDependencies = false; };


### PR DESCRIPTION
###### Description of changes
Makes Linux applications self-contained by copying in the libraries and plugins that the application uses, and optionally generates an AppImage. Can be used for Qt and other applications.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).