### PR TITLE
kcctl: init at 1.0.0.alpha5

### DIFF
--- a/pkgs/development/tools/kcctl/default.nix
+++ b/pkgs/development/tools/kcctl/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchzip
+, zlib
+, autoPatchelfHook
+,
+}:
+stdenv.mkDerivation rec {
+  name = "kcctl";
+  version = "1.0.0.alpha5";
+
+  baseURL = "https://github.com/kcctl/kcctl/releases/download/v${builtins.replaceStrings ["a"] ["A"] version}/${name}-${version}";
+
+  meta = with lib; {
+    description = "A modern and intuitive command line client for Kafka Connect";
+    homepage = "https://github.com/kcctl/kcctl";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+
+  src =
+    if stdenv.isLinux
+    then
+      fetchzip
+        {
+          url = "${baseURL}-linux-x86_64.zip";
+          sha256 = "sha256-FJOZrTzAXBh6K1HL4EF/4+doJWdua10+XH4nwSvS9No=";
+        }
+    else if stdenv.isDarwin
+    then
+      fetchzip
+        {
+          url = "${baseURL}-osx-x86_64.zip";
+          sha256 = "sha256-dhUcKys4Np2LlL9RtJtHT3osXupkbodP/4s9EW9MKM8=";
+        }
+    else throw "Unsupported system: ${stdenv.system}";
+
+  buildInputs = [
+    zlib
+  ];
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m755 -D source/bin/kcctl $out/bin/kcctl
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17252,6 +17252,8 @@ with pkgs;
 
   kcat = callPackage ../development/tools/kcat { };
 
+  kcctl = callPackage ../development/tools/kcctl { };
+
   kcc = libsForQt5.callPackage ../applications/graphics/kcc { };
 
   kconfig-frontends = callPackage ../development/tools/misc/kconfig-frontends {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[`kcctl`](https://github.com/kcctl/kcctl) is a command line client for managing Kafka Connect clusters in the same style as `kubectl`.

This is my first contribution to `nixpkgs`! Let me know of any possible improvements that could be made.

Regarding testing the package, the compilation step done via `./mvnw package` already executes unit tests, that's why I haven't added any. (**EDIT: this has changed and now I fetch the available binaries directly: see https://github.com/NixOS/nixpkgs/pull/199609#issuecomment-1310849043 below**)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (via Rosetta 2)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
