### PR TITLE
python310Packages.pydyf: 0.1.2 -> 0.5.0, python310Packages.weasyprint: 54.3 -> 57.0

### DIFF
--- a/pkgs/development/python-modules/pydyf/default.nix
+++ b/pkgs/development/python-modules/pydyf/default.nix
@@ -1,49 +1,47 @@
 { lib
 , buildPythonPackage
-, fetchpatch
 , fetchPypi
-, isPy3k
-, pytestCheckHook
-, coverage
+, flit-core
 , ghostscript
 , pillow
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pydyf";
-  version = "0.1.2";
-  disabled = !isPy3k;
+  version = "0.5.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit version;
-    pname = "pydyf";
-    sha256 = "sha256-Hi9d5IF09QXeAlp9HnzwG73ZQiyoq5RReCvwDuF4YCw=";
+    inherit pname version;
+    hash = "sha256-UedRrhUEA3wfwfSBURkTewEYAs1fbDU52wZsRVsUp+E=";
   };
-
-  patches = [
-    # Fix tests for Ghostscript 9.56
-    # Remove after v0.1.3 has been released
-    (fetchpatch {
-      url = "https://github.com/CourtBouillon/pydyf/commit/d4c34823f1d15368753c9c26f7acc7a24fc2d979.patch";
-      sha256 = "sha256-2hHZW/q5CbStbpSJYbm3b23qKXANEb5jbPGQ83uHC+Q=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace "--isort --flake8 --cov --no-cov-on-fail" ""
   '';
 
+  nativeBuildInputs = [
+    flit-core
+  ];
+
   checkInputs = [
-    pytestCheckHook
-    coverage
     ghostscript
     pillow
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pydyf"
   ];
 
   meta = with lib; {
-    homepage = "https://doc.courtbouillon.org/pydyf/stable/";
     description = "Low-level PDF generator written in Python and based on PDF specification 1.7";
+    homepage = "https://doc.courtbouillon.org/pydyf/stable/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ rprecenth ];
   };

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -1,39 +1,38 @@
-{ buildPythonPackage
-, fetchPypi
-, fetchpatch
-, pytestCheckHook
+{ lib
+, stdenv
+, buildPythonPackage
 , cairosvg
-, flit-core
-, fonttools
-, pydyf
-, pyphen
 , cffi
 , cssselect2
-, html5lib
-, tinycss2
+, fetchPypi
+, flit-core
+, fontconfig
+, fonttools
+, ghostscript
 , glib
 , harfbuzz
+, html5lib
 , pango
-, fontconfig
-, lib
-, stdenv
-, ghostscript
-, isPy3k
-, substituteAll
 , pillow
+, pydyf
+, pyphen
+, pytestCheckHook
+, pythonOlder
+, substituteAll
+, tinycss2
 }:
 
 buildPythonPackage rec {
   pname = "weasyprint";
-  version = "54.3";
-  disabled = !isPy3k;
-
+  version = "57.0";
   format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit version;
     pname = "weasyprint";
-    sha256 = "sha256-4E2gQGMFZsRMqiAgM/B/hYdl9TZwkEWoCXOfPQSOidY=";
+    hash = "sha256-e29cwTgZ6afYdIwdvw6NJET3pIGKmDOfgtzKqCK/kRs=";
   };
 
   patches = [
@@ -45,12 +44,6 @@ buildPythonPackage rec {
       pango = "${pango.out}/lib/libpango-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       pangocairo = "${pango.out}/lib/libpangocairo-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       harfbuzz = "${harfbuzz.out}/lib/libharfbuzz${stdenv.hostPlatform.extensions.sharedLibrary}";
-    })
-    # Disable tests for new Ghostscript
-    # Remove when next version is released
-    (fetchpatch {
-      url = "https://github.com/Kozea/WeasyPrint/commit/e544398b00d76bc0317ea7e2abe40dc46b380910.patch";
-      sha256 = "sha256-oQO3j9Mo1x98WaLPROxsOn0qkeYRJrCx5QWWKoHvabE=";
     })
   ];
 
@@ -96,9 +89,13 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
+  pythonImportsCheck = [
+    "weasyprint"
+  ];
+
   meta = with lib; {
-    homepage = "https://weasyprint.org/";
     description = "Converts web documents to PDF";
+    homepage = "https://weasyprint.org/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ elohmeier ];
   };

--- a/pkgs/development/python-modules/weasyprint/library-paths.patch
+++ b/pkgs/development/python-modules/weasyprint/library-paths.patch
@@ -1,10 +1,10 @@
 diff --git a/weasyprint/text/ffi.py b/weasyprint/text/ffi.py
-index 0734cbea..22e31a5e 100644
+index 09f614aad..cbe9a73dd 100644
 --- a/weasyprint/text/ffi.py
 +++ b/weasyprint/text/ffi.py
-@@ -387,22 +387,11 @@ def _dlopen(ffi, *names):
-     return ffi.dlopen(names[0])  # pragma: no cover
- 
+@@ -415,22 +415,11 @@ def _dlopen(ffi, *names):
+         with suppress((OSError, FileNotFoundError)):
+             os.add_dll_directory(dll_directory)
  
 -gobject = _dlopen(
 -    ffi, 'gobject-2.0-0', 'gobject-2.0', 'libgobject-2.0-0',
@@ -18,7 +18,7 @@ index 0734cbea..22e31a5e 100644
 -    'libharfbuzz-0.dll')
 -fontconfig = _dlopen(
 -    ffi, 'fontconfig-1', 'fontconfig', 'libfontconfig', 'libfontconfig.so.1',
--    'libfontconfig-1.dylib', 'libfontconfig-1.dll')
+-    'libfontconfig.1.dylib', 'libfontconfig-1.dll')
 -pangoft2 = _dlopen(
 -    ffi, 'pangoft2-1.0-0', 'pangoft2-1.0', 'libpangoft2-1.0-0',
 -    'libpangoft2-1.0.so.0', 'libpangoft2-1.0.dylib', 'libpangoft2-1.0-0.dll')
@@ -29,4 +29,3 @@ index 0734cbea..22e31a5e 100644
 +pangoft2 = _dlopen(ffi, '@pangoft2@')
  
  gobject.g_type_init()
-


### PR DESCRIPTION
###### Description of changes
- https://github.com/Kozea/WeasyPrint/releases/tag/v57.0
- https://github.com/CourtBouillon/pydyf/releases/tag/v0.5.0

Fixes #199195
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
