### PR TITLE
lemmy-help: init at 0.9.0

### DIFF
--- a/pkgs/tools/misc/lemmy-help/default.nix
+++ b/pkgs/tools/misc/lemmy-help/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lemmy-help";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "numToStr";
+    repo = "lemmy-help";
+    rev = "v${version}";
+    sha256 = "sha256-VY8sGxS8wwrezTe4ht9xdr4iE2n9fNSNhfCeGDJL5Lo=";
+  };
+
+  buildFeatures = [ "cli" ];
+
+  cargoSha256 = "sha256-yj14kg41EqOco0gx79n8xhf8cyotZ1Mxj2AbNV9TImU=";
+
+  meta = with lib; {
+    description = "A CLI for generating vim help docs from emmylua comments";
+    longDescription = ''
+      `lemmy-help` is an emmylua parser as well as a CLI which takes that parsed tree and converts it into vim help docs.
+    '';
+    homepage = "https://github.com/numToStr/lemmy-help";
+    license = with licenses; [ mit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8825,6 +8825,8 @@ with pkgs;
 
   lemmeknow = callPackage ../tools/misc/lemmeknow { };
 
+  lemmy-help = callPackage ../tools/misc/lemmy-help { };
+
   lethe = callPackage ../tools/security/lethe {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

Add the package `lemmy-help` at version 0.9.0.
I have tested this package as per the instructions in ["Submitting changes"](https://nixos.org/nixpkgs/manual/#chap-submitting-changes).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
