### PR TITLE
python3Packages.locust: init at 2.14.1

### DIFF
--- a/pkgs/development/python-modules/locust/default.nix
+++ b/pkgs/development/python-modules/locust/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, python3Packages
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "locust";
+  version = "2.16.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "locustio";
+    repo = "locust";
+    rev = version;
+    hash = "sha256-MKFzEFpDkD8e+ENZN0GAWYipPK9A4SCZZRHG5/5UaNM=";
+  };
+
+  patchPhase = ''
+     echo 'version = "${version}"' > locust/_version.py
+  '';
+
+  propagatedBuildInputs = with python3Packages; [
+    requests
+    flask-basicauth
+    flask-cors
+    msgpack
+    gevent
+    pyzmq
+    roundrobin
+    geventhttpclient
+    psutil
+    typing-extensions
+    configargparse
+    setuptools
+  ];
+
+  meta = with lib; {
+    description = "A load testing tool";
+    homepage = "https://locust.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ shyim ];
+  };
+}

--- a/pkgs/development/python-modules/roundrobin/default.nix
+++ b/pkgs/development/python-modules/roundrobin/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "roundrobin";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "linnik";
+    repo = pname;
+    rev = version;
+    hash = "sha256-eedE4PE43sbJE/Ktrc31KjVdfqe2ChKCYUNIl7fir0E=";
+  };
+
+  meta = with lib; {
+    description = "This is rather small collection of round robin utilites";
+    homepage = "https://github.com/linnik/roundrobin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ shyim ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6121,6 +6121,8 @@ self: super: with self; {
 
   lockfile = callPackage ../development/python-modules/lockfile { };
 
+  locustio = callPackage ../development/python-modules/locustio { };
+
   log-symbols = callPackage ../development/python-modules/log-symbols { };
 
   logbook = callPackage ../development/python-modules/logbook { };
@@ -11175,6 +11177,8 @@ self: super: with self; {
   rouge-score = callPackage ../development/python-modules/rouge-score { };
 
   routeros-api = callPackage ../development/python-modules/routeros-api { };
+
+  roundrobin = callPackage ../development/python-modules/roundrobin { };
 
   routes = callPackage ../development/python-modules/routes { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6121,7 +6121,7 @@ self: super: with self; {
 
   lockfile = callPackage ../development/python-modules/lockfile { };
 
-  locustio = callPackage ../development/python-modules/locustio { };
+  locust = callPackage ../development/python-modules/locust { };
 
   log-symbols = callPackage ../development/python-modules/log-symbols { };
 


### PR DESCRIPTION
###### Description of changes
 
Packed the open source load test tool [locustio](https://locust.io). It was a while ago packaged but has been removed because it was unmaintained in https://github.com/NixOS/nixpkgs/pull/104351

So this reads the newest version and makes me the maintainer


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
