### PR TITLE
Fix licenses in various packages

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -109,6 +109,11 @@ in mkLicense lset) ({
     fullName = "Apache License 2.0";
   };
 
+  bitstreamVera = {
+    spdxId = "Bitstream-Vera";
+    fullName = "Bitstream Vera Font License";
+  };
+
   bola11 = {
     url = "https://blitiri.com.ar/p/bola/";
     fullName = "Buena Onda License Agreement 1.1";

--- a/pkgs/data/fonts/arkpandora/default.nix
+++ b/pkgs/data/fonts/arkpandora/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl }:
+{ lib, fetchurl }:
 
 let
   version = "2.04";
@@ -21,5 +21,6 @@ in fetchurl {
 
   meta = {
     description = "Font, metrically identical to Arial and Times New Roman";
+    license = lib.licenses.bitstreamVera;
   };
 }

--- a/pkgs/data/fonts/dosemu-fonts/default.nix
+++ b/pkgs/data/fonts/dosemu-fonts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bdftopcf, mkfontdir, mkfontscale }:
+{ lib, stdenv, fetchurl, bdftopcf, mkfontdir, mkfontscale }:
 
 stdenv.mkDerivation rec {
   pname = "dosemu-fonts";
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Various fonts from the DOSEmu project";
+    license = lib.licenses.gpl2Only;
   };
 }

--- a/pkgs/data/fonts/tipa/default.nix
+++ b/pkgs/data/fonts/tipa/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "tipa";
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Phonetic font for TeX";
+    license = lib.licenses.lppl13c;
   };
 }
 

--- a/pkgs/data/icons/hicolor-icon-theme/default.nix
+++ b/pkgs/data/icons/hicolor-icon-theme/default.nix
@@ -15,5 +15,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Default fallback theme used by implementations of the icon theme specification";
     homepage = "https://icon-theme.freedesktop.org/releases/";
     platforms = platforms.unix;
+    license = licenses.gpl2Only;
   };
 }

--- a/pkgs/data/icons/tango-icon-theme/default.nix
+++ b/pkgs/data/icons/tango-icon-theme/default.nix
@@ -24,9 +24,10 @@ stdenv.mkDerivation rec {
 
   postInstall = '''${gtk.out}/bin/gtk-update-icon-cache' "$out/share/icons/Tango" '';
 
-  meta = {
+  meta = with lib; {
     description = "A basic set of icons";
     homepage = "http://tango.freedesktop.org/Tango_Icon_Library";
-    platforms = lib.platforms.linux;
+    platforms = platforms.linux;
+    license = licenses.publicDomain;
   };
 }

--- a/pkgs/data/misc/dns-root-data/default.nix
+++ b/pkgs/data/misc/dns-root-data/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "DNS root data including root zone and DNSSEC key";
     maintainers = with maintainers; [ fpletz vcunat ];
+    license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/development/tools/database/indradb/default.nix
+++ b/pkgs/development/tools/database/indradb/default.nix
@@ -16,7 +16,7 @@ let
   meta = with lib; {
     description = "A graph database written in rust ";
     homepage = "https://github.com/indradb/indradb";
-    license = licenses.asl20;
+    license = licenses.mpl20;
     maintainers = with maintainers; [ happysalada ];
     platforms = platforms.unix;
   };
@@ -25,7 +25,7 @@ in
   indradb-server = rustPlatform.buildRustPackage {
     pname = "indradb-server";
     version = "unstable-2021-01-05";
-    inherit src;
+    inherit src meta;
 
     cargoSha256 = "sha256-3WtiW31AkyNX7HiT/zqfNo2VSKR7Q57/wCigST066Js=";
 
@@ -43,7 +43,7 @@ in
   indradb-client = rustPlatform.buildRustPackage {
     pname = "indradb-client";
     version = "unstable-2021-01-05";
-    inherit src;
+    inherit src meta;
 
     cargoSha256 = "sha256-pxan6W/CEsOxv8DbbytEBuIqxWn/C4qT4ze/RnvESOM=";
 

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -17,7 +17,7 @@ luarocks.overrideAttrs (old: {
     updateScript = unstableGitUpdater { };
   };
 
-  meta = {
+  meta = old.meta // {
     mainProgram = "luarocks";
   };
 })


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


