### PR TITLE
victor-mono: Move LICENSE.txt to fonts directory

### DIFF
--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -21,9 +21,8 @@ fetchzip {
 
     mv $out/OTF $out/share/fonts/opentype
     mv $out/TTF $out/share/fonts/truetype
-    mv $out/LICENSE.txt $out/share/fonts/$name-LICENSE.txt
 
-    rm -r $out/{EOT,WOFF,WOFF2}
+    rm -r $out/{EOT,WOFF,WOFF2,LICENSE.txt}
   '';
 
   sha256 = "sha256-1si0d2lpuXaDcSc3giVMMMbZc/eKbHKU3wmwfYHZ8o0=";

--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -21,6 +21,7 @@ fetchzip {
 
     mv $out/OTF $out/share/fonts/opentype
     mv $out/TTF $out/share/fonts/truetype
+    mv $out/LICENSE.txt $out/share/fonts/$name-LICENSE.txt
 
     rm -r $out/{EOT,WOFF,WOFF2}
   '';


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

It seems cleaner to place Victor Mono's LICENSE.txt next to the fonts files with a font specific, rather than a generic filename. Otherwise the LICENSE.txt from Victor Mono gets symlinked into ~/.nix-profile, which seems less useful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
