### PR TITLE
nixos/pam: do not use mkDefault for login file to append to it by default instead of overwriting

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -446,236 +446,234 @@ let
       # !!! TODO: move the LDAP stuff to the LDAP module, and the
       # Samba stuff to the Samba module.  This requires that the PAM
       # module provides the right hooks.
-      text = mkDefault
-        (
-          ''
-            # Account management.
-          '' +
-          optionalString use_ldap ''
-            account sufficient ${pam_ldap}/lib/security/pam_ldap.so
-          '' +
-          optionalString cfg.mysqlAuth ''
-            account sufficient ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
-          '' +
-          optionalString (config.services.sssd.enable && cfg.sssdStrictAccess==false) ''
-            account sufficient ${pkgs.sssd}/lib/security/pam_sss.so
-          '' +
-          optionalString (config.services.sssd.enable && cfg.sssdStrictAccess) ''
-            account [default=bad success=ok user_unknown=ignore] ${pkgs.sssd}/lib/security/pam_sss.so
-          '' +
-          optionalString config.security.pam.krb5.enable ''
-            account sufficient ${pam_krb5}/lib/security/pam_krb5.so
-          '' +
-          optionalString cfg.googleOsLoginAccountVerification ''
-            account [success=ok ignore=ignore default=die] ${pkgs.google-guest-oslogin}/lib/security/pam_oslogin_login.so
-            account [success=ok default=ignore] ${pkgs.google-guest-oslogin}/lib/security/pam_oslogin_admin.so
-          '' +
-          # The required pam_unix.so module has to come after all the sufficient modules
-          # because otherwise, the account lookup will fail if the user does not exist
-          # locally, for example with MySQL- or LDAP-auth.
-          ''
-            account required pam_unix.so
+      text =
+        ''
+          # Account management.
+        '' +
+        optionalString use_ldap ''
+          account sufficient ${pam_ldap}/lib/security/pam_ldap.so
+        '' +
+        optionalString cfg.mysqlAuth ''
+          account sufficient ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
+        '' +
+        optionalString (config.services.sssd.enable && cfg.sssdStrictAccess==false) ''
+          account sufficient ${pkgs.sssd}/lib/security/pam_sss.so
+        '' +
+        optionalString (config.services.sssd.enable && cfg.sssdStrictAccess) ''
+          account [default=bad success=ok user_unknown=ignore] ${pkgs.sssd}/lib/security/pam_sss.so
+        '' +
+        optionalString config.security.pam.krb5.enable ''
+          account sufficient ${pam_krb5}/lib/security/pam_krb5.so
+        '' +
+        optionalString cfg.googleOsLoginAccountVerification ''
+          account [success=ok ignore=ignore default=die] ${pkgs.google-guest-oslogin}/lib/security/pam_oslogin_login.so
+          account [success=ok default=ignore] ${pkgs.google-guest-oslogin}/lib/security/pam_oslogin_admin.so
+        '' +
+        # The required pam_unix.so module has to come after all the sufficient modules
+        # because otherwise, the account lookup will fail if the user does not exist
+        # locally, for example with MySQL- or LDAP-auth.
+        ''
+          account required pam_unix.so
 
-            # Authentication management.
-          '' +
-          optionalString cfg.googleOsLoginAuthentication ''
-            auth [success=done perm_denied=die default=ignore] ${pkgs.google-guest-oslogin}/lib/security/pam_oslogin_login.so
-          '' +
-          optionalString cfg.rootOK ''
-            auth sufficient pam_rootok.so
-          '' +
-          optionalString cfg.requireWheel ''
-            auth required pam_wheel.so use_uid
-          '' +
-          optionalString cfg.logFailures ''
-            auth required pam_faillock.so
-          '' +
-          optionalString cfg.mysqlAuth ''
-            auth sufficient ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
-          '' +
-          optionalString (config.security.pam.enableSSHAgentAuth && cfg.sshAgentAuth) ''
-            auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=${lib.concatStringsSep ":" config.services.openssh.authorizedKeysFiles}
-          '' +
-          (let p11 = config.security.pam.p11; in optionalString cfg.p11Auth ''
-            auth ${p11.control} ${pkgs.pam_p11}/lib/security/pam_p11.so ${pkgs.opensc}/lib/opensc-pkcs11.so
-          '') +
-          (let u2f = config.security.pam.u2f; in optionalString cfg.u2fAuth (''
-              auth ${u2f.control} ${pkgs.pam_u2f}/lib/security/pam_u2f.so ${optionalString u2f.debug "debug"} ${optionalString (u2f.authFile != null) "authfile=${u2f.authFile}"} ''
-                + ''${optionalString u2f.interactive "interactive"} ${optionalString u2f.cue "cue"} ${optionalString (u2f.appId != null) "appid=${u2f.appId}"} ${optionalString (u2f.origin != null) "origin=${u2f.origin}"}
-          '')) +
-          optionalString cfg.usbAuth ''
-            auth sufficient ${pkgs.pam_usb}/lib/security/pam_usb.so
-          '' +
-          (let ussh = config.security.pam.ussh; in optionalString (config.security.pam.ussh.enable && cfg.usshAuth) ''
-            auth ${ussh.control} ${pkgs.pam_ussh}/lib/security/pam_ussh.so ${optionalString (ussh.caFile != null) "ca_file=${ussh.caFile}"} ${optionalString (ussh.authorizedPrincipals != null) "authorized_principals=${ussh.authorizedPrincipals}"} ${optionalString (ussh.authorizedPrincipalsFile != null) "authorized_principals_file=${ussh.authorizedPrincipalsFile}"} ${optionalString (ussh.group != null) "group=${ussh.group}"}
-          '') +
-          (let oath = config.security.pam.oath; in optionalString cfg.oathAuth ''
-            auth requisite ${pkgs.oath-toolkit}/lib/security/pam_oath.so window=${toString oath.window} usersfile=${toString oath.usersFile} digits=${toString oath.digits}
-          '') +
-          (let yubi = config.security.pam.yubico; in optionalString cfg.yubicoAuth ''
-            auth ${yubi.control} ${pkgs.yubico-pam}/lib/security/pam_yubico.so mode=${toString yubi.mode} ${optionalString (yubi.challengeResponsePath != null) "chalresp_path=${yubi.challengeResponsePath}"} ${optionalString (yubi.mode == "client") "id=${toString yubi.id}"} ${optionalString yubi.debug "debug"}
-          '') +
-          optionalString cfg.fprintAuth ''
-            auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so
-          '' +
-          # Modules in this block require having the password set in PAM_AUTHTOK.
-          # pam_unix is marked as 'sufficient' on NixOS which means nothing will run
-          # after it succeeds. Certain modules need to run after pam_unix
-          # prompts the user for password so we run it once with 'optional' at an
-          # earlier point and it will run again with 'sufficient' further down.
-          # We use try_first_pass the second time to avoid prompting password twice
-          (optionalString (cfg.unixAuth &&
-            (config.security.pam.enableEcryptfs
-              || cfg.pamMount
-              || cfg.enableKwallet
-              || cfg.enableGnomeKeyring
-              || cfg.googleAuthenticator.enable
-              || cfg.gnupg.enable
-              || cfg.duoSecurity.enable))
-            (
-              ''
-                auth optional pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} ${optionalString cfg.nodelay "nodelay"} likeauth
-              '' +
-              optionalString config.security.pam.enableEcryptfs ''
-                auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap
-              '' +
-              optionalString cfg.pamMount ''
-                auth optional ${pkgs.pam_mount}/lib/security/pam_mount.so disable_interactive
-              '' +
-              optionalString cfg.enableKwallet ''
-               auth optional ${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so kwalletd=${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5
-              '' +
-              optionalString cfg.enableGnomeKeyring ''
-                auth optional ${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so
-              '' +
-              optionalString cfg.gnupg.enable ''
-                auth optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so ${optionalString cfg.gnupg.storeOnly " store-only"}
-              '' +
-              optionalString cfg.googleAuthenticator.enable ''
-                auth required ${pkgs.google-authenticator}/lib/security/pam_google_authenticator.so no_increment_hotp
-              '' +
-              optionalString cfg.duoSecurity.enable ''
-                auth required ${pkgs.duo-unix}/lib/security/pam_duo.so
-              ''
-            )) +
-          optionalString cfg.unixAuth ''
-            auth sufficient pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} ${optionalString cfg.nodelay "nodelay"} likeauth try_first_pass
-          '' +
-          optionalString cfg.otpwAuth ''
-            auth sufficient ${pkgs.otpw}/lib/security/pam_otpw.so
-          '' +
-          optionalString use_ldap ''
-            auth sufficient ${pam_ldap}/lib/security/pam_ldap.so use_first_pass
-          '' +
-          optionalString config.services.sssd.enable ''
-            auth sufficient ${pkgs.sssd}/lib/security/pam_sss.so use_first_pass
-          '' +
-          optionalString config.security.pam.krb5.enable ''
-            auth [default=ignore success=1 service_err=reset] ${pam_krb5}/lib/security/pam_krb5.so use_first_pass
-            auth [default=die success=done] ${pam_ccreds}/lib/security/pam_ccreds.so action=validate use_first_pass
-            auth sufficient ${pam_ccreds}/lib/security/pam_ccreds.so action=store use_first_pass
-          '' +
-          ''
-            auth required pam_deny.so
-
-            # Password management.
-            password sufficient pam_unix.so nullok sha512
-          '' +
-          optionalString config.security.pam.enableEcryptfs ''
-            password optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so
-          '' +
-          optionalString cfg.pamMount ''
-            password optional ${pkgs.pam_mount}/lib/security/pam_mount.so
-          '' +
-          optionalString use_ldap ''
-            password sufficient ${pam_ldap}/lib/security/pam_ldap.so
-          '' +
-          optionalString cfg.mysqlAuth ''
-            password sufficient ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
-          '' +
-          optionalString config.services.sssd.enable ''
-            password sufficient ${pkgs.sssd}/lib/security/pam_sss.so use_authtok
-          '' +
-          optionalString config.security.pam.krb5.enable ''
-            password sufficient ${pam_krb5}/lib/security/pam_krb5.so use_first_pass
-          '' +
-          optionalString cfg.enableGnomeKeyring ''
-            password optional ${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so use_authtok
-          '' +
-          ''
-
-            # Session management.
-          '' +
-          optionalString cfg.setEnvironment ''
-            session required pam_env.so conffile=/etc/pam/environment readenv=0
-          '' +
-          ''
-            session required pam_unix.so
-          '' +
-          optionalString cfg.setLoginUid ''
-            session ${if config.boot.isContainer then "optional" else "required"} pam_loginuid.so
-          '' +
-          optionalString cfg.ttyAudit.enable (concatStringsSep " \\\n  " ([
-            "session required ${pkgs.pam}/lib/security/pam_tty_audit.so"
-          ] ++ optional cfg.ttyAudit.openOnly "open_only"
-          ++ optional (cfg.ttyAudit.enablePattern != null) "enable=${cfg.ttyAudit.enablePattern}"
-          ++ optional (cfg.ttyAudit.disablePattern != null) "disable=${cfg.ttyAudit.disablePattern}"
+          # Authentication management.
+        '' +
+        optionalString cfg.googleOsLoginAuthentication ''
+          auth [success=done perm_denied=die default=ignore] ${pkgs.google-guest-oslogin}/lib/security/pam_oslogin_login.so
+        '' +
+        optionalString cfg.rootOK ''
+          auth sufficient pam_rootok.so
+        '' +
+        optionalString cfg.requireWheel ''
+          auth required pam_wheel.so use_uid
+        '' +
+        optionalString cfg.logFailures ''
+          auth required pam_faillock.so
+        '' +
+        optionalString cfg.mysqlAuth ''
+          auth sufficient ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
+        '' +
+        optionalString (config.security.pam.enableSSHAgentAuth && cfg.sshAgentAuth) ''
+          auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=${lib.concatStringsSep ":" config.services.openssh.authorizedKeysFiles}
+        '' +
+        (let p11 = config.security.pam.p11; in optionalString cfg.p11Auth ''
+          auth ${p11.control} ${pkgs.pam_p11}/lib/security/pam_p11.so ${pkgs.opensc}/lib/opensc-pkcs11.so
+        '') +
+        (let u2f = config.security.pam.u2f; in optionalString cfg.u2fAuth (''
+            auth ${u2f.control} ${pkgs.pam_u2f}/lib/security/pam_u2f.so ${optionalString u2f.debug "debug"} ${optionalString (u2f.authFile != null) "authfile=${u2f.authFile}"} ''
+              + ''${optionalString u2f.interactive "interactive"} ${optionalString u2f.cue "cue"} ${optionalString (u2f.appId != null) "appid=${u2f.appId}"} ${optionalString (u2f.origin != null) "origin=${u2f.origin}"}
+        '')) +
+        optionalString cfg.usbAuth ''
+          auth sufficient ${pkgs.pam_usb}/lib/security/pam_usb.so
+        '' +
+        (let ussh = config.security.pam.ussh; in optionalString (config.security.pam.ussh.enable && cfg.usshAuth) ''
+          auth ${ussh.control} ${pkgs.pam_ussh}/lib/security/pam_ussh.so ${optionalString (ussh.caFile != null) "ca_file=${ussh.caFile}"} ${optionalString (ussh.authorizedPrincipals != null) "authorized_principals=${ussh.authorizedPrincipals}"} ${optionalString (ussh.authorizedPrincipalsFile != null) "authorized_principals_file=${ussh.authorizedPrincipalsFile}"} ${optionalString (ussh.group != null) "group=${ussh.group}"}
+        '') +
+        (let oath = config.security.pam.oath; in optionalString cfg.oathAuth ''
+          auth requisite ${pkgs.oath-toolkit}/lib/security/pam_oath.so window=${toString oath.window} usersfile=${toString oath.usersFile} digits=${toString oath.digits}
+        '') +
+        (let yubi = config.security.pam.yubico; in optionalString cfg.yubicoAuth ''
+          auth ${yubi.control} ${pkgs.yubico-pam}/lib/security/pam_yubico.so mode=${toString yubi.mode} ${optionalString (yubi.challengeResponsePath != null) "chalresp_path=${yubi.challengeResponsePath}"} ${optionalString (yubi.mode == "client") "id=${toString yubi.id}"} ${optionalString yubi.debug "debug"}
+        '') +
+        optionalString cfg.fprintAuth ''
+          auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so
+        '' +
+        # Modules in this block require having the password set in PAM_AUTHTOK.
+        # pam_unix is marked as 'sufficient' on NixOS which means nothing will run
+        # after it succeeds. Certain modules need to run after pam_unix
+        # prompts the user for password so we run it once with 'optional' at an
+        # earlier point and it will run again with 'sufficient' further down.
+        # We use try_first_pass the second time to avoid prompting password twice
+        (optionalString (cfg.unixAuth &&
+          (config.security.pam.enableEcryptfs
+            || cfg.pamMount
+            || cfg.enableKwallet
+            || cfg.enableGnomeKeyring
+            || cfg.googleAuthenticator.enable
+            || cfg.gnupg.enable
+            || cfg.duoSecurity.enable))
+          (
+            ''
+              auth optional pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} ${optionalString cfg.nodelay "nodelay"} likeauth
+            '' +
+            optionalString config.security.pam.enableEcryptfs ''
+              auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap
+            '' +
+            optionalString cfg.pamMount ''
+              auth optional ${pkgs.pam_mount}/lib/security/pam_mount.so disable_interactive
+            '' +
+            optionalString cfg.enableKwallet ''
+             auth optional ${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so kwalletd=${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5
+            '' +
+            optionalString cfg.enableGnomeKeyring ''
+              auth optional ${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so
+            '' +
+            optionalString cfg.gnupg.enable ''
+              auth optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so ${optionalString cfg.gnupg.storeOnly " store-only"}
+            '' +
+            optionalString cfg.googleAuthenticator.enable ''
+              auth required ${pkgs.google-authenticator}/lib/security/pam_google_authenticator.so no_increment_hotp
+            '' +
+            optionalString cfg.duoSecurity.enable ''
+              auth required ${pkgs.duo-unix}/lib/security/pam_duo.so
+            ''
           )) +
-          optionalString cfg.makeHomeDir ''
-            session required ${pkgs.pam}/lib/security/pam_mkhomedir.so silent skel=${config.security.pam.makeHomeDir.skelDirectory} umask=0077
-          '' +
-          optionalString cfg.updateWtmp ''
-            session required ${pkgs.pam}/lib/security/pam_lastlog.so silent
-          '' +
-          optionalString config.security.pam.enableEcryptfs ''
-            session optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so
-          '' +
-          optionalString cfg.pamMount ''
-            session optional ${pkgs.pam_mount}/lib/security/pam_mount.so disable_interactive
-          '' +
-          optionalString use_ldap ''
-            session optional ${pam_ldap}/lib/security/pam_ldap.so
-          '' +
-          optionalString cfg.mysqlAuth ''
-            session optional ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
-          '' +
-          optionalString config.services.sssd.enable ''
-            session optional ${pkgs.sssd}/lib/security/pam_sss.so
-          '' +
-          optionalString config.security.pam.krb5.enable ''
-            session optional ${pam_krb5}/lib/security/pam_krb5.so
-          '' +
-          optionalString cfg.otpwAuth ''
-            session optional ${pkgs.otpw}/lib/security/pam_otpw.so
-          '' +
-          optionalString cfg.startSession ''
-            session optional ${config.systemd.package}/lib/security/pam_systemd.so
-          '' +
-          optionalString cfg.forwardXAuth ''
-            session optional pam_xauth.so xauthpath=${pkgs.xorg.xauth}/bin/xauth systemuser=99
-          '' +
-          optionalString (cfg.limits != []) ''
-            session required ${pkgs.pam}/lib/security/pam_limits.so conf=${makeLimitsConf cfg.limits}
-          '' +
-          optionalString (cfg.showMotd && config.users.motd != null) ''
-            session optional ${pkgs.pam}/lib/security/pam_motd.so motd=${motd}
-          '' +
-          optionalString (cfg.enableAppArmor && config.security.apparmor.enable) ''
-            session optional ${pkgs.apparmor-pam}/lib/security/pam_apparmor.so order=user,group,default debug
-          '' +
-          optionalString (cfg.enableKwallet) ''
-            session optional ${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so kwalletd=${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5
-          '' +
-          optionalString (cfg.enableGnomeKeyring) ''
-            session optional ${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so auto_start
-          '' +
-          optionalString cfg.gnupg.enable ''
-            session optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so ${optionalString cfg.gnupg.noAutostart " no-autostart"}
-          '' +
-          optionalString (config.virtualisation.lxc.lxcfs.enable) ''
-            session optional ${pkgs.lxc}/lib/security/pam_cgfs.so -c all
-          ''
-        );
+        optionalString cfg.unixAuth ''
+          auth sufficient pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} ${optionalString cfg.nodelay "nodelay"} likeauth try_first_pass
+        '' +
+        optionalString cfg.otpwAuth ''
+          auth sufficient ${pkgs.otpw}/lib/security/pam_otpw.so
+        '' +
+        optionalString use_ldap ''
+          auth sufficient ${pam_ldap}/lib/security/pam_ldap.so use_first_pass
+        '' +
+        optionalString config.services.sssd.enable ''
+          auth sufficient ${pkgs.sssd}/lib/security/pam_sss.so use_first_pass
+        '' +
+        optionalString config.security.pam.krb5.enable ''
+          auth [default=ignore success=1 service_err=reset] ${pam_krb5}/lib/security/pam_krb5.so use_first_pass
+          auth [default=die success=done] ${pam_ccreds}/lib/security/pam_ccreds.so action=validate use_first_pass
+          auth sufficient ${pam_ccreds}/lib/security/pam_ccreds.so action=store use_first_pass
+        '' +
+        ''
+          auth required pam_deny.so
+
+          # Password management.
+          password sufficient pam_unix.so nullok sha512
+        '' +
+        optionalString config.security.pam.enableEcryptfs ''
+          password optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so
+        '' +
+        optionalString cfg.pamMount ''
+          password optional ${pkgs.pam_mount}/lib/security/pam_mount.so
+        '' +
+        optionalString use_ldap ''
+          password sufficient ${pam_ldap}/lib/security/pam_ldap.so
+        '' +
+        optionalString cfg.mysqlAuth ''
+          password sufficient ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
+        '' +
+        optionalString config.services.sssd.enable ''
+          password sufficient ${pkgs.sssd}/lib/security/pam_sss.so use_authtok
+        '' +
+        optionalString config.security.pam.krb5.enable ''
+          password sufficient ${pam_krb5}/lib/security/pam_krb5.so use_first_pass
+        '' +
+        optionalString cfg.enableGnomeKeyring ''
+          password optional ${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so use_authtok
+        '' +
+        ''
+
+          # Session management.
+        '' +
+        optionalString cfg.setEnvironment ''
+          session required pam_env.so conffile=/etc/pam/environment readenv=0
+        '' +
+        ''
+          session required pam_unix.so
+        '' +
+        optionalString cfg.setLoginUid ''
+          session ${if config.boot.isContainer then "optional" else "required"} pam_loginuid.so
+        '' +
+        optionalString cfg.ttyAudit.enable (concatStringsSep " \\\n  " ([
+          "session required ${pkgs.pam}/lib/security/pam_tty_audit.so"
+        ] ++ optional cfg.ttyAudit.openOnly "open_only"
+        ++ optional (cfg.ttyAudit.enablePattern != null) "enable=${cfg.ttyAudit.enablePattern}"
+        ++ optional (cfg.ttyAudit.disablePattern != null) "disable=${cfg.ttyAudit.disablePattern}"
+        )) +
+        optionalString cfg.makeHomeDir ''
+          session required ${pkgs.pam}/lib/security/pam_mkhomedir.so silent skel=${config.security.pam.makeHomeDir.skelDirectory} umask=0077
+        '' +
+        optionalString cfg.updateWtmp ''
+          session required ${pkgs.pam}/lib/security/pam_lastlog.so silent
+        '' +
+        optionalString config.security.pam.enableEcryptfs ''
+          session optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so
+        '' +
+        optionalString cfg.pamMount ''
+          session optional ${pkgs.pam_mount}/lib/security/pam_mount.so disable_interactive
+        '' +
+        optionalString use_ldap ''
+          session optional ${pam_ldap}/lib/security/pam_ldap.so
+        '' +
+        optionalString cfg.mysqlAuth ''
+          session optional ${pkgs.pam_mysql}/lib/security/pam_mysql.so config_file=/etc/security/pam_mysql.conf
+        '' +
+        optionalString config.services.sssd.enable ''
+          session optional ${pkgs.sssd}/lib/security/pam_sss.so
+        '' +
+        optionalString config.security.pam.krb5.enable ''
+          session optional ${pam_krb5}/lib/security/pam_krb5.so
+        '' +
+        optionalString cfg.otpwAuth ''
+          session optional ${pkgs.otpw}/lib/security/pam_otpw.so
+        '' +
+        optionalString cfg.startSession ''
+          session optional ${config.systemd.package}/lib/security/pam_systemd.so
+        '' +
+        optionalString cfg.forwardXAuth ''
+          session optional pam_xauth.so xauthpath=${pkgs.xorg.xauth}/bin/xauth systemuser=99
+        '' +
+        optionalString (cfg.limits != []) ''
+          session required ${pkgs.pam}/lib/security/pam_limits.so conf=${makeLimitsConf cfg.limits}
+        '' +
+        optionalString (cfg.showMotd && config.users.motd != null) ''
+          session optional ${pkgs.pam}/lib/security/pam_motd.so motd=${motd}
+        '' +
+        optionalString (cfg.enableAppArmor && config.security.apparmor.enable) ''
+          session optional ${pkgs.apparmor-pam}/lib/security/pam_apparmor.so order=user,group,default debug
+        '' +
+        optionalString (cfg.enableKwallet) ''
+          session optional ${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so kwalletd=${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5
+        '' +
+        optionalString (cfg.enableGnomeKeyring) ''
+          session optional ${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so auto_start
+        '' +
+        optionalString cfg.gnupg.enable ''
+          session optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so ${optionalString cfg.gnupg.noAutostart " no-autostart"}
+        '' +
+        optionalString (config.virtualisation.lxc.lxcfs.enable) ''
+          session optional ${pkgs.lxc}/lib/security/pam_cgfs.so -c all
+        '';
     };
 
   };


### PR DESCRIPTION
I had the following in my config which cleared the file entirely.

```
security.pam.services.login.text = ''
  session optional pam_umask.so usergroups=some-group umask=0002
'';
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
