### PR TITLE
hyprpicker: init at unstable-2022-11-06

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprpicker/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprpicker/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, libjpeg
+, mesa
+, pango
+, pkg-config
+, wayland
+, wayland-protocols
+, wayland-scanner
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprpicker";
+  version = "unstable-2022-11-06";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprpicker";
+    rev = "06be1c9348fdf8ff58fd05f54b62bdd73544db6a";
+    hash = "sha256-jgiDWLwCf6PQhXLUtSk4btaS/jZwJed2XLnlA51ANQk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    libjpeg
+    mesa
+    pango
+    wayland
+    wayland-protocols
+  ];
+
+  preConfigure = ''
+    make protocols
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./hyprpicker -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit (finalAttrs.src.meta) homepage;
+    description = "A wlroots-compatible Wayland color picker that does not suck";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ wozeparrot ];
+    inherit (wayland.meta) platforms;
+    # ofborg failure: g++ does not recognize '-std=c++23'
+    broken = stdenv.isAarch64;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4310,6 +4310,8 @@ with pkgs;
 
   hyprpaper = callPackage ../applications/window-managers/hyprwm/hyprpaper { };
 
+  hyprpicker = callPackage ../applications/window-managers/hyprwm/hyprpicker { };
+
   hysteria = callPackage ../tools/networking/hysteria { };
 
   hyx = callPackage ../tools/text/hyx { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [hyprpicker](https://github.com/hyprwm/hyprpicker).
Closes #199913.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
