### PR TITLE
mudlet: 4.15.1 -> 4.16.0

### DIFF
--- a/pkgs/games/mudlet/default.nix
+++ b/pkgs/games/mudlet/default.nix
@@ -18,24 +18,50 @@
 , pugixml
 , qtbase
 , qtmultimedia
+, discord-rpc
 , yajl
 }:
 
 let
-  luaEnv = lua.withPackages(ps: with ps; [
-    luazip luafilesystem lrexlib-pcre luasql-sqlite3 lua-yajl luautf8
+  overrideLua =
+    let
+      packageOverrides = self: super: {
+        # luasql-sqlite3 master branch broke compatibility with lua 5.1. Pin to
+        # an earlier commit.
+        # https://github.com/lunarmodules/luasql/issues/147
+        luasql-sqlite3 = super.luaLib.overrideLuarocks super.luasql-sqlite3
+          (drv: {
+            version = "2.6.0-1-custom";
+            src = fetchFromGitHub {
+              owner = "lunarmodules";
+              repo = "luasql";
+              rev = "8c58fd6ee32faf750daf6e99af015a31402578d1";
+              hash = "sha256-XlTB5O81yWCrx56m0cXQp7EFzeOyfNeqGbuiYqMrTUk=";
+            };
+          });
+      };
+    in
+    lua.override { inherit packageOverrides; };
+
+  luaEnv = overrideLua.withPackages (ps: with ps; [
+    luazip
+    luafilesystem
+    lrexlib-pcre
+    luasql-sqlite3
+    lua-yajl
+    luautf8
   ]);
 in
 stdenv.mkDerivation rec {
   pname = "mudlet";
-  version = "4.15.1";
+  version = "4.16.0";
 
   src = fetchFromGitHub {
     owner = "Mudlet";
     repo = "Mudlet";
     rev = "Mudlet-${version}";
     fetchSubmodules = true;
-    hash = "sha256-GnTQc0Jh4YaQnfy7fYsTCACczlzWCQ+auKYoU9ET83M=";
+    hash = "sha256-HrrEbcMv35IGmYD1L1zmdcpYdFM2PLBEqPY+jMJioTA=";
   };
 
   nativeBuildInputs = [
@@ -60,6 +86,7 @@ stdenv.mkDerivation rec {
     qtbase
     qtmultimedia
     yajl
+    discord-rpc
   ];
 
   cmakeFlags = [
@@ -70,7 +97,7 @@ stdenv.mkDerivation rec {
   WITH_FONTS = "NO";
   WITH_UPDATER = "NO";
 
-  installPhase =  ''
+  installPhase = ''
     runHook preInstall
 
     mkdir -pv $out/lib
@@ -89,7 +116,7 @@ stdenv.mkDerivation rec {
     makeQtWrapper $out/mudlet $out/bin/mudlet \
       --set LUA_CPATH "${luaEnv}/lib/lua/${lua.luaversion}/?.so" \
       --prefix LUA_PATH : "$NIX_LUA_PATH" \
-      --prefix LD_LIBRARY_PATH : "${libsForQt5.qtkeychain}/lib/" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsForQt5.qtkeychain discord-rpc ]}" \
       --chdir "$out";
 
     runHook postInstall
@@ -98,7 +125,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Crossplatform mud client";
     homepage = "https://www.mudlet.org/";
-    maintainers = [ maintainers.wyvie maintainers.pstn ];
+    maintainers = with maintainers; [ wyvie pstn cpu ];
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
   };


### PR DESCRIPTION
###### Description of changes

This PR updates Mudlet from version 4.15.1 to 4.16.0. This requires fixing a lua 5.1 compatibility regression in luasql-sqlite3 by using a packageOverride to set the version to a commit before the regression. This resolves an "undefined symbol: lua_isinteger" error that will occur at application runtime otherwise.

Along with the version update I've also fixed the Discord integration. Prior to this PR running Mudlet would produce errors in the console window related to not finding the required `.so` for the Discord integration to function.

This PR wires through the required `libdiscord-rpc.so` from the discord-rpc package. On startup Mudlet now prints:
> Discord integration loaded. Using functions from: "libdiscord-rpc.so"

Replaces https://github.com/NixOS/nixpkgs/pull/183665

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
