### PR TITLE
texlab: 4.3.0 → 4.3.1

### DIFF
--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -14,16 +14,16 @@ let
   isCross = stdenv.hostPlatform != stdenv.buildPlatform;
 in rustPlatform.buildRustPackage rec {
   pname = "texlab";
-  version = "4.3.0";
+  version = "4.3.1";
 
   src = fetchFromGitHub {
     owner = "latex-lsp";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-PhzxWLkqsHU32vIZwHzdy86bwIzDDmnxp12PS774P3k=";
+    sha256 = "sha256-gtPnuKmKfUBZDM6DATJB5NxndOwvG5JpBRO4cEU6lIU=";
   };
 
-  cargoSha256 = "sha256-tH566L0oHnI9mNp1KtJYaBaWCkiAOrtBYkfVSCA2N6w=";
+  cargoSha256 = "sha256-nu2KltPgexBTxG13kUgHgMrxefPD+Gaj5qBIWWFPdFs=";
 
   outputs = [ "out" ] ++ lib.optional (!isCross) "man";
 
@@ -36,19 +36,11 @@ in rustPlatform.buildRustPackage rec {
     CoreServices
   ];
 
-  postInstall = ''
-    # Remove generated dylib of human_name dependency. TexLab statically
-    # links to the generated rlib and doesn't reference the dylib. I
-    # couldn't find any way to prevent building this by passing cargo flags.
-    # See https://github.com/djudd/human-name/blob/master/Cargo.toml#L43
-    rm "$out/lib/libhuman_name${stdenv.hostPlatform.extensions.sharedLibrary}"
-    rmdir "$out/lib"
-  ''
   # When we cross compile we cannot run the output executable to
   # generate the man page
-  + lib.optionalString (!isCross) ''
+  postInstall = lib.optionalString (!isCross) ''
     # TexLab builds man page separately in CI:
-    # https://github.com/latex-lsp/texlab/blob/v4.3.0/.github/workflows/publish.yml#L131-L135
+    # https://github.com/latex-lsp/texlab/blob/v4.3.1/.github/workflows/publish.yml#L126-L130
     help2man --no-info "$out/bin/texlab" > texlab.1
     installManPage texlab.1
   '';

--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -12,13 +12,14 @@
 
 let
   isCross = stdenv.hostPlatform != stdenv.buildPlatform;
-in rustPlatform.buildRustPackage rec {
+in
+rustPlatform.buildRustPackage rec {
   pname = "texlab";
   version = "4.3.1";
 
   src = fetchFromGitHub {
     owner = "latex-lsp";
-    repo = pname;
+    repo = "texlab";
     rev = "refs/tags/v${version}";
     sha256 = "sha256-gtPnuKmKfUBZDM6DATJB5NxndOwvG5JpBRO4cEU6lIU=";
   };
@@ -28,7 +29,7 @@ in rustPlatform.buildRustPackage rec {
   outputs = [ "out" ] ++ lib.optional (!isCross) "man";
 
   nativeBuildInputs = [ installShellFiles ]
-  ++ lib.optional (!isCross) help2man;
+    ++ lib.optional (!isCross) help2man;
 
   buildInputs = lib.optionals stdenv.isDarwin [
     libiconv


### PR DESCRIPTION
###### Description of changes

Update to the latest version: https://github.com/latex-lsp/texlab/releases/tag/v4.3.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).