### PR TITLE
python3.pkgs.junos-eznc: 2.6.3 -> 2.6.5

### DIFF
--- a/pkgs/development/python-modules/junos-eznc/default.nix
+++ b/pkgs/development/python-modules/junos-eznc/default.nix
@@ -26,28 +26,15 @@
 
 buildPythonPackage rec {
   pname = "junos-eznc";
-  version = "2.6.3";
+  version = "2.6.5";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "Juniper";
     repo = "py-junos-eznc";
     rev = version;
-    hash = "sha256-XhQJwtS518AzSwyaWE392nfNdYe9+iYHvXxQsjJfzI8=";
+    hash = "sha256-BoHT6ejccInfREbYtW6psm3fvsQxLS1vpj/aPDqqpnY=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Fixes tests with lxml>=4.8.0; remove > 2.6.3
-      url = "https://github.com/Juniper/py-junos-eznc/commit/048f750bb7357b6f6b9db8ad64bea479298c74fb.patch";
-      hash = "sha256-DYVj0BNPwDSbxDrzHhaq4F4kz1bliXB6Au3I63mRauc=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "ncclient==0.6.9" "ncclient"
-  '';
 
   propagatedBuildInputs = [
     jinja2


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
