### PR TITLE
doc: Describe list arguments to submodule

### DIFF
--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -197,13 +197,16 @@ merging is handled.
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).
 
-`types.submodule` *`o`*
+`types.submodule` *`module`*
 
-:   A set of sub options *`o`*. *`o`* can be an attribute set, a function
-    returning an attribute set, or a path to a file containing such a
-    value. Submodules are used in composed types to create modular
-    options. This is equivalent to
+:   A nested module evaluation, containing its own set of options.
+    `module` can either be a single module (in the form of an attribute
+    set, a function, or a path), or as a list of modules (which then
+    gets processed just like a list assigned to `imports`). This type is
+    equivalent to
     `types.submoduleWith { modules = toList o; shorthandOnlyDefinesConfig = true; }`.
+    Submodules can be used in composed types to create multiple
+    occurrences of the submodule. 
 
 `types.submoduleWith` { *`modules`*, *`specialArgs`* ? {}, *`shorthandOnlyDefinesConfig`* ? false }
 

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -402,18 +402,19 @@
       <varlistentry>
         <term>
           <literal>types.submodule</literal>
-          <emphasis><literal>o</literal></emphasis>
+          <emphasis><literal>module</literal></emphasis>
         </term>
         <listitem>
           <para>
-            A set of sub options
-            <emphasis><literal>o</literal></emphasis>.
-            <emphasis><literal>o</literal></emphasis> can be an
-            attribute set, a function returning an attribute set, or a
-            path to a file containing such a value. Submodules are used
-            in composed types to create modular options. This is
-            equivalent to
+            A nested module evaluation, containing its own set of
+            options. <literal>module</literal> can either be a single
+            module (in the form of an attribute set, a function, or a
+            path), or as a list of modules (which then gets processed
+            just like a list assigned to <literal>imports</literal>).
+            This type is equivalent to
             <literal>types.submoduleWith { modules = toList o; shorthandOnlyDefinesConfig = true; }</literal>.
+            Submodules can be used in composed types to create multiple
+            occurrences of the submodule.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
See https://discourse.nixos.org/t/submodule-with-list-argument/22956

###### Description of changes

I updated the documentation according to what I just learned on discourse. I have not built the documentation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
