### PR TITLE
pkgsStatic.cmark: fix build

### DIFF
--- a/pkgs/development/libraries/cmark/default.nix
+++ b/pkgs/development/libraries/cmark/default.nix
@@ -13,10 +13,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [
-    # Link the executable with the shared library
-    "-DCMARK_STATIC=OFF"
-  ];
+  cmakeFlags =
+    # Link the executable with the shared library on system with shared libraries.
+    lib.optional (!stdenv.hostPlatform.isStatic) "-DCMARK_STATIC=OFF"
+    # Do not attempt to build .so library on static platform.
+    ++ lib.optional stdenv.hostPlatform.isStatic "-DCMARK_SHARED=OFF";
 
   doCheck = true;
 


### PR DESCRIPTION
Pass configuration flag to prevent build system from attempting to build .so
shared library during pkgsStatic build. Upstream build system is not capable of
figuring on its own that it is impossible.
