### PR TITLE
portmod: 2.1.0 -> 2.4.2, bsatool2: init at 2.0.1

### DIFF
--- a/pkgs/development/libraries/zstr/default.nix
+++ b/pkgs/development/libraries/zstr/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "zstr";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "mateidavid";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-2GykW2IH8o7v2xAa2IIPuTEMS6WK6Edg+sw4xC/fV/U=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib/zstr/
+    cp CMakeLists.txt $out/lib/zstr/zstrConfig.cmake
+    cp -r src $out/include
+  '';
+
+  meta = with lib; {
+    description = "A C++ header-only ZLib wrapper";
+    homepage = "https://github.com/mateidavid/zstr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ marius851000 ];
+  };
+}

--- a/pkgs/games/bsatool2/default.nix
+++ b/pkgs/games/bsatool2/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchFromGitLab, lz4, openssl, argparse, zstr, zlib, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "bsatool2";
+  version = "2.0.1";
+
+  src = fetchFromGitLab {
+    owner = "bmwinger";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-3t/82b6hc8P+C5Dk1YPiMBIIMGO3wHXkhC5ZqgkJQq8=";
+  };
+
+  patches = [ ./local_deps.patch ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ lz4 openssl argparse zstr zlib ];
+
+  checkPhase = "bsatool2 --help";
+
+  meta = with lib; {
+    description = "A version of OpenMW's bsatool which supports the creation of bsa files from the later Bethesda games.";
+    homepage = "https://gitlab.com/bmwinger/bsatool2";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ marius851000 ];
+  };
+}

--- a/pkgs/games/bsatool2/local_deps.patch
+++ b/pkgs/games/bsatool2/local_deps.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b410c6f..6920160 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,12 +10,7 @@ find_package(LZ4 REQUIRED)
+ include_directories(${LZ4_INCLUDE_DIR})
+ find_package(OpenSSL REQUIRED COMPONENTS SSL)
+ 
+-include(FetchContent)
+-FetchContent_Declare(argparse
+-    GIT_REPOSITORY https://github.com/p-ranav/argparse.git
+-    GIT_TAG	   "v2.6"
+-)
+-FetchContent_MakeAvailable(argparse)
++find_package(argparse REQUIRED)
+ 
+ # Main executable
+ add_executable(bsatool2 bsatool.cpp)
+@@ -24,7 +19,6 @@ add_subdirectory(components)
+ 
+ target_link_libraries(bsatool2
+   components
+-  argparse
+ )
+ 
+ install(TARGETS bsatool2 DESTINATION bin)
+diff --git a/components/CMakeLists.txt b/components/CMakeLists.txt
+index 2ae8c64..222ab19 100644
+--- a/components/CMakeLists.txt
++++ b/components/CMakeLists.txt
+@@ -1,11 +1,6 @@
+ project (Components)
+ 
+-include(FetchContent)
+-FetchContent_Declare(ZStrGitRepo
+-  GIT_REPOSITORY    "https://github.com/mateidavid/zstr"
+-  GIT_TAG           "v1.0.6"
+-)
+-FetchContent_MakeAvailable(ZStrGitRepo)
++find_package(zstr REQUIRED)
+ 
+ add_library(components STATIC bsa/bsa_file.cpp bsa/memorystream.cpp
+     files/constrainedfilestream.cpp files/lowlevelfile.cpp)

--- a/pkgs/games/portmod/default.nix
+++ b/pkgs/games/portmod/default.nix
@@ -3,20 +3,20 @@
 , jre, makeWrapper, tr-patcher, tes3cmd, openmw }:
 
 let
-  version = "2.1.0";
+  version = "2.4.2";
 
   src = fetchFromGitLab {
     owner = "portmod";
     repo = "Portmod";
     rev = "v${version}";
-    sha256 = "sha256-b/ENApFovMPNUMbJhwY+TZCnSzpr1e/IKJ/5XAGTQjE=";
+    sha256 = "sha256-zD2DfuHu0tRzO0fYKiB8MOQvxJWDfpXFTwvidx6LOC8==";
   };
 
   portmod-rust = rustPlatform.buildRustPackage rec {
     inherit src version;
     pname = "portmod-rust";
 
-    cargoHash = "sha256-3EfMMpSWSYsB3nXaoGGDuKQ9duyCKzbrT6oeATnzqLE=";
+    cargoHash = "sha256-fVazs5+/d9b90FOh45lPQdCCRnR3Co9KfaOllSk8WJw=";
 
     nativeBuildInputs = [ python3Packages.python ];
 
@@ -84,6 +84,8 @@ python3Packages.buildPythonApplication rec {
     "test_sync"
     "test_manifest"
     "test_add_repo"
+    "test_scan_sources"
+    "test_unpack"
   ];
 
   # for some reason, installPhase doesn't copy the compiled binary

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33840,6 +33840,8 @@ with pkgs;
 
   brutalmaze = callPackage ../games/brutalmaze { };
 
+  bsatool2 = callPackage ../games/bsatool2 { };
+
   bsdgames = callPackage ../games/bsdgames { };
 
   btanks = callPackage ../games/btanks { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23044,6 +23044,8 @@ with pkgs;
 
   zita-resampler = callPackage ../development/libraries/audio/zita-resampler { };
 
+  zstr = callPackage ../development/libraries/zstr { };
+
   zz = callPackage ../development/compilers/zz { };
 
   zziplib = callPackage ../development/libraries/zziplib { };


### PR DESCRIPTION
###### Description of changes

1. Update portmod from 2.1.0 to 2.4.2
2. Add bsatool2 as a binary. It should fix the problem of portmod not working with fallout: new vegas and other, more recent Bethesda games. Turns out this actually isn’t needed, but I’ll still keep it, as I already needed a tool like this in the past, and might need one again in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I checked that it work well with Morrowind. I add two issues, related to updating:
1. The metadatas should be update (``portmod sync``)
2. With morrowind, I add to unmerge openmw-config and merge configtool (``portmod <prefix> merge -C openmw-config`` and ``portmod morrowind merge configtool``. But it seems that everything depends on configtool.)

Fix https://github.com/NixOS/nixpkgs/issues/198109 and should fix https://github.com/NixOS/nixpkgs/issues/197624 (untested for now)