### PR TITLE
nixos/containerd: Add nerdctl rootless support

### DIFF
--- a/nixos/modules/virtualisation/containerd.nix
+++ b/nixos/modules/virtualisation/containerd.nix
@@ -1,47 +1,82 @@
 { pkgs, lib, config, ... }:
 let
   cfg = config.virtualisation.containerd;
+  proxy_env = config.networking.proxy.envVars;
 
-  configFile = if cfg.configFile == null then
-    settingsFormat.generate "containerd.toml" cfg.settings
-  else
-    cfg.configFile;
+  configFile =
+    if cfg.configFile == null then
+      settingsFormat.generate "containerd.toml" cfg.settings
+    else
+      cfg.configFile;
 
-  containerdConfigChecked = pkgs.runCommand "containerd-config-checked.toml" {
-    nativeBuildInputs = [ pkgs.containerd ];
-  } ''
+  containerdConfigChecked = pkgs.runCommand "containerd-config-checked.toml"
+    {
+      nativeBuildInputs = [ pkgs.containerd ];
+    } ''
     containerd -c ${configFile} config dump >/dev/null
     ln -s ${configFile} $out
   '';
 
-  settingsFormat = pkgs.formats.toml {};
+  settingsFormat = pkgs.formats.toml { };
+
+  containerdUnit = "containerd.service";
 in
 {
 
   options.virtualisation.containerd = with lib.types; {
     enable = lib.mkEnableOption (lib.mdDoc "containerd container runtime");
 
+    package = lib.mkOption {
+      default = pkgs.containerd;
+      defaultText = lib.literalExpression "pkgs.containerd";
+      type = types.package;
+      description = lib.mdDoc ''
+        containerd package to be used in the module.
+      '';
+    };
+
     configFile = lib.mkOption {
       default = null;
       description = lib.mdDoc ''
-       Path to containerd config file.
-       Setting this option will override any configuration applied by the settings option.
+        Path to containerd config file.
+        Setting this option will override any configuration applied by the settings option.
       '';
       type = nullOr path;
     };
 
     settings = lib.mkOption {
       type = settingsFormat.type;
-      default = {};
+      default = { };
       description = lib.mdDoc ''
         Verbatim lines to add to containerd.toml
       '';
     };
 
     args = lib.mkOption {
-      default = {};
+      default = { };
       description = lib.mdDoc "extra args to append to the containerd cmdline";
       type = attrsOf str;
+    };
+
+    nerdctl.enable = lib.mkOption {
+      type = bool;
+      default = true;
+      example = false;
+      description = lib.mdDoc "Whether to enable nerdctl rootless mode.";
+    };
+
+    nerdctl.package = lib.mkOption {
+      default = pkgs.nerdctl;
+      defaultText = lib.literalExpression "pkgs.nerdctl";
+      type = types.package;
+      description = lib.mdDoc "nerdctl package to be used in the module.";
+    };
+
+    nerdctl.portDriver = lib.mkOption {
+      default = "builtin";
+      defaultText = lib.literalExpression "pkgs.nerdctl";
+      type = types.enum [ "builtin" "slirp4netns" ];
+      description = lib.mdDoc "Port driver to be used";
     };
   };
 
@@ -55,14 +90,15 @@ in
       settings = {
         version = 2;
         plugins."io.containerd.grpc.v1.cri" = {
-         containerd.snapshotter =
-           lib.mkIf config.boot.zfs.enabled (lib.mkOptionDefault "zfs");
-         cni.bin_dir = lib.mkOptionDefault "${pkgs.cni-plugins}/bin";
+          containerd.snapshotter =
+            lib.mkIf config.boot.zfs.enabled (lib.mkOptionDefault "zfs");
+          cni.bin_dir = lib.mkOptionDefault "${pkgs.cni-plugins}/bin";
         };
       };
     };
 
