### PR TITLE
python310Packages.cairocffi: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/cairocffi/default.nix
+++ b/pkgs/development/python-modules/cairocffi/default.nix
@@ -7,6 +7,7 @@
 , substituteAll
 , makeFontsConf
 , freefont_ttf
+, pikepdf
 , pytest
 , glibcLocales
 , cairo
@@ -21,41 +22,14 @@
 
 buildPythonPackage rec {
   pname = "cairocffi";
-  version = "1.3.0";
+  version = "1.4.0";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-EIo6fLCeIDvdhQHZuq2R14bSBFYb1x6TZOizSJfEe5E=";
+    sha256 = "sha256-UJM5syzNjXsAwiBMMnNs3njbU6MuahYtMSR40lYmzZo=";
   };
-
-  LC_ALL = "en_US.UTF-8";
-
-  # checkPhase require at least one 'normal' font and one 'monospace',
-  # otherwise glyph tests fails
-  FONTCONFIG_FILE = makeFontsConf {
-    fontDirectories = [ freefont_ttf ];
-  };
-
-  propagatedBuildInputs = [ cairo cffi ] ++ lib.optional withXcffib xcffib;
-  propagatedNativeBuildInputs = [ cffi ];
-
-  # pytestCheckHook does not work
-  checkInputs = [ numpy pytest glibcLocales ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "pytest-runner" "" \
-      --replace "pytest-cov" "" \
-      --replace "pytest-flake8" "" \
-      --replace "pytest-isort" "" \
-      --replace "--flake8 --isort" ""
-  '';
-
-  checkPhase = ''
-    py.test $out/${python.sitePackages}
-  '';
 
   patches = [
     # OSError: dlopen() failed to load a library: gdk-pixbuf-2.0 / gdk-pixbuf-2.0-0
@@ -68,6 +42,35 @@ buildPythonPackage rec {
     })
     ./fix_test_scaled_font.patch
   ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "pytest-runner" "" \
+      --replace "pytest-cov" "" \
+      --replace "pytest-flake8" "" \
+      --replace "pytest-isort" "" \
+      --replace "--flake8 --isort" ""
+  '';
+
+  LC_ALL = "en_US.UTF-8";
+
+  # checkPhase require at least one 'normal' font and one 'monospace',
+  # otherwise glyph tests fails
+  FONTCONFIG_FILE = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
+
+  propagatedNativeBuildInputs = [ cffi ];
+
+  propagatedBuildInputs = [ cairo cffi ]
+    ++ lib.optional withXcffib xcffib;
+
+  # pytestCheckHook does not work
+  checkInputs = [ numpy pikepdf pytest glibcLocales ];
+
+  checkPhase = ''
+    py.test $out/${python.sitePackages}
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/SimonSapin/cairocffi";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
