### PR TITLE
python310Packages.ale-py: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/ale-py/cmake-pybind11.patch
+++ b/pkgs/development/python-modules/ale-py/cmake-pybind11.patch
@@ -1,0 +1,18 @@
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index 911e280..d484943 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -1,12 +1,6 @@
+ find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
+ 
+-include(FetchContent)
+-FetchContent_Declare(
+-    pybind11
+-    GIT_REPOSITORY https://github.com/pybind/pybind11
+-    GIT_TAG v2.10.0)
+-FetchContent_MakeAvailable(pybind11)
+-
++find_package(pybind11 REQUIRED)
+ add_library(ale-py MODULE ale_python_interface.cpp)
+ # Depend on the ALE and pybind11 module
+ target_link_libraries(ale-py PUBLIC ale ale-lib)

--- a/pkgs/development/python-modules/ale-py/default.nix
+++ b/pkgs/development/python-modules/ale-py/default.nix
@@ -14,6 +14,7 @@
 , python
 , pythonOlder
 , setuptools
+, stdenv
 , typing-extensions
 , wheel
 , zlib
@@ -77,5 +78,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/mgbellemare/Arcade-Learning-Environment";
     license = licenses.gpl2;
     maintainers = with maintainers; [ billhuang ];
+    broken = stdenv.isDarwin; # fails to link with missing library
   };
 }

--- a/pkgs/development/python-modules/ale-py/default.nix
+++ b/pkgs/development/python-modules/ale-py/default.nix
@@ -1,0 +1,81 @@
+{ buildPythonPackage
+, SDL2
+, cmake
+, fetchFromGitHub
+, git
+, gym
+, importlib-metadata
+, importlib-resources
+, lib
+, ninja
+, numpy
+, pybind11
+, pytestCheckHook
+, python
+, pythonOlder
+, setuptools
+, typing-extensions
+, wheel
+, zlib
+}:
+
+buildPythonPackage rec {
+  pname = "ale-py";
+  version = "0.8.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "mgbellemare";
+    repo = "Arcade-Learning-Environment";
+    rev = "v${version}";
+    sha256 = "sha256-OPAtCc2RapK1lALTKHd95bkigxcZ9bcONu32I/91HIg=";
+  };
+
+  patches = [
+    # don't download pybind11, use local pybind11
+    ./cmake-pybind11.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    setuptools
+    wheel
+    pybind11
+  ];
+
+  buildInputs = [
+    zlib
+    SDL2
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+    importlib-resources
+    numpy
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    gym
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'dynamic = ["version"]' 'version = "${version}"'
+    substituteInPlace setup.py \
+      --replace 'subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=here)' 'b"${src.rev}"'
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "ale_py" ];
+
+  meta = with lib; {
+    description = "a simple framework that allows researchers and hobbyists to develop AI agents for Atari 2600 games";
+    homepage = "https://github.com/mgbellemare/Arcade-Learning-Environment";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ billhuang ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -366,6 +366,8 @@ self: super: with self; {
 
   alarmdecoder = callPackage ../development/python-modules/alarmdecoder { };
 
+  ale-py = callPackage ../development/python-modules/ale-py { };
+
   alectryon = callPackage ../development/python-modules/alectryon { };
 
   alembic = callPackage ../development/python-modules/alembic { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ale-py (Arcade-Learning-Environment) is a python package that allows researchers and hobbyists to develop AI agents for Atari 2600 games.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
