### PR TITLE
python3Packages.numba: 0.56.2 -> 0.56.4, fix tests and CUDA

### DIFF
--- a/pkgs/development/python-modules/numba/cuda_path.patch
+++ b/pkgs/development/python-modules/numba/cuda_path.patch
@@ -1,5 +1,5 @@
 diff --git a/numba/cuda/cuda_paths.py b/numba/cuda/cuda_paths.py
-index b9988bc..a642680 100644
+index 0da435d33..7b1fde087 100644
 --- a/numba/cuda/cuda_paths.py
 +++ b/numba/cuda/cuda_paths.py
 @@ -24,10 +24,7 @@ def _find_valid_path(options):
@@ -14,15 +14,12 @@ index b9988bc..a642680 100644
      ]
      by, libdir = _find_valid_path(options)
      return by, libdir
-@@ -35,18 +32,16 @@ def _get_libdevice_path_decision():
+@@ -35,16 +32,14 @@ def _get_libdevice_path_decision():
  
  def _nvvm_lib_dir():
      if IS_WIN32:
 -        return 'nvvm', 'bin'
 +        return 'bin',
-     elif IS_OSX:
--        return 'nvvm', 'lib'
-+        return 'lib',
      else:
 -        return 'nvvm', 'lib64'
 +        return 'lib64',
@@ -33,13 +30,13 @@ index b9988bc..a642680 100644
 -        ('Conda environment', get_conda_ctk()),
 -        ('CUDA_HOME', get_cuda_home(*_nvvm_lib_dir())),
 -        ('System', get_system_ctk(*_nvvm_lib_dir())),
-+        ('Nix store', get_nix_ctk(*_nvvm_lib_dir())),        
++        ('Nix store', get_nix_ctk(*_nvvm_lib_dir())),
      ]
      by, path = _find_valid_path(options)
      return by, path
-@@ -74,14 +69,12 @@ def _cudalib_path():
-     elif IS_OSX:
-         return 'lib'
+@@ -64,14 +59,12 @@ def _cudalib_path():
+     if IS_WIN32:
+         return 'bin'
      else:
 -        return 'lib64'
 +        return 'lib'
@@ -54,7 +51,7 @@ index b9988bc..a642680 100644
      ]
      by, libdir = _find_valid_path(options)
      return by, libdir
-@@ -92,6 +85,22 @@ def _get_cudalib_dir():
+@@ -82,6 +75,22 @@ def _get_cudalib_dir():
      return _env_path_tuple(by, libdir)
  
  

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -11,6 +11,8 @@
 , libcxx
 , importlib-metadata
 , substituteAll
+, runCommand
+, fetchpatch
 
 # CUDA-only dependencies:
 , addOpenGLRunpath ? null
@@ -23,14 +25,14 @@
 let
   inherit (cudaPackages) cudatoolkit;
 in buildPythonPackage rec {
-  version = "0.56.2";
+  version = "0.56.4";
   pname = "numba";
   format = "setuptools";
   disabled = pythonOlder "3.6" || pythonAtLeast "3.11";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-NJLwpdCeJX/FIfU3emxrkH7sGSDRRznwskWLnSmUalo=";
+    hash = "sha256-Mtn+9BLIFIPX7+DOts9NMxD96LYkqc7MoA95BXOslu4=";
   };
 
   postPatch = ''
@@ -55,7 +57,15 @@ in buildPythonPackage rec {
     cudatoolkit.lib
   ];
 
-  patches = lib.optionals cudaSupport [
+  patches = [
+    # fix failure in test_cache_invalidate (numba.tests.test_caching.TestCache)
+    # remove when upgrading past version 0.56
+    (fetchpatch {
+      name = "fix-test-cache-invalidate-readonly.patch";
+      url = "https://github.com/numba/numba/commit/993e8c424055a7677b2755b184fc9e07549713b9.patch";
+      hash = "sha256-IhIqRLmP8gazx+KWIyCxZrNLMT4jZT8CWD3KcH4KjOo=";
+    })
+  ] ++ lib.optionals cudaSupport [
     (substituteAll {
       src = ./cuda_path.patch;
       cuda_toolkit_path = cudatoolkit;
@@ -70,17 +80,39 @@ in buildPythonPackage rec {
     done
   '';
 
-  # Copy test script into $out and run the test suite.
+  # run a smoke test in a temporary directory so that
+  # a) Python picks up the installed library in $out instead of the build files
+  # b) we have somewhere to put $HOME so some caching tests work
+  # c) it doesn't take 6 CPU hours for the full suite
   checkPhase = ''
-    ${python.interpreter} -m numba.runtests
-  '';
+    runHook preCheck
 
-  # ImportError: cannot import name '_typeconv'
-  doCheck = false;
+    pushd $(mktemp -d)
+    HOME=. ${python.interpreter} -m numba.runtests -m $NIX_BUILD_CORES numba.tests.test_usecases
+    popd
+
+    runHook postCheck
+  '';
 
   pythonImportsCheck = [
     "numba"
   ];
+
+  passthru.tests = {
+    # CONTRIBUTOR NOTE: numba also contains CUDA tests, though these cannot be run in
+    # this sandbox environment. Consider running similar commands to those below outside the
+    # sandbox manually if you have the appropriate hardware; support will be detected
+    # and the corresponding tests enabled automatically.
+    # Also, the full suite currently does not complete on anything but x86_64-linux.
+    fullSuite = runCommand "${pname}-test" {} ''
+      pushd $(mktemp -d)
+      # pip and python in $PATH is needed for the test suite to pass fully
+      PATH=${python.withPackages (p: [ p.numba p.pip ])}/bin:$PATH
+      HOME=$PWD python -m numba.runtests -m $NIX_BUILD_CORES
+      popd
+      touch $out # stop Nix from complaining no output was generated and failing the build
+    '';
+  };
 
   meta =  with lib; {
     description = "Compiling Python code using LLVM";


### PR DESCRIPTION
###### Description of changes

I also ran the full test suite outside of the sandbox to validate CUDA functioning. It takes 6 or 7 CPU hours even when not in CUDA mode.

It is sensitive to your driver version, but this might be fixed soon: https://github.com/numba/numba/pull/8180

Closes #197045

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
