### PR TITLE
miopengemm: init at 5.3.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -377,6 +377,7 @@ in {
   minidlna = handleTest ./minidlna.nix {};
   miniflux = handleTest ./miniflux.nix {};
   minio = handleTest ./minio.nix {};
+  miopengemm = handleTest ./miopengemm.nix {};
   misc = handleTest ./misc.nix {};
   mjolnir = handleTest ./matrix/mjolnir.nix {};
   mod_perl = handleTest ./mod_perl.nix {};

--- a/nixos/tests/miopengemm.nix
+++ b/nixos/tests/miopengemm.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+
+with lib;
+
+{
+  name = "miopengemm";
+  meta.maintainers = with maintainers; [ Madouura ];
+  nodes.machine = { };
+
+  # This will likely always fail due to this being a virtual machine with no gpu
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.succeed("find ${(pkgs.miopengemm.override { buildTests = true; }).test}/bin -maxdepth 1 -type f -executable > tests")
+
+    # We can do this directly with find, but can't get the command to fail
+    machine.succeed("for test in $(cat tests); do $test; done")
+  '';
+})

--- a/pkgs/development/libraries/miopengemm/default.nix
+++ b/pkgs/development/libraries/miopengemm/default.nix
@@ -1,0 +1,129 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, rocm-cmake
+, rocm-opencl-runtime
+, clang
+, texlive ? null
+, doxygen ? null
+, sphinx ? null
+, python3Packages ? null
+, openblas ? null
+, buildDocs ? false
+, buildTests ? false
+, buildBenchmarks ? false
+}:
+
+assert buildDocs -> texlive != null;
+assert buildDocs -> doxygen != null;
+assert buildDocs -> sphinx != null;
+assert buildDocs -> python3Packages != null;
+assert buildTests -> openblas != null;
+
+let
+  latex = lib.optionalAttrs buildDocs (texlive.combine {
+    inherit (texlive) scheme-small
+    latexmk
+    tex-gyre
+    fncychap
+    wrapfig
+    capt-of
+    framed
+    needspace
+    tabulary
+    varwidth
+    titlesec;
+  });
+in stdenv.mkDerivation rec {
+  pname = "miopengemm";
+  rocmVersion = "5.3.1";
+  version = rocmVersion;
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildDocs [
+    "docs"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "MIOpenGEMM";
+    rev = "rocm-${rocmVersion}";
+    hash = "sha256-AiRzOMYRA/0nbQomyq4oOEwNZdkPYWRA2W6QFlctvFc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    clang
+  ];
+
+  buildInputs = [
+    rocm-opencl-runtime
+  ] ++ lib.optionals buildDocs [
+    latex
+    doxygen
+    sphinx
+    python3Packages.sphinx_rtd_theme
+    python3Packages.breathe
+  ] ++ lib.optionals buildTests [
+    openblas
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_C_COMPILER=clang"
+    "-DCMAKE_CXX_COMPILER=clang++"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals buildTests [
+    "-DOPENBLAS=ON"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DAPI_BENCH_MIOGEMM=ON"
+    # Needs https://github.com/CNugteren/CLBlast
+    # "-DAPI_BENCH_CLBLAST=ON"
+    # Needs https://github.com/openai/triton
+    # "-DAPI_BENCH_ISAAC=ON"
+  ];
+
+  # Unfortunately, it seems like we have to call make on these manually
+  postBuild = lib.optionalString buildDocs ''
+    export HOME=$(mktemp -d)
+    make doc
+  '' + lib.optionalString buildTests ''
+    make check
+  '' + lib.optionalString buildBenchmarks ''
+    make examples
+  '';
+
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    find tests -executable -type f -exec mv {} $test/bin \;
+    patchelf --set-rpath ${lib.makeLibraryPath buildInputs}:$out/lib $test/bin/*
+  '' + lib.optionalString buildBenchmarks ''
+    mkdir -p $benchmark/bin
+    find examples -executable -type f -exec mv {} $benchmark/bin \;
+    patchelf --set-rpath ${lib.makeLibraryPath buildInputs}:$out/lib $benchmark/bin/*
+  '';
+
+  postFixup = lib.optionalString buildDocs ''
+    mkdir -p $docs/share/doc/miopengemm
+    mv ../doc/html $docs/share/doc/miopengemm
+    mv ../doc/pdf/miopengemm.pdf $docs/share/doc/miopengemm
+  '';
+
+  meta = with lib; {
+    description = "OpenCL general matrix multiplication API for ROCm";
+    homepage = "https://github.com/ROCmSoftwarePlatform/MIOpenGEMM";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ Madouura ];
+    broken = rocmVersion != clang.version;
+  };
+}

--- a/pkgs/development/libraries/miopengemm/default.nix
+++ b/pkgs/development/libraries/miopengemm/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nixosTests
 , cmake
 , rocm-cmake
 , rocm-opencl-runtime
@@ -118,6 +119,10 @@ in stdenv.mkDerivation rec {
     mv ../doc/html $docs/share/doc/miopengemm
     mv ../doc/pdf/miopengemm.pdf $docs/share/doc/miopengemm
   '';
+
+  passthru.tests = {
+    smoke-test = nixosTests.miopengemm;
+  };
 
   meta = with lib; {
     description = "OpenCL general matrix multiplication API for ROCm";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14859,6 +14859,10 @@ with pkgs;
 
   rocminfo = callPackage ../development/tools/rocminfo { };
 
+  miopengemm = callPackage ../development/libraries/miopengemm {
+    inherit (llvmPackages_rocm) clang;
+  };
+
   rtags = callPackage ../development/tools/rtags {
     inherit (darwin) apple_sdk;
   };


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
``miopengemm.passthru.tests`` will likely always fail due to it being in a vm, but I have confirmed the tests generated do work on hardware. Benchmarks may require different packages or options at runtime, not really sure, some work.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
