### PR TITLE
OpenJDK: init 19.0.1

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -32,12 +32,12 @@
 , which
 , icu
 , boost
-, jdk
+, jdk17
 , ant
 , cups
 , xorg
 , fontforge
-, jre_minimal
+, jre17_minimal
 , openssl
 , gperf
 , cppunit
@@ -121,7 +121,7 @@ let
     getDev getLib
     optional optionals optionalString;
 
-  jre' = jre_minimal.override {
+  jre' = jre17_minimal.override {
     modules = [ "java.base" "java.desktop" "java.logging" "java.sql" ];
   };
 
@@ -460,7 +460,7 @@ in
     bison
     fontforge
     gdb
-    jdk
+    jdk17
     libtool
     pkg-config
   ]

--- a/pkgs/development/compilers/openjdk/19.nix
+++ b/pkgs/development/compilers/openjdk/19.nix
@@ -1,0 +1,169 @@
+{ stdenv, lib, fetchurl, fetchFromGitHub, bash, pkg-config, autoconf, cpio
+, file, which, unzip, zip, perl, cups, freetype, alsa-lib, libjpeg, giflib
+, libpng, zlib, lcms2, libX11, libICE, libXrender, libXext, libXt, libXtst
+, libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk19-bootstrap
+, ensureNewerSourcesForZipFilesHook
+, setJavaClassPath
+, headless ? false
+, enableJavaFX ? openjfx.meta.available, openjfx
+, enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
+}:
+
+let
+  version = {
+    feature = "19";
+    interim = ".0.1";
+    build = "10";
+  };
+
+  openjdk = stdenv.mkDerivation {
+    pname = "openjdk" + lib.optionalString headless "-headless";
+    version = "${version.feature}${version.interim}+${version.build}";
+
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jdk${version.feature}u";
+      rev = "jdk-${version.feature}${version.interim}+${version.build}";
+      hash = "sha256-IS6ABnVdW1qJ4gu4YSgMVFXBTNdtWFdbNNz+kMaiyk8=";
+    };
+
+    nativeBuildInputs = [ pkg-config autoconf unzip ensureNewerSourcesForZipFilesHook ];
+    buildInputs = [
+      cpio file which zip perl zlib cups freetype alsa-lib libjpeg giflib
+      libpng zlib lcms2 libX11 libICE libXrender libXext libXtst libXt libXtst
+      libXi libXinerama libXcursor libXrandr fontconfig openjdk19-bootstrap
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      gtk3 gnome_vfs GConf glib
+    ];
+
+    patches = [
+      ./fix-java-home-jdk10.patch
+      ./read-truststore-from-env-jdk10.patch
+      ./currency-date-range-jdk10.patch
+      ./increase-javadoc-heap-jdk13.patch
+      ./ignore-LegalNoticeFilePlugin-jdk18.patch
+
+      # -Wformat etc. are stricter in newer gccs, per
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79677
+      # so grab the work-around from
+      # https://src.fedoraproject.org/rpms/java-openjdk/pull-request/24
+      (fetchurl {
+        url = "https://src.fedoraproject.org/rpms/java-openjdk/raw/06c001c7d87f2e9fe4fedeef2d993bcd5d7afa2a/f/rh1673833-remove_removal_of_wformat_during_test_compilation.patch";
+        sha256 = "082lmc30x64x583vqq00c8y0wqih3y4r0mp1c4bqq36l22qv6b6r";
+      })
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      ./swing-use-gtk-jdk13.patch
+    ];
+
+    postPatch = ''
+      chmod +x configure
+      patchShebangs --build configure
+    '';
+
+    configureFlags = [
+      "--with-boot-jdk=${openjdk19-bootstrap.home}"
+      "--with-version-build=${version.build}"
+      "--with-version-opt=nixos"
+      "--with-version-pre="
+      "--enable-unlimited-crypto"
+      "--with-native-debug-symbols=internal"
+      "--with-libjpeg=system"
+      "--with-giflib=system"
+      "--with-libpng=system"
+      "--with-zlib=system"
+      "--with-lcms=system"
+      "--with-stdc++lib=dynamic"
+    ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
+      ++ lib.optional headless "--enable-headless-only"
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+
+    separateDebugInfo = true;
+
+    NIX_CFLAGS_COMPILE = "-Wno-error";
+
+    NIX_LDFLAGS = toString (lib.optionals (!headless) [
+      "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      "-lgtk-3" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
+    ]);
+
+    # -j flag is explicitly rejected by the build system:
+    #     Error: 'make -jN' is not supported, use 'make JOBS=N'
+    # Note: it does not make build sequential. Build system
+    # still runs in parallel.
+    enableParallelBuilding = false;
+
+    buildFlags = [ "images" ];
+
+    installPhase = ''
+      mkdir -p $out/lib
+
+      mv build/*/images/jdk $out/lib/openjdk
+
+      # Remove some broken manpages.
+      rm -rf $out/lib/openjdk/man/ja*
+
+      # Mirror some stuff in top-level.
+      mkdir -p $out/share
+      ln -s $out/lib/openjdk/include $out/include
+      ln -s $out/lib/openjdk/man $out/share/man
+
+      # IDEs use the provided src.zip to navigate the Java codebase (https://github.com/NixOS/nixpkgs/pull/95081)
+      ln -s $out/lib/openjdk/lib/src.zip $out/lib/src.zip
+
+      # jni.h expects jni_md.h to be in the header search path.
+      ln -s $out/include/linux/*_md.h $out/include/
+
+      # Remove crap from the installation.
+      rm -rf $out/lib/openjdk/demo
+      ${lib.optionalString headless ''
+        rm $out/lib/openjdk/lib/{libjsound,libfontmanager}.so
+      ''}
+
+      ln -s $out/lib/openjdk/bin $out/bin
+    '';
+
+    preFixup = ''
+      # Propagate the setJavaClassPath setup hook so that any package
+      # that depends on the JDK has $CLASSPATH set up properly.
+      mkdir -p $out/nix-support
+      #TODO or printWords?  cf https://github.com/NixOS/nixpkgs/pull/27427#issuecomment-317293040
+      echo -n "${setJavaClassPath}" > $out/nix-support/propagated-build-inputs
+
+      # Set JAVA_HOME automatically.
+      mkdir -p $out/nix-support
+      cat <<EOF > $out/nix-support/setup-hook
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      EOF
+    '';
+
+    postFixup = ''
+      # Build the set of output library directories to rpath against
+      LIBDIRS=""
+      for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
+        LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
+      done
+      # Add the local library paths to remove dependencies on the bootstrap
+      for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
+        OUTPUTDIR=$(eval echo \$$output)
+        BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
+        echo "$BINLIBS" | while read i; do
+          patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
+          patchelf --shrink-rpath "$i" || true
+        done
+      done
+    '';
+
+    disallowedReferences = [ openjdk19-bootstrap ];
+
+    meta = import ./meta.nix lib version.feature;
+
+    passthru = {
+      architecture = "";
+      home = "${openjdk}/lib/openjdk";
+      inherit gtk3;
+    };
+  };
+in openjdk

--- a/pkgs/development/compilers/openjdk/darwin/19.nix
+++ b/pkgs/development/compilers/openjdk/darwin/19.nix
@@ -1,0 +1,81 @@
+{ lib, stdenv, fetchurl, unzip, setJavaClassPath }:
+let
+  # Details from https://www.azul.com/downloads/?version=java-19-sts&os=macos&package=jdk
+  # Note that the latest build may differ by platform
+  dist = {
+    x86_64-darwin = {
+      arch = "x64";
+      zuluVersion = "19.30.11";
+      jdkVersion = "19.0.1";
+      sha256 = "1h0qj0xgpxjy506ikbgdn74pi4860lsnh5n3q3bayfmn0pxc5ksn";
+    };
+
+    aarch64-darwin = {
+      arch = "aarch64";
+      zuluVersion = "19.30.11";
+      jdkVersion = "19.0.1";
+      sha256 = "0g8i371h5fv686xhiff0431sgvdk80lbp2lkz86jpfdv9lgg0qnk";
+    };
+  }."${stdenv.hostPlatform.system}";
+
+  jce-policies = fetchurl {
+    # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
+    url = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
+  };
+
+  jdk = stdenv.mkDerivation rec {
+    pname = "zulu${dist.zuluVersion}-ca-jdk";
+    version = dist.jdkVersion;
+
+    src = fetchurl {
+      url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-ca-jdk${dist.jdkVersion}-macosx_${dist.arch}.tar.gz";
+      inherit (dist) sha256;
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
+    };
+
+    nativeBuildInputs = [ unzip ];
+
+    installPhase = ''
+      mkdir -p $out
+      mv * $out
+
+      unzip ${jce-policies}
+      mv -f ZuluJCEPolicies/*.jar $out/lib/security/
+
+      # jni.h expects jni_md.h to be in the header search path.
+      ln -s $out/include/darwin/*_md.h $out/include/
+
+      if [ -f $out/LICENSE ]; then
+        install -D $out/LICENSE $out/share/zulu/LICENSE
+        rm $out/LICENSE
+      fi
+    '';
+
+    preFixup = ''
+      # Propagate the setJavaClassPath setup hook from the JDK so that
+      # any package that depends on the JDK has $CLASSPATH set up
+      # properly.
+      mkdir -p $out/nix-support
+      printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+      # Set JAVA_HOME automatically.
+      cat <<EOF >> $out/nix-support/setup-hook
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+      EOF
+    '';
+
+    # fixupPhase is moving the man to share/man which breaks it because it's a
+    # relative symlink.
+    postFixup = ''
+      ln -nsf ../zulu-${lib.versions.major version}.jdk/Contents/Home/man $out/share/man
+    '';
+
+    passthru = {
+      home = jdk;
+    };
+
+    meta = import ./meta.nix lib version;
+  };
+in
+jdk

--- a/pkgs/development/compilers/openjdk/openjfx/19.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/19.nix
@@ -1,0 +1,123 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, writeText, openjdk17_headless
+, openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
+, libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, icu68 }:
+
+let
+  major = "19";
+  update = "";
+  build = "+11";
+  repover = "${major}${update}${build}";
+  gradle_ = (gradle_7.override {
+    # note: gradle does not yet support running on 19
+    java = openjdk17_headless;
+  });
+
+  makePackage = args: stdenv.mkDerivation ({
+    version = "${major}${update}${build}";
+
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jfx";
+      rev = repover;
+      hash = "sha256-UXTaXtJ8py83V7IQK9wACIEWDAMRUaYNgH9e/Aeyuzc=";
+    };
+
+    patches = [
+      # 8295962: Reference to State in Task.java is ambiguous when building with JDK 19
+      (fetchpatch {
+        url = "https://github.com/openjdk/jfx/pull/933/commits/cfaee2a52350eff39dd4352484c892716076d3de.patch";
+        hash = "sha256-hzJMenhvtmHs/6BJj8GfaLp14myV8VCXCLLC8n32yEw=";
+      })
+      # ditto
+      (fetchpatch {
+        url = "https://github.com/openjdk/jfx/pull/933/commits/bd46ce12df0a93a56fe0d58d3653d08e58409b7f.patch";
+        hash = "sha256-o9908uw9vYvULmAh/lbfyHhgxz6jpgPq2fcAltWsYoU=";
+      })
+    ];
+
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 icu68 ];
+    nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
+
+    dontUseCmakeConfigure = true;
+
+    config = writeText "gradle.properties" (''
+      CONF = Release
+      JDK_HOME = ${openjdk19_headless.home}
+    '' + args.gradleProperties or "");
+
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME=$(mktemp -d)
+      ln -s $config gradle.properties
+      export NIX_CFLAGS_COMPILE="$(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
+      gradle --no-daemon $gradleFlags sdk
+
+      runHook postBuild
+    '';
+  } // args);
+
+  # Fake build to pre-download deps into fixed-output derivation.
+  # We run nearly full build because I see no other way to download everything that's needed.
+  # Anyone who knows a better way?
+  deps = makePackage {
+    pname = "openjfx-deps";
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME -type f -regex '.*/modules.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+      rm -rf $out/tmp
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    # suspiciously the same as for openjfx 17 ...
+    # could they really not have changed any of their dependencies?
+    # or did we miss changing another upstream hash when copy-pasting?
+    outputHash = "sha256-dV7/U5GpFxhI13smZ587C6cVE4FRNPY0zexZkYK4Yqo=";
+  };
+
+in makePackage {
+  pname = "openjfx-modular-sdk";
+
+  gradleProperties = ''
+    COMPILE_MEDIA = true
+    COMPILE_WEBKIT = false
+  '';
+
+  preBuild = ''
+    swtJar="$(find ${deps} -name org.eclipse.swt\*.jar)"
+    substituteInPlace build.gradle \
+      --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }' \
+      --replace 'name: SWT_FILE_NAME' "files('$swtJar')"
+  '';
+
+  installPhase = ''
+    cp -r build/modular-sdk $out
+  '';
+
+  stripDebugList = [ "." ];
+
+  postFixup = ''
+    # Remove references to bootstrap.
+    export openjdkOutPath='${openjdk19_headless.outPath}'
+    find "$out" -name \*.so | while read lib; do
+      new_refs="$(patchelf --print-rpath "$lib" | perl -pe 's,:?\Q$ENV{openjdkOutPath}\E[^:]*,,')"
+      patchelf --set-rpath "$new_refs" "$lib"
+    done
+  '';
+
+  disallowedReferences = [ openjdk17_headless openjdk19_headless ];
+
+  passthru.deps = deps;
+
+  meta = with lib; {
+    homepage = "https://openjdk.org/projects/openjfx/";
+    license = licenses.gpl2Classpath;
+    description = "The next-generation Java client toolkit";
+    maintainers = with maintainers; [ abbradar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/temurin-bin/generate-sources.py
+++ b/pkgs/development/compilers/temurin-bin/generate-sources.py
@@ -6,7 +6,7 @@ import re
 import requests
 import sys
 
-feature_versions = (8, 11, 16, 17)
+feature_versions = (8, 11, 16, 17, 18, 19)
 oses = ("mac", "linux", "alpine-linux")
 types = ("jre", "jdk")
 impls = ("hotspot")

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -10,6 +10,13 @@ in
   jdk-11 = common { sourcePerArch = sources.jdk.openjdk11; };
   jre-11 = common { sourcePerArch = sources.jre.openjdk11; };
   jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; };
+
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };
   jre-17 = common { sourcePerArch = sources.jre.openjdk17; };
