### PR TITLE
zfp: 0.5.5 -> 1.0.0, fix issues

### DIFF
--- a/pkgs/tools/compression/zfp/default.nix
+++ b/pkgs/tools/compression/zfp/default.nix
@@ -1,7 +1,6 @@
 { cmake, cudatoolkit, fetchFromGitHub, gfortran, lib, llvmPackages, python3Packages, stdenv, targetPlatform
 , enableCfp ? true
 , enableCuda ? false
-, enableExamples ? true
 , enableFortran ? builtins.elem targetPlatform.system gfortran.meta.platforms
 , enableOpenMP ? true
 , enablePython ? true
@@ -9,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zfp";
-  version = "0.5.5";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "LLNL";
     repo = "zfp";
     rev = version;
-    sha256 = "19ycflz35qsrzfcvxdyy0mgbykfghfi9y5v684jb4awjp7nf562c";
+    sha256 = "sha256-E2LI1rWo1HO5O/sxPHAmLDs3Z5xouzlgMj11rQFPNYQ=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -25,26 +24,23 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableOpenMP llvmPackages.openmp
     ++ lib.optionals enablePython (with python3Packages; [ cython numpy python ]);
 
+  # compile CUDA code for all extant GPUs so the binary will work with any GPU
+  # and driver combination. to be ultimately solved upstream:
+  # https://github.com/LLNL/zfp/issues/178
+  # NB: not in cmakeFlags due to https://github.com/NixOS/nixpkgs/issues/114044
+  preConfigure = lib.optionalString enableCuda ''
+    cmakeFlagsArray+=(
+      "-DCMAKE_CUDA_FLAGS=-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_87,code=sm_87 -gencode=arch=compute_86,code=compute_86"
+    )
+  '';
+
   cmakeFlags = [
-    # More tests not enabled by default
-    ''-DZFP_BINARY_DIR=${placeholder "out"}''
-    ''-DZFP_BUILD_TESTING_LARGE=ON''
-  ]
-    ++ lib.optionals targetPlatform.isDarwin [
-      "-DCMAKE_INSTALL_BINDIR=bin"
-      "-DCMAKE_INSTALL_LIBDIR=lib"
-    ]
-    ++ lib.optional enableCfp "-DBUILD_CFP=ON"
+  ] ++ lib.optional enableCfp "-DBUILD_CFP=ON"
     ++ lib.optional enableCuda "-DZFP_WITH_CUDA=ON"
-    ++ lib.optional enableExamples "-DBUILD_EXAMPLES=ON"
     ++ lib.optional enableFortran "-DBUILD_ZFORP=ON"
     ++ lib.optional enableOpenMP "-DZFP_WITH_OPENMP=ON"
     ++ lib.optional enablePython "-DBUILD_ZFPY=ON"
     ++ ([ "-DBUILD_UTILITIES=${if enableUtilities then "ON" else "OFF"}" ]);
-
-  preCheck = lib.optional targetPlatform.isDarwin ''
-    export DYLD_LIBRARY_PATH="$out/lib:$DYLD_LIBRARY_PATH"
-  '';
 
   doCheck = true;
 


### PR DESCRIPTION
Remove examples as they have some common executable names likely to cause conflicts, there is no way to properly install them, and they are not particularly useful. Remove now-unnecessary installation hacks.

Disable the long tests as they are just bigger versions of the short tests and end up being pretty slow.

Build CUDA kernels for all GPUs to avoid issues at runtime.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/LLNL/zfp/releases/tag/1.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin (Rosetta)
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
