### PR TITLE
jami: 20220825.0828.c10f01f -> 20221031.1308.130cc26

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jami/client.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/client.nix
@@ -2,6 +2,7 @@
 , src
 , jami-meta
 , lib
+, fetchpatch
 , stdenv
 , pkg-config
 , cmake
@@ -25,13 +26,20 @@
 }:
 
 stdenv.mkDerivation {
-  pname = "jami-client-qt";
+  pname = "jami-client";
   inherit version src;
 
   sourceRoot = "source/client-qt";
 
+  patches = [
+    (fetchpatch {
+      name = "fix-build-without-webengine.patch";
+      url = "https://git.jami.net/savoirfairelinux/jami-client-qt/-/commit/9b2dbb64eaa9256f800dfa69d897545f4b0affd2.patch";
+      hash = "sha256-lgDlSlXIjtdymBa7xSe1PabSK9DnSG5KnJggOLWyn+A=";
+    })
+  ];
+
   preConfigure = ''
-    python gen-resources.py
     echo 'const char VERSION_STRING[] = "${version}";' > src/app/version.h
   '';
 
@@ -61,8 +69,8 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DRING_BUILD_DIR=${jami-daemon}/include"
-    "-DRING_XML_INTERFACES_DIR=${jami-daemon}/share/dbus-1/interfaces"
+    "-DLIBJAMI_INCLUDE_DIR=${jami-daemon}/include/jami"
+    "-DLIBJAMI_XML_INTERFACES_DIR=${jami-daemon}/share/dbus-1/interfaces"
   ] ++ lib.optionals (!withWebengine) [
     "-DWITH_WEBENGINE=false"
   ];

--- a/pkgs/applications/networking/instant-messengers/jami/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/default.nix
@@ -12,11 +12,11 @@
 }:
 
 let
-  version = "20220825.0828.c10f01f";
+  version = "20221031.1308.130cc26";
 
   src = fetchzip {
     url = "https://dl.jami.net/release/tarballs/jami_${version}.tar.gz";
-    hash = "sha256-axQYU7+kOFE9SnI8fR4F6NFvD9ITZ85UJhg5OVniSlg=";
+    hash = "sha256-+xpSoSsG+G+w8+g0FhXx+6Phroj83ijW8xWvYO+kdqY=";
 
     stripRoot = false;
     postFetch = ''
@@ -87,7 +87,7 @@ rec {
     inherit version src udev jack jami-meta ffmpeg-jami pjsip-jami opendht-jami;
   };
 
-  jami-client-qt = qt6Packages.callPackage ./client-qt.nix {
+  jami-client = qt6Packages.callPackage ./client.nix {
     inherit version src jami-meta ffmpeg-jami;
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -661,6 +661,7 @@ mapAliases ({
 
   jack2Full = jack2; # moved from top-level 2021-03-14
   jami-client-gnome = throw "jami-client-gnome has been removed: abandoned upstream"; # Added 2022-05-15
+  jami-client-qt = jami-client; # Added 2022-11-06
   jami-libclient = throw "jami-libclient has been removed: moved into jami-qt"; # Added 2022-07-29
   jamomacore = throw "jamomacore has been removed: abandoned upstream"; # Added 2020-11-21
   jbidwatcher = throw "jbidwatcher was discontinued in march 2021"; # Added 2021-03-15

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38014,7 +38014,7 @@ with pkgs;
     udev = systemdMinimal;
     jack = libjack2;
   };
-  inherit (jami) jami-daemon jami-client-qt;
+  inherit (jami) jami-daemon jami-client;
 
   jitsi-meet-electron = callPackage ../applications/networking/instant-messengers/jitsi-meet-electron { };
 


### PR DESCRIPTION
###### Description of changes
jami-client-qt is renamed to jami-client. https://git.jami.net/savoirfairelinux/jami-client-qt/-/commit/bf4a8c314f308877841dcfa8c567cdd097c0fbb0
withWebengine option is removed due to an upstream bug. https://git.jami.net/savoirfairelinux/jami-client-qt/-/issues/881

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