-    environment.systemPackages = [ pkgs.containerd ];
+    environment.systemPackages = [ cfg.package ]
+      ++ lib.optional cfg.nerdctl.enable cfg.nerdctl.package;
 
     systemd.services.containerd = {
       description = "containerd - container runtime";
@@ -81,7 +117,7 @@ in
         Restart = "always";
         RestartSec = "10";
 
-        # "limits" defined below are adopted from upstream: https://github.com/containerd/containerd/blob/master/containerd.service
+        # "limits" defined below are adopted from upstream: https://github.com/containerd/containerd/blob/main/containerd.service
         LimitNPROC = "infinity";
         LimitCORE = "infinity";
         LimitNOFILE = "infinity";
@@ -95,6 +131,69 @@ in
       unitConfig = {
         StartLimitBurst = "16";
         StartLimitIntervalSec = "120s";
+      };
+    };
+
+    # User services adapted from
+    # https://github.com/containerd/nerdctl/blob/master/extras/rootless/containerd-rootless-setuptool.sh
+    systemd.user.services = lib.mkIf (cfg.nerdctl.enable) {
+      containerd = {
+        wantedBy = [ "default.target" ];
+
+        description = "containerd (Rootless)";
+        environment = {
+          CONTAINERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER = cfg.nerdctl.portDriver;
+        };
+        # needs newuidmap
+        path = [ "/run/wrappers" ]
+          ++ lib.optional config.boot.zfs.enabled config.boot.zfs.package;
+        unitConfig = {
+          ConditionUser = "!root";
+          StartLimitInterval = "60s";
+        };
+
+        serviceConfig = {
+          ExecStart = "${pkgs.nerdctl}/bin/containerd-rootless";
+          ExecReload = "${pkgs.procps}/bin/kill -s HUP $MAINPID";
+          TimeoutSec = 0;
+          RestartSec = 2;
+          Restart = "always";
+          StartLimitBurst = 3;
+          LimitNOFILE = "infinity";
+          LimitNPROC = "infinity";
+          LimitCORE = "infinity";
+          TasksMax = "infinity";
+          Delegate = true;
+          Type = "simple";
+          KillMode = "mixed";
+        };
+      };
+
+
+      buildkit = {
+        wantedBy = [ "default.target" ];
+
+        description = "BuildKit (Rootless)";
+        partOf = [ containerdUnit ];
+        path = with pkgs; [ buildkit coreutils util-linux ];
+        serviceConfig =
+          let
+            # Helper script:
+            # https://github.com/containerd/nerdctl/blob/884dc5480da0c4db5e2e18b008a9a7578af59b51/extras/rootless/containerd-rootless-setuptool.sh#L142-L147
+            nsenterScript = pkgs.writeShellScript "nsenter"
+              ''
+                pid=$(cat "$XDG_RUNTIME_DIR/containerd-rootless/child_pid")
+                exec nsenter --no-fork --wd="$(pwd)" --preserve-credentials -m -n -U -t "$pid" -- "$@"
+              '';
+          in
+          {
+            ExecStart = "${nsenterScript} buildkitd";
+            ExecReload = "kill -s HUP $MAINPID";
+            RestartSec = 2;
+            Restart = "always";
+            Type = "simple";
+            KillMode = "mixed";
+          };
       };
     };
   };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -130,6 +130,7 @@ in {
   cockroachdb = handleTestOn ["x86_64-linux"] ./cockroachdb.nix {};
   collectd = handleTest ./collectd.nix {};
   consul = handleTest ./consul.nix {};
+  containerd = handleTest ./containerd.nix {};
   containers-bridge = handleTest ./containers-bridge.nix {};
   containers-custom-pkgs.nix = handleTest ./containers-custom-pkgs.nix {};
   containers-ephemeral = handleTest ./containers-ephemeral.nix {};

--- a/nixos/tests/containerd.nix
+++ b/nixos/tests/containerd.nix
@@ -1,0 +1,51 @@
+# This test runs containerd and checks if simple container starts
+
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
+  name = "containerd";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ jlesquembre ];
+  };
+
+  nodes = {
+    machine = { pkgs, ... }: {
+      virtualisation.containerd.enable = true;
+      virtualisation.containerd.nerdctl.portDriver = "slirp4netns";
+
+      users.users.alice = {
+        uid = 1000;
+        isNormalUser = true;
+        password = "";
+      };
+    };
+  };
+
+  testScript = { nodes, ... }:
+    let
+      user = nodes.machine.config.users.users.alice;
+      runtimeDir = "/run/user/${toString user.uid}";
+      sudo = lib.concatStringsSep " " [
+        "XDG_RUNTIME_DIR=${runtimeDir}"
+        "sudo"
+        "--preserve-env=XDG_RUNTIME_DIR"
+        "-u"
+        "alice"
+      ];
+    in
+    ''
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed("loginctl enable-linger alice")
+      machine.wait_until_succeeds("${sudo} systemctl --user is-active containerd.service")
+      machine.wait_until_succeeds("${sudo} systemctl --user is-active buildkit.service")
+      machine.wait_for_file("${runtimeDir}/containerd-rootless/child_pid")
+      machine.wait_for_file("${runtimeDir}/buildkit/buildkitd.sock")
+
+      machine.succeed("echo 'FROM scratch' > Dockerfile",
+                      "${sudo} nerdctl build -t scratchimg .")
+      machine.succeed(
+          "${sudo} nerdctl run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+      )
+      machine.succeed("${sudo} nerdctl ps | grep sleeping")
+      machine.succeed("${sudo} nerdctl stop sleeping")
+    '';
+})

