### PR TITLE
ociTools.buildContainer: Expose more options

### DIFF
--- a/pkgs/build-support/oci-tools/default.nix
+++ b/pkgs/build-support/oci-tools/default.nix
@@ -7,6 +7,14 @@
     , os ? "linux"
     , arch ? "x86_64"
     , readonly ? false
+    , readonlyPaths ? []
+    , user ? { uid = 0; gid = 0; }
+    , capabilities ? {}
+    , namespaces ? [ "pid" "network" "mount" "ipc" "uts" ]
+    , uidMappings ? []
+    , gidMappings ? []
+    , sysctl ? {}
+    , terminal ? false
     }:
   let
     sysMounts = {
@@ -52,14 +60,14 @@
       };
 
       linux = {
-        namespaces = map (type: { inherit type; }) [ "pid" "network" "mount" "ipc" "uts" ];
+        inherit uidMappings gidMappings readonlyPaths sysctl;
+        namespaces = map (type: { inherit type; }) namespaces;
       };
 
       root = { path = "rootfs"; inherit readonly; };
 
       process = {
-        inherit args;
-        user = { uid = 0; gid = 0; };
+        inherit args capabilities user terminal;
         cwd = "/";
       };
 


### PR DESCRIPTION
###### Description of changes

At the moment it is not even possible to specify a user other than root that should run the container. This PR exposes the most useful options of the JSON as optional arguments of the function.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
