### PR TITLE
wallutils: 5.11.1 -> 5.12.4

### DIFF
--- a/pkgs/tools/graphics/wallutils/default.nix
+++ b/pkgs/tools/graphics/wallutils/default.nix
@@ -1,35 +1,56 @@
-{ buildGoPackage, fetchFromGitHub, lib
+{ lib
+, buildGoModule
+, fetchFromGitHub
 , pkg-config
-, wayland, libX11, xbitmaps, libXcursor, libXmu, libXpm, libheif
+, wayland
+, libX11
+, xbitmaps
+, libXcursor
+, libXmu
+, libXpm
+, libheif
 }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "wallutils";
-  version = "5.11.1";
+  version = "5.12.4";
 
   src = fetchFromGitHub {
     owner = "xyproto";
     repo = "wallutils";
     rev = version;
-    sha256 = "sha256-FL66HALXsf7shoUKIZp6HORyuxhOfgTrY+PQAe92yk8=";
+    sha256 = "sha256-NODG4Lw/7X1aoT+dDSWxWEbDX6EAQzzDJPwsWOLaJEM=";
   };
 
-  goPackagePath = "github.com/xyproto/wallutils";
+  vendorSha256 = null;
 
   patches = [ ./lscollection-Add-NixOS-paths-to-DefaultWallpaperDirectories.patch ];
 
-  postPatch = ''
-    # VersionString is sometimes not up-to-date:
-    sed -iE 's/VersionString = "[0-9].[0-9].[0-9]"/VersionString = "${version}"/' wallutils.go
-  '';
+  excludedPackages = [
+    "./pkg/event/cmd" # Development tools
+  ];
+
+  ldflags = [ "-s" "-w" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ wayland libX11 xbitmaps libXcursor libXmu libXpm libheif ];
 
+  preCheck =
+    let skippedTests = [
+      "TestClosest" # Requiring Wayland or X.
+      "TestNewSimpleEvent" # Blocking
+      "TestEveryMinute" # Blocking
+    ]; in
+    ''
+      export XDG_RUNTIME_DIR=`mktemp -d`
+
+      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
+    '';
+
   meta = with lib; {
     description = "Utilities for handling monitors, resolutions, and (timed) wallpapers";
     inherit (src.meta) homepage;
-    license = licenses.mit;
+    license = licenses.bsd3;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
