### PR TITLE
NetworkManager is a service

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -25,7 +25,7 @@ with lib;
   services.xserver.enable = true;
 
   # Provide networkmanager for easy wireless configuration.
-  networking.networkmanager.enable = true;
+  services.networkmanager.enable = true;
   networking.wireless.enable = mkImageMediaOverride false;
 
   # KDE complains if power management is disabled (to be precise, if

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -137,7 +137,7 @@ in
         # networking.hostName = "nixos"; # Define your hostname.
         # Pick only one of the below networking options.
         # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
-        # networking.networkmanager.enable = true;  # Easiest to use and most distros use this by default.
+        # services.networkmanager.enable = true;  # Easiest to use and most distros use this by default.
 
         # Set your time zone.
         # time.timeZone = "Europe/Amsterdam";

--- a/nixos/modules/programs/captive-browser.nix
+++ b/nixos/modules/programs/captive-browser.nix
@@ -109,7 +109,7 @@ in
           optionalString cfg.bindInterface (escapeShellArgs (prefixes ++ [ cfg.interface ]));
       in
       mkOptionDefault (
-        if config.networking.networkmanager.enable then
+        if config.services.networkmanager.enable then
           "${pkgs.networkmanager}/bin/nmcli dev show ${iface []} | ${pkgs.gnugrep}/bin/fgrep IP4.DNS"
         else if config.networking.dhcpcd.enable then
           "${pkgs.dhcpcd}/bin/dhcpcd ${iface ["-U"]} | ${pkgs.gnugrep}/bin/fgrep domain_name_servers"

--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   cfg = config.services.tlp;
-  enableRDW = config.networking.networkmanager.enable;
+  enableRDW = config.services.networkmanager.enable;
   tlp = pkgs.tlp.override { inherit enableRDW; };
   # TODO: Use this for having proper parameters in the future
   mkTlpConfig = tlpConfig: generators.toKeyValue {

--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -98,8 +98,8 @@ in {
     }{
       # TODO: connman seemingly can be used along network manager and
       # connmanFull supports this - so this should be worked out somehow
-      assertion = !config.networking.networkmanager.enable;
-      message = "You can not use services.connman with networking.networkmanager";
+      assertion = !config.services.networkmanager.enable;
+      message = "You can not use services.connman with services.networkmanager";
     }];
 
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -10,7 +10,7 @@ let
   defaults = {
     # without UseDefaultInterface, sometimes wlan0 simply goes AWOL with NetworkManager
     # https://iwd.wiki.kernel.org/interface_lifecycle#interface_management_in_iwd
-    General.UseDefaultInterface = with config.networking.networkmanager; (enable && (wifi.backend == "iwd"));
+    General.UseDefaultInterface = with config.services.networkmanager; (enable && (wifi.backend == "iwd"));
   };
   configFile = ini.generate "main.conf" (recursiveUpdate defaults cfg.settings);
 

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -384,6 +384,9 @@ in {
 
   imports = [
     (mkRenamedOptionModule
+      [ "networking" "networkmanager" ]
+      [ "services" "networkmanager" ])
+    (mkRenamedOptionModule
       [ "networking" "networkmanager" "packages" ]
       [ "networking" "networkmanager" "plugins" ])
     (mkRenamedOptionModule

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -386,20 +386,6 @@ in {
     (mkRenamedOptionModule
       [ "networking" "networkmanager" ]
       [ "services" "networkmanager" ])
-    (mkRenamedOptionModule
-      [ "networking" "networkmanager" "packages" ]
-      [ "networking" "networkmanager" "plugins" ])
-    (mkRenamedOptionModule
-      [ "networking" "networkmanager" "useDnsmasq" ]
-      [ "networking" "networkmanager" "dns" ])
-    (mkRemovedOptionModule [ "networking" "networkmanager" "dynamicHosts" ] ''
-      This option was removed because allowing (multiple) regular users to
-      override host entries affecting the whole system opens up a huge attack
-      vector. There seem to be very rare cases where this might be useful.
-      Consider setting system-wide host entries using networking.hosts, provide
-      them via the DNS server in your network, or use environment.etc
-      to add a file into /etc/NetworkManager/dnsmasq.d reconfiguring hostsdir.
-    '')
   ];
 
 

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -136,7 +136,7 @@ in {
 
   options = {
 
-    networking.networkmanager = {
+    services.networkmanager = {
 
       enable = mkOption {
         type = types.bool;

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  cfg = config.networking.networkmanager;
+  cfg = config.services.networkmanager;
 
   delegateWireless = config.networking.wireless.enable == true && cfg.unmanaged != [];
 
@@ -364,7 +364,7 @@ in {
 
           If you enable this option the
           `networkmanager_strongswan` plugin will be added to
-          the {option}`networking.networkmanager.plugins` option
+          the {option}`services.networkmanager.plugins` option
           so you don't need to to that yourself.
         '';
       };
@@ -410,7 +410,7 @@ in {
     assertions = [
       { assertion = config.networking.wireless.enable == true -> cfg.unmanaged != [];
         message = ''
-          You can not use networking.networkmanager with networking.wireless.
+          You can not use services.networkmanager with networking.wireless.
           Except if you mark some interfaces as <literal>unmanaged</literal> by NetworkManager.
         '';
       }

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -386,8 +386,10 @@ in {
     (mkRenamedOptionModule
       [ "networking" "networkmanager" "packages" ]
       [ "networking" "networkmanager" "plugins" ])
-    (mkRenamedOptionModule [ "networking" "networkmanager" "useDnsmasq" ] [ "networking" "networkmanager" "dns" ])
-    (mkRemovedOptionModule ["networking" "networkmanager" "dynamicHosts"] ''
+    (mkRenamedOptionModule
+      [ "networking" "networkmanager" "useDnsmasq" ]
+      [ "networking" "networkmanager" "dns" ])
+    (mkRemovedOptionModule [ "networking" "networkmanager" "dynamicHosts" ] ''
       This option was removed because allowing (multiple) regular users to
       override host entries affecting the whole system opens up a huge attack
       vector. There seem to be very rare cases where this might be useful.

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -105,7 +105,7 @@ in
     }];
     boot.blacklistedKernelModules = [ "ip_tables" ];
     environment.systemPackages = [ pkgs.nftables ];
-    networking.networkmanager.firewallBackend = mkDefault "nftables";
+    services.networkmanager.firewallBackend = mkDefault "nftables";
     systemd.services.nftables = {
       description = "nftables firewall";
       before = [ "network-pre.target" ];

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -488,7 +488,7 @@ in {
       {
         assertion = length cfg.interfaces > 1 -> !cfg.dbusControlled;
         message =
-          let daemon = if config.networking.networkmanager.enable then "NetworkManager" else
+          let daemon = if config.services.networkmanager.enable then "NetworkManager" else
                        if config.services.connman.enable then "connman" else null;
               n = toString (length cfg.interfaces);
           in ''

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -107,7 +107,7 @@ in
       services.upower.enable = mkDefault config.powerManagement.enable;
       services.xserver.libinput.enable = mkDefault true;
       services.xserver.updateDbusEnvironment = true;
-      networking.networkmanager.enable = mkDefault true;
+      services.networkmanager.enable = mkDefault true;
 
       # Enable colord server
       services.colord.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -359,7 +359,7 @@ in
         style = mkDefault "adwaita";
       };
 
-      networking.networkmanager.enable = mkDefault true;
+      services.networkmanager.enable = mkDefault true;
 
       services.xserver.updateDbusEnvironment = true;
 

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -174,7 +174,7 @@ in
         pkgs.pantheon.gnome-settings-daemon
       ];
       programs.dconf.enable = true;
-      networking.networkmanager.enable = mkDefault true;
+      services.networkmanager.enable = mkDefault true;
 
       # Global environment
       environment.systemPackages = (with pkgs.pantheon; [

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -375,7 +375,7 @@ in
 
         # Optional hardware support features
         ++ lib.optionals config.hardware.bluetooth.enable [ bluedevil bluez-qt pkgs.openobex pkgs.obexftp ]
-        ++ lib.optional config.networking.networkmanager.enable plasma-nm
+        ++ lib.optional config.services.networkmanager.enable plasma-nm
         ++ lib.optional config.hardware.pulseaudio.enable plasma-pa
         ++ lib.optional config.services.pipewire.pulse.enable plasma-pa
         ++ lib.optional config.powerManagement.enable powerdevil
@@ -527,7 +527,7 @@ in
       assertions = [
         {
           # The user interface breaks without NetworkManager
-          assertion = config.networking.networkmanager.enable;
+          assertion = config.services.networkmanager.enable;
           message = "Plasma Mobile requires NetworkManager.";
         }
         {
@@ -576,7 +576,7 @@ in
       # The following services are needed or the UI is broken.
       hardware.bluetooth.enable = true;
       hardware.pulseaudio.enable = true;
-      networking.networkmanager.enable = true;
+      services.networkmanager.enable = true;
 
       # Recommendations can be found here:
       #  - https://invent.kde.org/plasma-mobile/plasma-phone-settings/-/tree/master/etc/xdg

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -106,7 +106,7 @@ in
       xfce4-taskmanager
       xfce4-terminal
     ] # TODO: NetworkManager doesn't belong here
-      ++ optional config.networking.networkmanager.enable networkmanagerapplet
+      ++ optional config.services.networkmanager.enable networkmanagerapplet
       ++ optional config.powerManagement.enable xfce4-power-manager
       ++ optionals config.hardware.pulseaudio.enable [
         pavucontrol

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -143,7 +143,7 @@ in
     };
 
     # If networkmanager is enabled, ask it to interface with resolved.
-    networking.networkmanager.dns = "systemd-resolved";
+    services.networkmanager.dns = "systemd-resolved";
 
     networking.resolvconf.package = pkgs.systemd;
 

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -79,7 +79,7 @@ in
       assertion = pkgs.stdenv.hostPlatform.isx86;
       message = "Azure not currently supported on ${pkgs.stdenv.hostPlatform.system}";
     } {
-      assertion = config.networking.networkmanager.enable == false;
+      assertion = config.services.networkmanager.enable == false;
       message = "Windows Azure Linux Agent is not compatible with NetworkManager";
     } ];
 

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -860,7 +860,7 @@ in
 
     networking.dhcpcd.denyInterfaces = [ "ve-*" "vb-*" ];
 
-    services.udev.extraRules = optionalString config.networking.networkmanager.enable ''
+    services.udev.extraRules = optionalString config.services.networkmanager.enable ''
       # Don't manage interfaces created by nixos-container.
       ENV{INTERFACE}=="v[eb]-*", ENV{NM_UNMANAGED}="1"
     '';

--- a/nixos/modules/virtualisation/virtualbox-host.nix
+++ b/nixos/modules/virtualisation/virtualbox-host.nix
@@ -158,7 +158,7 @@ in
     networking.interfaces.vboxnet0.ipv4.addresses = [{ address = "192.168.56.1"; prefixLength = 24; }];
     # Make sure NetworkManager won't assume this interface being up
     # means we have internet access.
-    networking.networkmanager.unmanaged = ["vboxnet0"];
+    services.networkmanager.unmanaged = ["vboxnet0"];
   }) (mkIf config.networking.useNetworkd {
     systemd.network.networks."40-vboxnet0".extraConfig = ''
       [Link]

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -658,7 +658,7 @@ let
         # ModemManager is installed when NetworkManager is enabled. Ensure it is
         # started and is wanted by NM and the exporter to start everything up
         # in the right order.
-        networking.networkmanager.enable = true;
+        services.networkmanager.enable = true;
         systemd.services.ModemManager = {
           enable = true;
           wantedBy = [ "NetworkManager.service" "prometheus-modemmanager-exporter.service" ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

It is confusing to configure networkmanager as part of networking, when it is clearly a management service.
Indeed, the same was made to ConnMan before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