+
+  jdk-18 = common { sourcePerArch = sources.jdk.openjdk18; };
+  jre-18 = common { sourcePerArch = sources.jre.openjdk18; };
+
+  jdk-19 = common { sourcePerArch = sources.jdk.openjdk19; };
+  jre-19 = common { sourcePerArch = sources.jre.openjdk19; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -11,6 +11,13 @@ in
   jdk-11 = common { sourcePerArch = sources.jdk.openjdk11; };
   jre-11 = common { sourcePerArch = sources.jre.openjdk11; };
   jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; };
+
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };
   jre-17 = common { sourcePerArch = sources.jre.openjdk17; };
+
+  jdk-18 = common { sourcePerArch = sources.jdk.openjdk18; };
+  jre-18 = common { sourcePerArch = sources.jre.openjdk18; };
+
+  jdk-19 = common { sourcePerArch = sources.jdk.openjdk19; };
+  jre-19 = common { sourcePerArch = sources.jre.openjdk19; };
 }

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -32,6 +32,26 @@
             "version": "17.0.5"
           }
         },
+        "openjdk18": {
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "1",
+            "sha256": "478c8f56dec7378ed8c687e8d7d0fbf729973c62c497cfc8cf58bd621849d764",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jdk_x64_alpine-linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          }
+        },
+        "openjdk19": {
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "76cfcdf47cdf24331b51939fd2840fd387cf62471da99e4718e2e42b486a9270",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jdk_x64_alpine-linux_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -62,6 +82,26 @@
             "sha256": "56daddc4c38cda4fa8716d0a6c5b3197305b94ed7011f06adfcd55357952ae17",
             "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_x64_alpine-linux_hotspot_17.0.5_8.tar.gz",
             "version": "17.0.5"
+          }
+        },
+        "openjdk18": {
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "1",
+            "sha256": "ad23309a82e690f769037b1e6417022f588702d214da533289f116bba0f61f4e",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_x64_alpine-linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          }
+        },
+        "openjdk19": {
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "32426b790ac99a21a69abec793bfa47996a4fe7f74c7c89484836237f121640b",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jre_x64_alpine-linux_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
           }
         },
         "openjdk8": {
@@ -162,6 +202,62 @@
             "version": "17.0.5"
           }
         },
