### PR TITLE
python3Packages.aiolifx-themes: init at v0.2.0

### DIFF
--- a/pkgs/development/python-modules/aiolifx-themes/default.nix
+++ b/pkgs/development/python-modules/aiolifx-themes/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pythonOlder
+, aiolifx
+, poetry-core
+, pytest-asyncio
+, pytestCheckHook
+, async-timeout
+, typer
+}:
+
+buildPythonPackage rec {
+  pname = "aiolifx-themes";
+  version = "0.2.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "Djelibeybi";
+    repo = "aiolifx-themes";
+    rev = "v${version}";
+    hash = "sha256:17498vdg8i20hk4i8hzc67qaj206ik3s1zn1k70plsjr9zlgs6vz";
+  };
+
+  prePatch = ''
+    # Don't run coverage, or depend on typer for no reason.
+    substituteInPlace pyproject.toml \
+      --replace " --cov=aiolifx_themes --cov-report=term-missing:skip-covered" "" \
+      --replace "typer = " "# unused: typer = "
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiolifx
+  ];
+
+  checkInputs = [
+    async-timeout
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [
+    "aiolifx_themes"
+  ];
+
+  meta = with lib; {
+    description = "Color themes for LIFX lights running on aiolifx";
+    homepage = "https://github.com/Djelibeybi/aiolifx-themes";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -238,6 +238,8 @@ self: super: with self; {
 
   aiolifx-effects = callPackage ../development/python-modules/aiolifx-effects { };
 
+  aiolifx-themes = callPackage ../development/python-modules/aiolifx-themes { };
+
   aiolimiter = callPackage ../development/python-modules/aiolimiter { };
 
   aiolip = callPackage ../development/python-modules/aiolip { };


### PR DESCRIPTION
###### Description of changes

New package needed for lifx support in HomeAssistant 2022.11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
