### PR TITLE
oauth2ms: init at 2021-07-09

### DIFF
--- a/pkgs/by-name/oa/oauth2ms/package.nix
+++ b/pkgs/by-name/oa/oauth2ms/package.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, python3 }:
+
+stdenv.mkDerivation {
+  pname = "oauth2ms";
+  version = "2021-07-09";
+
+  src = fetchFromGitHub {
+    owner = "harishkrupo";
+    repo = "oauth2ms";
+    rev = "a1ef0cabfdea57e9309095954b90134604e21c08"; # No tags or releases in the repo
+    sha256 = "sha256-xPSWlHJAXhhj5I6UMjUtH1EZqCZWHJMFWTu3a4k1ETc";
+  };
+
+  buildInputs = [
+    (python3.withPackages (ps: with ps; [
+      pyxdg
+      msal
+      python-gnupg
+    ]))
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D oauth2ms $out/bin/oauth2ms
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/harishkrupo/oauth2ms";
+    description = "XOAUTH2 compatible Office365 token fetcher";
+    platforms = platforms.all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ wentasah ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

[This tool](https://github.com/harishkrupo/oauth2ms) can be used to fetch oauth2 tokens from the Microsoft identity endpoint. Additionally, it can encode the token in the [XOAUTH2 format](https://docs.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth#sasl-xoauth2) to be used as authentication in IMAP mail servers. Example configuration for Emacs [is provided by the upstream project](https://github.com/harishkrupo/oauth2ms/blob/main/steps.org).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
