### PR TITLE
pkgsStatic.rcshist: fix static build

### DIFF
--- a/pkgs/applications/version-management/rcshist/default.nix
+++ b/pkgs/applications/version-management/rcshist/default.nix
@@ -1,11 +1,16 @@
 { lib
 , stdenv
 , fetchurl
+, musl-fts
 }:
 
 stdenv.mkDerivation {
   pname = "rcshist";
   version = "1.04";
+
+  configureFlags = lib.optional stdenv.hostPlatform.isMusl "LIBS=-lfts";
+
+  buildInputs = lib.optional stdenv.hostPlatform.isMusl musl-fts;
 
   src = fetchurl {
     url = "https://web.archive.org/web/20220508220019/https://invisible-island.net/datafiles/release/rcshist.tar.gz";


### PR DESCRIPTION
Add dependency on musl standalone implementation of "fts.h" in case of
pkgsMusl/pkgsStatic build; this interface is provided as part of libc
proper by glibc.
