### PR TITLE
cyrus-sasl-xoauth2: init at 0.2

### DIFF
--- a/pkgs/development/libraries/cyrus-sasl-xoauth2/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl-xoauth2/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, autoconf, libtool, automake, cyrus_sasl }:
+
+stdenv.mkDerivation rec {
+  pname = "cyrus-sasl-xoauth2";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "moriyoshi";
+    repo = "cyrus-sasl-xoauth2";
+    rev = "v${version}";
+    sha256 = "sha256-lI8uKtVxrziQ8q/Ss+QTgg1xTObZUTAzjL3MYmtwyd8=";
+  };
+
+  nativeBuildInputs = [ autoconf libtool automake ];
+
+  buildInputs = [ cyrus_sasl ];
+
+  preConfigure = "./autogen.sh";
+
+  configureFlags = [
+    "--with-cyrus-sasl=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/moriyoshi/cyrus-sasl-xoauth2";
+    description = "XOAUTH2 mechanism plugin for cyrus-sasl";
+    platforms = platforms.unix;
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ wentasah ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18439,6 +18439,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
+  cyrus-sasl-xoauth2 = callPackage ../development/libraries/cyrus-sasl-xoauth2 { };
+
   # Make bdb5 the default as it is the last release under the custom
   # bsd-like license
   db = db5;


### PR DESCRIPTION
###### Description of changes

[This plugin](https://github.com/moriyoshi/cyrus-sasl-xoauth2) allows using XOAUTH2-enabled SMTP / IMAP servers (e.g. Office365) with your favorite *nix MUAs.

Closes  #108480.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
