### PR TITLE
arpack: fix ILP64 checks and MPI support

### DIFF
--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -8,6 +8,7 @@
 }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
+assert (blas.isILP64 == arpack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "octopus";

--- a/pkgs/applications/science/math/calculix/default.nix
+++ b/pkgs/applications/science/math/calculix/default.nix
@@ -1,5 +1,9 @@
 { lib, stdenv, fetchurl, gfortran, arpack, spooles, blas, lapack }:
 
+assert (blas.isILP64 == lapack.isILP64 &&
+        blas.isILP64 == arpack.isILP64 &&
+        !blas.isILP64);
+
 stdenv.mkDerivation rec {
   pname = "calculix";
   version = "2.19";

--- a/pkgs/development/libraries/igraph/default.nix
+++ b/pkgs/development/libraries/igraph/default.nix
@@ -21,6 +21,10 @@
 , xmlto
 }:
 
+assert (blas.isILP64 == lapack.isILP64 &&
+        blas.isILP64 == arpack.isILP64 &&
+        !blas.isILP64);
+
 stdenv.mkDerivation rec {
   pname = "igraph";
   version = "0.9.10";

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -1,5 +1,13 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, cmake
-, gfortran, blas, lapack, eigen }:
+, gfortran, blas, lapack, eigen
+, useMpi ? false
+, mpi
+, openssh
+}:
+
+# MPI version can only be built with LP64 interface.
+# See https://github.com/opencollab/arpack-ng#readme
+assert useMpi -> !blas.isILP64;
 
 stdenv.mkDerivation rec {
   pname = "arpack";
@@ -27,13 +35,16 @@ stdenv.mkDerivation rec {
     blas
     lapack
     eigen
-  ];
+  ] ++ lib.optional useMpi mpi;
+
+  checkInputs = lib.optional useMpi openssh;
 
   doCheck = true;
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
     "-DINTERFACE64=${if blas.isILP64 then "1" else "0"}"
+    "-DMPI=${if useMpi then "ON" else "OFF"}"
   ];
 
   preCheck = ''

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation rec {
     install_name_tool -change libblas.dylib ${blas}/lib/libblas.dylib $out/lib/libarpack.dylib
   '';
 
+  passthru = { inherit (blas) isILP64; };
+
   meta = {
     homepage = "https://github.com/opencollab/arpack-ng";
     description = ''


### PR DESCRIPTION
###### Description of changes
Add the `isILP64` flag to `arpack` to allow packages, which use it, 
to check that `blas`, `lapack` and `arpack` have a matching API.
Allow building with optional MPI support.

Added `isILP64` asserts to the following packages to automatically prevent mismatches:
* `octopus`
* `calculix`
* `igraph`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
