### PR TITLE
steam-tui: 0.1.0 → unstable-2022-08-29

### DIFF
--- a/pkgs/games/steam-tui/default.nix
+++ b/pkgs/games/steam-tui/default.nix
@@ -2,27 +2,35 @@
 , rustPlatform
 , steamcmd
 , fetchFromGitHub
-, steam-run
+, openssl
+, pkg-config
 , runtimeShell
+, steam-run
 , withWine ? false
 , wine
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "steam-tui";
-  version = "0.1.0";
+  # 0.2.1 has build issues for the tests a later commit cleaned up
+  # (additional unreleased enchancements have been added as well)
+  version = "unstable-2022-12-24";
 
   src = fetchFromGitHub {
     owner = "dmadisetti";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-UTXYlPecv0MVonr9zZwfwopfC/Fdch/ZSCxqgUsem40=";
+    rev = "236a3b592c23d576730f6c168db33affb7dbff5a";
+    sha256 = "czNId8LBaI8T6ot/1xG/xfS34DMwpAC47WglGNLJF+8=";
   };
 
-  cargoSha256 = "sha256-VYBzwDLSV4N4qt2dNgIS399T2HIbPTdQ2rDIeheLlfo=";
+  cargoSha256 = "M7AOlfzRhmhDKYJCG9R9iJUtpgmI8I24wUTh4cI9S/c=";
 
-  buildInputs = [ steamcmd ]
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl steamcmd ]
     ++ lib.optional withWine wine;
+
+  checkFlags = [ "--skip=impure" ];
 
   preFixup = ''
     mv $out/bin/steam-tui $out/bin/.steam-tui-unwrapped


### PR DESCRIPTION
I would have bumped to 0.2.1, but it had issues build with Nix fixed right after the release (or at least made easier, but I didn’t read too far into it). This version covers the fix plus a rendering issue.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
