### PR TITLE
python3Packages.jupyter_core: 4.9.2 -> 4.11.2

### DIFF
--- a/pkgs/development/python-modules/jupyter_core/default.nix
+++ b/pkgs/development/python-modules/jupyter_core/default.nix
@@ -5,6 +5,7 @@
 , fetchpatch
 , python
 , ipython
+, hatchling
 , traitlets
 , glibcLocales
 , mock
@@ -14,23 +15,21 @@
 
 buildPythonPackage rec {
   pname = "jupyter_core";
-  version = "4.9.2";
+  version = "4.11.2";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-1puuuf+xKLjNJlf88nA/icdp0Wc8hRgSEZ46Kg6TrZo=";
+    sha256 = "sha256-wpCbm8fcp1VgpsWueMNP0wXt4xzYZNo8DQuy7Ymqkzc=";
   };
+  format = "pyproject";
+
+  buildInputs = [ hatchling ];
 
   checkInputs = [ pytestCheckHook mock glibcLocales nose ];
   propagatedBuildInputs = [ ipython traitlets ];
 
   patches = [
-    # install jupyter_core/*.py files
-    (fetchpatch {
-      url = "https://github.com/jupyter/jupyter_core/pull/253/commits/3bbeaebec0a53520523162d5e8d5c6ca02b1b782.patch";
-      sha256 = "sha256-QeAfj7wLz4egVUPMAgrZ9Wn/Tv60LrIXLgHGVoH41wQ=";
-    })
     ./tests_respect_pythonpath.patch
   ];
 

--- a/pkgs/development/python-modules/jupyter_core/tests_respect_pythonpath.patch
+++ b/pkgs/development/python-modules/jupyter_core/tests_respect_pythonpath.patch
@@ -1,20 +1,20 @@
 --- a/jupyter_core/tests/test_command.py
 +++ b/jupyter_core/tests/test_command.py
-@@ -131,7 +131,7 @@ def test_not_on_path(tmpdir):
-     witness_src = '#!%s\n%s\n' % (sys.executable, 'print("WITNESS ME")')
+@@ -174,7 +174,7 @@ def test_not_on_path(tmpdir):
+     witness_src = "#!{}\n{}\n".format(sys.executable, 'print("WITNESS ME")')
      write_executable(witness, witness_src)
-
--    env = {'PATH': ''}
+ 
+-    env = {"PATH": ""}
 +    env = {'PATH': '', 'PYTHONPATH': os.environ['PYTHONPATH']}
-     if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-         env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
-     if sys.platform == 'win32':
-@@ -157,7 +157,7 @@ def test_path_priority(tmpdir):
-     witness_b_src = '#!%s\n%s\n' % (sys.executable, 'print("WITNESS B")')
+     if "SYSTEMROOT" in os.environ:  # Windows http://bugs.python.org/issue20614
+         env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+     if sys.platform == "win32":
+@@ -197,7 +197,7 @@ def test_path_priority(tmpdir):
+     witness_b_src = "#!{}\n{}\n".format(sys.executable, 'print("WITNESS B")')
      write_executable(witness_b, witness_b_src)
-
--    env = {'PATH':  str(b)}
-+    env = {'PATH':  str(b), 'PYTHONPATH': os.environ['PYTHONPATH']}
-     if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-         env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
-     if sys.platform == 'win32':
+ 
+-    env = {"PATH": str(b)}
++    env = {'PATH': str(b), 'PYTHONPATH': os.environ['PYTHONPATH']}
+     if "SYSTEMROOT" in os.environ:  # Windows http://bugs.python.org/issue20614
+         env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+     if sys.platform == "win32":

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -51,6 +51,12 @@ buildPythonPackage rec {
       url = "https://github.com/jupyter/nbconvert/commit/d3900ed4527f024138dc3a8658c6a1b1dfc43c09.patch";
       hash = "sha256-AFE1Zhw29JMLB0Sj17zHcOfy7VEFqLekO8NYbyMLrdI=";
     })
+
+    (fetchpatch {
+      name = "fix-test-default-config-jupyter-core-4.11.2.patch";
+      url = "https://github.com/jupyter/nbconvert/commit/7227d68acde5e3f2959dd5f4db30af1ee4b222b7.patch";
+      hash = "sha256-hrPgvTubig7grEo0F9QIcfxaz5X3p/C2U7Gnhp/uTWY=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-39286 aka GHSA-m678-f26j-3hrp

Have rebuilt quite a few packages on x86_64 linux, but am unable to do a full rebuild right now, would appreciate someone helping out with that.

Hoping to be able to patch stable branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
