### PR TITLE
python3.pkgs.pylddwrap: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/icontract/default.nix
+++ b/pkgs/development/python-modules/icontract/default.nix
@@ -2,20 +2,14 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, asttokens
-, typing-extensions
-, pytestCheckHook
-, yapf
-, docutils
-, pygments
-, dpcontracts
-, tabulate
-, py-cpuinfo
-, typeguard
 , astor
-, numpy
+, asttokens
 , asyncstdlib
 , deal
+, dpcontracts
+, numpy
+, pytestCheckHook
+, typing-extensions
 }:
 
 buildPythonPackage rec {
@@ -38,40 +32,39 @@ buildPythonPackage rec {
     export ICONTRACT_SLOW=1
   '';
 
-
   propagatedBuildInputs = [
     asttokens
     typing-extensions
   ];
 
   checkInputs = [
-    pytestCheckHook
-    yapf
-    docutils
-    pygments
-    dpcontracts
-    tabulate
-    py-cpuinfo
-    typeguard
     astor
-    numpy
     asyncstdlib
     deal
+    dpcontracts
+    numpy
+    pytestCheckHook
   ];
 
   disabledTestPaths = [
-    # mypy decorator checks don't pass. For some reaseon mypy
+    # mypy decorator checks don't pass. For some reason mypy
     # doesn't check the python file provided in the test.
     "tests/test_mypy_decorators.py"
   ];
+
+  # Upstream adds some plain text files direct to the package's root directory
+  # https://github.com/Parquery/icontract/blob/master/setup.py#L63
+  postInstall = ''
+    rm -f $out/{LICENSE.txt,README.rst,requirements.txt}
+  '';
 
   pythonImportsCheck = [ "icontract" ];
 
   meta = with lib; {
     description = "Provide design-by-contract with informative violation messages";
     homepage = "https://github.com/Parquery/icontract";
-    changelog = "https://github.com/Parquery/icontract/blob/master/CHANGELOG.rst";
+    changelog = "https://github.com/Parquery/icontract/blob/v${version}/CHANGELOG.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ gador ];
+    maintainers = with maintainers; [ gador thiagokokada ];
   };
 }

--- a/pkgs/development/python-modules/pylddwrap/default.nix
+++ b/pkgs/development/python-modules/pylddwrap/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, coreutils
+, fetchFromGitHub
+, icontract
+, pytestCheckHook
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "pylddwrap";
+  version = "1.2.2";
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Parquery";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Gm82VRu8GP52BohQzpMUJfh6q2tiUA2GJWOcG7ymGgg=";
+  };
+
+  postPatch = ''
+    substituteInPlace lddwrap/__init__.py \
+      --replace '/usr/bin/env' '${coreutils}/bin/env'
+  '';
+
+  # Upstream adds some plain text files direct to the package's root directory
+  # https://github.com/Parquery/pylddwrap/blob/master/setup.py#L71
+  postInstall = ''
+    rm -f $out/{LICENSE,README.rst,requirements.txt}
+  '';
+
+  propagatedBuildInputs = [
+    icontract
+    typing-extensions
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "lddwrap" ];
+
+  meta = with lib; {
+    description = "Python wrapper around ldd *nix utility to determine shared libraries of a program";
+    homepage = "https://github.com/Parquery/pylddwrap";
+    changelog = "https://github.com/Parquery/pylddwrap/blob/v${version}/CHANGELOG.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ thiagokokada ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6947,6 +6947,8 @@ self: super: with self; {
 
   pykrakenapi = callPackage ../development/python-modules/pykrakenapi { };
 
+  pylddwrap = callPackage ../development/python-modules/pylddwrap { };
+
   pynndescent = callPackage ../development/python-modules/pynndescent { };
 
   pynobo = callPackage ../development/python-modules/pynobo { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is used for https://github.com/thiagokokada/nix-alien, so packaging it upstream.

Also some fixes for `icontract`, that is a dependency of `pylddwrap`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
