### PR TITLE
espeakedit: migrate to wxGTK32

### DIFF
--- a/pkgs/applications/audio/espeak/edit.nix
+++ b/pkgs/applications/audio/espeak/edit.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, unzip, portaudio, wxGTK, sox }:
+{ lib, stdenv, fetchurl, pkg-config, unzip, portaudio, wxGTK32, sox }:
 
 stdenv.mkDerivation rec {
   pname = "espeakedit";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config unzip ];
-  buildInputs = [ portaudio wxGTK ];
+  buildInputs = [ portaudio wxGTK32 ];
 
   # TODO:
   # Uhm, seems like espeakedit still wants espeak-data/ in $HOME, even thought
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     ./espeakedit-configurable-sox-path.patch
     ./espeakedit-configurable-path-espeak-data.patch
     ./espeakedit-gcc6.patch
+    ./espeakedit-wxgtk30.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/audio/espeak/espeakedit-wxgtk30.patch
+++ b/pkgs/applications/audio/espeak/espeakedit-wxgtk30.patch
@@ -1,0 +1,32 @@
+diff -uNr a/src/espeakedit.cpp b/src/espeakedit.cpp
+--- a/src/espeakedit.cpp
++++ b/src/espeakedit.cpp
+@@ -123,7 +126,7 @@ bool MyApp::OnInit(void)
+ {//=====================
+ 
+ int j;
+-wxChar *p;
++const wxChar *p;
+ char param[120];
+ 
+ 
+diff -uNr a/src/spect.cpp b/src/spect.cpp
+--- a/src/spect.cpp
++++ b/src/spect.cpp
+@@ -1,6 +1,7 @@
+ /***************************************************************************
+  *   Copyright (C) 2005 to 2007 by Jonathan Duddington                     *
+  *   email: jonsd@users.sourceforge.net                                    *
++ *   Copyright (C) 2013 by Reece H. Dunn                                   *
+  *                                                                         *
+  *   This program is free software; you can redistribute it and/or modify  *
+  *   it under the terms of the GNU General Public License as published by  *
+@@ -92,6 +93,8 @@ float SpectTilt(int value, int freq)
+ 
+ 
+ SpectFrame::SpectFrame(SpectFrame *copy)
++	: FONT_SMALL(8,wxSWISS,wxNORMAL,wxNORMAL)
++	, FONT_MEDIUM(9,wxSWISS,wxNORMAL,wxNORMAL)
+ {//=====================================
+ 
+ 	int  ix;


### PR DESCRIPTION
###### Description of changes

As in the title. Note that this is one of the last two packages that depend on wxGTK28.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