+        "openjdk18": {
+          "aarch64": {
+            "build": "1",
+            "sha256": "262be608e266fd76d7496af83b2832be853c3aaf7460d6a4da198cd40db74553",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jdk_aarch64_linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          },
+          "armv6l": {
+            "build": "1",
+            "sha256": "4cd49b92d13847bfad7b3bf635cca349e2c89c7641748c5288bc40d612cdbbd6",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jdk_arm_linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          },
+          "armv7l": {
+            "build": "1",
+            "sha256": "4cd49b92d13847bfad7b3bf635cca349e2c89c7641748c5288bc40d612cdbbd6",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jdk_arm_linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "1",
+            "sha256": "7d6beba8cfc0a8347f278f7414351191a95a707d46b6586e9a786f2669af0f8b",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jdk_x64_linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          }
+        },
+        "openjdk19": {
+          "aarch64": {
+            "build": "10",
+            "sha256": "5e8d7b3189364afd78d936bad140dbe1e7025d4b96d530ed5536d035c21afb7c",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jdk_aarch64_linux_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
+          },
+          "armv6l": {
+            "build": "36",
+            "sha256": "34a786548033391de80b857fe02a9c7bd42fcb94243e7273e89012df73f1adef",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19%2B36/OpenJDK19U-jdk_arm_linux_hotspot_19_36.tar.gz",
+            "version": "19.0.0"
+          },
+          "armv7l": {
+            "build": "36",
+            "sha256": "34a786548033391de80b857fe02a9c7bd42fcb94243e7273e89012df73f1adef",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19%2B36/OpenJDK19U-jdk_arm_linux_hotspot_19_36.tar.gz",
+            "version": "19.0.0"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "163da7ea140210bae97c6a4590c757858ab4520a78af0e3e33129863d4087552",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jdk_x64_linux_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "8",
@@ -248,6 +344,62 @@
             "version": "17.0.5"
           }
         },
