### PR TITLE
pkgsStatic.doas: fix build

### DIFF
--- a/pkgs/tools/security/doas/default.nix
+++ b/pkgs/tools/security/doas/default.nix
@@ -32,10 +32,17 @@ stdenv.mkDerivation rec {
     # Allow doas to discover binaries in /run/current-system/sw/{s,}bin and
     # /run/wrappers/bin
     ./0001-add-NixOS-specific-dirs-to-safe-PATH.patch
+
+    # Standard environment supports "dontDisableStatic" knob, but has no
+    # equivalent for "--disable-shared", so I have to patch "configure"
+    # script instead.
+    ./disable-shared.patch
   ];
 
   postPatch = ''
     sed -i '/\(chown\|chmod\)/d' GNUmakefile
+  '' + lib.optionalString (withPAM && stdenv.hostPlatform.isStatic) ''
+    sed -i 's/-lpam/-lpam -laudit/' configure
   '';
 
   nativeBuildInputs = [ bison ];

--- a/pkgs/tools/security/doas/disable-shared.patch
+++ b/pkgs/tools/security/doas/disable-shared.patch
@@ -1,0 +1,13 @@
+Accept and ignore "--disable-shared" option passed by pkgsStatic.stdenv.
+Without this patch, configure phase fails with "unknown option".
+
+--- a/configure	1970-01-01 00:00:00.000000000 -0500
++++ b/configure	1970-01-01 00:00:00.000000000 -0500
+@@ -46,6 +46,7 @@
+ 	opt=${x%%=*}
+ 	var=${x#*=}
+ 	case "$opt" in
++	--disable-shared) : ;;
+ 	--prefix) PREFIX=$var ;;
+ 	--exec-prefix) EPREFIX=$var ;;
+ 	--bindir) BINDIR=$var ;;


### PR DESCRIPTION
 * Patch configure script to not die on unrecognized --disable-shared
 * Pass -laudit when building statically with PAM support. Upstream buiild
   system does not use pkg-config, unfortunately.
