### PR TITLE
cinnamon.cinnamon-control-center: Fix some localization issues

### DIFF
--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -75,6 +75,10 @@ stdenv.mkDerivation rec {
     ./panels/datetime/tz.h:34:#  define TZ_DATA_FILE "/usr/share/lib/zoneinfo/tab/zone_sun.tab" */
 
   postPatch = ''
+    find . -type f -exec sed -i \
+      -e s,/usr/share/locale,/run/current-system/sw/share/locale,g \
+      {} +
+
     sed 's|TZ_DIR "/usr/share/zoneinfo/"|TZ_DIR "${tzdata}/share/zoneinfo/"|g' -i ./panels/datetime/test-timezone.c
     sed 's|TZ_DATA_FILE "/usr/share/zoneinfo/zone.tab"|TZ_DATA_FILE "${tzdata}/share/zoneinfo/zone.tab"|g' -i ./panels/datetime/tz.h
     sed 's|"/usr/share/i18n/locales/"|"${glibc}/share/i18n/locales/"|g' -i panels/datetime/test-endianess.c


### PR DESCRIPTION
###### Description of changes

- Helps https://github.com/NixOS/nixpkgs/issues/121307 (note that this PR does **not** fully address that issue)

cinnamon-settings is a weird app, some of the modules are actually loaded from the external cinnamon-control-center app (which is a forked gnome-control-center but most users never directly opens it), so to fix translations sometimes you need to fix there.

We do pass `localedir` to cinnamon-control-center, but cinnamon-control-center does not always respect this and [what they do is](https://github.com/linuxmint/cinnamon-control-center/search?q=%2Fusr%2Fshare%2Flocale):

```c
bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
```

The situation is still better than the previous Pantheon, though, and we can resolve most issues by simply `sed` all the paths so I am doing it here. Making proper fix on upstream [is possible](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) but I don't have the time so far, note that is still a little different from Pantheon since cinnamon-control-center does not contain the translations itself and again it is loaded from external packages :sleeping: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