+        "openjdk18": {
+          "aarch64": {
+            "build": "1",
+            "sha256": "e11e00438c2f6f79f86ff1ca2b015913b0e16bd9491953a082d5c786402cb50a",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_aarch64_linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          },
+          "armv6l": {
+            "build": "1",
+            "sha256": "0ae7281fa883de0d39a75b39bfbbcec1d2a5f8ed8691af12226962ce1a761cd7",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_arm_linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          },
+          "armv7l": {
+            "build": "1",
+            "sha256": "0ae7281fa883de0d39a75b39bfbbcec1d2a5f8ed8691af12226962ce1a761cd7",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_arm_linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "1",
+            "sha256": "74f602ab5abaa554859a5e92a65e5bb6e23c2d4165228299c7f54ed56dbc5959",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_x64_linux_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          }
+        },
+        "openjdk19": {
+          "aarch64": {
+            "build": "10",
+            "sha256": "c69ffc5474be076b200e8cc72417b838e4f830b36603d593fb8ca6d11b81969b",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jre_aarch64_linux_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
+          },
+          "armv6l": {
+            "build": "36",
+            "sha256": "f6c4895b8d33118c75403d08f9697af0b77769d0e8574cb678518a0ab3b74a12",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19%2B36/OpenJDK19U-jre_arm_linux_hotspot_19_36.tar.gz",
+            "version": "19.0.0"
+          },
+          "armv7l": {
+            "build": "36",
+            "sha256": "f6c4895b8d33118c75403d08f9697af0b77769d0e8574cb678518a0ab3b74a12",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19%2B36/OpenJDK19U-jre_arm_linux_hotspot_19_36.tar.gz",
+            "version": "19.0.0"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "68cae46c973e48ca6777cd0026bbf25f3457bd3d6730c36bd79d4f3b398c8338",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jre_x64_linux_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "8",
@@ -322,6 +474,38 @@
             "version": "17.0.5"
           }
         },
