### PR TITLE
humility: update libusb alias and vendor hash

### DIFF
--- a/pkgs/development/tools/rust/humility/default.nix
+++ b/pkgs/development/tools/rust/humility/default.nix
@@ -1,10 +1,12 @@
 { lib
+, stdenv
 , rustPlatform
 , fetchFromGitHub
-, libusb
+, libusb1
 , libftdi
 , cargo-readme
 , pkg-config
+, AppKit
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -12,7 +14,9 @@ rustPlatform.buildRustPackage rec {
   version = "unstable-2022-09-15";
 
   nativeBuildInputs = [ pkg-config cargo-readme ];
-  buildInputs = [ libusb libftdi ];
+  buildInputs = [ libusb1 libftdi ] ++ lib.optionals stdenv.isDarwin [
+    AppKit
+  ];
 
   src = fetchFromGitHub {
     owner = "oxidecomputer";
@@ -21,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-yW7QcxTWbL2YsV2bvfhbqQ2nawlPQbYxBfIGCWo28GY=";
   };
 
-  cargoSha256 = "sha256-UhO8VO3OCfYc8Xq/P+l9f5ZrhOD/TBzSClAeAXLJLlc=";
+  cargoSha256 = "sha256-IurLI0ZQNpmiYwfcMZuxi7FWtSX+Ts7GYWFwUfD+Ji8=";
 
   meta = with lib; {
     description = "Debugger for Hubris";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24995,7 +24995,9 @@ with pkgs;
 
   htop-vim = callPackage ../tools/system/htop/htop-vim.nix { };
 
-  humility = callPackage ../development/tools/rust/humility {};
+  humility = callPackage ../development/tools/rust/humility {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
 
   btop = callPackage ../tools/system/btop {
     stdenv = gcc11Stdenv;


### PR DESCRIPTION
###### Description of changes

I do not know why the hash is wrong, but it is not just failing locally for me but also [on Hydra](https://hydra.nixos.org/eval/1784782?filter=humility&compare=1784756&full=).

This was affecting a nixpkgs-review run I was doing. It supersedes https://github.com/NixOS/nixpkgs/pull/198673 and fixes https://github.com/NixOS/nixpkgs/pull/192842.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
