### PR TITLE
buf: remove reliance of tests on git file transport

### DIFF
--- a/pkgs/development/tools/buf/buf-tests-dont-use-file-transport.patch
+++ b/pkgs/development/tools/buf/buf-tests-dont-use-file-transport.patch
@@ -1,0 +1,51 @@
+commit e9219b88de5ed37af337ee2d2e71e7ec7c0aad1b
+Author: Robbert van Ginkel <rvanginkel@buf.build>
+Date:   Thu Oct 20 16:43:28 2022 -0400
+
+    Fix git unit test by using fake git server rather than file:// (#1518)
+    
+    More recent versions of git fix a CVE by disabling some usage of the
+    `file://` transport, see
+    https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253.
+    We were using this transport in tests.
+    
+    Instead, use https://git-scm.com/docs/git-http-backend to serve up this
+    repository locally so we don't have to use the file protocol. This
+    should be a more accurate tests, since we mostly expect submodules to
+    come from servers.
+
+diff --git a/private/pkg/git/git_test.go b/private/pkg/git/git_test.go
+index 7b77b6cd..7132054e 100644
+--- a/private/pkg/git/git_test.go
++++ b/private/pkg/git/git_test.go
+@@ -17,6 +17,8 @@ package git
+ import (
+ 	"context"
+ 	"errors"
++	"net/http/cgi"
++	"net/http/httptest"
+ 	"os"
+ 	"os/exec"
+ 	"path/filepath"
+@@ -213,6 +215,21 @@ func createGitDirs(
+ 	runCommand(ctx, t, container, runner, "git", "-C", submodulePath, "add", "test.proto")
+ 	runCommand(ctx, t, container, runner, "git", "-C", submodulePath, "commit", "-m", "commit 0")
+ 
++	gitExecPath, err := command.RunStdout(ctx, container, runner, "git", "--exec-path")
++	require.NoError(t, err)
++	t.Log(filepath.Join(string(gitExecPath), "git-http-backend"))
++	// https://git-scm.com/docs/git-http-backend#_description
++	f, err := os.Create(filepath.Join(submodulePath, ".git", "git-daemon-export-ok"))
++	require.NoError(t, err)
++	require.NoError(t, f.Close())
++	server := httptest.NewServer(&cgi.Handler{
++		Path: filepath.Join(strings.TrimSpace(string(gitExecPath)), "git-http-backend"),
++		Dir:  submodulePath,
++		Env:  []string{"GIT_PROJECT_ROOT=" + submodulePath},
++	})
++	t.Cleanup(server.Close)
++	submodulePath = server.URL
++
+ 	originPath := filepath.Join(tmpDir, "origin")
+ 	require.NoError(t, os.MkdirAll(originPath, 0777))
+ 	runCommand(ctx, t, container, runner, "git", "-C", originPath, "init")

--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -26,6 +26,9 @@ buildGoModule rec {
     ./skip_test_requiring_network.patch
     # Skip TestWorkspaceGit which requires .git and commits.
     ./skip_test_requiring_dotgit.patch
+    # Remove reliance of tests on file protocol which is disabled in git by default now
+    # Rebased upstream change https://github.com/bufbuild/buf/commit/bcaa77f8bbb8f6c198154c7c8d53596da4506dab
+    ./buf-tests-dont-use-file-transport.patch
   ];
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
A recent git security update disabled the file transport by default, see https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253

We can pick an upstream patch which needed to be rebased unfortunately, so we can't fetch it directly from GitHub.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