+        "openjdk18": {
+          "aarch64": {
+            "build": "1",
+            "sha256": "c5ec423f52d8f3aa632941f29fd289f2e31dce5fe6f3abed9b72bd374f54cd41",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jdk_aarch64_mac_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "1",
+            "sha256": "2ed916b0c9d197a6bf71b76e84d94125023c2609e0a9b22c64553eff5c9c29c1",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jdk_x64_mac_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          }
+        },
+        "openjdk19": {
+          "aarch64": {
+            "build": "10",
+            "sha256": "2be4ffbf7c59b3148886b48ecf3f7d7edb7c745917ceae2a6be145a4678bf014",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jdk_aarch64_mac_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "0d80a8787fa97f5fc2f0000a849b54f4d41c5b87726c29ea1de215e382c8380c",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jdk_x64_mac_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -364,6 +548,38 @@
             "sha256": "c4884b6cd8d43497ff46e4fd475ddde5ab91004db435f0c29a801b081662f7ee",
             "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_x64_mac_hotspot_17.0.5_8.tar.gz",
             "version": "17.0.5"
+          }
+        },
+        "openjdk18": {
+          "aarch64": {
+            "build": "1",
+            "sha256": "071f073efb9550838bc02e429ef972f9450b477360f803dd1cf19096ca41182e",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_aarch64_mac_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "1",
+            "sha256": "3629e3dc9dbab7ed13070fbea3a827030acdd62afa557496e88a6d01f9300474",
+            "url": "https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_x64_mac_hotspot_18.0.2.1_1.tar.gz",
+            "version": "18.0.2"
+          }
+        },
+        "openjdk19": {
+          "aarch64": {
+            "build": "10",
+            "sha256": "d6d4a51d2eefb98cabdbdd9118ca473e9b07ced8d784541177f74e9bf09d4a2e",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jre_aarch64_mac_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "8bf67ece0915f5847caec5060e93eafbeeb1a3c99132a72a9424255b3b7cd063",
+            "url": "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.1%2B10/OpenJDK19U-jre_x64_mac_hotspot_19.0.1_10.tar.gz",
+            "version": "19.0.1"
           }
         },
         "openjdk8": {

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -6,10 +6,10 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "327b3bfd1c14e15bf6c7fb4d0c6c3f9406c1282a16e24b1424215d764f687cb6",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_x64_alpine-linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "774d5955c09893dda14e3eb0fd3e239a6b2cec58615fcf4ec68747260b6e1cc1",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_x64_alpine-linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           }
         },
         "openjdk16": {
@@ -26,20 +26,20 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "1a1706304c26da0d8d2e05127c5aa7dba00e5401b2c0228c8ae894d2812beee0",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_alpine-linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "cb154396ff3bfb6a9082e3640c564643d31ecae1792fab0956149ed5258ad84b",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_x64_alpine-linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           }
         },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "e5dcb8f947b687597f92fa80c008a2a17ce86f739dd6dce7ca741921621acb21",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u345b01.tar.gz",
-            "version": "8.0.345"
+            "build": "8",
+            "sha256": "aa782e3c561b041a5730cbe728c210e234db71fa7222bd8b661f9f4df7799375",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u352-b08/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u352b08.tar.gz",
+            "version": "8.0.352"
           }
         }
       },
@@ -48,30 +48,30 @@
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "4cdebb54ead80e6dff562ad51db850244b1b419ba72062782156df59854a6b22",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jre_x64_alpine-linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "96d26887d042f3c5630cca208b6cd365679a59bf9efb601b28363e827439796c",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jre_x64_alpine-linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           }
         },
         "openjdk17": {
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "cd0300449a26b3141e313f6ab55b20edfa4b289dc44a7a3989fa2c29152bf7fb",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jre_x64_alpine-linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "56daddc4c38cda4fa8716d0a6c5b3197305b94ed7011f06adfcd55357952ae17",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_x64_alpine-linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           }
         },
         "openjdk8": {
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "6352a4d55373266af90b2f2ec13f4397ada58f5cdc57944ea046c9c538341fd3",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jre_x64_alpine-linux_hotspot_8u345b01.tar.gz",
-            "version": "8.0.345"
+            "build": "8",
+            "sha256": "0f4a4a3c092d8cca171fc36003ac82e2f3d8d768bd6f530a20e2a4caf79bdb9e",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u352-b08/OpenJDK8U-jre_x64_alpine-linux_hotspot_8u352b08.tar.gz",
+            "version": "8.0.352"
           }
         }
       }
