### PR TITLE
vis: 0.7 → 0.8

### DIFF
--- a/pkgs/applications/editors/vis/default.nix
+++ b/pkgs/applications/editors/vis/default.nix
@@ -9,11 +9,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vis";
-  version  = "0.7";
+  version  = "0.8";
 
   src = fetchFromGitHub {
     rev = "v${version}";
-    sha256 = "1g05ncsnk57kcqm9wsv6sz8b24kyzj8r5rfpa1wfwj8qkjzx3vji";
+    hash = "sha256-XvWj6fZxzXeRA5oCAqIIwlfjrJcHnDrjeiPExEQKSkY=";
     repo = "vis";
     owner = "martanne";
   };
@@ -29,10 +29,6 @@ stdenv.mkDerivation rec {
     acl
     libselinux
   ];
-
-  postPatch = ''
-    patchShebangs ./configure
-  '';
 
   postInstall = ''
     wrapProgram $out/bin/vis \
@@ -58,7 +54,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A vim like editor";
+    description = "A vi-like editor based on Plan 9's structural regular expressions";
     homepage = "https://github.com/martanne/vis";
     license = licenses.isc;
     maintainers = with maintainers; [ vrthra ramkromberg ];


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/martanne/vis/releases/tag/v0.8)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
