### PR TITLE
tiptop-py: init at 0.2.8

### DIFF
--- a/pkgs/tools/system/tiptop-py/default.nix
+++ b/pkgs/tools/system/tiptop-py/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchFromGitHub, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "tiptop-py";
+  version = "0.2.8";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "nschloe";
+    repo = "tiptop";
+    rev = "v${version}";
+    hash = "sha256-3nrYwcdqGGRvYB5FOW/OCqlRHIlCdkxClBfyKnVC1rQ=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    setuptools
+    py-cpuinfo
+    distro
+    psutil
+    rich
+    textual
+  ];
+
+  checkInputs = [ python3.pkgs.pytestCheckHook ];
+
+  pythonImportsCheck = [ "tiptop" ];
+
+  meta = with lib; {
+    description = "Command-line system monitoring tool in the spirit of top";
+    homepage = "https://github.com/nschloe/tiptop";
+    license = licenses.mit;
+    mainProgram = "tiptop";
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25738,6 +25738,8 @@ with pkgs;
 
   tiptop = callPackage ../os-specific/linux/tiptop { };
 
+  tiptop-py = callPackage ../tools/system/tiptop-py { };
+
   tpacpi-bat = callPackage ../os-specific/linux/tpacpi-bat { };
 
   trickster = callPackage ../servers/trickster/trickster.nix {};


### PR DESCRIPTION
###### Description of changes

tiptop is a command-line system monitoring tool like `top` `btop` `htop` `gotop`. 
It displays various interesting system stats and graphs them.

https://github.com/nschloe/tiptop

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
