### PR TITLE
unicorn: 2.0.0-rc7 -> 2.0.1

### DIFF
--- a/pkgs/development/libraries/unicorn/default.nix
+++ b/pkgs/development/libraries/unicorn/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-D8kwrHo58zksVjB13VtzoVqmz++FRfJ4zI2CT+YeBVE=";
   };
 
+  patches = [
+    # Fix compilation on aarch64-darwin
+    # See https://github.com/unicorn-engine/unicorn/issues/1730
+    ./tests_unit_endian_aarch64.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -28,6 +34,13 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optionals stdenv.isDarwin [
     IOKit
   ];
+
+  cmakeFlags = lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+    # Some x86 tests are interrupted by signal 10
+    "-DCMAKE_CTEST_ARGUMENTS=--exclude-regex;test_x86"
+  ];
+
+  doCheck = true;
 
   meta = with lib; {
     description = "Lightweight multi-platform CPU emulator library";

--- a/pkgs/development/libraries/unicorn/default.nix
+++ b/pkgs/development/libraries/unicorn/default.nix
@@ -4,22 +4,25 @@
 , pkg-config
 , cmake
 , IOKit
+, cctools
 }:
 
 stdenv.mkDerivation rec {
   pname = "unicorn";
-  version = "2.0.0-rc7";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "unicorn-engine";
     repo = pname;
     rev = version;
-    hash = "sha256-qlxtFCJBmouPuUEu8RduZM+rbOr52sGjdb8ZRHWmJ/w=";
+    hash = "sha256-D8kwrHo58zksVjB13VtzoVqmz++FRfJ4zI2CT+YeBVE=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
+  ] ++ lib.optionals stdenv.isDarwin [
+    cctools
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/unicorn/tests_unit_endian_aarch64.patch
+++ b/pkgs/development/libraries/unicorn/tests_unit_endian_aarch64.patch
@@ -1,0 +1,20 @@
+diff --git a/tests/unit/endian.h b/tests/unit/endian.h
+index 5bc86308..b455899e 100644
+--- a/tests/unit/endian.h
++++ b/tests/unit/endian.h
+@@ -54,6 +54,7 @@
+    || defined(_POWER) || defined(__powerpc__) \
+    || defined(__ppc__) || defined(__hpux) || defined(__hppa) \
+    || defined(_MIPSEB) || defined(_POWER) \
++   || defined(__ARMEB__) || defined(__AARCH64EB__) \
+    || defined(__s390__)
+ # define BOOST_BIG_ENDIAN
+ # define BOOST_BYTE_ORDER 4321
+@@ -63,6 +64,7 @@
+    || defined(_M_ALPHA) || defined(__amd64) \
+    || defined(__amd64__) || defined(_M_AMD64) \
+    || defined(__x86_64) || defined(__x86_64__) \
++   || defined(__ARMEL__) || defined(__AARCH64EL__) \
+    || defined(_M_X64) || defined(__bfin__)
+ 
+ # define BOOST_LITTLE_ENDIAN

--- a/pkgs/development/python-modules/unicorn/default.nix
+++ b/pkgs/development/python-modules/unicorn/default.nix
@@ -15,8 +15,7 @@ buildPythonPackage rec {
   sourceRoot = "source/bindings/python";
 
   prePatch = ''
-    ln -s ${unicorn-emu}/lib/libunicorn${stdenv.targetPlatform.extensions.sharedLibrary} prebuilt/
-    ln -s ${unicorn-emu}/lib/libunicorn.a prebuilt/
+    ln -s ${unicorn-emu}/lib/libunicorn.* prebuilt/
   '';
 
   # needed on non-x86 linux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12694,6 +12694,7 @@ with pkgs;
 
   unicorn = callPackage ../development/libraries/unicorn {
     inherit (darwin.apple_sdk.frameworks) IOKit;
+    inherit (darwin) cctools;
   };
 
   units = callPackage ../tools/misc/units {


### PR DESCRIPTION
###### Description of changes

Based on https://github.com/NixOS/nixpkgs/pull/199191 but with a fix for Unicorn-Engine Python module.
Also fix darwin build using fix proposed by https://github.com/NixOS/nixpkgs/pull/199191#pullrequestreview-1167755288.
Fix aarch64-darwin build by introducing a patch.
Enable tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
