### PR TITLE
cargo-nextest: fix tests

### DIFF
--- a/pkgs/development/tools/rust/cargo-nextest/default.nix
+++ b/pkgs/development/tools/rust/cargo-nextest/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, stdenv, Security }:
+{ lib, rustPlatform, fetchFromGitHub, fetchpatch, stdenv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-nextest";
@@ -11,12 +11,31 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-7Ujm5xqgyw4/P/XBZKh9yE9sWz9n+WmZbGdmif9oK+w=";
   };
 
+  patches = [
+    # Update uuid version in fixtures to match nextest
+    (fetchpatch {
+      name = "update-uuid-version-nextest-tests.patch";
+      url = "https://github.com/nextest-rs/nextest/commit/c5d9c527b84f69555bb8e1d036e5bbb41424cd9f.diff";
+      hash = "sha256-Z/wkK3wPJW+uNwGVtVAxTzK/fuvJ+N0Ch/ov1sndXO8=";
+    })
+    # Remove a warning about double license declaration
+    (fetchpatch {
+      name = "remove-warning-license.patch";
+      url = "https://github.com/nextest-rs/nextest/commit/126ad4d2590400e5dcb752d7994202d9642b1648.diff";
+      hash = "sha256-jo7KYNfsXqYIoUuOx/1M1IjVfNuWrOnRgsLJbhY3dUw=";
+    })
+  ];
+
   cargoSha256 = "sha256-S46W+6+FyjI8BrdedDCzHHK+j3EyofQ9u8Ut1yr1/TI=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 
   cargoBuildFlags = [ "-p" "cargo-nextest" ];
   cargoTestFlags = [ "-p" "cargo-nextest" ];
+
+  checkFlags = [
+    "--skip=test_run_from_archive"
+  ];
 
   meta = with lib; {
     description = "Next-generation test runner for Rust projects";


### PR DESCRIPTION
###### Description of changes

Another try at https://github.com/NixOS/nixpkgs/pull/199810.

Fixes https://github.com/NixOS/nixpkgs/issues/199803

Upstream pull request: https://github.com/nextest-rs/nextest/pull/626

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
