### PR TITLE
python310Packages.pdfminer: 20220524 -> 20221105

### DIFF
--- a/pkgs/development/python-modules/pdfminer-six/default.nix
+++ b/pkgs/development/python-modules/pdfminer-six/default.nix
@@ -4,13 +4,16 @@
 , isPy3k
 , cryptography
 , charset-normalizer
+, pythonOlder
+, typing-extensions
 , pytestCheckHook
 , ocrmypdf
 }:
 
 buildPythonPackage rec {
   pname = "pdfminer-six";
-  version = "20220524";
+  version = "20221105";
+  format = "setuptools";
 
   disabled = !isPy3k;
 
@@ -18,10 +21,13 @@ buildPythonPackage rec {
     owner = "pdfminer";
     repo = "pdfminer.six";
     rev = version;
-    sha256 = "sha256-XO9sdHeS/8MgVW0mxbTe2AY5BDfnBSDNzZwLsSKmQh0=";
+    sha256 = "sha256-OyEeQBuYfj4iEcRt2/daSaUfTOjCVSCyHW2qffal+Bk=";
   };
 
-  propagatedBuildInputs = [ charset-normalizer cryptography ];
+  propagatedBuildInputs = [
+    charset-normalizer
+    cryptography
+  ] ++ lib.optionals (pythonOlder "3.8") [ typing-extensions ];
 
   postInstall = ''
     for file in $out/bin/*.py; do
@@ -30,14 +36,19 @@ buildPythonPackage rec {
   '';
 
   postPatch = ''
-    # Verion is not stored in repo, gets added by a GitHub action after tag is created
+    # Version is not stored in repo, gets added by a GitHub action after tag is created
     # https://github.com/pdfminer/pdfminer.six/pull/727
     substituteInPlace pdfminer/__init__.py --replace "__VERSION__" ${version}
   '';
 
-  pythonImportsCheck = [ "pdfminer" ];
+  pythonImportsCheck = [
+    "pdfminer"
+    "pdfminer.high_level"
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   passthru = {
     tests = {


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/pdfminer/pdfminer.six/releases/tag/20221105

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
