### PR TITLE
tg_history_dumper: init at unstable-2022-06-29

### DIFF
--- a/pkgs/tools/misc/tg_history_dumper/default.nix
+++ b/pkgs/tools/misc/tg_history_dumper/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, fioctl }:
+
+buildGoModule rec {
+  pname = "tg_history_dumper";
+  version = "unstable-2022-06-29";
+
+  src = fetchFromGitHub {
+    owner = "3bl3gamer";
+    repo = "tg_history_dumper";
+    rev = "d5690ecf35b57fe4e5fcb977a984b4dc6b7c4ae0";
+    sha256 = "sha256-3hK+UpVVa6AEX0fmSS02OALViUhXeGRKopK3lGrMQ0E=";
+  };
+
+  vendorSha256 = "sha256-SncnWd+gkhgDP0qWGoOj04QLiWUEghhoUTx0eCXTyqI=";
+
+  patchPhase = ''
+    substituteInPlace main.go \
+      --replace "os.Executable()" "os.Getwd()"
+  '';
+
+  meta = with lib; {
+    description = "Exports messages and media from Telegram dialogs, groups and channels";
+    homepage = "https://github.com/3bl3gamer/tg_history_dumper";
+#    license = licenses.asl20;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25087,6 +25087,8 @@ with pkgs;
 
   tgt = callPackage ../tools/networking/tgt { };
 
+  tg_history_dumper = callPackage ../tools/misc/tg_history_dumper { };
+
   lkl = callPackage ../applications/virtualization/lkl { };
   lklWithFirewall = callPackage ../applications/virtualization/lkl { firewallSupport = true; };
 


### PR DESCRIPTION
###### Description of changes

Adds https://github.com/3bl3gamer/tg_history_dumper to Nixpkgs. It is a sort-of scraper for telegram channel, group and message history.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
