### PR TITLE
libbpf: make libbpf_1 the default libbpf

### DIFF
--- a/pkgs/servers/dns/knot-dns/default.nix
+++ b/pkgs/servers/dns/knot-dns/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, gnutls, liburcu, lmdb, libcap_ng, libidn2, libunistring
 , systemd, nettle, libedit, zlib, libiconv, libintl, libmaxminddb, libbpf, nghttp2, libmnl
-, ngtcp2-gnutls
+, ngtcp2-gnutls, xdp-tools
 , autoreconfHook
 , nixosTests, knot-resolver, knot-dns, runCommandLocal
 }:
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     # TODO: add dnstap support?
   ] ++ lib.optionals stdenv.isLinux [
     libcap_ng systemd
-    libbpf libmnl # XDP support (it's Linux kernel API)
+    xdp-tools libbpf libmnl # XDP support (it's Linux kernel API)
   ] ++ lib.optional stdenv.isDarwin zlib; # perhaps due to gnutls
 
   enableParallelBuilding = true;
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
     deps = runCommandLocal "knot-deps-test"
       { nativeBuildInputs = [ (lib.getBin stdenv.cc.libc) ]; }
       ''
-        for libname in libngtcp2 libbpf; do
+        for libname in libngtcp2 libxdp libbpf; do
           echo "Checking for $libname:"
           ldd '${knot-dns.bin}/bin/knotd' | grep -F "$libname"
           echo "OK"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -748,6 +748,7 @@ mapAliases ({
   libayatana-appindicator-gtk3 = libayatana-appindicator; # Added 2022-10-18
   libbencodetools = bencodetools; # Added 2022-07-30
   libbluedevil = throw "'libbluedevil' (Qt4) is unmaintained and unused since 'kde4.bluedevil's removal in 2017"; # Added 2022-06-14
+  libbpf_1 = libbpf; # Added 2022-12-06
   libcanberra_gtk2 = throw "'libcanberra_gtk2' has been renamed to/replaced by 'libcanberra-gtk2'"; # Converted to throw 2022-02-22
   libcanberra_gtk3 = throw "'libcanberra_gtk3' has been renamed to/replaced by 'libcanberra-gtk3'"; # Converted to throw 2022-02-22
   libcap_manpages = throw "'libcap_manpages' has been renamed to/replaced by 'libcap.doc'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11717,6 +11717,7 @@ with pkgs;
 
   suricata = callPackage ../applications/networking/ids/suricata {
     python = python3;
+    libbpf = libbpf_0;
   };
 
   sof-firmware = callPackage ../os-specific/linux/firmware/sof-firmware { };
@@ -12339,9 +12340,7 @@ with pkgs;
 
   tracebox = callPackage ../tools/networking/tracebox { stdenv = gcc10StdenvCompat; };
 
-  tracee = callPackage ../tools/security/tracee {
-    libbpf = libbpf_1; # keep inline with their submodule
-  };
+  tracee = callPackage ../tools/security/tracee { };
 
   tracefilegen = callPackage ../development/tools/analysis/garcosim/tracefilegen { };
 
@@ -16763,10 +16762,8 @@ with pkgs;
 
   bump = callPackage ../development/tools/github/bump { };
 
-  libbpf_1 = callPackage ../os-specific/linux/libbpf { };
+  libbpf = callPackage ../os-specific/linux/libbpf { };
   libbpf_0 = callPackage ../os-specific/linux/libbpf/0.x.nix { };
-  # until more issues are fixed default to libbpf 0.x
-  libbpf = libbpf_0;
 
   bundlewrap = with python3.pkgs; toPythonApplication bundlewrap;
 
@@ -16774,12 +16771,10 @@ with pkgs;
 
   bcc = callPackage ../os-specific/linux/bcc {
     python = python3;
-    libbpf = libbpf_1;
     llvmPackages = llvmPackages_14;
   };
 
   bpftrace = callPackage ../os-specific/linux/bpftrace {
-    libbpf = libbpf_1;
     llvmPackages = llvmPackages_14;
   };
 
@@ -17686,9 +17681,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  pahole = callPackage ../development/tools/misc/pahole {
-    libbpf = libbpf_1;
-  };
+  pahole = callPackage ../development/tools/misc/pahole { };
 
   panopticon = callPackage ../development/tools/analysis/panopticon {};
 
@@ -25947,7 +25940,6 @@ with pkgs;
       enableMinimal = true;
       guiSupport = false;
     };
-    libbpf = libbpf_1;
   };
   systemdMinimal = systemd.override {
     pname = "systemd-minimal";


### PR DESCRIPTION
###### Description of changes

There is absolutely no hurry, but now systemd uses libbpf_1 in staging it's probably a good time to change the default libbpf, so most systems can get rid of libbpf_0 if they still needed it.

Opening as draft until the below points are addressed. I assume it's probably better to wait for the 2022.11 branching as well.

- [x] This PR builds on top of #189078 and will be rebased once that is merged; that PR is also ready. The only commit here is the top commit; github still cannot handle cascading PRs...
- [x] This PR should not be merged before #199618 gets back into master; that shouldn't be too long.
- [x] knot does not build with libbpf_1, because of libxdp -- @vcunat , does libxdp need an upgrade or something? I made it use libbpf_0, but since there's been an upstream release that should be compatible that should be fixable.
- [ ] suricata will require an upgrade to 7.0.0 to build with libbpf_1, I've made it use libbpf_0 for now. (They released 7.0.0-beta with libbpf1 compatibility last week, so shouldn't be long)
- [x] I've built the following packages with libbpf_1 successfully: slurm, dpdk, odp-dpdk, xdp-tools, p4c. I didn't test, but the breakages with libbpf1 are rather obvious, so if it builds I think it should work -- I'll prod maintainers when we're about to merge this.
- [x] The following packages already were using libbpf_1 and the explicit parameter got removed: tracee, bcc/bpftrace (through #189078), systemd (through #199618), pahole
- [x] I didn't see any other package using libbpf.

(As a side note, on fedora, at least iproute2 and qemu use libbpf -- perhaps some option we might want to turn on at some point in the future. iproute2 uses it for xdp programs manipulations, qemu uses it for its [eBPF RSS loader](https://www.qemu.org/docs/master/devel/ebpf_rss.html) which apparently is something to load-balance incoming packets on predefined cpus. Both are apparently compatible with either libbpf 0.8 or 1.0, but I'll look into it later if we want to.)