### PR TITLE
mutt: add options to disable support for pop3 and smtp

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -12,6 +12,8 @@
 , gpgSupport   ? false
 , gpgmeSupport ? true
 , imapSupport  ? true
+, pop3Support  ? true
+, smtpSupport  ? true
 , withSidebar  ? true
 , gssSupport   ? true
 , writeScript
@@ -44,9 +46,9 @@ stdenv.mkDerivation rec {
     (lib.enableFeature headerCache  "hcache")
     (lib.enableFeature gpgmeSupport "gpgme")
     (lib.enableFeature imapSupport  "imap")
+    (lib.enableFeature smtpSupport  "smtp")
+    (lib.enableFeature pop3Support  "pop")
     (lib.enableFeature withSidebar  "sidebar")
-    "--enable-smtp"
-    "--enable-pop"
     "--with-mailpath="
 
     # Look in $PATH at runtime, instead of hardcoding /usr/bin/sendmail


### PR DESCRIPTION
Default configuration is unaffected -- both are enabled, but new options make
it easier to recompile mutt without redundant pop3/smtp support for setups
where something else provides MTA functionality.
