### PR TITLE
linuxPackages.rtw88: 2022-06-03 to 2022-11-05

### DIFF
--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "rtw88";
-  version = "unstable-2022-06-03";
+  version = "unstable-2022-11-05";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw88";
-    rev = "03da251c76ea1005b42625825c39181e12d75693";
-    sha256 = "0l5ysp4x5wzrn48sfjv3rciqhq5ldcmk86b9x6j9775zjj7yw8hw";
+    rev = "c0dfe571fd7b307e036f186ef5711b4c0d9f3f08";
+    sha256 = "1gc5nv5pyrfag826z36vsrbirg6iww99yx45pcgpp7rmrpbwamvg";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
     license = with licenses; [ bsd3 gpl2Only ];
     maintainers = with maintainers; [ tvorog atila ];
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "4.14";
+    broken = kernel.kernelOlder "4.20";
     priority = -1;
   };
 }


### PR DESCRIPTION
###### Description of changes

The previous version was breaking with kernel 6.*. This bump fixed it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_14.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_4_14_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_4_19.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_4_19_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_4_9.rtlwifi_new</li>
    <li>rtlwifi_new-firmware</li>
  </ul>
</details>
<details>
  <summary>15 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_10.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_10_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_5_15.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_hardened.rtlwifi_new (linuxKernel.packages.linux_5_15_hardened.rtlwifi_new)</li>
    <li>linuxKernel.packages.linux_5_4.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_6_0.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_6_0_hardened.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_latest_libre.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_libre.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_lqx.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_testing_bcachefs.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_xanmod.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_xanmod_latest.rtlwifi_new (linuxKernel.packages.linux_xanmod_stable.rtlwifi_new)</li>
    <li>linuxKernel.packages.linux_zen.rtlwifi_new</li>
    <li>rtw88-firmware</li>
  </ul>
</details>
