### PR TITLE
Add documentation for moved secrets in stage 1 

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -640,6 +640,11 @@ in
             path the secret should have inside the initrd, the value
             is the path it should be copied from (or null for the same
             path inside and out).
+
+            Note that `nixos-rebuild switch` will generate the initrd
+            also for past generations, so if secrets are moved or deleted
+            you will also have to garbage collect the generations that
+            use those secrets.
           '';
         example = literalExpression
           ''


### PR DESCRIPTION
Add documentation for moved secrets in stage 1 

###### Description of changes

I ran into the issue that I could not switch to a new generation because nixos-rebuild tried to regenerate initrd that referenced moved secrets, I thought it would be good to document this behaviour because it's unintuitive at first. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

