### PR TITLE
gcc-arm-embedded: remove aarch64-darwin from platforms

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/10/default.nix
@@ -11,7 +11,6 @@ stdenv.mkDerivation rec {
   release = "10.3-2021.10";
 
   suffix = {
-    aarch64-darwin = "mac";  # use intel binaries via rosetta
     aarch64-linux = "aarch64-linux";
     x86_64-darwin = "mac";
     x86_64-linux  = "x86_64-linux";
@@ -20,7 +19,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${release}/gcc-arm-none-eabi-${release}-${suffix}.tar.bz2";
     sha256 = {
-      aarch64-darwin = "0fr8pki2g4bfk1rk90dzwql37d0b71ngzs9zyx0g2jainan3sqgv";
       aarch64-linux = "020j8gkzc0i0b74vz98gvngnwjm5222j1gk5nswfk6587krba1gn";
       x86_64-darwin = "0fr8pki2g4bfk1rk90dzwql37d0b71ngzs9zyx0g2jainan3sqgv";
       x86_64-linux  = "18y92vpl22hf74yqdvmpw8adrkl92s4crzzs6avm05md37qb9nwp";
@@ -51,6 +49,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
     maintainers = with maintainers; [ prusnak ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/11/default.nix
@@ -10,7 +10,6 @@ stdenv.mkDerivation rec {
   version = "11.3.rel1";
 
   platform = {
-    aarch64-darwin = "darwin-x86_64";  # use intel binaries via rosetta
     aarch64-linux = "aarch64";
     x86_64-darwin = "darwin-x86_64";
     x86_64-linux  = "x86_64";
@@ -19,7 +18,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu/${version}/binrel/arm-gnu-toolchain-${version}-${platform}-arm-none-eabi.tar.xz";
     sha256 = {
-      aarch64-darwin = "1kr9kd9p2xk84fa99zf3gz5lkww2i9spqkjigjwakfkzbva56qw2";
       aarch64-linux = "0pmm5r0k5mxd5drbn2s8a7qkm8c4fi8j5y31c70yrp0qs08kqwbc";
       x86_64-darwin = "1kr9kd9p2xk84fa99zf3gz5lkww2i9spqkjigjwakfkzbva56qw2";
       x86_64-linux  = "08b1w1zmj4z80k59zmlc1bf34lg8d7z65fwvp5ir2pb1d1zxh86l";
@@ -49,6 +47,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
     maintainers = with maintainers; [ prusnak ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   subdir = "6-2017q2";
 
   suffix = {
-    aarch64-darwin = "mac";  # use intel binaries via rosetta
     x86_64-darwin = "mac";
     x86_64-linux  = "linux";
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -20,7 +19,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${release}-${suffix}.tar.bz2";
     sha256 = {
-      aarch64-darwin = "0019ylpq4inq7p5gydpmc9m8ni72fz2csrjlqmgx1698998q0c3x";
       x86_64-darwin = "0019ylpq4inq7p5gydpmc9m8ni72fz2csrjlqmgx1698998q0c3x";
       x86_64-linux  = "1hvwi02mx34al525sngnl0cm7dkmzxfkb1brq9kvbv28wcplp3p6";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -50,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
     maintainers = with maintainers; [ prusnak ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   subdir = "7-2018q2";
 
   suffix = {
-    aarch64-darwin = "mac";  # use intel binaries via rosetta
     x86_64-darwin = "mac";
     x86_64-linux  = "linux";
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -20,7 +19,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${release}-${suffix}.tar.bz2";
     sha256 = {
-      aarch64-darwin = "0nc7m0mpa39qyhfyydxkkyqm7spfc27xf6ygi2vd2aym4r9azi61";
       x86_64-darwin = "0nc7m0mpa39qyhfyydxkkyqm7spfc27xf6ygi2vd2aym4r9azi61";
       x86_64-linux  = "0sgysp3hfpgrkcbfiwkp0a7ymqs02khfbrjabm52b5z61sgi05xv";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -50,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
     maintainers = with maintainers; [ prusnak ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/gcc-arm-embedded/8/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/8/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   subdir = "8-2019q3/RC1.1";
 
   suffix = {
-    aarch64-darwin = "mac";  # use intel binaries via rosetta
     x86_64-darwin = "mac";
     x86_64-linux  = "linux";
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -20,7 +19,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${release}-${suffix}.tar.bz2";
     sha256 = {
-      aarch64-darwin = "fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085";
       x86_64-darwin = "fc235ce853bf3bceba46eff4b95764c5935ca07fc4998762ef5e5b7d05f37085";
       x86_64-linux  = "b50b02b0a16e5aad8620e9d7c31110ef285c1dde28980b1a9448b764d77d8f92";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -50,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
     maintainers = with maintainers; [ prusnak ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/gcc-arm-embedded/9/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/9/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   subdir = "9-2020q2";
 
   suffix = {
-    aarch64-darwin = "mac";  # use intel binaries via rosetta
     aarch64-linux = "aarch64-linux";
     x86_64-darwin = "mac";
     x86_64-linux  = "x86_64-linux";
@@ -21,7 +20,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${release}-${suffix}.tar.bz2";
     sha256 = {
-      aarch64-darwin = "1ils9z16wrvglh72m428y5irmd36biq79yj86756whib8izbifdv";
       aarch64-linux = "1b5q2y710hy7lddj8vj3zl54gfl74j30kx3hk3i81zrcbv16ah8z";
       x86_64-darwin = "1ils9z16wrvglh72m428y5irmd36biq79yj86756whib8izbifdv";
       x86_64-linux  = "07zi2yr5gvhpbij5pnj49zswb9g2gw7zqp4xwwniqmq477h2xp2s";
@@ -52,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
     license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
     maintainers = with maintainers; [ prusnak ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
reverts c3557f2e6495722db017b76871c0870c8b95752d
reverts 4c5fbc98d2989c5ddf63056db3ee382f42d87e9c

one can use gcc-arm-embedded on aarch64-darwin via pkgsx86_64Darwin (introduced in #161657)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
