### PR TITLE
timeloop: init at unstable-2022-10-28 and accelergy: init at unstable-2022-05-03

### DIFF
--- a/pkgs/applications/science/computer-architecture/accelergy/default.nix
+++ b/pkgs/applications/science/computer-architecture/accelergy/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, python3Packages, pkgs }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "accelergy";
+  version = "unstable-2022-05-03";
+
+  src = fetchFromGitHub {
+    owner = "Accelergy-Project";
+    repo = "accelergy";
+    rev = "34df8e87a889ae55cecba58992d4573466b40565";
+    hash = "sha256-SRtt1EocHy5fKszpoumC+mOK/qhreoA2/Ff1wcu5WKo=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pyyaml
+    yamlordereddictloader
+    pyfiglet
+    setuptools
+  ];
+
+  meta = with lib; {
+    description = "An architecture-level energy/area estimator for accelerator designs";
+    license = licenses.mit;
+    homepage = "https://accelergy.mit.edu/";
+    maintainers = with maintainers; [ gdinh ];
+  };
+}

--- a/pkgs/applications/science/computer-architecture/timeloop/default.nix
+++ b/pkgs/applications/science/computer-architecture/timeloop/default.nix
@@ -1,0 +1,99 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, scons
+, libconfig
+, boost
+, libyaml
+, libyamlcpp
+, ncurses
+, gpm
+, enableAccelergy ? true
+, enableISL ? false
+, accelergy
+}:
+
+stdenv.mkDerivation rec {
+  pname = "timeloop";
+  version = "unstable-2022-11-29";
+
+  src = fetchFromGitHub {
+    owner = "NVlabs";
+    repo = "timeloop";
+    rev = "905ba953432c812772de935d57fd0a674a89d3c1";
+    hash = "sha256-EXiWXf8hdX4vFRNk9wbFSOsix/zVkwrafGUtFrsoAN0=";
+  };
+
+  nativeBuildInputs = [ scons ];
+
+  buildInputs = [
+    libconfig
+    boost
+    libyaml
+    libyamlcpp
+    ncurses
+    accelergy
+   ] ++ lib.optionals stdenv.isLinux [ gpm ];
+
+  preConfigure = ''
+    cp -r ./pat-public/src/pat ./src/pat
+  '';
+
+  enableParallelBuilding = true;
+
+  #link-time optimization fails on darwin
+  #see https://github.com/NixOS/nixpkgs/issues/19098
+  NIX_CFLAGS_COMPILE = lib.optional stdenv.isDarwin "-fno-lto";
+
+  postPatch = ''
+    # use nix ar/ranlib
+    substituteInPlace ./SConstruct \
+      --replace "env.Replace(AR = \"gcc-ar\")" "" \
+      --replace "env.Replace(RANLIB = \"gcc-ranlib\")" ""
+    '' + lib.optionalString stdenv.isDarwin ''
+    # prevent clang from dying on errors that gcc is fine with
+    substituteInPlace ./src/SConscript --replace "-Werror" "-Wno-inconsistent-missing-override"
+
+    # disable LTO on macos
+    substituteInPlace ./src/SConscript --replace ", '-flto'" ""
+
+    # static builds on mac fail as no static libcrt is provided by apple
+    # see https://stackoverflow.com/questions/3801011/ld-library-not-found-for-lcrt0-o-on-osx-10-6-with-gcc-clang-static-flag
+    substituteInPlace ./src/SConscript \
+      --replace "'-static-libgcc', " "" \
+      --replace "'-static-libstdc++', " "" \
+      --replace "'-Wl,--whole-archive', '-static', " "" \
+      --replace ", '-Wl,--no-whole-archive'" ""
+
+    #remove hardcoding of gcc
+    sed -i '40i env.Replace(CC = "${stdenv.cc.targetPrefix}cc")' ./SConstruct
+    sed -i '40i env.Replace(CXX = "${stdenv.cc.targetPrefix}c++")' ./SConstruct
+
+    #gpm doesn't exist on darwin
+    substituteInPlace ./src/SConscript --replace ", 'gpm'" ""
+   '';
+
+  sconsFlags =
+    # will fail on clang/darwin on link without --static due to undefined extern
+    # however, will fail with static on linux as nixpkgs deps aren't static
+    lib.optional stdenv.isDarwin "--static"
+    ++ lib.optional enableAccelergy "--accelergy"
+    ++ lib.optional enableISL "--with-isl";
+
+
+  installPhase = ''
+    cp -r ./bin ./lib $out
+    mkdir -p $out/share
+    cp -r ./doc $out/share
+    mkdir -p $out/data
+    cp -r ./problem-shapes ./configs $out/data
+   '';
+
+  meta = with lib; {
+    description = "Chip modeling/mapping benchmarking framework";
+    homepage = "https://timeloop.csail.mit.edu";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ gdinh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36908,6 +36908,8 @@ with pkgs;
 
   shellz = callPackage ../tools/security/shellz { };
 
+  timeloop = pkgs.darwin.apple_sdk_11_0.callPackage ../applications/science/computer-architecture/timeloop { };
+
   canon-cups-ufr2 = callPackage ../misc/cups/drivers/canon { };
 
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1990,6 +1990,8 @@ with pkgs;
 
   twine = with python3Packages; toPythonApplication twine;
 
+  accelergy = callPackage ../applications/science/computer-architecture/accelergy { };
+
   aldo = callPackage ../applications/radio/aldo { };
 
   alglib = callPackage ../development/libraries/alglib { };


### PR DESCRIPTION
###### Description of changes

Added Timeloop and Accelergy, two tools to model energy and area for accelerator chips. Timeloop depends on accelergy by default, as it requires an energy model to work (the [upstream documentation](https://timeloop.csail.mit.edu/timeloop/installation) assumes they will be installed together). However, this can be disabled by setting the enableAccelergy input to false if a user has their own energy model.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
