### PR TITLE
mod,fix: nixpkgs - if pkgs option is defined, pass on its config

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -167,7 +167,9 @@ in
         details, see the Nixpkgs documentation.)  It allows you to set
         package configuration options.
 
-        Ignored when `nixpkgs.pkgs` is set.
+        If `nixpkgs.pkgs` is set: merges `nixpkgs.pkgs.config` for
+        consumption by the module system, but doesn't re-import
+        `nixpkgs.pkgs` with the module-modified config.
       '';
     };
 
@@ -344,6 +346,11 @@ in
     _module.args = {
       pkgs = finalPkgs.__splicedPackages;
     };
+
+    # pass along the pkgs.config, if pkgs is defined
+    # don't set as defaults so that it is merged with
+    # other values set by the module system
+    nixpkgs.config = if opt.pkgs.isDefined then cfg.pkgs.config else {};
 
     assertions = [
       (


### PR DESCRIPTION
# Motivation (accessors)
```console
hardware/all-firmware.nix:        assertion = !cfg.enableAllFirmware || config.nixpkgs.config.allowUnfree;
virtualisation/virtualbox-host.nix:    warnings = mkIf (config.nixpkgs.config.virtualbox.enableExtensionPack or false)
```

# Still unsolved (setters)
```console
hardware/video/amdgpu-pro.nix:    nixpkgs.config.xorg.abiCompat = "1.20";
misc/locate.nix:    nixpkgs.config = { locate.dbfile = cfg.output; };
programs/browserpass.nix:    nixpkgs.config.firefox.enableBrowserpass = true;
services/x11/display-managers/lightdm-greeters/tiny.nix:    nixpkgs.config.lightdm-tiny-greeter.conf =
services/x11/desktop-managers/plasma5.nix:      nixpkgs.config.firefox.enablePlasmaBrowserIntegration = true;
services/x11/desktop-managers/gnome.nix:      nixpkgs.config.vim.gui = "gtk3";
config/debug-info.nix:            nixpkgs.config.packageOverrides = pkgs: {
services/desktops/gnome/gnome-browser-connector.nix:    nixpkgs.config.firefox.enableGnomeExtensions = true;
```

But now, at least the option description is a little more accurate (less surprising if you're in such a situation).