### PR TITLE
nixos/bitcoind: fix rare startup error

### DIFF
--- a/nixos/modules/services/networking/bitcoind.nix
+++ b/nixos/modules/services/networking/bitcoind.nix
@@ -204,7 +204,7 @@ in
         '';
       in {
         description = "Bitcoin daemon";
-        after = [ "network.target" ];
+        after = [ "network-online.target" ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
           User = cfg.user;


### PR DESCRIPTION
#### Copy of commit msg
Previously, dhcpcd and bitcoind starting up in parallel could lead to the following error in bitcoind:
```
bitcoind: libevent: getaddrinfo: address family for nodename not supported
bitcoind: Binding RPC on address 127.0.0.1 port 8332 failed.
bitcoind: Unable to bind any endpoint for
```
After the initial failure, the bitcoind service would always restart successfully.

This race condition, where both applications were simultaneously manipulating network resources, was only triggered under specific hardware conditions.

Fix it by running bitcoind after dhcp has started (by running after `network-online.target`).
This bug and the fix only affect the default NixOS scripted networking backend.

#### Discussion

[bitcoin/contrib/init/bitcoind.service](https://github.com/bitcoin/bitcoin/blob/39f026b1ec17ef8100457ef46a1e4980767c0fe2/contrib/init/bitcoind.service#L17) also uses `network-online.target`.

To reproduce the bug, run the following:
```bash
git clone -b debug-bitcoind-startup https://github.com/erikarvstedt/nix-bitcoin
# On faster desktop systems, this shows a failure rate of about 30%
nix-bitcoin/test/test-bitcoind-startup.sh
# Remove tmp dir
rm /tmp/test-bitcoind-startup
```
The bug dissappears when adding `before = [ "dhcpcd.service" ];` or  `after = [ "dhcpcd.service" ];` to `systemd.services.bitcoind` in `nix-bitcoin/test/modules/bitcoind.nix`.

#### Things done

- [x] `nixosTests.bitcoind` succeeds on `x86_64-linux`
