### PR TITLE
nixos/power-management: fix deadlock with post-resume.{target,service}

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -94,7 +94,7 @@ in
         after = [ "suspend.target" "hibernate.target" "hybrid-sleep.target" "suspend-then-hibernate.target" ];
         script =
           ''
-            /run/current-system/systemd/bin/systemctl try-restart post-resume.target
+            /run/current-system/systemd/bin/systemctl try-restart --no-block post-resume.target
             ${cfg.resumeCommands}
             ${cfg.powerUpCommands}
           '';


### PR DESCRIPTION
Fixes a deadlock where post-resume.target has After=post-resume.service and post-resume.service runs systemctl try-restart post-resume.target the systemctl call cannot complete if post-resume.target was already queued at that time.


cc @NixOS/systemd 
I think this kind of changes should be done systematically to all systemctl calls in systemd services in nixos modules, I can do that if you also think it is a good idea

tested on my system, but the deadlock is not 100% of the time so :shrug:

