### PR TITLE
pythonPackages.pystray: Add appindicator support

### DIFF
--- a/pkgs/applications/video/jellyfin-mpv-shim/default.nix
+++ b/pkgs/applications/video/jellyfin-mpv-shim/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonApplication
 , fetchPypi
+, gobject-introspection
 , jellyfin-apiclient-python
 , jinja2
 , mpv
@@ -9,6 +10,7 @@
 , python-mpv-jsonipc
 , pywebview
 , tkinter
+, wrapGAppsHook
 }:
 
 buildPythonApplication rec {
@@ -19,6 +21,11 @@ buildPythonApplication rec {
     inherit pname version;
     sha256 = "sha256-JiSC6WjrLsWk3/m/EHq7KNXaJ6rqT2fG9TT1jPvYlK0=";
   };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gobject-introspection
+  ];
 
   propagatedBuildInputs = [
     jellyfin-apiclient-python
@@ -51,6 +58,12 @@ buildPythonApplication rec {
       --replace "check_updates: bool = True" "check_updates: bool = False" \
       --replace "notify_updates: bool = True" "notify_updates: bool = False"
   '';
+
+  # needed for pystray to access appindicator using GI
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+  dontWrapGApps = true;
 
   # no tests
   doCheck = false;

--- a/pkgs/applications/video/plex-mpv-shim/default.nix
+++ b/pkgs/applications/video/plex-mpv-shim/default.nix
@@ -1,4 +1,5 @@
-{ lib, buildPythonApplication, fetchFromGitHub, mpv, requests, python-mpv-jsonipc, pystray, tkinter }:
+{ lib, buildPythonApplication, fetchFromGitHub, mpv, requests, python-mpv-jsonipc, pystray, tkinter
+, wrapGAppsHook, gobject-introspection }:
 
 buildPythonApplication rec {
   pname = "plex-mpv-shim";
@@ -11,7 +12,18 @@ buildPythonApplication rec {
     sha256 = "0hgv9g17dkrh3zbsx27n80yvkgix9j2x0rgg6d3qsf7hp5j3xw4r";
   };
 
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gobject-introspection
+  ];
+
   propagatedBuildInputs = [ mpv requests python-mpv-jsonipc pystray tkinter ];
+
+  # needed for pystray to access appindicator using GI
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+  dontWrapGApps = true;
 
   # does not contain tests
   doCheck = false;

--- a/pkgs/development/python-modules/pystray/default.nix
+++ b/pkgs/development/python-modules/pystray/default.nix
@@ -1,5 +1,15 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, pillow, xlib, six, xvfb-run, sphinx }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pillow
+, xlib
+, six
+, xvfb-run
+, sphinx
+, gobject-introspection
+, pygobject3
+, gtk3
+, libayatana-appindicator }:
 
 buildPythonPackage rec {
   pname = "pystray";
@@ -12,8 +22,8 @@ buildPythonPackage rec {
     sha256 = "sha256-8B178MSe4ujlnGBmQhIu+BoAh1doP9V5cL0ermLQTvs=";
   };
 
-  nativeBuildInputs = [ sphinx ];
-  propagatedBuildInputs = [ pillow xlib six ];
+  nativeBuildInputs = [ gobject-introspection sphinx ];
+  propagatedBuildInputs = [ pillow xlib six pygobject3 gtk3 libayatana-appindicator ];
   checkInputs = [ xvfb-run ];
 
   checkPhase = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The pystray python package has three backends for Linux: appindicator, gtk and xlib. So far only xlib has been supported, but is broken with the appindicator extension on GNOME. This introduces the dependencies required to make it work.

As this is based on gobject-introspection applications depending on pystray needs to be wrapped using wrapGApps, in this case it was only `jellyfin-mpv-shim`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
