### PR TITLE
[22.05] jami-*: backport pjsip CVE fix for jami

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jami/daemon.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/daemon.nix
@@ -67,7 +67,7 @@ let
 
       src = fetchFromGitHub src-args;
 
-      patches = old.patches ++ (map (x: patch-src + x) (readLinesToList ./config/pjsip_patches));
+      patches = map (x: patch-src + x) (readLinesToList ./config/pjsip_patches);
     });
 
   opendht-jami = opendht.override {

--- a/pkgs/applications/networking/instant-messengers/jami/pjproject-src.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/pjproject-src.nix
@@ -1,6 +1,6 @@
 {
   owner = "savoirfairelinux";
   repo = "pjproject";
-  rev = "e1f389d0b905011e0cb62cbdf7a8b37fc1bcde1a";
-  sha256 = "0inpmyb6mhrzr0g309d6clkc99lddqdvyf9xajz0igvgp9pvgpza";
+  rev = "513a3f14c44b2c2652f9219ec20dea64b236b713";
+  hash = "sha256-93AlJGMnlzJMrJquelpHQQKjhEgfpTFXTMqkBnm87u8=";
 }


### PR DESCRIPTION
###### Description of changes
@risicle @SuperSandro2000 Sorry for the noise. I pushed the jami update to that branch by mistake.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