@@ -80,30 +80,30 @@
       "jdk": {
         "openjdk11": {
           "aarch64": {
-            "build": "1",
-            "sha256": "2b89cabf0ce1c2cedadd92b798d6e9056bc27c71a06f5ba24ede5dc9c316e3e8",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "d18b5dd73fce9edd5c58f623a1173f9ee2d45023836b8753b96beae51673a432",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           },
           "armv6l": {
-            "build": "1",
-            "sha256": "a703acfd04ece4a4aac4cb9bda26b7d225874008bba324237bd6f53792edb778",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_arm_linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "9ff3b4bd2bac18fb39f3356148efa2dc710ac029e12dc8f18ea1fe6be23bf299",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_arm_linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           },
           "armv7l": {
-            "build": "1",
-            "sha256": "a703acfd04ece4a4aac4cb9bda26b7d225874008bba324237bd6f53792edb778",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_arm_linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "9ff3b4bd2bac18fb39f3356148efa2dc710ac029e12dc8f18ea1fe6be23bf299",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_arm_linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "5f6b513757d386352cf91514ed5859d1ab59364b4453e1f1c57152ba2039b8e2",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "b8d46ed08ef4859476fe6421a7690d899ed83dce63f13fd894f994043177ef3c",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           }
         },
         "openjdk16": {
@@ -136,38 +136,38 @@
         },
         "openjdk17": {
           "aarch64": {
-            "build": "1",
-            "sha256": "3c7460de77421284b38b4e57cb1bd584a6cef55c34fc51a12270620544de2b8a",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "1c26c0e09f1641a666d6740d802beb81e12180abaea07b47c409d30c7f368109",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           },
           "armv6l": {
-            "build": "1",
-            "sha256": "efba97cd38af8f43b61f09cb5041f81d92ecd005dcd51c81678fbcf4f24d8461",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_arm_linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "e7c81596f67b6325036e9182d012f2266ced5663c5d4b0de0540ce62dcc67718",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_arm_linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           },
           "armv7l": {
-            "build": "1",
-            "sha256": "efba97cd38af8f43b61f09cb5041f81d92ecd005dcd51c81678fbcf4f24d8461",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_arm_linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "e7c81596f67b6325036e9182d012f2266ced5663c5d4b0de0540ce62dcc67718",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_arm_linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "5fbf8b62c44f10be2efab97c5f5dbf15b74fae31e451ec10abbc74e54a04ff44",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "482180725ceca472e12a8e6d1a4af23d608d78287a77d963335e2a0156a020af",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           }
         },
         "openjdk8": {
           "aarch64": {
-            "build": "1",
-            "sha256": "c1965fb24dded7d7944e2da36cd902adf3b7b1d327aaa21ea507cff00a5a0090",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_aarch64_linux_hotspot_8u345b01.tar.gz",
-            "version": "8.0.345"
+            "build": "8",
+            "sha256": "a70768968bbcccccf977f036e87e545c3b080ed6c44072a01e9dadb94051c454",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u352-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u352b08.tar.gz",
+            "version": "8.0.352"
           },
           "armv6l": {
             "build": "1",
@@ -184,76 +184,76 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "ed6c9db3719895584fb1fd69fc79c29240977675f26631911c5a1dbce07b7d58",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz",
-            "version": "8.0.345"
+            "build": "8",
+            "sha256": "1633bd7590cb1cd72f5a1378ae8294451028b274d798e2a4ac672059a2f00fee",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u352-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u352b08.tar.gz",
+            "version": "8.0.352"
           }
         }
       },
       "jre": {
         "openjdk11": {
           "aarch64": {
-            "build": "1",
-            "sha256": "b6607f28fa2906d612d517f0babe4f0f895aa1c3f901edcddb493e33c1e27364",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "bd6efe3290c8b5a42f695a55a26f3e3c9c284288574879d4b7089f31f5114177",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           },
           "armv6l": {
-            "build": "1",
-            "sha256": "2ee7fe636a6a57e4718dfe597e8097b93ef8d976e4b05384433777c9f0526f5a",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jre_arm_linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "8cf113d3d7fa808895c8d2e41bb890af21c47e38c2460e0588147a4bb8fc658d",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jre_arm_linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           },
           "armv7l": {
-            "build": "1",
-            "sha256": "2ee7fe636a6a57e4718dfe597e8097b93ef8d976e4b05384433777c9f0526f5a",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jre_arm_linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "8cf113d3d7fa808895c8d2e41bb890af21c47e38c2460e0588147a4bb8fc658d",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jre_arm_linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "1ffe1a682e8179e35238bf3f93aba0cb185850e202c676f41d38cb0561883eda",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jre_x64_linux_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "752616097e09d7f60a3ad8bd312f90eaf50ac72577e55df229fe6e8091148f79",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jre_x64_linux_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           }
         },
         "openjdk17": {
           "aarch64": {
-            "build": "1",
-            "sha256": "2e4137529319cd7935f74e1289025b7b4c794c0fb47a3d138adffbd1bbc0ea58",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "34d6414710db27cd7760fe369135f3b9927ccc81410280606613166d4106d60a",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           },
           "armv6l": {
-            "build": "1",
-            "sha256": "b63f532cb8b30e4d0bd18d52f08c1933e3cf66aeb373180d002274b6d94b4a25",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jre_arm_linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "9e0d1745139fe502f22df1e261d2ed1ad807085dd75a8b333d481289b579870d",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_arm_linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           },
           "armv7l": {
-            "build": "1",
-            "sha256": "b63f532cb8b30e4d0bd18d52f08c1933e3cf66aeb373180d002274b6d94b4a25",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jre_arm_linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "9e0d1745139fe502f22df1e261d2ed1ad807085dd75a8b333d481289b579870d",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_arm_linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "e96814ee145a599397d91e16831d2dddc3c6b8e8517a8527e28e727649aaa2d1",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jre_x64_linux_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "11326464a14b63e6328d1d2088a23fb559c0e36b3f380e4c1f8dcbe160a8b95e",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_x64_linux_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           }
         },
         "openjdk8": {
           "aarch64": {
-            "build": "1",
-            "sha256": "65b8bd74382d6514d2458ff4375468651791a55a186a5bffe0803204801e9c94",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jre_aarch64_linux_hotspot_8u345b01.tar.gz",
-            "version": "8.0.345"
+            "build": "8",
+            "sha256": "cce4db7c4311378d8d2a174b2cf680d57b52a4036f37c995b14f936b6fc1141a",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u352-b08/OpenJDK8U-jre_aarch64_linux_hotspot_8u352b08.tar.gz",
+            "version": "8.0.352"
           },
           "armv6l": {
             "build": "1",
@@ -270,10 +270,10 @@
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "2422a8831fe414b9dba4c443ee3562431dfcde27577124f0db58ec903afc262a",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jre_x64_linux_hotspot_8u345b01.tar.gz",
-            "version": "8.0.345"
+            "build": "8",
+            "sha256": "40b6b4c3d8f7332ea479527b530413bf0dbc13cff3c0ed9fcadf1ca053bed106",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u352-b08/OpenJDK8U-jre_x64_linux_hotspot_8u352b08.tar.gz",
+            "version": "8.0.352"
           }
         }
       }
