### PR TITLE
nixos/plasma: leave `displayManager.setupCommands` alone

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -28,51 +28,10 @@ let
 
   libsForQt5 = pkgs.plasma5Packages;
   inherit (libsForQt5) kdeGear kdeFrameworks plasma5;
-  inherit (pkgs) writeText;
   inherit (lib)
     getBin optionalString literalExpression
     mkRemovedOptionModule mkRenamedOptionModule
     mkDefault mkIf mkMerge mkOption types;
-
-  ini = pkgs.formats.ini { };
-
-  gtkrc2 = writeText "gtkrc-2.0" ''
-    # Default GTK+ 2 config for NixOS Plasma 5
-    include "/run/current-system/sw/share/themes/Breeze/gtk-2.0/gtkrc"
-    style "user-font"
-    {
-      font_name="Sans Serif Regular"
-    }
-    widget_class "*" style "user-font"
-    gtk-font-name="Sans Serif Regular 10"
-    gtk-theme-name="Breeze"
-    gtk-icon-theme-name="breeze"
-    gtk-fallback-icon-theme="hicolor"
-    gtk-cursor-theme-name="breeze_cursors"
-    gtk-toolbar-style=GTK_TOOLBAR_ICONS
-    gtk-menu-images=1
-    gtk-button-images=1
-  '';
-
-  gtk3_settings = ini.generate "settings.ini" {
-    Settings = {
-      gtk-font-name = "Sans Serif Regular 10";
-      gtk-theme-name = "Breeze";
-      gtk-icon-theme-name = "breeze";
-      gtk-fallback-icon-theme = "hicolor";
-      gtk-cursor-theme-name = "breeze_cursors";
-      gtk-toolbar-style = "GTK_TOOLBAR_ICONS";
-      gtk-menu-images = 1;
-      gtk-button-images = 1;
-    };
-  };
-
-  kcminputrc = ini.generate "kcminputrc" {
-    Mouse = {
-      cursorTheme = "breeze_cursors";
-      cursorSize = 0;
-    };
-  };
 
   activationScript = ''
     ${set_XDG_CONFIG_HOME}
@@ -117,37 +76,6 @@ let
     # expected to set the default themselves.
     # 2. Contaminate / if $HOME is unset; do not check if $HOME is set.
     XDG_CONFIG_HOME=''${XDG_CONFIG_HOME:-$HOME/.config}
-  '';
-
-  startplasma = ''
-    ${set_XDG_CONFIG_HOME}
-    mkdir -p "''${XDG_CONFIG_HOME}"
-  '' + optionalString config.hardware.pulseaudio.enable ''
-    # Load PulseAudio module for routing support.
-    # See also: http://colin.guthr.ie/2009/10/so-how-does-the-kde-pulseaudio-support-work-anyway/
-      ${getBin config.hardware.pulseaudio.package}/bin/pactl load-module module-device-manager "do_routing=1"
-  '' + ''
-    ${activationScript}
-
-    # Create default configurations if Plasma has never been started.
-    kdeglobals="''${XDG_CONFIG_HOME}/kdeglobals"
-    if ! [ -f "$kdeglobals" ]; then
-      kcminputrc="''${XDG_CONFIG_HOME}/kcminputrc"
-      if ! [ -f "$kcminputrc" ]; then
-          cat ${kcminputrc} >"$kcminputrc"
-      fi
-
-      gtkrc2="$HOME/.gtkrc-2.0"
-      if ! [ -f "$gtkrc2" ]; then
-          cat ${gtkrc2} >"$gtkrc2"
-      fi
-
-      gtk3_settings="''${XDG_CONFIG_HOME}/gtk-3.0/settings.ini"
-      if ! [ -f "$gtk3_settings" ]; then
-          mkdir -p "$(dirname "$gtk3_settings")"
-          cat ${gtk3_settings} >"$gtk3_settings"
-      fi
-    fi
   '';
 
 in
@@ -449,7 +377,6 @@ in
 
       # Update the start menu for each user that is currently logged in
       system.userActivationScripts.plasmaSetup = activationScript;
-      services.xserver.displayManager.setupCommands = startplasma;
 
       nixpkgs.config.firefox.enablePlasmaBrowserIntegration = true;
     })


### PR DESCRIPTION
###### Description of changes

Fix https://github.com/NixOS/nixpkgs/issues/187963 .  I bisected the problem down to commit https://github.com/NixOS/nixpkgs/commit/4832352d023fdd9546748f33c499034d722382ba from https://github.com/NixOS/nixpkgs/pull/100057 .

That commit replaced the plasma5 session startup script with its upstream version from the `pkgs.libsForQt5.plasma5.plasma-workspace` package.  The old script performs some basic initializations in the user's home directory: It adds files/directories like `.config` and `.gtkrc-2.0`.  Besides, it calls the `activationScript` of the plasma module which rebuilds the "kbuildsyscoca5 cache" (plasma start menu) in `.cache`.

However, the old session startup script wasn't removed; it is now used as display manager setup script, i.e., it was added to the option `displayManager.setupCommands`.  I am not sure if this happened intentionally and if it has any advantage.

Most likely, this means all the initialization efforts described above

* are no longer applied to the user session that is opened by the display manager at login,
* are now applied when the display manager itself initializes, with `HOME=/`.  So the display manager will create some dot files in the root filesystem.

I suppose this is not the desired outcome.

The pull-request at hand completely removes the old session startup script.  **I guess this is the right thing to do, but I am not sure.** The script wasn't applied to any user session since https://github.com/NixOS/nixpkgs/pull/100057 got merged in Oct 2021, so apparently it is not needed.  All plasma-related tests (`plasma5`, `plasma5-systemd-start`, `plasma-bigscreen` and even `maestral`) still pass with the pull request at hand applied.  On the other hand, running the session startup script when the display manager starts up might have some positive effect that I am overlooking right now.

###### Further notes

* notifying the sole KDE desktop maintainer team (`qt-kde`) member @ttuegel
* notifying the author of the previous commit @pasqui23

Note that the effect of this pull request can easily be applied to a NixOS system -- without merging anything -- by just setting `services.xserver.displayManager.setupCommands = lib.mkForce "";` in `configuration.nix`.  This is what I am using on my desktop PC (NixOS 22.05 with plasma5 and lightdm) right now, without any issues.  But it should probably be tested by some else as well, e.g. with `sddm` as display manager.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
