### PR TITLE
nixos options markdown: fix html escaping

### DIFF
--- a/nixos/lib/make-options-doc/generateCommonMark.py
+++ b/nixos/lib/make-options-doc/generateCommonMark.py
@@ -3,7 +3,7 @@ import sys
 
 options = json.load(sys.stdin)
 for (name, value) in options.items():
-    print('##', name.replace('<', '\\<').replace('>', '\\>'))
+    print('##', name.replace('<', '&lt;').replace('>', '&gt;'))
     print(value['description'])
     print()
     if 'type' in value:


### PR DESCRIPTION
\<foo\> will often be displayed like \<foo>, for example by mkdocs.

I've tested a number of markdown renderers and they render html escape sequences fine.

cc @pennae