@@ -282,18 +282,18 @@
       "jdk": {
         "openjdk11": {
           "aarch64": {
-            "build": "1",
-            "sha256": "1953f06702d45eb54bae3ccf453b57c33de827015f5623a2dfc16e1c83e6b0a1",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "79b18cbd398b67a52ebaf033dfca15c7af4c1a84ec5fa68a88f3bf742bb082f7",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "723548e36e0b3e0a5a2f36a38b22ea825d3004e26054a0e254854adc57045352",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jdk_x64_mac_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "f408a12f10d93b3205bef851af62707531b699963cef79408d59197d08763c94",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jdk_x64_mac_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           }
         },
         "openjdk16": {
@@ -308,18 +308,18 @@
         },
         "openjdk17": {
           "aarch64": {
-            "build": "1",
-            "sha256": "3a976943a9e6a635e68e2b06bd093fc096aad9f5894acda673d3bea0cb3a6f38",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "2dc3e425b52d1cd2915d93af5e468596b9e6a90112056abdcebac8b65bf57049",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "94fe50982b09a179e603a096e83fd8e59fd12c0ae4bcb37ae35f00ef30a75d64",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_x64_mac_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           }
         },
         "openjdk8": {
@@ -336,34 +336,34 @@
       "jre": {
         "openjdk11": {
           "aarch64": {
-            "build": "1",
-            "sha256": "c84f38a7d87d50649ffc1f625facb4398fa54885371336a2cbf6ae2b435cbd10",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jre_aarch64_mac_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "2a5cbc2888f8e382c7d0a5bf2c6d2c3bad120ceff51b00d3a62805dae4473c02",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jre_aarch64_mac_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "10be61a8dd3766f7c12e2e823a6eca48cc6361d97e1b76310c752bd39770c7fe",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1%2B1/OpenJDK11U-jre_x64_mac_hotspot_11.0.16.1_1.tar.gz",
-            "version": "11.0.16"
+            "build": "8",
+            "sha256": "66508958b5da6e36021d960b65490ab70cc7d44851c98301a3d6d3552f305674",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.17%2B8/OpenJDK11U-jre_x64_mac_hotspot_11.0.17_8.tar.gz",
+            "version": "11.0.17"
           }
         },
         "openjdk17": {
           "aarch64": {
-            "build": "1",
-            "sha256": "63a32fe611f2666856e84b79305eb80609de229bbce4f13991b961797aa88bf8",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "d98b7f5ee6cb4a1c49288bd932008e3e37f9bb5d9a0eb9396ea236786e6ab570",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "1",
-            "sha256": "9c59e45a9a6cbc1b8d671c4a88bb8d9b8929fae067df0d0a73b1ca71781a0996",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/OpenJDK17U-jre_x64_mac_hotspot_17.0.4.1_1.tar.gz",
-            "version": "17.0.4"
+            "build": "8",
+            "sha256": "c4884b6cd8d43497ff46e4fd475ddde5ab91004db435f0c29a801b081662f7ee",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jre_x64_mac_hotspot_17.0.5_8.tar.gz",
+            "version": "17.0.5"
           }
         },
         "openjdk8": {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14357,6 +14357,7 @@ with pkgs;
 
   /* default JDK */
   jdk = jdk17;
+  jdk_headless = jdk17_headless;
 
   # Since the introduction of the Java Platform Module System in Java 9, Java
   # no longer ships a separate JRE package.
@@ -14365,13 +14366,13 @@ with pkgs;
   # 'jre_minimal' to build a bespoke JRE containing only the modules you need.
   #
   # For a general-purpose system, 'jre' defaults to the full JDK:
-  jre = jdk17;
-  jre_headless = jdk17_headless;
+  jre = jdk;
+  jre_headless = jdk_headless;
 
   jre_minimal = callPackage ../development/compilers/openjdk/jre.nix { };
 
-  openjdk = openjdk17;
-  openjdk_headless = openjdk17_headless;
+  openjdk = jdk;
+  openjdk_headless = jdk_headless;
 
   graalvmCEPackages =
     recurseIntoAttrs (callPackage ../development/compilers/graalvm/community-edition {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13318,16 +13318,23 @@ with pkgs;
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
 
+  temurin-bin-19 = javaPackages.compiler.temurin-bin.jdk-19;
+  temurin-jre-bin-19 = javaPackages.compiler.temurin-bin.jre-19;
+
+  temurin-bin-18 = javaPackages.compiler.temurin-bin.jdk-18;
+  temurin-jre-bin-18 = javaPackages.compiler.temurin-bin.jre-18;
+
   temurin-bin-17 = javaPackages.compiler.temurin-bin.jdk-17;
   temurin-jre-bin-17 = javaPackages.compiler.temurin-bin.jre-17;
+
   temurin-bin-16 = javaPackages.compiler.temurin-bin.jdk-16;
   temurin-bin-11 = javaPackages.compiler.temurin-bin.jdk-11;
   temurin-jre-bin-11 = javaPackages.compiler.temurin-bin.jre-11;
   temurin-bin-8 = javaPackages.compiler.temurin-bin.jdk-8;
   temurin-jre-bin-8 = javaPackages.compiler.temurin-bin.jre-8;
 
-  temurin-bin = temurin-bin-17;
-  temurin-jre-bin = temurin-jre-bin-17;
+  temurin-bin = temurin-bin-19;
+  temurin-jre-bin = temurin-jre-bin-19;
 
   semeru-bin-17 = javaPackages.compiler.semeru-bin.jdk-17;
   semeru-jre-bin-17 = javaPackages.compiler.semeru-bin.jre-17;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14356,15 +14356,14 @@ with pkgs;
 
   openjdk16-bootstrap = javaPackages.compiler.openjdk16-bootstrap;
 
-  openjdk18-bootstrap = javaPackages.compiler.openjdk18-bootstrap;
-  openjdk18 = javaPackages.compiler.openjdk18;
-  openjdk18_headless = javaPackages.compiler.openjdk18.headless;
-  jdk18 = openjdk18;
-  jdk18_headless = openjdk18_headless;
+  openjdk19 = javaPackages.compiler.openjdk19;
+  openjdk19_headless = javaPackages.compiler.openjdk19.headless;
+  jdk19 = openjdk19;
+  jdk19_headless = openjdk19_headless;
 
   /* default JDK */
-  jdk = jdk17;
-  jdk_headless = jdk17_headless;
+  jdk = jdk19;
+  jdk_headless = jdk19_headless;
 
   # Since the introduction of the Java Platform Module System in Java 9, Java
   # no longer ships a separate JRE package.
@@ -14376,6 +14375,9 @@ with pkgs;
   jre = jdk;
   jre_headless = jdk_headless;
 
+  jre17_minimal = callPackage ../development/compilers/openjdk/jre.nix {
+    jdk = jdk17;
+  };
   jre_minimal = callPackage ../development/compilers/openjdk/jre.nix { };
 
   openjdk = jdk;
@@ -29524,7 +29526,7 @@ with pkgs;
   };
 
   jabref = callPackage ../applications/office/jabref {
-    jdk = jdk18;
+    jdk = javaPackages.compiler.openjdk18;
   };
 
   jack_capture = callPackage ../applications/audio/jack-capture { };

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -9,11 +9,12 @@ let
   openjfx11 = callPackage ../development/compilers/openjdk/openjfx/11.nix { };
   openjfx15 = callPackage ../development/compilers/openjdk/openjfx/15.nix { };
   openjfx17 = callPackage ../development/compilers/openjdk/openjfx/17.nix { };
+  openjfx19 = callPackage ../development/compilers/openjdk/openjfx/19.nix { };
 
   mavenfod = callPackage ../development/java-modules/maven-fod.nix { };
 
 in {
-  inherit mavenbuild mavenfod fetchMaven openjfx11 openjfx15 openjfx17;
+  inherit mavenbuild mavenfod fetchMaven openjfx11 openjfx15 openjfx17 openjfx19;
 
   compiler = let
 
@@ -196,6 +197,14 @@ in {
       {
         inherit openjdk18-bootstrap;
         openjfx = openjfx17;
+      };
+
+    openjdk19 = mkOpenjdk
+      ../development/compilers/openjdk/19.nix
+      ../development/compilers/openjdk/darwin/19.nix
+      {
+        openjdk19-bootstrap = temurin-bin.jdk-19;
+        openjfx = openjfx19;
       };
 
     temurin-bin = recurseIntoAttrs (callPackage (


### PR DESCRIPTION
###### Description of changes

supporting work:

```
temurin-bin: 8.0.345 -> 8.0.352; 11.0.16 -> 11.0.17; 17.0.4 -> 17.0.5

simple run of generate_sources.py
```
```
openjdk: reduce number of places where default jdk version is specified
```
```
temurin-bin: init 18.0.2 and 19.0.1
```

... and the main event:

```
openjdk: init 19.0.1

as usual this is mostly copy-pasted from 18, so this commit is best
reviewed with '--find-copies-harder'

stop exposing openjdk 18 since it was not a long-term support release

change the default openjdk from 17 to 19 since nixpkgs is a
rolling-release repository

drop the ceremony around bootstrapping via adoptopenjdk for 64-bit
builds vs. via earlier openjdk builds for 32-bit, because, to be
frank, since we're using temurin now, it's not a simple copy-paste
job.  :-/  if someone needs a 32-bit openjdk, that work can be done
separately.

JavaFX revs from 17 to 19; it looks like 18 was never packaged along
with JDK 18.

* the gradle invocation used to build JavaFX must still be done with
  Java 18, as gradle does not yet support running itself on Java 19.

* a couple of patches need to be applied, since a new State enum was
  introduced in the JDK that collides with one in JavaFX.

* the hash of the gradle dependencies has not changed, which is
  surprising, but as far as I can tell correct.
```

cc @edwtjo @asbachb @xeals @Jonpez2

fixes #195638

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