--- a/pkgs/applications/networking/cluster/nerdctl/default.nix
+++ b/pkgs/applications/networking/cluster/nerdctl/default.nix
@@ -4,6 +4,14 @@
 , makeWrapper
 , installShellFiles
 , buildkit
+, libselinux
+, rootlesskit
+, containerd
+, runc # Default container runtime
+, slirp4netns # User-mode networking for unprivileged namespaces
+, util-linux # nsenter
+, iptables
+, iproute2
 , cni-plugins
 , extraPackages ? [ ]
 }:
@@ -29,16 +37,35 @@ buildGoModule rec {
   # Many checks require a containerd socket and running nerdctl after it's built
   doCheck = false;
 
-  postInstall = ''
-    wrapProgram $out/bin/nerdctl \
-      --prefix PATH : "${lib.makeBinPath ([ buildkit ] ++ extraPackages)}" \
-      --prefix CNI_PATH : "${cni-plugins}/bin"
+  postInstall =
+    let
+      binPath =
+        lib.makeBinPath ([
+          libselinux
+          rootlesskit
+          containerd
+          runc
+          slirp4netns
+          util-linux
+          iptables
+          iproute2
+        ]);
+    in
+    ''
+      wrapProgram $out/bin/nerdctl \
+        --prefix PATH : "${lib.makeBinPath ([ buildkit runc ] ++ extraPackages)}" \
+        --prefix CNI_PATH : "${cni-plugins}/bin"
 
-    installShellCompletion --cmd nerdctl \
-      --bash <($out/bin/nerdctl completion bash) \
-      --fish <($out/bin/nerdctl completion fish) \
-      --zsh <($out/bin/nerdctl completion zsh)
-  '';
+      install -D extras/rootless/containerd-rootless.sh $out/bin/containerd-rootless
+
+      wrapProgram $out/bin/containerd-rootless \
+        --prefix PATH : ${lib.escapeShellArg binPath}
+
+      installShellCompletion --cmd nerdctl \
+        --bash <($out/bin/nerdctl completion bash) \
+        --fish <($out/bin/nerdctl completion fish) \
+        --zsh <($out/bin/nerdctl completion zsh)
+    '';
 
   doInstallCheck = true;
   installCheckPhase = ''
@@ -53,7 +80,7 @@ buildGoModule rec {
     changelog = "https://github.com/containerd/nerdctl/releases/tag/v${version}";
     description = "A Docker-compatible CLI for containerd";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jk ];
+    maintainers = with maintainers; [ jk jlesquembre ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -42,7 +42,7 @@ buildGoModule rec {
     runHook postInstall
   '';
 
-  passthru.tests = { inherit (nixosTests) docker; };
+  passthru.tests = { inherit (nixosTests) docker containerd; };
 
   meta = with lib; {
     homepage = "https://containerd.io/";


### PR DESCRIPTION
###### Description of changes

Add nerdctl rootless support.
Currently, running any `nerdctl` command fails because the required systemd units are not installed

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
