### PR TITLE
vimPlugins.nvim-treesitter: follow up to #198606

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/generated.nix
@@ -25,12 +25,12 @@
   };
   bash = buildGrammar {
     language = "bash";
-    version = "f1a86d3";
+    version = "77cf8a7";
     source = fetchFromGitHub {
       owner = "tree-sitter";
       repo = "tree-sitter-bash";
-      rev = "f1a86d3cc5aeeb67e0e52442e893af7f813025b4";
-      hash = "sha256-zzHA+kGw67WFyPVFRWRyKmhAjxp5jkv0K2yhGxNfFM4=";
+      rev = "77cf8a7cab8904baf1a721762e012644ac1d4c7b";
+      hash = "sha256-UPMJ7iL8Y0NkAHtPDrkTjG1qFwr8rXuGqvsG+LTWqEY=";
     };
   };
   beancount = buildGrammar {
@@ -503,12 +503,12 @@
   };
   help = buildGrammar {
     language = "help";
-    version = "8df3266";
+    version = "49cdef5";
     source = fetchFromGitHub {
       owner = "neovim";
       repo = "tree-sitter-vimdoc";
-      rev = "8df3266b423d24c9ac3f3b4b9928e65eb1e5e741";
-      hash = "sha256-t9SHuymK5pYlryWGpORGPYLgPZ3xBx0XH69s5RtRnEI=";
+      rev = "49cdef52ded4a886bf34bc474876b09f9270d48f";
+      hash = "sha256-szNY2yw5i9pgF+MpaEAkP8BgSYEe6nrFW+17sbSZ6Yc=";
     };
   };
   hjson = buildGrammar {
@@ -693,12 +693,12 @@
   };
   lua = buildGrammar {
     language = "lua";
-    version = "887dfd4";
+    version = "fb30e8c";
     source = fetchFromGitHub {
       owner = "MunifTanjim";
       repo = "tree-sitter-lua";
-      rev = "887dfd4e83c469300c279314ff1619b1d0b85b91";
-      hash = "sha256-5i+UN6Es+K7KDD1qz3ZrVn8IfGdTswcISUyV2sGtY9M=";
+      rev = "fb30e8cb605e2ebd6c643e6981325a63fbbde320";
+      hash = "sha256-gT2WHH3rkFzb6iER0ryVU7bqVbh36RbTI9HSWMh3DsI=";
     };
   };
   m68k = buildGrammar {
@@ -731,7 +731,6 @@
       hash = "sha256-gKbjAcY/x9sIxiG7edolAQp2JWrx78mEGeCpayxFOuE=";
     };
     location = "tree-sitter-markdown";
-
   };
   markdown_inline = buildGrammar {
     language = "markdown_inline";
@@ -743,7 +742,6 @@
       hash = "sha256-gKbjAcY/x9sIxiG7edolAQp2JWrx78mEGeCpayxFOuE=";
     };
     location = "tree-sitter-markdown-inline";
-
   };
   menhir = buildGrammar {
     language = "menhir";
@@ -815,7 +813,6 @@
       hash = "sha256-gTmRBFFCBrA48Yn1MO2mMQPpa6u3uv5McC4BDuMXKuM=";
     };
     location = "ocaml";
-
   };
   ocaml_interface = buildGrammar {
     language = "ocaml_interface";
@@ -827,7 +824,6 @@
       hash = "sha256-gTmRBFFCBrA48Yn1MO2mMQPpa6u3uv5McC4BDuMXKuM=";
     };
     location = "interface";
