### PR TITLE
fetchurl: accept SRI in hex and base32 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -6,7 +6,7 @@ rec {
     version = "106.0.5";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "879b054340d632c5d972888ceb67da0d02f28f6755e9683c8e4e7fb71b55bde0e588b98e24bae448ffea8ddd3e30c44dc0563554ecd69506862796a64ca040d7";
+      hash = "sha512-879b054340d632c5d972888ceb67da0d02f28f6755e9683c8e4e7fb71b55bde0e588b98e24bae448ffea8ddd3e30c44dc0563554ecd69506862796a64ca040d7";
     };
 
     # This patch could be applied anywhere (just rebuild, no effect)

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -21,7 +21,7 @@ unwrapped = stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://secure.nic.cz/files/knot-resolver/${pname}-${version}.tar.xz";
-    sha256 = "a38f57c68b7d237d662784d8406e6098aad66a148f44dcf498d1e9664c5fed2d";
+    hash = "sha256-a38f57c68b7d237d662784d8406e6098aad66a148f44dcf498d1e9664c5fed2d";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Proof of concept stemming from https://github.com/NixOS/rfcs/pull/131

Problem statement:
- single attribute name for `fetch*` hashes would be nice; the currently most common are `sha256` and `hash`
- copy&paste of hash from upstream seems attractive (e.g. https-secured release announcements)
- SRI hashes (`hash` attribute on nixpkgs level) only support base64 encoding
- upstreams don't use base64 encoding commonly
- implementing on nixpkgs level allows *immediate* usage; with nix we'd have to wait at least a year, I think
