### PR TITLE
Task/add purple mattermost

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3091,6 +3091,12 @@
     githubId = 1298344;
     name = "Daniel Fullmer";
   };
+  danielsiepmann = {
+    email = "coding@daniel-siepmann.de";
+    github = "danielsiepmann";
+    githubId = 354250;
+    name = "Daniel Siepmann";
+  };
   danth = {
     name = "Daniel Thwaites";
     email = "danthwaites30@btinternet.com";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-mattermost/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-mattermost/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, lib, git,
+  pidgin, glib, json-glib,
+  # markdown implementation
+  discount
+}:
+
+stdenv.mkDerivation rec {
+  pname = "purple-mattermost";
+  version = "v2.1";
+  src = fetchFromGitHub {
+    owner = "EionRobb";
+    repo = pname;
+    rev = version;
+    leaveDotGit = true;
+    sha256 = "sha256-/lFGr6s4R/LQ2N60b6lJwQjjIoZxZTiKupmHV1APl9A=";
+  };
+
+  PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";
+  PKG_CONFIG_PURPLE_DATAROOTDIR = "${placeholder "out"}/share";
+
+  nativeBuildInputs = [
+    git
+    glib
+    json-glib
+    discount
+    pidgin
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/EionRobb/purple-mattermost";
+    description = "Plugin for Pidgin which adds support for Mattermost";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ danielsiepmann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31208,6 +31208,8 @@ with pkgs;
 
   purple-matrix = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-matrix { };
 
+  purple-mattermost = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-mattermost { };
+
   purple-mm-sms = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-mm-sms { };
 
   purple-plugin-pack = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-plugin-pack { };


### PR DESCRIPTION
###### Description of changes

https://github.com/EionRobb/purple-mattermost

Plugin for Pidgin which adds support for Mattermost

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
