### PR TITLE
bazarr: update expr

### DIFF
--- a/pkgs/servers/bazarr/default.nix
+++ b/pkgs/servers/bazarr/default.nix
@@ -1,5 +1,11 @@
 { stdenv, lib, fetchurl, makeWrapper, unzip, python3, unrar, ffmpeg, nixosTests }:
 
+let
+  runtimeProgDeps = [
+    ffmpeg
+    unrar
+  ];
+in
 stdenv.mkDerivation rec {
   pname = "bazarr";
   version = "1.1.1";
@@ -13,16 +19,26 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip makeWrapper ];
 
+  buildInputs = [
+    (python3.withPackages (ps: [ ps.lxml ps.numpy ps.gevent ps.gevent-websocket ]))
+  ] ++ runtimeProgDeps;
+
   installPhase = ''
-    mkdir -p $out/{bin,share/${pname}-${version}}
-    cp -r * $out/share/${pname}-${version}
-    makeWrapper "${
-      (python3.withPackages
-        (ps: [ ps.lxml ps.numpy ps.gevent ps.gevent-websocket ])).interpreter
-    }" \
-      $out/bin/bazarr \
-      --add-flags "$out/share/${pname}-${version}/bazarr.py" \
-      --suffix PATH : ${lib.makeBinPath [ unrar ffmpeg ]}
+    runHook preInstall
+
+    mkdir -p "$out"/{bin,share/${pname}}
+    cp -r * "$out/share/${pname}"
+
+    # Add missing shebang and execute perms so that patchShebangs can do its
+    # thing.
+    sed -i "1i #!/usr/bin/env python3" "$out/share/${pname}/bazarr.py"
+    chmod +x "$out/share/${pname}/bazarr.py"
+
+    makeWrapper "$out/share/${pname}/bazarr.py" \
+        "$out/bin/bazarr" \
+        --suffix PATH : ${lib.makeBinPath runtimeProgDeps}
+
+    runHook postInstall
   '';
 
   passthru.tests = {


### PR DESCRIPTION
###### Description of changes
* Add runtime program dependencies to buildInputs, instead of setting
  that up as part of the install phase. This allows hacking on bazarr
  straight from `nix-shell -A bazarr`.
* Add missing preInstall/postInstall hooks.
* Quote shell variables.
* Simplify install path: `$out/share/${pname}-${version}` -> `$out/share/${pname}`.
  (There's no point in having the version there, and without proper deep
  overrides it can also create some problems.)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
