### PR TITLE
python310Packages.amaranth: make compatible with newer setuptools

### DIFF
--- a/pkgs/development/python-modules/amaranth/default.nix
+++ b/pkgs/development/python-modules/amaranth/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
+, fetchpatch
 , setuptools
 , setuptools-scm
 , pyvcd
@@ -30,6 +31,23 @@ buildPythonPackage rec {
     rev = "39a83f4d995d16364cc9b99da646ff8db6394166";
     sha256 = "P9AG3t30eGeeCN5+t7mjhRoOWIGZVzWQji9eYXphjA0=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-for-setuptools-64.0.2-preparation.patch";
+      url = "https://github.com/amaranth-lang/amaranth/commit/64771a065a280fa683c1e6692383bec4f59f20fa.patch";
+      hash = "sha256-Rsh9vVvUQj9nIcrsRirmR6XwFrfZ2VMaYJ4RCQ8sBE0=";
+      # This commit removes support for Python 3.6, which is unnecessary to fix
+      # the build when using new setuptools. Include only one file, which has a
+      # harmless comment change so that the subsequent patch applies cleanly.
+      includes = ["amaranth/_toolchain/cxx.py"];
+    })
+    (fetchpatch {
+      name = "fix-for-setuptools-64.0.2.patch";
+      url = "https://github.com/amaranth-lang/amaranth/pull/722/commits/e5a56b07c568e5f4cc2603eefebd14c5cc4e13d8.patch";
+      hash = "sha256-C8FyMSKHA7XsEMpO9eYNZx/X5rGaK7p3eXP+jSb6wVg=";
+    })
+  ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}";
 


### PR DESCRIPTION
###### Description of changes

The latest version of `setuptools` changed some internal details that `amaranth` was unintentionally relying upon, as explained in https://github.com/pypa/setuptools/issues/3583 and fixed in https://github.com/amaranth-lang/amaranth/pull/722.

This started affecting `amaranth` in nixpkgs after https://github.com/NixOS/nixpkgs/pull/191333 and, in particular, https://github.com/NixOS/nixpkgs/commit/f3b298708e2f18dd06daf4ff6567dd7df6ed15f1.

ZHF: #199919

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
