### PR TITLE
Dendrite: custom "package" option and upload dir bugfix

### DIFF
--- a/nixos/modules/services/matrix/dendrite.nix
+++ b/nixos/modules/services/matrix/dendrite.nix
@@ -4,6 +4,7 @@ let
   settingsFormat = pkgs.formats.yaml { };
   configurationYaml = settingsFormat.generate "dendrite.yaml" cfg.settings;
   workingDir = "/var/lib/dendrite";
+  mediaStore = "${workingDir}/media_store";
 in
 {
   options.services.dendrite = {
@@ -177,7 +178,7 @@ in
           };
           base_path = lib.mkOption {
             type = lib.types.str;
-            default = "${workingDir}/media_store";
+            default = "${mediaStore}";
             description = lib.mdDoc ''
               Storage path for uploaded media.
             '';
@@ -289,6 +290,8 @@ in
         DynamicUser = true;
         StateDirectory = "dendrite";
         WorkingDirectory = workingDir;
+        ReadWritePaths = lib.mkIf (cfg.settings.media_api.base_path != mediaStore)
+          [ cfg.settings.media_api.base_path ];
         RuntimeDirectory = "dendrite";
         RuntimeDirectoryMode = "0700";
         LimitNOFILE = 65535;

--- a/nixos/modules/services/matrix/dendrite.nix
+++ b/nixos/modules/services/matrix/dendrite.nix
@@ -8,6 +8,12 @@ in
 {
   options.services.dendrite = {
     enable = lib.mkEnableOption (lib.mdDoc "matrix.org dendrite");
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.dendrite;
+      defaultText = lib.literalExpression "pkgs.dendrite";
+      description = lib.mdDoc "Which Dendrite package to use.";
+    };
     httpPort = lib.mkOption {
       type = lib.types.nullOr lib.types.port;
       default = 8008;


### PR DESCRIPTION
###### Description of changes

Dendrite matrix server:

* let the user select the package to be used, for easier testing and switching between stable/unstable
* when the user uses a nonstandard upload path (`services.dendrite.settings.media_api.base_path`) add `ReadWritePaths` to the systemd service. Thanks to systemd's `ProtectSystem=strict` the whole filesystem is otherwise read-only

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I am currently using this on a small private server

pinging matrix maintainers: @ma27 @fadenb @mguentner @ekleog @ralith @dandellion @sumnerevans

