### PR TITLE
crimson-pro: init at unstable-2022-08-30

### DIFF
--- a/pkgs/data/fonts/crimson-pro/default.nix
+++ b/pkgs/data/fonts/crimson-pro/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "crimson-pro";
+  version = "unstable-2022-08-30";
+
+  outputs = [ "out" "woff2" ];
+
+  src = fetchFromGitHub {
+    owner = "Fonthausen";
+    repo = "CrimsonPro";
+    rev = "24e8f7bf59ec45d77c67879ad80d97e5f94c787b";
+    hash = "sha256-3zFB1AMcC7eNEVA2Mx1OE8rLN9zPzexZ3FtER9wH5ss=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m444 -Dt $out/share/fonts/truetype fonts/ttf/*.ttf
+    install -m444 -Dt $out/share/fonts/opentype fonts/otf/*.otf
+    install -m444 -Dt $woff2/share/fonts/woff2 fonts/webfonts/*.woff2
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Fonthausen/CrimsonPro";
+    description = "A professionally produced redesign of Crimson by Jacques Le Bailly";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ncfavier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26043,6 +26043,8 @@ with pkgs;
 
   crimson = callPackage ../data/fonts/crimson {};
 
+  crimson-pro = callPackage ../data/fonts/crimson-pro {};
+
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts {});
 
   # solve collision for nix-env before https://github.com/NixOS/nix/pull/815


### PR DESCRIPTION
A professionally produced redesign of Crimson by Jacques Le Bailly. https://github.com/Fonthausen/CrimsonPro

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