-
   };
   ocamllex = buildGrammar {
     language = "ocamllex";
@@ -1163,14 +1159,14 @@
   };
   swift = buildGrammar {
     language = "swift";
-    version = "c88b5d7";
+    version = "d7808f0";
     source = fetchFromGitHub {
       owner = "alex-pinkus";
       repo = "tree-sitter-swift";
       nativeBuildInputs = [ nodejs tree-sitter ];
       postFetch = "pushd $out && tree-sitter generate && popd";
-      rev = "c88b5d73f193f5b0762b1a5f0299a275e6a728fb";
-      hash = "sha256-OfFMGxL72SPZW4AtHoThhYtjmKWabStLKAB9TxmjMDw=";
+      rev = "d7808f030a44dc8768948042baa7566949785e2f";
+      hash = "sha256-7Gjpf2isOpeOV3ZMTMibK+F4C4v8ywOPin2Wv86s+AM=";
     };
   };
   sxhkdrc = buildGrammar {
@@ -1245,7 +1241,6 @@
       hash = "sha256-Nx+K7Ic/ePKAXPIMlrRn6zELYE59f/FnnZ/LM5ELaU8=";
     };
     location = "tsx";
-
   };
   turtle = buildGrammar {
     language = "turtle";
@@ -1259,12 +1254,12 @@
   };
   twig = buildGrammar {
     language = "twig";
-    version = "6a01f20";
+    version = "035f549";
     source = fetchFromGitHub {
       owner = "gbprod";
       repo = "tree-sitter-twig";
-      rev = "6a01f20e73038300d205d370212c361949be3035";
-      hash = "sha256-M+57mGl4Sgn0yUGAyxHxE6ShR+E/ki4m8/x/f/KHetA=";
+      rev = "035f549ec8c043e734f04341d7ccdc669bb2ba91";
+      hash = "sha256-XSE0E6a9o+WpvmMIXHu0N89VqzaIk9eFHofKAPHtT20=";
     };
   };
   typescript = buildGrammar {
@@ -1277,7 +1272,6 @@
       hash = "sha256-Nx+K7Ic/ePKAXPIMlrRn6zELYE59f/FnnZ/LM5ELaU8=";
     };
     location = "typescript";
-
   };
   v = buildGrammar {
     language = "v";
@@ -1289,7 +1283,6 @@
       hash = "sha256-d1NeZixsN9992Q1UC5ZKGN4LNxlsvdL91QW2K8d1J9Y=";
     };
     location = "tree_sitter_v";
-
   };
   vala = buildGrammar {
     language = "vala";

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -49,5 +49,7 @@ in
 
     withAllGrammars = withPlugins (_: allGrammars);
   };
+
+  meta.maintainers = with lib.maintainers; [ figsoda ];
 }
 

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -9,6 +9,11 @@ let
 
   generatedDerivations = lib.filterAttrs (_: lib.isDerivation) generatedGrammars;
 
+  # add aliases so grammars from `tree-sitter` are overwritten in `withPlugins`
+  # for example, for ocaml_interface, the following aliases will be added
+  #   ocaml-interface
+  #   tree-sitter-ocaml-interface
+  #   tree-sitter-ocaml_interface
   builtGrammars = generatedGrammars // lib.listToAttrs
     (lib.concatLists (lib.mapAttrsToList
       (k: v:

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/update.py
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/update.py
@@ -4,10 +4,10 @@
 import json
 import re
 import subprocess
-from os import getenv
+from os import environ
 from os.path import dirname, join
 
-lockfile = json.load(open(join(getenv("NVIM_TREESITTER"), "lockfile.json")))
+lockfile = json.load(open(join(environ["NVIM_TREESITTER"], "lockfile.json")))
 
 configs = json.loads(
     subprocess.check_output(
@@ -98,8 +98,7 @@ def generate_grammar(item):
     location = info.get("location")
     if location:
         generated += f"""
-    location = "{location}";
-"""
+    location = "{location}";"""
 
     generated += """
   };


### PR DESCRIPTION
###### Description of changes

- fix formatting of the generated file
- update nvim-treesitter grammars
- create aliases for `nvim-treesitter.builtGrammars` to overwrite tree-sitter grammars in `nvim-treesitter.withPlugins`
- add myself as a maintainer

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
