### PR TITLE
mgmt, nex: init at unstable

### DIFF
--- a/pkgs/applications/system/mgmt/default.nix
+++ b/pkgs/applications/system/mgmt/default.nix
@@ -1,0 +1,67 @@
+{ augeas
+, buildGoModule
+, fetchFromGitHub
+, gotools
+, lib
+, libvirt
+, libxml2
+, nex
+, pkg-config
+, ragel
+}:
+buildGoModule rec {
+  pname = "mgmt";
+  version = "unstable-2022-10-24";
+
+  src = fetchFromGitHub {
+    owner = "purpleidea";
+    repo = pname;
+    rev = "d8820fa1855668d9e0f7a7829d9dd0d122b2c5a9";
+    hash = "sha256-jurZvEtiaTjWeDkmCJDIFlTzR5EVglfoDxkFgOilo8s=";
+  };
+
+  # patching must be done in prebuild, so it is shared with go-modules
+  # see https://github.com/NixOS/nixpkgs/issues/208036
+  preBuild = ''
+    for file in `find -name Makefile -type f`; do
+      substituteInPlace $file --replace "/usr/bin/env " ""
+    done
+
+    substituteInPlace lang/types/Makefile \
+      --replace "unset GOCACHE && " ""
+    patchShebangs misc/header.sh
+    make lang funcgen
+  '';
+
+  buildInputs = [
+    augeas
+    libvirt
+    libxml2
+  ];
+
+  nativeBuildInputs = [
+    gotools
+    nex
+    pkg-config
+    ragel
+  ];
+
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.program=${pname}"
+    "-X main.version=${version}"
+  ];
+
+  subPackages = [ "." ];
+
+  vendorHash = "sha256-Dtqy4TILN+7JXiHKHDdjzRTsT8jZYG5sPudxhd8znXY=";
+
+  meta = with lib; {
+    description = "Next generation distributed, event-driven, parallel config management!";
+    homepage = "https://mgmtconfig.com";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/development/tools/parsing/nex/default.nix
+++ b/pkgs/development/tools/parsing/nex/default.nix
@@ -1,0 +1,27 @@
+{ buildGoPackage
+, fetchFromGitHub
+, lib
+}:
+# upstream is pretty stale, but it still works, so until they merge module
+# support we have to use gopath: see blynn/nex#57
+buildGoPackage rec {
+  pname = "nex";
+  version = "unstable-2021-03-30";
+
+  src = fetchFromGitHub {
+    owner = "blynn";
+    repo = pname;
+    rev = "1a3320dab988372f8910ccc838a6a7a45c8980ff";
+    hash = "sha256-DtJkV380T2B5j0+u7lYZfbC0ej0udF4GW2lbRmmbjAM=";
+  };
+
+  goPackagePath = "github.com/blynn/nex";
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Lexer for Go";
+    homepage = "https://github.com/blynn/nex";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17804,6 +17804,8 @@ with pkgs;
 
   nap = callPackage ../development/tools/nap { };
 
+  nex = callPackage ../development/tools/parsing/nex {};
+
   ninja = callPackage ../development/tools/build-managers/ninja { };
 
   nimbo = with python3Packages; callPackage ../applications/misc/nimbo { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1429,6 +1429,8 @@ with pkgs;
 
   mnc = callPackage ../tools/misc/mnc { };
 
+  mgmt = callPackage ../applications/system/mgmt {};
+
   mprocs = callPackage ../tools/misc/mprocs { };
 
   nominatim = callPackage ../servers/nominatim { };


### PR DESCRIPTION
###### Description of changes

This change adds two packages: mgmt and nex. The latter is a build dependency for the former. Unfortunately both do not have stable releases, thus each tracks the tip of their respective upstream branches. Go module pseudo versions are used.

mgmt: Next generation distributed, event-driven, parallel config management!
nex: Lexer for Go

Fixes #98458 purpleidea/mgmt#610

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
