### PR TITLE
lightdm-mobile-greeter: init at 2022-10-30

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/mobile.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/mobile.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  dmcfg = config.services.xserver.displayManager;
+  ldmcfg = dmcfg.lightdm;
+  cfg = ldmcfg.greeters.mobile;
+in
+{
+  options = {
+    services.xserver.displayManager.lightdm.greeters.mobile = {
+      enable = mkEnableOption (lib.mdDoc
+        "lightdm-mobile-greeter as the lightdm greeter"
+      );
+    };
+  };
+
+  config = mkIf (ldmcfg.enable && cfg.enable) {
+    services.xserver.displayManager.lightdm.greeters.gtk.enable = false;
+
+    services.xserver.displayManager.lightdm.greeter = mkDefault {
+      package = pkgs.lightdm-mobile-greeter.xgreeters;
+      name = "lightdm-mobile-greeter";
+    };
+  };
+}

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -83,6 +83,7 @@ in
     ./lightdm-greeters/pantheon.nix
     ./lightdm-greeters/tiny.nix
     ./lightdm-greeters/slick.nix
+    ./lightdm-greeters/mobile.nix
     (mkRenamedOptionModule [ "services" "xserver" "displayManager" "lightdm" "autoLogin" "enable" ] [
       "services"
       "xserver"

--- a/pkgs/applications/display-managers/lightdm-mobile-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-mobile-greeter/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, fetchFromGitea
+, gtk3
+, libhandy_0
+, lightdm
+, lightdm-mobile-greeter
+, linkFarm
+, pkg-config
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lightdm-mobile-greeter";
+  version = "2022-10-30";
+
+  src = fetchFromGitea {
+    domain = "git.raatty.club";
+    owner = "raatty";
+    repo = "lightdm-mobile-greeter";
+    rev = "8c8d6dfce62799307320c8c5a1f0dd5c8c18e4d3";
+    hash = "sha256-SrAR2+An3BN/doFl/s8PcYZMUHLfVPXKZOo6ndO60nY=";
+  };
+  cargoHash = "sha256-NZ0jOkEBNa5oOydfyKm0XQB/vkAvBv9wHBbnM9egQFQ=";
+
+  buildInputs = [
+    gtk3
+    libhandy_0
+    lightdm
+  ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/xgreeters
+    substitute lightdm-mobile-greeter.desktop \
+      $out/share/xgreeters/lightdm-mobile-greeter.desktop \
+      --replace lightdm-mobile-greeter $out/bin/lightdm-mobile-greeter
+  '';
+
+  passthru.xgreeters = linkFarm "lightdm-mobile-greeter-xgreeters" [{
+    path = "${lightdm-mobile-greeter}/share/xgreeters/lightdm-mobile-greeter.desktop";
+    name = "lightdm-mobile-greeter.desktop";
+  }];
+
+  meta = with lib; {
+    description = "A simple log in screen for use on touch screens";
+    homepage = "https://git.raatty.club/raatty/lightdm-mobile-greeter";
+    maintainers = with maintainers; [ colinsane ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31888,6 +31888,8 @@ with pkgs;
 
   lightdm-mini-greeter = callPackage ../applications/display-managers/lightdm-mini-greeter { };
 
+  lightdm-mobile-greeter = callPackage ../applications/display-managers/lightdm-mobile-greeter { };
+
   lightdm-tiny-greeter = callPackage ../applications/display-managers/lightdm-tiny-greeter {
     conf = config.lightdm-tiny-greeter.conf or "";
   };


### PR DESCRIPTION
###### Description of changes

this PR adds the `lightdm-mobile-greeter` package and then defines a module to simplify enabling of it. built on x86 and aarch64; tested on my aarch64 Pinephone.

lightdm-mobile-greeter is a greeter designed for mobile hardware. although most mobile DEs are capable of running without an external greeter by using their own lock screens, those tend to have different limitations. for example, the lock screen in Phosh doesn't do PAM session management -- but by using this lightdm-mobile-greeter which integrates with PAM, one can do things like decrypt a home directory or unlock keys on login.

the upstream project lacks many images/videos, so here's what the software looks like: <https://www.youtube.com/watch?v=whcFag0drLk>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
