### PR TITLE
haskell.compiler: ghc942 -> ghc943

### DIFF
--- a/pkgs/development/compilers/ghc/9.4.3.nix
+++ b/pkgs/development/compilers/ghc/9.4.3.nix
@@ -176,12 +176,12 @@ assert buildTargetLlvmPackages.llvm == llvmPackages.llvm;
 assert stdenv.targetPlatform.isDarwin -> buildTargetLlvmPackages.clang == llvmPackages.clang;
 
 stdenv.mkDerivation (rec {
-  version = "9.4.2";
+  version = "9.4.3";
   pname = "${targetPrefix}ghc${variantSuffix}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";
-    sha256 = "7227ef3b5e15a0d70b8f1a43aec32867e2a9b2d857cc0ed556aeed172d4db3a5";
+    sha256 = "eaf63949536ede50ee39179f2299d5094eb9152d87cc6fb2175006bc98e8905a";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -158,7 +158,7 @@ assert !enableNativeBignum -> gmp != null;
 
 assert stdenv.hostPlatform == stdenv.targetPlatform || throw ''
   hadrian doesn't support building an installable GHC cross-compiler at the moment.
-  Consider using GHC 9.4.2 or lower which support this via the make build system.
+  Consider using GHC 9.4 or lower which support this via the make build system.
   See also: https://gitlab.haskell.org/ghc/ghc/-/issues/22090
 '';
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -18,7 +18,7 @@ let
     "ghc90"
     "ghc924"
     "ghc92"
-    "ghc942"
+    "ghc943"
     "ghc94"
     "ghcHEAD"
   ];
@@ -29,7 +29,7 @@ let
     "ghc92"
     "ghc924"
     "ghc94"
-    "ghc942"
+    "ghc943"
     "ghcHEAD"
   ];
 
@@ -165,7 +165,7 @@ in {
       llvmPackages = pkgs.llvmPackages_12;
     };
     ghc92 = ghc924;
-    ghc942 = callPackage ../development/compilers/ghc/9.4.2.nix {
+    ghc943 = callPackage ../development/compilers/ghc/9.4.3.nix {
       bootPkgs =
         # Building with 9.2 is broken due to
         # https://gitlab.haskell.org/ghc/ghc/-/issues/21914
@@ -189,7 +189,7 @@ in {
       buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_12;
       llvmPackages = pkgs.llvmPackages_12;
     };
-    ghc94 = ghc942;
+    ghc94 = ghc943;
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
       bootPkgs =
         # For GHC 9.2.3 and 9.2.4 no armv7l bindists are available.
@@ -311,12 +311,12 @@ in {
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.2.x.nix { };
     };
     ghc92 = ghc924;
-    ghc942 = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc942;
-      ghc = bh.compiler.ghc942;
+    ghc943 = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc943;
+      ghc = bh.compiler.ghc943;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.4.x.nix { };
     };
-    ghc94= ghc942;
+    ghc94 = ghc943;
     ghcHEAD = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghcHEAD;
       ghc = bh.compiler.ghcHEAD;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -53,7 +53,7 @@ let
     ghc8107
     ghc902
     ghc924
-    ghc942
+    ghc943
   ];
 
   # packagePlatforms applied to `haskell.packages.*`


### PR DESCRIPTION
https://www.haskell.org/ghc/download_ghc_9_4_3.html

Dropping GHC 9.4.2, since there is no Stackage snapshot which uses GHC 9.4.*, so the stack Nix integration should not get any ideas.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
