### PR TITLE
azure-functions-core-tools: remove jshcmpbll as maintainer

### DIFF
--- a/pkgs/development/tools/azure-functions-core-tools/default.nix
+++ b/pkgs/development/tools/azure-functions-core-tools/default.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
       binaryNativeCode
     ];
     license = licenses.mit;
-    maintainers = with maintainers; [ jshcmpbll ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
I don't use this tool anymore and dont really have the means to maintain it

###### Description of changes

Removing myself from the maintainers list. Hopefully someone who uses this more regularly can pick it up.