### PR TITLE
ngspice: 37 -> 38, maintain, build tweaks

### DIFF
--- a/pkgs/applications/science/electronics/ngspice/default.nix
+++ b/pkgs/applications/science/electronics/ngspice/default.nix
@@ -1,5 +1,7 @@
 { lib, stdenv
 , fetchurl
+, glibcLocales
+, makeWrapper
 , bison
 , flex
 , readline
@@ -14,23 +16,39 @@
 
 stdenv.mkDerivation rec {
   pname = "ngspice";
-  version = "37";
+  version = "38";
 
   src = fetchurl {
     url = "mirror://sourceforge/ngspice/ngspice-${version}.tar.gz";
-    sha256 = "1gpcic6b6xk3g4956jcsqljf33kj5g43cahmydq6m8rn39sadvlv";
+    hash = "sha256-LD4i9sR7Fl2yQc81U3Ggp1WFQKsq8/i17t7rKJoxfFY=";
   };
 
-  nativeBuildInputs = [ flex bison ];
+  nativeBuildInputs = [ flex bison makeWrapper ];
   buildInputs = [ readline libX11 libICE libXaw libXmu libXext libXt fftw ];
 
-  configureFlags = [ "--enable-x" "--with-x" "--with-readline" "--enable-xspice" "--enable-cider" ];
+  # disable FORTIFY_SOURCE, since apparently the makefile compiles most
+  # modules without optimization, anyway, so it doesn't take effect...
+  hardeningDisable = [ "fortify" ];
+  configureFlags = [
+    "--enable-x"
+    "--with-x"
+    "--with-readline"
+    "--enable-openmp"
+    "--enable-xspice"
+    "--enable-cider"
+  ];
+  enableParallelBuilding = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/ngspice \
+      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
+  '';
 
   meta = with lib; {
     description = "The Next Generation Spice (Electronic Circuit Simulator)";
     homepage = "http://ngspice.sourceforge.net";
     license = with licenses; [ "BSD" gpl2 ];
-    maintainers = with maintainers; [ bgamari rongcuid ];
+    maintainers = with maintainers; [ bgamari rongcuid thoughtpolice ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
This fixes an issue with finding `glibcLocales`, updates the version, and also enables openmp support for multithreaded models where appropriate. Tested with a simple dual RC ladder circuit and using the X11 plotting window.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).