### PR TITLE
esbuild_netlify: fix darwin build

### DIFF
--- a/pkgs/development/tools/esbuild/netlify.nix
+++ b/pkgs/development/tools/esbuild/netlify.nix
@@ -1,4 +1,8 @@
-{ buildGoModule, fetchFromGitHub, lib }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, fetchpatch
+}:
 
 buildGoModule rec {
   pname = "esbuild";
@@ -11,7 +15,19 @@ buildGoModule rec {
     sha256 = "0asjmqfzdrpfx2hd5hkac1swp52qknyqavsm59j8xr4c1ixhc6n9";
   };
 
-  vendorSha256 = "sha256-2ABWPqhK2Cf4ipQH7XvRrd+ZscJhYPc3SV2cGT0apdg=";
+  vendorSha256 = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+
+  patches = [
+    # Both upstream patches update the same dependency "x/sys". It's required for darwin compatibility.
+    (fetchpatch {
+      url = "https://github.com/evanw/esbuild/commit/2567e099fcc6959e630f100b2c737ca80e88ba82.patch";
+      hash = "sha256-KdX/Ru9TBX0mSDaS1ijxgzDI+2AoCvt6Wilhpca3VC0=";
+    })
+    (fetchpatch {
+      url = "https://github.com/evanw/esbuild/commit/fd13718c6195afb9e63682476a774fa6d4483be0.patch";
+      hash = "sha256-va/bXRBQf9qgE9LZXcKKAa0ZpMt/QG7BFClJ8bPWG1Y=";
+    })
+  ];
 
   meta = with lib; {
     description = "A fork of esbuild maintained by netlify";

--- a/pkgs/development/tools/esbuild/netlify.nix
+++ b/pkgs/development/tools/esbuild/netlify.nix
@@ -2,6 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 , fetchpatch
+, netlify-cli
 }:
 
 buildGoModule rec {
@@ -28,6 +29,12 @@ buildGoModule rec {
       hash = "sha256-va/bXRBQf9qgE9LZXcKKAa0ZpMt/QG7BFClJ8bPWG1Y=";
     })
   ];
+
+  passthru = {
+    tests = {
+      inherit netlify-cli;
+    };
+  };
 
   meta = with lib; {
     description = "A fork of esbuild maintained by netlify";


### PR DESCRIPTION
###### Description of changes

Fix the x/sys failure:
```
vendor/golang.org/x/sys/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:121:3: too many errors
```
by bumping the version.

ZHF: #199919

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
