### PR TITLE
python3Packages.dask: 2022.9.1 -> 2022.10.2

### DIFF
--- a/pkgs/development/python-modules/dask-glm/default.nix
+++ b/pkgs/development/python-modules/dask-glm/default.nix
@@ -54,6 +54,11 @@ buildPythonPackage rec {
     "dask_glm/tests/test_utils.py"
   ];
 
+  disabledTests = [
+    # missing fixture with distributed>=2022.8.0
+    "test_determinism_distributed"
+  ];
+
   meta = with lib; {
     description = "Generalized Linear Models with Dask";
     homepage = "https://github.com/dask/dask-glm/";

--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , bokeh
 , buildPythonPackage
+, click
 , cloudpickle
 , distributed
 , fastparquet
@@ -26,19 +27,28 @@
 
 buildPythonPackage rec {
   pname = "dask";
-  version = "2022.9.1";
+  version = "2022.10.2";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = pname;
     rev = version;
-    hash = "sha256-4Tok9eYhi2FF+8bpKnwKT3KIRGHIMtxczTkZ6qD8x7g=";
+    hash = "sha256-zHJR2WjHigUMWtRJW25+gk1fKGKedU53BBjwx5zaodA=";
   };
 
+  patches = [
+    (fetchpatch {
+      # Fix test_repartition_npartitions on platforms other than x86-64
+      url = "https://github.com/dask/dask/commit/65f40ad461c57065f981e6213e33b1d13cc9bc8f.patch";
+      hash = "sha256-KyTSms4ik1kYtL+I/huAxD+zK2AAuPkwmHA9FYk601Y=";
+    })
+  ];
+
   propagatedBuildInputs = [
+    click
     cloudpickle
     fsspec
     packaging
@@ -109,6 +119,8 @@ buildPythonPackage rec {
     "test_read_dir_nometa"
   ] ++ [
     "test_chunksize_files"
+    # TypeError: 'ArrowStringArray' with dtype string does not support reduction 'min'
+    "test_set_index_string"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "2022.9.1";
+  version = "2022.10.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-upj1TipRhhvulyuhX4bfbQSWar9m7Xu3mIsi48G+ewE=";
+    hash = "sha256-U/Clv276uaWrM0XNkT9tPz1OpETuLtvqMxx/75b9Z9A=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/threadpoolctl/default.nix
+++ b/pkgs/development/python-modules/threadpoolctl/default.nix
@@ -33,10 +33,14 @@ buildPythonPackage rec {
     # developers' hardware
     "test_architecture"
     # https://github.com/joblib/threadpoolctl/issues/128
-    "test_threadpool_limits_by_prefix"
-    "test_controller_info_actualized"
     "test_command_line_command_flag"
     "test_command_line_import_flag"
+    "test_controller_info_actualized"
+    "test_set_threadpool_limits_by_api"
+    "test_set_threadpool_limits_no_limit"
+    "test_threadpool_limits_by_prefix"
+    "test_threadpool_limits_function_with_side_effect"
+    "test_threadpool_limits_manual_restore"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
https://github.com/dask/dask/blob/main/docs/source/changelog.rst#2022102

And fix the test around dask and threadpoolctl on aarch64-linux.

ZHF #199919 :clown_face: 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
