### PR TITLE
tetrio-desktop: cleanup, fix GApps wrapping, add tetrio-plus option

### DIFF
--- a/pkgs/games/tetrio-desktop/default.nix
+++ b/pkgs/games/tetrio-desktop/default.nix
@@ -2,16 +2,17 @@
 , lib
 , fetchurl
 , autoPatchelfHook
+, wrapGAppsHook
 , alsa-lib
 , cups
-, libpulseaudio
 , libX11
 , libXScrnSaver
 , libXtst
 , mesa
 , nss
+, gtk3
+, libpulseaudio
 , systemd
-, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -37,19 +38,13 @@ stdenv.mkDerivation rec {
     libXtst
     mesa
     nss
+    gtk3
   ];
 
   dontWrapGApps = true;
 
   libPath = lib.makeLibraryPath [
-    alsa-lib
-    cups
     libpulseaudio
-    libX11
-    libXScrnSaver
-    libXtst
-    mesa
-    nss
     systemd
   ];
 
@@ -61,15 +56,21 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     cp -R $TMP/tetrio-desktop/{usr/share,opt} $out/
-
-    wrapProgram $out/opt/TETR.IO/tetrio-desktop \
-      --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/TETR.IO
-
     ln -s $out/opt/TETR.IO/tetrio-desktop $out/bin/
 
     substituteInPlace $out/share/applications/tetrio-desktop.desktop \
       --replace "Exec=\"/opt/TETR.IO/tetrio-desktop\"" "Exec=\"$out/opt/TETR.IO/tetrio-desktop\""
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/opt/TETR.IO/tetrio-desktop \
+      --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/TETR.IO \
+      ''${gappsWrapperArgs[@]}
   '';
 
   meta = with lib; {

--- a/pkgs/games/tetrio-desktop/default.nix
+++ b/pkgs/games/tetrio-desktop/default.nix
@@ -13,6 +13,9 @@
 , gtk3
 , libpulseaudio
 , systemd
+, callPackage
+, withTetrioPlus ? false
+, tetrio-plus ? callPackage ./tetrio-plus.nix { }
 }:
 
 stdenv.mkDerivation rec {
@@ -66,6 +69,10 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  postInstall = lib.strings.optionalString withTetrioPlus ''
+      cp ${tetrio-plus} $out/opt/TETR.IO/resources/app.asar
+    '';
 
   postFixup = ''
     wrapProgram $out/opt/TETR.IO/tetrio-desktop \

--- a/pkgs/games/tetrio-desktop/tetrio-plus.nix
+++ b/pkgs/games/tetrio-desktop/tetrio-plus.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  pname = "tetrio-plus";
+  version = "0.23.13";
+
+  src = fetchzip {
+    url = "https://gitlab.com/UniQMG/tetrio-plus/uploads/a9647feffc484304ee49c4d3fd4ce718/tetrio-plus_0.23.13_app.asar.zip";
+    sha256 = "sha256-NSOVZjm4hDXH3f0gFG8ijLmdUTyMRFYGhxpwysoYIVg=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install app.asar $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "TETR.IO customization toolkit";
+    homepage = "https://gitlab.com/UniQMG/tetrio-plus";
+    license = licenses.mit;
+    maintainers = with maintainers; [ huantian ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

The first commit reorganizes derivation arguments to fit usage order, removes packages from `libPath` which were already patched by `autoPatchelfHook`, and most importantly, properly wraps the program with `wrapGAppsHook`. Previously `dontWrapGApps` was correctly set to prevent double wrapping; however, `gappsWrapperArgs` wasn't passed to `wrapProgram` so no wrapping was done. This properly passes the arguments to `wrapProgram` and moves `wrapProgram` to the fixup phase, as `gappsWrapperArgs` isn't fully populated until then. Proper GTK wrapping is necessary for certain features of `tetrio-plus` to function.

The second commit adds the `tetrio-plus` tool as an optional add-on to `tetrio-desktop`. 

For reviewers:
 - Does removing packages from `libPath` break anything?
 - Is `withTetrioPlus` a good name for the option?
 - Consider building `tetrio-plus` from source. Currently downloads prebuilt version, since it requires manually using `npm i` which doesn't work in a nix sandbox. Maybe it's possible with #189539?

@wackbyte 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
