### PR TITLE
bats.libraries: reduce output size

### DIFF
--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -10,8 +10,9 @@
     };
     dontBuild = true;
     installPhase = ''
-      mkdir -p "$out/share/bats"
-      cp -r . "$out/share/bats/bats-assert"
+      mkdir -p "$out/share/bats/bats-assert"
+      cp load.bash "$out/share/bats/bats-assert"
+      cp -r src "$out/share/bats/bats-assert"
     '';
     meta = {
       description = "Common assertions for Bats";
@@ -33,8 +34,9 @@
     };
     dontBuild = true;
     installPhase = ''
-      mkdir -p "$out/share/bats"
-      cp -r . "$out/share/bats/bats-file"
+      mkdir -p "$out/share/bats/bats-file"
+      cp load.bash "$out/share/bats/bats-file"
+      cp -r src "$out/share/bats/bats-file"
     '';
     meta = {
       description = "Common filesystem assertions for Bats";
@@ -56,8 +58,9 @@
     };
     dontBuild = true;
     installPhase = ''
-      mkdir -p "$out/share/bats"
-      cp -r . "$out/share/bats/bats-support"
+      mkdir -p "$out/share/bats/bats-support"
+      cp load.bash "$out/share/bats/bats-support"
+      cp -r src "$out/share/bats/bats-support"
     '';
     meta = {
       description = "Supporting library for Bats test helpers";


### PR DESCRIPTION
###### Description of changes

I was peeking at these to see how bats libraries are structured and noticed a fair number of extraneous files (mainly tests).

@infinisil Sanity check? I wasn't already familiar with how these are structured, so I might be wrong about what's essential. If I'm understanding right, though, it's just the `load.bash` in the root and then (by convention) the `src/*` files that it in turn sources.

```console
# before
$ du -hd0 $(nix-build -A bats.libraries)
140K	/nix/store/sp1hdvm01b6yl4iyvil85qqbj15a0rry-bats-assert-2.0.0
312K	/nix/store/hlbxap6izd16fk15mflq1vv0wsymvld5-bats-file-0.3.0
104K	/nix/store/0mpr9jmcb4k86bx4r0clyy79353n3irm-bats-support-0.3.0

# after
$ du -hd0 $(nix-build -A bats.libraries)
28K	/nix/store/7ms6v8lkcj0z59svi97s3f5vabzhxzz4-bats-assert-2.0.0
44K	/nix/store/v6iwvl00ma6i04025jkhqkamb6kykmhc-bats-file-0.3.0
20K	/nix/store/kkxs3624k5fldwmjn65rdiqx3d6xx2gr-bats-support-0.3.0
```

###### Things done

`nix-build -A bats.tests` is clean; nothing in nixpkgs depends on the bats libraries, so `nixpkgs-review` resulted in no rebuilds.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
