### PR TITLE
sane_backends: more complete hwdb files

### DIFF
--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -37,6 +37,9 @@ stdenv.mkDerivation {
       url = "https://raw.githubusercontent.com/void-linux/void-packages/4b97cd2fb4ec38712544438c2491b6d7d5ab334a/srcpkgs/sane/patches/sane-desc-cross.patch";
       sha256 = "sha256-y6BOXnOJBSTqvRp6LwAucqaqv+OLLyhCS/tXfLpnAPI=";
     })
+    # generate hwdb entries for scanners handled by other backends like epkowa
+    # https://gitlab.com/sane-project/backends/-/issues/619
+    ./sane-desc-generate-entries-unsupported-scanners.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/graphics/sane/backends/sane-desc-generate-entries-unsupported-scanners.patch
+++ b/pkgs/applications/graphics/sane/backends/sane-desc-generate-entries-unsupported-scanners.patch
@@ -1,0 +1,19 @@
+sane-desc does not include unsupported .desc entries like EPSON V300 PHOTO,
+which can be supported by the (unfree) epkowa driver.
+But we need those entries so that unprivileged users which have installed epkowa
+can use the scanner.
+diff --git a/tools/sane-desc.c b/tools/sane-desc.c
+index 7a8645dea..9c9719fef 100644
+--- a/tools/sane-desc.c
++++ b/tools/sane-desc.c
+@@ -3243,10 +3243,6 @@ create_usbids_table (void)
+ 
+ 	      for (model = mfg->model; model; model = model->next)
+ 		{
+-		  if ((model->status == status_unsupported)
+-		      || (model->status == status_unknown))
+-		    continue;
+-
+ 		  if (model->usb_vendor_id && model->usb_product_id)
+ 		    {
+ 		      first_usbid = add_usbid (first_usbid, mfg->name,


### PR DESCRIPTION
We used to ship the pre-computed udev rules that are distributed in the tarballs. This is problematic as it changes the group of scanners to scanner which removes the group lp and prevents cups from using it. (https://github.com/NixOS/nixpkgs/issues/147217)
For this reason we switched to generating udev and hwdb files as follows:

    ./tools/sane-desc -m udev+hwdb -s doc/descriptions:doc/descriptions-external > $out/etc/udev/rules.d/49-libsane.rules
    ./tools/sane-desc -m udev+hwdb -s doc/descriptions -m hwdb > $out/etc/udev/hwdb.d/20-sane.hwdb

following what other distros do.
(https://github.com/NixOS/nixpkgs/pull/176412)

this is great, but sane-desc does not include unsupported .desc entries like EPSON V300 PHOTO, which was present in the distributed udev rules. So even when installing all the required unfree stuff to make the corresponding epkowa backend work, it only works as root as there is no corresponding hwdb entry. As the .desc entry contains the usb ids, we can just patch sane-desc to generate hwdb entries even for unsupported models.


----

this fixes a regression from https://github.com/NixOS/nixpkgs/pull/176412 (and its followup https://github.com/NixOS/nixpkgs/pull/185700) but we cannot revert it because it was a bugfix  (https://github.com/NixOS/nixpkgs/issues/147217)
It would be nice to wait from the opinion of upstream https://gitlab.com/sane-project/backends/-/issues/619 but I'd like to get this in 22.11

cc @Profpatsch 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
