### PR TITLE
flent: 2.0.1 -> 2.1.1; fixes

### DIFF
--- a/pkgs/applications/networking/flent/default.nix
+++ b/pkgs/applications/networking/flent/default.nix
@@ -1,23 +1,39 @@
-{ lib, buildPythonApplication, fetchPypi, matplotlib, procps, pyqt5, python
-, pythonPackages, qt5, sphinx, xvfb-run }:
-
+{
+  lib,
+  buildPythonApplication,
+  fetchPypi,
+  procps,
+  python,
+  qt5,
+  xvfb-run,
+}:
 buildPythonApplication rec {
   pname = "flent";
-  version = "2.0.1";
+  version = "2.1.1";
   src = fetchPypi {
     inherit pname version;
-    sha256 = "300a09938dc2b4a0463c9144626f25e0bd736fd47806a9444719fa024d671796";
+    sha256 = "sha256-21gd6sPYCZll3Q2O7kucTRhXvc5byXeQr50+1bZVT3M=";
   };
 
-  buildInputs = [ sphinx ];
-  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
-  propagatedBuildInputs = [ matplotlib procps pyqt5 ];
-  checkInputs = [ procps pythonPackages.mock pyqt5 xvfb-run ];
+  buildInputs = [python.pkgs.sphinx];
+  nativeBuildInputs = [qt5.wrapQtAppsHook];
+  propagatedBuildInputs = [
+    procps
+    python.pkgs.matplotlib
+    python.pkgs.pyqt5
+    python.pkgs.qtpy
+  ];
+  checkInputs = [
+    python.pkgs.mock
+    xvfb-run
+  ];
 
   checkPhase = ''
+    # we want the gui tests to always run
+    sed -i 's|self.skip|pass; #&|' unittests/test_gui.py
+
     cat >test-runner <<EOF
     #!/bin/sh
-
     ${python.pythonForBuild.interpreter} nix_run_setup test
     EOF
     chmod +x test-runner
@@ -34,6 +50,6 @@ buildPythonApplication rec {
     homepage = "https://flent.org";
     license = licenses.gpl3;
 
-    maintainers = [ maintainers.mmlb ];
+    maintainers = [maintainers.mmlb];
   };
 }


### PR DESCRIPTION
###### Description of changes

* Fixes flent-gui usage since we were missing the `qtpy` dependency.
* Ensures the gui tests are always run (by default upstream skips the gui test if there's an issue importing `qtpy`).
* Update from 2.0.1 -> 2.1.1:
  https://github.com/tohojo/flent/releases/tag/v2.1.0
  https://github.com/tohojo/flent/releases/tag/v2.1.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).