### PR TITLE
composable_kernel: init at unstable-2022-11-02

### DIFF
--- a/pkgs/development/libraries/composable_kernel/default.nix
+++ b/pkgs/development/libraries/composable_kernel/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, rocm-cmake
+, hip
+, openmp
+, gtest ? null
+, buildTests ? false
+, buildExamples ? false
+, gpuTargets ? null # gpuTargets = [ "gfx803" "gfx900" "gfx1030" ... ]
+}:
+
+assert buildTests -> gtest != null;
+
+# Several tests seem to either not compile or have a race condition
+# Undefined reference to symbol '_ZTIN7testing4TestE'
+# Try removing this next update
+assert buildTests == false;
+
+stdenv.mkDerivation rec {
+  pname = "composable_kernel";
+  version = "unstable-2022-11-02";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildExamples [
+    "example"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "composable_kernel";
+    rev = "79aa3fb1793c265c59d392e916baa851a55521c8";
+    hash = "sha256-vIfMdvRYCTqrjMGSb7gQfodzLw2wf3tGoCAa5jtfbvw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+  ];
+
+  buildInputs = [
+    openmp
+  ] ++ lib.optionals buildTests [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_C_COMPILER=hipcc"
+    "-DCMAKE_CXX_COMPILER=hipcc"
+  ] ++ lib.optionals (gpuTargets != null) [
+    "-DGPU_TARGETS=${lib.strings.concatStringsSep ";" gpuTargets}"
+  ];
+
+  # No flags to build selectively it seems...
+  postPatch = ''
+    substituteInPlace test/CMakeLists.txt \
+      --replace "include(googletest)" ""
+
+    substituteInPlace CMakeLists.txt \
+      --replace "enable_testing()" ""
+  '' + lib.optionalString (!buildTests) ''
+    substituteInPlace CMakeLists.txt \
+      --replace "add_subdirectory(test)" ""
+  '' + lib.optionalString (!buildExamples) ''
+    substituteInPlace CMakeLists.txt \
+      --replace "add_subdirectory(example)" ""
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    mv bin/ckProfiler $out/bin
+  '' + lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv bin/test_* $test/bin
+  '' + lib.optionalString buildExamples ''
+    mkdir -p $example/bin
+    mv bin/example_* $example/bin
+  '';
+
+  meta = with lib; {
+    description = "Performance portable programming model for machine learning tensor operators";
+    homepage = "https://github.com/ROCmSoftwarePlatform/composable_kernel";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ Madouura ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14825,6 +14825,10 @@ with pkgs;
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
+  composable_kernel = callPackage ../development/libraries/composable_kernel {
+    inherit (llvmPackages) openmp;
+  };
+
   rgxg = callPackage ../tools/text/rgxg { };
 
   rocclr = callPackage ../development/libraries/rocclr { };


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
Disabled tests due to either them not compiling/linking or some sort of race condition.
Doesn't seem consistent.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
