### PR TITLE
upx: apply patch for CVE-2021-20285

### DIFF
--- a/pkgs/tools/compression/upx/default.nix
+++ b/pkgs/tools/compression/upx/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ucl, zlib, perl }:
+{ lib, stdenv, fetchurl, ucl, zlib, perl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "upx";
@@ -9,6 +9,14 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ ucl zlib perl ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/upx/upx/commit/13bc031163863cb3866aa6cdc018dff0697aa5d4.patch";
+      sha256 = "sha256-7uazgx1lOgHh2J7yn3yb1q9lTJsv4BbexdGlWRiAG/M=";
+      name = "CVE-2021-20285.patch";
+    })
+  ];
 
   preConfigure = ''
     export UPX_UCLDIR=${ucl}


### PR DESCRIPTION


###### Description of changes

Did not bump to 4.0.0 yet because the 4.0.0 release is affected by CVE-2021-30500 and CVE-2021-30501.
The patch for CVE-2021-30500 does not apply cleanly on top of 4.0.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
