### PR TITLE
python3Packages.deploykit: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/deploykit/default.nix
+++ b/pkgs/development/python-modules/deploykit/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, bash
+, openssh
+, pytestCheckHook
+, stdenv
+}:
+
+buildPythonPackage rec {
+  pname = "deploykit";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "numtide";
+    repo = pname;
+    rev = version;
+    hash = "sha256-eKyqsGgnJmF2wUYa7HjC1Jwsh03qVTJEP1MtL7JL4Ts=";
+  };
+
+  buildInputs = [
+    setuptools
+  ];
+
+  checkInputs = [
+    bash
+    openssh
+    pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals stdenv.isDarwin [ "test_ssh" ];
+
+  # don't swallow stdout/stderr
+  pytestFlagsArray = [ "-s" ];
+
+  meta = with lib; {
+    description = "Execute commands remote via ssh and locally in parallel with python";
+    homepage = "https://github.com/numtide/deploykit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mic92 zowoq ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2287,6 +2287,8 @@ self: super: with self; {
 
   dependency-injector = callPackage ../development/python-modules/dependency-injector { };
 
+  deploykit = callPackage ../development/python-modules/deploykit { };
+
   deprecated = callPackage ../development/python-modules/deprecated { };
 
   deprecation = callPackage ../development/python-modules/deprecation { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @Mic92 