### PR TITLE
nixos: add per-user groups by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -12,6 +12,11 @@ In addition to numerous new and upgraded packages, this release has the followin
   Take the time to review [the release notes](https://gitlab.com/cryptsetup/cryptsetup/-/raw/v2.7.0/docs/v2.7.0-ReleaseNotes).
   One of the highlight is that it is now possible to use hardware OPAL-based encryption of your disk with `cryptsetup`, it has a lot of caveats, see the above notes for the full details.
 
+- A new option, `users.solitaryByDefault`, controls whether normal users default to a primary group named the same as the user, and with group id same as user id, or use the shared group "users" with group id 100.
+  System users always default to a group named after them, with GID = UID.
+  Per-user groups gives better control over permissions/file sharing and aligns NixOS with other distros like Arch Linux/Debian/Fedora/Ubuntu.
+  The option defaults to `system.stateVersion >= 24.11`, which means it's opt-in (to per-user groups) up to and including NixOS 24.05, but after that the option must be set to `false` to keep the current/old behaviour.
+
 - `screen`'s module has been cleaned, and will now require you to set `programs.screen.enable` in order to populate `screenrc` and add the program to the environment.
 
 - `linuxPackages_testing_bcachefs` is now fully deprecated by `linuxPackages_latest`, and is therefore no longer available.

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -10,6 +10,9 @@
 
 with lib;
 
+let
+  normalUsers = lib.filterAttrs (n: v: v.isNormalUser) config.users.users;
+in
 {
   meta = {
     maintainers = [ maintainers.joachifm maintainers.emily ];
@@ -17,7 +20,11 @@ with lib;
 
   boot.kernelPackages = mkDefault pkgs.linuxPackages_hardened;
 
-  nix.settings.allowed-users = mkDefault [ "@users" ];
+  nix.settings.allowed-users = mkDefault (
+    if config.users.solitaryByDefault then
+      lib.mapAttrsToList (n: v: v.name) normalUsers
+    else [ "@users" ]
+  );
 
   environment.memoryAllocator.provider = mkDefault "scudo";
   environment.variables.SCUDO_OPTIONS = mkDefault "ZeroContents=1";

--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -23,6 +23,7 @@ in
       ];
       # swraid's default depends on stateVersion
       config.boot.swraid.enable = false;
+      config.users.solitaryByDefault = true;
       options.boot.isContainer = lib.mkOption { default = false; internal = true; };
     }
   ];

--- a/nixos/tests/user-group-membership.nix
+++ b/nixos/tests/user-group-membership.nix
@@ -1,0 +1,39 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "user-group-membership";
+  meta = with lib.maintainers; { maintainers = [ bjornfor ]; };
+
+  nodes =
+    let
+      commonConfig = {
+        users.users.alice = {
+          isNormalUser = true;
+        };
+        users.users.bob = {
+          isNormalUser = true;
+          group = "users";
+        };
+      };
+    in
+      {
+        shared = {
+          imports = [ commonConfig ];
+          users.solitaryByDefault = false;
+        };
+        solitary = {
+          imports = [ commonConfig ];
+          users.solitaryByDefault = true;
+        };
+      };
+
+  testScript = ''
+    start_all()
+
+    with subtest("solitaryByDefault = false"):
+        shared.succeed('[ "$(stat -c %G /home/alice)" == "users" ]')
+        shared.succeed('[ "$(stat -c %G /home/bob)" == "users" ]')
+
+    with subtest("solitaryByDefault = true"):
+        solitary.succeed('[ "$(stat -c %G /home/alice)" == "alice" ]')
+        solitary.succeed('[ "$(stat -c %G /home/bob)" == "users" ]')
+  '';
+})


### PR DESCRIPTION
###### Description of changes
Each user now defaults to primary group `<user_name>`. Before it was
`users` for normal users and system users required explicit setting the
group -- because the default was "" (empty) which triggered an assert
saying the group must be set.

This change allows finer grained control over file access, and aligns
NixOS with other distros. Here, the result of `useradd -m user1 && ls
-ld /home/user1`:

```
Ubuntu 22.04 : drwxr-x--- 2 user1 user1 4096 Oct 28 15:17 /home/user1
Fedora 36    : drwx------ 2 user1 user1 4096 Oct 28 15:17 /home/user1
Debian 11    : drwxr-xr-x 2 user1 user1 4096 Oct 28 15:17 /home/user1
Arch Linux   : drwx------ 2 user1 user1 4096 Oct 28 15:17 /home/user1
```

The new functionality is gated behind an option called
`users.solitaryByDefault`, which defaults to true for
`system.stateVersion >= 24.05`.

Fixes https://github.com/NixOS/nixpkgs/issues/198296.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
