### PR TITLE
ldmud: fix undefined reference to 'crypt'

### DIFF
--- a/pkgs/games/ldmud/default.nix
+++ b/pkgs/games/ldmud/default.nix
@@ -7,6 +7,7 @@
 , libiconv
 , pcre
 , libgcrypt
+, libxcrypt
 , json_c
 , libxml2
 , ipv6Support ? false
@@ -39,12 +40,13 @@ stdenv.mkDerivation rec {
   sourceRoot = "${src.name}/src";
 
   nativeBuildInputs =
-    [ autoreconfHook pkg-config bison libgcrypt pcre json_c libxml2 ]
+    [ autoreconfHook pkg-config bison ];
+  buildInputs = [ libgcrypt libxcrypt pcre json_c libxml2 ]
     ++ lib.optional mccpSupport zlib ++ lib.optional mysqlSupport libmysqlclient
     ++ lib.optional postgresSupport postgresql
     ++ lib.optional sqliteSupport sqlite ++ lib.optional tlsSupport openssl
-    ++ lib.optional pythonSupport python310;
-  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+    ++ lib.optional pythonSupport python310
+    ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   # To support systems without autoconf LD puts its configure.ac in a non-default
   # location and uses a helper script. We skip that script and symlink the .ac


### PR DESCRIPTION
###### Description of changes

Adding `libxcrypt` as a build input is required to avoid a link time error from an undefined reference to `crypt` in non-TLS-enabled builds now that glibc crypt support is optional (See ff30c899d8bd92d1a1c9f4d4e81455b04cb0868e and https://github.com/NixOS/nixpkgs/pull/181764).

Additionally, many of the `nativeBuildInputs` should be `buildInputs` since they are used at runtime and not build time. This is also fixed in this commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
