### PR TITLE
librewolf: build with `MOZ_REQUIRE_SIGNING = ""`

### DIFF
--- a/pkgs/applications/networking/browsers/librewolf/default.nix
+++ b/pkgs/applications/networking/browsers/librewolf/default.nix
@@ -3,7 +3,7 @@
 let
   librewolf-src = callPackage ./librewolf.nix { };
 in
-(buildMozillaMach rec {
+((buildMozillaMach rec {
   pname = "librewolf";
   applicationName = "LibreWolf";
   binaryName = "librewolf";
@@ -30,4 +30,6 @@ in
   crashreporterSupport = false;
   enableOfficialBranding = false;
   pgoSupport = false; # Profiling gets stuck and doesn't terminate.
-}
+}).overrideAttrs (prev: {
+  MOZ_REQUIRE_SIGNING = "";
+})


### PR DESCRIPTION
this allows sideloading unsigned browser extensions (via the `nixExtensions` option in the [firefox-wrapper]). i believe librewolf is meant to allow unsigned sideloading, based on upstream discussions and this bit that already exists in [librewolf.nix]:

```nix
extraConfigureFlags = [
    "--with-unsigned-addon-scopes=app,system"
    "--allow-addon-sideload"
];
```

but Mozilla changed some defaults over the years. this `MOZ_REQUIRE_SIGNING` option is mentioned [upstream] and we can see that the arch [pkgbuild] clears it in a similar manner.

[upstream]: https://gitlab.com/librewolf-community/browser/arch/-/issues/49
[pkgbuild]: https://gitlab.com/librewolf-community/browser/arch/-/blob/master/PKGBUILD#L95
[firefox-wrapper]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/networking/browsers/firefox/wrapper.nix
[librewolf.nix]:  https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/networking/browsers/librewolf/librewolf.nix

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
