### PR TITLE
[22.05] python3Packages.jupyter_core: add patch for CVE-2022-39286 

### DIFF
--- a/pkgs/development/python-modules/jupyter_core/4.9.2-CVE-2022-39286.patch
+++ b/pkgs/development/python-modules/jupyter_core/4.9.2-CVE-2022-39286.patch
@@ -1,0 +1,97 @@
+combination of upstream 1118c8ce01800cb689d51f655f5ccef19516e283 and
+part of d6a8168b9f6b8a28bba5f7cca3d6a9c31da041b6 to allow the test
+alterations to apply
+
+diff --git a/jupyter_core/application.py b/jupyter_core/application.py
+index 77b5c33..e321410 100644
+--- a/jupyter_core/application.py
++++ b/jupyter_core/application.py
+@@ -78,8 +78,8 @@ class JupyterApp(Application):
+     def config_file_paths(self):
+         path = jupyter_config_path()
+         if self.config_dir not in path:
++            # Insert config dir as first item.
+             path.insert(0, self.config_dir)
+-        path.insert(0, os.getcwd())
+         return path
+     
+     data_dir = Unicode()
+diff --git a/jupyter_core/tests/test_application.py b/jupyter_core/tests/test_application.py
+index 0d87e4f..e24ec5d 100644
+--- a/jupyter_core/tests/test_application.py
++++ b/jupyter_core/tests/test_application.py
+@@ -65,43 +65,51 @@ def test_generate_config():
+ 
+ def test_load_config():
+     config_dir = mkdtemp()
+-    wd = mkdtemp()
+-    with open(pjoin(config_dir, 'dummy_app_config.py'), 'w', encoding='utf-8') as f:
+-        f.write('c.DummyApp.m = 1\n')
+-        f.write('c.DummyApp.n = 1')
+-    with patch.object(os, 'getcwd', lambda : wd):
+-        app = DummyApp(config_dir=config_dir)
+-        app.initialize([])
++    os.environ["JUPYTER_CONFIG_PATH"] = str(config_dir)
++    with open(pjoin(config_dir, "dummy_app_config.py"), "w", encoding="utf-8") as f:
++        f.write("c.DummyApp.m = 1\n")
++        f.write("c.DummyApp.n = 1")
++
++    app = DummyApp(config_dir=config_dir)
++    app.initialize([])
+ 
+     assert app.n == 1, "Loaded config from config dir"
+-    
+-    with open(pjoin(wd, 'dummy_app_config.py'), 'w', encoding='utf-8') as f:
+-        f.write('c.DummyApp.n = 2')
++    assert app.m == 1, "Loaded config from config dir"
++
++    shutil.rmtree(config_dir)
++    del os.environ["JUPYTER_CONFIG_PATH"]
+ 
+-    with patch.object(os, 'getcwd', lambda : wd):
++
++def test_load_config_no_cwd():
++    config_dir = mkdtemp()
++    wd = mkdtemp()
++    with open(pjoin(wd, "dummy_app_config.py"), "w", encoding="utf-8") as f:
++        f.write("c.DummyApp.m = 1\n")
++        f.write("c.DummyApp.n = 1")
++    with patch.object(os, "getcwd", lambda: wd):
+         app = DummyApp(config_dir=config_dir)
+         app.initialize([])
+ 
+-    assert app.m == 1, "Loaded config from config dir"
+-    assert app.n == 2, "Loaded config from CWD"
+-    
++    assert app.n == 0
++    assert app.m == 0
++
+     shutil.rmtree(config_dir)
+     shutil.rmtree(wd)
+ 
+ 
+ def test_load_bad_config():
+     config_dir = mkdtemp()
+-    wd = mkdtemp()
+-    with open(pjoin(config_dir, 'dummy_app_config.py'), 'w', encoding='utf-8') as f:
+-        f.write('c.DummyApp.m = "a\n') # Syntax error
+-    with patch.object(os, 'getcwd', lambda : wd):
+-        with pytest.raises(SyntaxError):
+-            app = DummyApp(config_dir=config_dir)
+-            app.raise_config_file_errors=True
+-            app.initialize([])
++    os.environ["JUPYTER_CONFIG_PATH"] = str(config_dir)
++    with open(pjoin(config_dir, "dummy_app_config.py"), "w", encoding="utf-8") as f:
++        f.write('c.DummyApp.m = "a\n')  # Syntax error
++
++    with pytest.raises(SyntaxError):
++        app = DummyApp(config_dir=config_dir)
++        app.raise_config_file_errors = True
++        app.initialize([])
+ 
+     shutil.rmtree(config_dir)
+-    shutil.rmtree(wd)
++    del os.environ["JUPYTER_CONFIG_PATH"]
+ 
+ 
+ def test_runtime_dir_changed():

--- a/pkgs/development/python-modules/jupyter_core/default.nix
+++ b/pkgs/development/python-modules/jupyter_core/default.nix
@@ -32,6 +32,7 @@ buildPythonPackage rec {
       sha256 = "sha256-QeAfj7wLz4egVUPMAgrZ9Wn/Tv60LrIXLgHGVoH41wQ=";
     })
     ./tests_respect_pythonpath.patch
+    ./4.9.2-CVE-2022-39286.patch
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , defusedxml
 , fetchPypi
+, fetchpatch
 , ipywidgets
 , jinja2
 , jupyterlab-pygments
@@ -30,6 +31,11 @@ buildPythonPackage rec {
   # various exporter templates
   patches = [
     ./templates.patch
+    (fetchpatch {
+      name = "fix-test-default-config-jupyter-core-4.11.2.patch";
+      url = "https://github.com/jupyter/nbconvert/commit/7227d68acde5e3f2959dd5f4db30af1ee4b222b7.patch";
+      hash = "sha256-hrPgvTubig7grEo0F9QIcfxaz5X3p/C2U7Gnhp/uTWY=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-39286 aka GHSA-m678-f26j-3hrp

~See #199768 for unstable. Keeping this as a draft for now because I'll have to finalize the cherry-pick reference if cbcb53ed4282c2c7b72d0413b1f74b53732cd956 doesn't end up being the final commit id.~

~Similar situation as #199768 in regards to testing - would appreciate anyone willing to do a full `nixpkgs-review` of this.~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
