### PR TITLE
nagelfar: init at 1.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9954,6 +9954,12 @@
       fingerprint = "7A10 AB8E 0BEC 566B 090C  9BE3 D812 6E55 9CE7 C35D";
     }];
   };
+  nat-418 = {
+    email = "93013864+nat-418@users.noreply.github.com";
+    github = "nat-418";
+    githubId = 93013864;
+    name = "nat-418";
+  };
   nathanruiz = {
     email = "nathanruiz@protonmail.com";
     github = "nathanruiz";

--- a/pkgs/development/tools/nagelfar/default.nix
+++ b/pkgs/development/tools/nagelfar/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchzip, tcl, tcllib, tk, }:
+
+tcl.mkTclDerivation {
+  pname = "nagelfar";
+  version = "1.3.3";
+
+  src = fetchzip {
+    url = "https://sourceforge.net/projects/nagelfar/files/Rel_133/nagelfar133.tar.gz";
+    sha256 = "sha256-bdH53LSOKMwq53obVQitl7bpaSpwvMce8oJgg/GKrg0=";
+  };
+
+  buildInputs = [
+    tcl
+    tcllib
+    tk
+  ];
+
+  installPhase = ''
+    install -Dm 755 $src/nagelfar.tcl $out/bin/nagelfar
+  '';
+
+  meta = with lib; {
+    homepage = "https://nagelfar.sourceforge.net/";
+    description = "A static syntax checker (linter) for Tcl";
+    longDescription = ''
+      Provides static syntax checking, code coverage instrumentation,
+      and is very extendable through its syntax database and plugins.
+    '';
+    mainProgram = "nagelfar";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = [ maintainers.nat-418 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9009,6 +9009,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  nagelfar = callPackage ../development/tools/nagelfar { };
+
   nats-top = callPackage ../tools/system/nats-top { };
 
   natscli = callPackage ../tools/system/natscli { };


### PR DESCRIPTION

###### Description of changes

Nagelfar is a static syntax checker for the Tcl programming language.

Homepage: https://nagelfar.sourceforge.net/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
