### PR TITLE
laminar: pass version to the build system

### DIFF
--- a/pkgs/development/tools/continuous-integration/laminar/default.nix
+++ b/pkgs/development/tools/continuous-integration/laminar/default.nix
@@ -38,6 +38,8 @@ in stdenv.mkDerivation rec {
   # We need both binary from "capnproto" and library files.
   nativeBuildInputs = [ cmake pandoc capnproto ];
   buildInputs = [ capnproto sqlite boost zlib rapidjson ];
+  cmakeFlags = [ "-DLAMINAR_VERSION=${version}" ];
+
   preBuild = ''
     mkdir -p js css
     cp  ${js.vue}         js/vue.min.js


### PR DESCRIPTION
Without this patch, laminar identifies itself as xx-unversioned both in command
line interface (laminarc --help) and in web interface.
