### PR TITLE
WIP: granted: init at 0.4.0

### DIFF
--- a/pkgs/tools/admin/granted/default.nix
+++ b/pkgs/tools/admin/granted/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, makeWrapper
+, xdg-utils
+}:
+buildGoModule rec {
+  pname = "granted";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "common-fate";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-5NEwd1SN+SwKMhbcgVBYbYsF1+H+xWx5zLl91eD9Ig8=";
+  };
+  vendorSha256 = "sha256-jO26atvv/PXvmx6wxpYaBtQREIi3b9Ne31RCG1b2b00=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/granted \
+      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/common-fate/granted";
+    description = "The easiest way to access your cloud.";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ymatsiuk ];
+    mainProgram = "granted";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2671,6 +2671,8 @@ with pkgs;
     inherit (darwin) cctools;
   };
 
+  granted = callPackage ../tools/admin/granted { };
+
   hakrawler = callPackage ../tools/security/hakrawler { };
 
   harvid = callPackage ../tools/video/harvid { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Yet another aws helper cli. The killer feature - it supports opening multiple tabs with different accounts.
[More details](https://granted.dev/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
