### PR TITLE
discord-screenaudio: init at 1.8.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord-screenaudio/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord-screenaudio/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, wrapQtAppsHook
+, pkg-config
+, qtbase
+, qtwebengine
+, knotifications
+, kxmlgui
+, kglobalaccel
+, pipewire
+, xdg-desktop-portal
+}:
+
+stdenv.mkDerivation rec {
+  pname = "discord-screenaudio";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "maltejur";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-PPP/+7x0dcQHowB7hUZu85LK/G+ohrPeRB0vv6e3PBg=";
+    fetchSubmodules = true;
+  };
+
+  cmakeFlags = [
+    "-DPipeWire_INCLUDE_DIRS=${pipewire.dev}/include/pipewire-0.3"
+    "-DSpa_INCLUDE_DIRS=${pipewire.dev}/include/spa-0.2"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtwebengine
+    knotifications
+    kxmlgui
+    kglobalaccel
+    pipewire
+    pipewire.pulse
+    xdg-desktop-portal
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/maltejur/discord-screenaudio";
+    description = "A custom discord client that supports streaming with audio on Linux";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ michaelBelsanti ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39599,6 +39599,8 @@ with pkgs;
     branch = "canary";
   };
 
+  discord-screenaudio = libsForQt5.callPackage ../applications/networking/instant-messengers/discord-screenaudio { };
+
   golden-cheetah = libsForQt5.callPackage ../applications/misc/golden-cheetah { };
 
   golden-cheetah-bin = callPackage ../applications/misc/golden-cheetah-bin {};


### PR DESCRIPTION
###### Description of changes

Added discord-screenaudio package, a 3rd part discord client that allows screen sharing with audio on Linux.

Currently, does not build, so I'm creating a draft while I try to get it working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
