### PR TITLE
isync: Fix "Buffer too small" error

### DIFF
--- a/pkgs/tools/networking/isync/0001-Increase-imap_vprintf-buffer-size.patch
+++ b/pkgs/tools/networking/isync/0001-Increase-imap_vprintf-buffer-size.patch
@@ -1,0 +1,34 @@
+From e8a3a20aed135272a9ec0103f4055411c075f043 Mon Sep 17 00:00:00 2001
+From: Michal Sojka <michal.sojka@cvut.cz>
+Date: Mon, 7 Nov 2022 00:07:22 +0100
+Subject: [PATCH] Increase imap_vprintf buffer size
+
+This fixes "Fatal: buffer too small. Please report a bug." error. See
+https://sourceforge.net/p/isync/mailman/isync-devel/thread/87fsevvebj.fsf%40steelpick.2x.cz/#msg37731590
+for related discussion.
+
+When using mbsync with XOAUTH2 authentication (needed for Office365
+mailboxes), the access token used for the LOGIN command may not fit
+into the currently used buffer of 1000 characters. In my case, I need
+the buffer to be at least 2000 characters long. To make this more
+future-proof, I increase the buffer size to 4000 characters.
+---
+ src/drv_imap.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/drv_imap.c b/src/drv_imap.c
+index c5a7aed..7847192 100644
+--- a/src/drv_imap.c
++++ b/src/drv_imap.c
+@@ -528,7 +528,7 @@ imap_vprintf( const char *fmt, va_list ap )
+ 	uint totlen = 0;
+ 	const char *segs[MAX_SEGS];
+ 	uint segls[MAX_SEGS];
+-	char buf[1000];
++	char buf[4000];
+ 
+ 	d = buf;
+ 	ed = d + sizeof(buf);
+-- 
+2.38.1
+

--- a/pkgs/tools/networking/isync/default.nix
+++ b/pkgs/tools/networking/isync/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
     sha256 = "1zq0wwvmqsl9y71546dr0aygzn9gjjfiw19hlcq87s929y4p6ckw";
   };
 
+  patches = [
+    # Fixes "Fatal: buffer too small" error
+    ./0001-Increase-imap_vprintf-buffer-size.patch
+  ];
+
   nativeBuildInputs = [ pkg-config perl ];
   buildInputs = [ openssl db cyrus_sasl zlib ]
     ++ lib.optionals stdenv.isDarwin [ Security ];


### PR DESCRIPTION
###### Description of changes

This fixes "Fatal: buffer too small. Please report a bug." error. See [this thread in isync mailing list](https://sourceforge.net/p/isync/mailman/isync-devel/thread/87fsevvebj.fsf%40steelpick.2x.cz/#msg37731590) for related discussion. I'm not the only one who encounters this.

When using mbsync with XOAUTH2 authentication (needed for Office365 mailboxes), the access token used for the LOGIN command may not fit into the currently used buffer of 1000 characters. In my case, I need the buffer to be at least 2000 characters long. To make this more future-proof, I increase the buffer size to 4000 characters.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
