### PR TITLE
systemd: 251.5 -> 251.7

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -122,7 +122,7 @@ assert withHomed -> withCryptsetup;
 let
   wantCurl = withRemote || withImportd;
   wantGcrypt = withResolved || withImportd;
-  version = "251.5";
+  version = "251.7";
 
   # Bump this variable on every (major) version change. See below (in the meson options list) for why.
   # command:
@@ -139,7 +139,7 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "sha256-2MEmvFT1D+9v8OazBwjnKc7i/x7i196Eoi8bODk1cM4=";
+    sha256 = "sha256-Sa5diyNFyYtREo1xSCcufAW83ZZGZvueoDVuQ2r8wno=";
   };
 
   # On major changes, or when otherwise required, you *must* reformat the patches,
@@ -243,12 +243,14 @@ stdenv.mkDerivation {
           opt = condition: pkg: if condition then pkg else null;
         in
         [
-          # bpf compilation support
-          { name = "libbpf.so.0"; pkg = opt withLibBPF libbpf; }
+          # bpf compilation support. We use libbpf 1 now.
+          { name = "libbpf.so.1"; pkg = opt withLibBPF libbpf; }
+          { name = "libbpf.so.0"; pkg = null; }
 
           # We did never provide support for libxkbcommon & qrencode
           { name = "libxkbcommon.so.0"; pkg = null; }
           { name = "libqrencode.so.4"; pkg = null; }
+          { name = "libqrencode.so.3"; pkg = null; }
 
           # We did not provide libpwquality before so it is safe to disable it for
           # now.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25710,6 +25710,7 @@ with pkgs;
       enableMinimal = true;
       guiSupport = false;
     };
+    libbpf = libbpf_1;
   };
   systemdMinimal = systemd.override {
     pname = "systemd-minimal";


### PR DESCRIPTION
###### Description of changes
```
06dc900efa network/bridge: fix UseBPDU= and AllowPortToBeRoot=
b0972e4df0 homed: properly initialize all return params
d61ccd0252 meson: always use libatomic if found
833ad5f950 Revert "Fix issue with system time set back (#24131)"
73d1dc665b bash-completion: add systemd-dissect support
d89e9993d2 dissect: add missing --umount to the help output
087cbfd936 coredump: avoid deadlock when passing processed backtrace data
ab587aaf8e shared/json: use different return code for empty input
219272f7b2 shared/json: allow json_variant_dump() to return an error
d1066f33b5 man: document restrictions on naming interfaces
e2a07cdac6 qrcode-util: Add support for libqrencode 3.0
8be601f7ef seccomp: add riscv_flush_icache to allow list
3028e05955 logind: fix getting property OnExternalPower via D-Bus
5da595db39 shared/condition: avoid nss lookup in PID1
40053e60f5 test: add more tests for StateDirectory= with DynamicUser=
0ba2e4bb69 core: do not create symlink to private directory if parent already exists
1de3cb97ee core: make exec_directory_add() extends existing symlinks
d7b83b9986 sd-ndisc: ignore failure in sending solicitation
e0ba044985 analyze: add forgotten return statement
40742ac74f basic/log: include the log syntax callback in the errno protection block
3e38c39600 logind: do not emit beep in wall messages
bf13ffec59 udev: drop assertion which is always false
78a8e938e4 man/shutdown: document how to switch to single-user mode
9de8a5d5d0 libbpf: add compat helpers for libbpf down to 0.1.0
9d5d267ab3 Try to load libbpf.so.1 as well
8cc2387b03 libbpf: Remove use of deprecated APIs
4abc5b2cfe repart: always honour `--discard=no`
b3d5724bfc ata_id: Fixed getting Response Code from SCSI Sense Data (#24921)
e91ea65aba resolve: unsupported DNSSEC algorithms are considered INSECURE; not BOGUS
73db7d9932 generator: skip fsck if fsck command is missing
80dc4425db udevadm: do not try to find device unit when a path like string is provided
7add2f21f1 resolved: don't access sshfp fields from tlsa printer
9d9a970ad7 resolved: fix parameter reuse in DNS_ANSWER_FOREACH_ITEM() iterator macro
913d22cf8d kernel-install: do not fail if $layout is not "bls"
25facc6e7f units: udev: partially emulate ProtectClock=
2e6e0498aa nspawn: fix two error strings
5befffa69a xdg-autostart-service: expand tilde in Exec lines
4cb75191c4 fix typo in log
738eca5e05 meson: add libatomic dependency
c40fa78968 xdg-autostart-service: Use common boolean parser
```

systemd 251.6 added support for libbpf 1.0.0, so use new libbpf version.

~(Note there's also systemd 252 that got released recently, not sure which version we want)~

I intend to change the default version of libbpf after this and the bcc/bpftrace update get merged in master; there's no real hurry.

~I'm never sure if I should target staging or master, systemd is a core component so staging is probably better? happy to retarget if appropriate.~

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
