### PR TITLE
libstdcxx: building from current version of gcc

### DIFF
--- a/pkgs/development/libraries/gcc/libstdc++/default.nix
+++ b/pkgs/development/libraries/gcc/libstdc++/default.nix
@@ -1,0 +1,19 @@
+{gcc, stdenv}:
+
+stdenv.mkDerivation rec {
+
+  pname = "libstdc++";
+  inherit (gcc.cc) src version;
+
+  postUnpack = ''
+    mkdir -p ./build
+    buildRoot=$(readlink -e "./build")
+  '';
+
+  preConfigure = ''
+    sourceRoot=$(readlink -e "./libstdc++-v3")
+    cd $buildRoot
+    configureScript=$sourceRoot/configure
+  '';
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16706,7 +16706,7 @@ with pkgs;
       then targetPackages.stdenv.cc.cc
     else gcc.cc;
 
-  libstdcxx5 = callPackage ../development/libraries/gcc/libstdc++/5.nix { };
+  libstdcxx = callPackage ../development/libraries/gcc/libstdc++ { };
 
   libsigrok = callPackage ../development/tools/libsigrok {
     python = python3;


### PR DESCRIPTION
building the GNU C++ standard library separately from GCC inspired by https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/gcc/libgcc/default.nix. 

Main motivation is https://github.com/NixOS/nixpkgs/issues/132340

Have compiled some simple programs against it, and it seems to be working, but it might be broken in subtle ways I am missing. Also, it might be broken regards to cross compiling.

If we were to merge this, it would probably be a good idea to delete `pkgs/development/libraries/gcc/libstdc++/5.nix`, since that derivation is much more specific, and doesn't seem to be in use anywhere else in nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
