### PR TITLE
pkgsStatic.laminar: fix build

### DIFF
--- a/pkgs/development/tools/continuous-integration/laminar/default.nix
+++ b/pkgs/development/tools/continuous-integration/laminar/default.nix
@@ -34,7 +34,9 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-PLnfiWpelgKhs4FNry60sm6/QdhYs76FnZ/ZcRmb4Ok=";
   };
   patches = [ ./patches/no-network.patch ];
-  nativeBuildInputs = [ cmake pandoc ];
+
+  # We need both binary from "capnproto" and library files.
+  nativeBuildInputs = [ cmake pandoc capnproto ];
   buildInputs = [ capnproto sqlite boost zlib rapidjson ];
   preBuild = ''
     mkdir -p js css


### PR DESCRIPTION
Add "capnproto" into nativeBuildInputs so build system has access to capnp(1).
