### PR TITLE
go2tv: init at 1.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4939,6 +4939,13 @@
     githubId = 37017396;
     name = "gbtb";
   };
+  gdamjan = {
+    email = "gdamjan@gmail.com";
+    matrix = "@gdamjan:spodeli.org";
+    github = "gdamjan";
+    githubId = 81654;
+    name = "Damjan Georgievski";
+  };
   gdinh = {
     email = "nix@contact.dinh.ai";
     github = "gdinh";

--- a/pkgs/applications/video/go2tv/default.nix
+++ b/pkgs/applications/video/go2tv/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, Carbon
+, Cocoa
+, Kernel
+, UserNotifications
+, xorg
+, libglvnd
+, pkg-config
+, withGui ? true
+}:
+
+buildGoModule rec {
+  pname = "go2tv" + lib.optionalString (!withGui) "-lite";
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner = "alexballas";
+    repo = "go2tv";
+    rev = "v${version}";
+    sha256 = "sha256-ZHKfBKOX3/kVR6Nc+jSmLgfmpihc6QMb6NvTFlsBr5E=";
+  };
+
+  vendorSha256 = "sha256-msXfXFWXyZeT6zrRPZkBV7PEyPqYkx+JlpTWUwgFavI=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXinerama
+    xorg.libXi
+    xorg.libXext
+    xorg.libXxf86vm
+    libglvnd
+  ] ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa Kernel UserNotifications ];
+
+  ldflags = [
+    "-s" "-w"
+    "-linkmode=external"
+  ];
+
+  # conditionally build with GUI or not (go2tv or go2tv-lite sub-packages)
+  subPackages = [ "cmd/${pname}" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Cast media files to UPnP/DLNA Media Renderers and Smart TVs";
+    homepage = "https://github.com/alexballas/go2tv";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gdamjan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2690,6 +2690,11 @@ with pkgs;
 
   gmnitohtml = callPackage ../applications/misc/gmnitohtml { };
 
+  go2tv = darwin.apple_sdk_11_0.callPackage ../applications/video/go2tv {
+    inherit (darwin.apple_sdk_11_0.frameworks) Carbon Cocoa Kernel UserNotifications;
+  };
+  go2tv-lite = go2tv.override { withGui = false; };
+
   goimapnotify = callPackage ../tools/networking/goimapnotify { };
 
   gojsontoyaml = callPackage ../development/tools/gojsontoyaml { };


### PR DESCRIPTION
Cast media files to UPnP/DLNA Media Renderers and Smart TVs.
https://github.com/alexballas/go2tv

provides 2 packages:
- go2tv the GUI version (based on go-gl/glfw)
- go2tv-lite just a cli version

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
