### PR TITLE
GNOME Updates

### DIFF
--- a/pkgs/applications/editors/gnome-latex/default.nix
+++ b/pkgs/applications/editors/gnome-latex/default.nix
@@ -21,12 +21,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.41.2";
+  version = "3.42.0";
   pname = "gnome-latex";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "8xDwoUUEmfDP92y5+cXWaZGpUGH6s9bmcMSlZHOF1jM=";
+    sha256 = "ASMecEE3WNGu1pYNqhoigfqRNaYFkQuodM7VMn3LhUM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell-extensions/default.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extensions";
-  version = "43.0";
+  version = "43.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "5Hw51CeCpyRJu/fes28D/ZbLWSkZRikTkSEuL9mNX5M=";
+    sha256 = "rd4EvZRqExE1V+TDTIkLvpB3UFpqPwdV8XvqHG5KLRc=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -68,13 +68,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "gnome-shell";
-  version = "43.0";
+  version = "43.1";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "9u7JdwP588xv5ua0H23IIbGOyE34NRxN+XsXroJ0G0E=";
+    sha256 = "3wREdl3vG9Cv7pYX0rWRm8ebTbhufnV6wOH3N0jsG9w=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -49,13 +49,13 @@
 
 let self = stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "43.0";
+  version = "43.1";
 
   outputs = [ "out" "dev" "man" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "jZulKO2Z72eZZC4Uez/p8ry+ypvs7ShFwcrbMxzT5SU=";
+    sha256 = "8vCLJSeDlIpezILwDp6TWmHrv4VkhEvdkniKtEqngmQ=";
   };
 
   patches = [
@@ -65,15 +65,6 @@ let self = stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/285a5a4d54ca83b136b787ce5ebf1d774f9499d5.patch";
       sha256 = "/npUE3idMSTVlFptsDpZmGWjZ/d2gqruVlJKq4eF4xU=";
     })
-
-    # color-device: Don't create profiles from obvious garbage data
-    # https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2627
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2627.patch";
-      sha256 = "SafC29+gjcj6JswHY6yuwcOS16LPYvFwYW1TEpNNSHc=";
-    })
-
-
   ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/amtk/default.nix
+++ b/pkgs/development/libraries/amtk/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "amtk";
-  version = "5.5.2";
+  version = "5.6.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "x33S2PVex2tQItmW5RJ82S7GqhePo+jzP1fbukXfiIY=";
+    sha256 = "89uHl0Qqm4UGKs0LPheskSWgtIfhQhbQmwOwiEGCDrk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gjs/default.nix
+++ b/pkgs/development/libraries/gjs/default.nix
@@ -32,13 +32,13 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "gjs";
-  version = "1.74.0";
+  version = "1.74.1";
 
   outputs = [ "out" "dev" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-fWQYr2LMc1VqssJbSt9n9FI4q4kliI96VyUTWdTr7R4=";
+    sha256 = "sha256-8h+c0zN6ZypEx+ZL+ajYrXfBuIuVKythhMevmx8+9Fk=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gtksourceview";
-  version = "4.8.3";
+  version = "4.8.4";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "wwAZUGMgyiR02DTM7R4iF+pTPgDrKj9Ot4eQB5QOxoI=";
+    sha256 = "fsnRj7KD0fhKOj7/O3pysJoQycAGWXs/uru1lYQgqH0=";
   };
 
   patches = [

--- a/pkgs/development/libraries/libpanel/default.nix
+++ b/pkgs/development/libraries/libpanel/default.nix
@@ -15,14 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libpanel";
-  version = "1.0.1";
+  version = "1.0.2";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
   src = fetchurl {
     url = "mirror://gnome/sources/libpanel/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "hBtqtx6wcv1lIAI+H3Gqx/8lDGbq37sXyVXaa/QeIwY=";
+    sha256 = "pnIEOkiuIAUAl8mp+dmPKnOh7IVHgirnu6VNPMiNf+I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/tepl/default.nix
+++ b/pkgs/development/libraries/tepl/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tepl";
-  version = "6.1.2";
+  version = "6.2.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "Cv4uyaWNT6ixBntqc0/TxzNqn/+3VyyWPFLqbYckoZs=";
+    sha256 = "jNaGXCw4GIdgyzjK4z3J4KiI+tGNCwTx1V5laqmJqEQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/misc/yelp-tools/default.nix
+++ b/pkgs/development/misc/yelp-tools/default.nix
@@ -13,13 +13,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "yelp-tools";
-  version = "42.0";
+  version = "42.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/yelp-tools/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "LNQwY/+nJi3xXdjTeao+o5mdQmYfB1Y/SALaoRSfffQ=";
+    sha256 = "PklqQCDUFFuZ/VCKJfoJM2pQOk6JAAKEIecsaksR+QU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Ran the update script, targeting first staging-next cycle

Excluded a glib update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
