### PR TITLE
gamescope: 3.11.39 -> 3.11.48

### DIFF
--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -23,10 +23,11 @@
 , libliftoff
 , lib
 , makeBinaryWrapper
+, cmake
 }:
 let
   pname = "gamescope";
-  version = "3.11.39";
+  version = "3.11.48";
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -35,7 +36,7 @@ stdenv.mkDerivation {
     owner = "Plagman";
     repo = "gamescope";
     rev = "refs/tags/${version}";
-    hash = "sha256-MpJczFZk0syt/CMwAhA7H+01G8E4syFsJGnzD/RneQQ=";
+    hash = "sha256-/a0fW0NVIrg9tuK+mg+D+IOcq3rJJxKdFwspM1ZRR9M=";
   };
 
   patches = [ ./use-pkgconfig.patch ];
@@ -45,6 +46,7 @@ stdenv.mkDerivation {
     pkg-config
     ninja
     makeBinaryWrapper
+    cmake
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/stb/default.nix
+++ b/pkgs/development/libraries/stb/default.nix
@@ -1,5 +1,8 @@
-{ lib, stdenv, fetchFromGitHub }:
-
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
 stdenv.mkDerivation {
   pname = "stb";
   version = "unstable-2021-09-10";
@@ -14,8 +17,24 @@ stdenv.mkDerivation {
   dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/include/stb
     cp *.h $out/include/stb/
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+
+    cat << EOF > $out/lib/pkgconfig/stb.pc
+    prefix=$out
+    includedir=$out/include
+
+    Cflags: -I$out/include/stb
+    Description: Single-file public domain libraries for C/C++
+    Name: stb
+    Version: 1
+    EOF
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 , substituteAll
 , meson
 , pkg-config
@@ -30,19 +29,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "wayland";
-  version = "1.20.0";
+  version = "1.21.0";
 
   src = fetchurl {
-    url = "https://wayland.freedesktop.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "09c7rpbwavjg4y16mrfa57gk5ix6rnzpvlnv1wp7fnbh9hak985q";
+    url = "https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/${pname}-${version}.tar.xz";
+    sha256 = "1b0ixya9bfw5c9jx8mzlr7yqnlyvd3jv5z8wln9scdv8q5zlvikd";
   };
-
-  patches = [
-    (substituteAll {
-      src = ./0001-add-placeholder-for-nm.patch;
-      nm = "${stdenv.cc.targetPrefix}nm";
-    })
-  ];
 
   postPatch = lib.optionalString withDocumentation ''
     patchShebangs doc/doxygen/gen-doxygen.py


### PR DESCRIPTION
wayland: 1.20.0 -> 1.21.0


###### Description of changes

Fixes #189464

The `makePkgconfigItem` doesn't appear to exist in the release branch so instead I just made a `stb` pkgconfig file manually.

This is a custom patch for this branch as the master build is already working and up to date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->