### PR TITLE
openssl: 3.0.5 -> 3.0.7

### DIFF
--- a/pkgs/development/libraries/openssl/3.0/openssl-disable-kernel-detection.patch
+++ b/pkgs/development/libraries/openssl/3.0/openssl-disable-kernel-detection.patch
@@ -1,22 +1,25 @@
 diff --git a/Configure b/Configure
-index f0ad787bc4..a48d2008c6 100755
+index a558e5ab1a..9a884f0b0f 100755
 --- a/Configure
 +++ b/Configure
-@@ -1688,17 +1688,6 @@ unless ($disabled{devcryptoeng}) {
+@@ -1714,20 +1714,6 @@ unless ($disabled{devcryptoeng}) {
+ 
  unless ($disabled{ktls}) {
      $config{ktls}="";
-     if ($target =~ m/^linux/) {
--        my $usr = "/usr/$config{cross_compile_prefix}";
--        chop($usr);
--        if ($config{cross_compile_prefix} eq "") {
--            $usr = "/usr";
--        }
--        my $minver = (4 << 16) + (13 << 8) + 0;
--        my @verstr = split(" ",`cat $usr/include/linux/version.h | grep LINUX_VERSION_CODE`);
--
--        if ($verstr[2] < $minver) {
+-    my $cc = $config{CROSS_COMPILE}.$config{CC};
+-    if ($target =~ m/^linux/) {
+-        system("printf '#include <sys/types.h>\n#include <linux/tls.h>' | $cc -E - >/dev/null 2>&1");
+-        if ($? != 0) {
 -            disable('too-old-kernel', 'ktls');
 -        }
-     } elsif ($target =~ m/^BSD/) {
-         my $cc = $config{CROSS_COMPILE}.$config{CC};
-         system("printf '#include <sys/types.h>\n#include <sys/ktls.h>' | $cc -E - >/dev/null 2>&1");
+-    } elsif ($target =~ m/^BSD/) {
+-        system("printf '#include <sys/types.h>\n#include <sys/ktls.h>' | $cc -E - >/dev/null 2>&1");
+-        if ($? != 0) {
+-            disable('too-old-freebsd', 'ktls');
+-        }
+-    } else {
+-        disable('not-linux-or-freebsd', 'ktls');
+-    }
+ }
+ 
+ push @{$config{openssl_other_defines}}, "OPENSSL_NO_KTLS" if ($disabled{ktls});

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -228,8 +228,8 @@ in {
   };
 
   openssl_3 = common {
-    version = "3.0.5";
-    sha256 = "sha256-qn2Nm+9xrWUlxVuhHl9Dl4ic5Jwsk0nc6m0+TwsCSno=";
+    version = "3.0.7";
+    sha256 = "sha256-gwSdBComDmlvYkBqxcCL9wb9hDg/lFzyG9YentlcOW4=";
     patches = [
       ./3.0/nix-ssl-cert-file.patch
 


### PR DESCRIPTION
```
### Changes between 3.0.6 and 3.0.7 [1 Nov 2022]

 * Fixed two buffer overflows in punycode decoding functions.

   A buffer overrun can be triggered in X.509 certificate verification,
   specifically in name constraint checking. Note that this occurs after
   certificate chain signature verification and requires either a CA to
   have signed the malicious certificate or for the application to continue
   certificate verification despite failure to construct a path to a trusted
   issuer.

   In a TLS client, this can be triggered by connecting to a malicious
   server.  In a TLS server, this can be triggered if the server requests
   client authentication and a malicious client connects.

   An attacker can craft a malicious email address to overflow
   an arbitrary number of bytes containing the `.`  character (decimal 46)
   on the stack.  This buffer overflow could result in a crash (causing a
   denial of service).
   ([CVE-2022-3786])

   An attacker can craft a malicious email address to overflow four
   attacker-controlled bytes on the stack.  This buffer overflow could
   result in a crash (causing a denial of service) or potentially remote code
   execution depending on stack layout for any given platform/compiler.
   ([CVE-2022-3602])

   *Paul Dale*

 * Removed all references to invalid OSSL_PKEY_PARAM_RSA names for CRT
   parameters in OpenSSL code.
   Applications should not use the names OSSL_PKEY_PARAM_RSA_FACTOR,
   OSSL_PKEY_PARAM_RSA_EXPONENT and OSSL_PKEY_PARAM_RSA_COEFFICIENT.
   Use the numbered names such as OSSL_PKEY_PARAM_RSA_FACTOR1 instead.
   Using these invalid names may cause algorithms to use slower methods
   that ignore the CRT parameters.

   *Shane Lontis*

 * Fixed a regression introduced in 3.0.6 version raising errors on some stack
   operations.

   *Tomáš Mráz*

 * Fixed a regression introduced in 3.0.6 version not refreshing the certificate
   data to be signed before signing the certificate.

   *Gibeom Gwon*

 * Added RIPEMD160 to the default provider.

   *Paul Dale*

 * Ensured that the key share group sent or accepted for the key exchange
   is allowed for the protocol version.

   *Matt Caswell*
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
