### PR TITLE
nixos/nix-daemon: default nix.settings.max-jobs to 1

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -808,6 +808,22 @@
       </listitem>
       <listitem>
         <para>
+          The NixOS option <literal>nix.settings.max-jobs</literal> has
+          been changed from auto to 1. This default is the same as
+          documented in manpage for nix.conf.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The build environments do not set the maximum system load for
+          make and ninja (see (treewide: drop
+          -l$NIX_BUILD_CORES)[https://github.com/NixOS/nixpkgs/pull/192447]).
+          Please check Nix configurations <literal>max-jobs</literal>
+          and <literal>cores</literal> to prevent high system loads.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           (Neo)Vim can not be configured with
           <literal>configure.pathogen</literal> anymore to reduce
           maintainance burden. Use <literal>configure.packages</literal>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -253,6 +253,12 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - The top-level `termonad-with-packages` alias for `termonad` has been removed.
 
+- The NixOS option `nix.settings.max-jobs` has been changed from auto to 1.
+  This default is the same as documented in manpage for nix.conf.
+
+- The build environments do not set the maximum system load for make and ninja (see (treewide: drop -l$NIX_BUILD_CORES)[https://github.com/NixOS/nixpkgs/pull/192447]).
+  Please check Nix configurations `max-jobs` and `cores` to prevent high system loads.
+
 - (Neo)Vim can not be configured with `configure.pathogen` anymore to reduce maintainance burden.
   Use `configure.packages` instead.
 - Neovim can not be configured with plug anymore (still works for vim).

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -484,12 +484,11 @@ in
           options = {
             max-jobs = mkOption {
               type = types.either types.int (types.enum [ "auto" ]);
-              default = "auto";
+              default = 1;
               example = 64;
               description = lib.mdDoc ''
                 This option defines the maximum number of jobs that Nix will try to
-                build in parallel. The default is auto, which means it will use all
-                available logical cores. It is recommend to set it to the total
+                build in parallel. The special value auto causes Nix to use the
                 number of logical cores in your system (e.g., 16 for two CPUs with 4
                 cores each and hyper-threading).
               '';


### PR DESCRIPTION
###### Description of changes

fixes https://github.com/NixOS/nixpkgs/issues/198668

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
