### PR TITLE
libxcrypt: Fix build error on AVX platform

### DIFF
--- a/pkgs/development/libraries/libxcrypt/0001-Fix-warning-about-truncating-conversion.patch
+++ b/pkgs/development/libraries/libxcrypt/0001-Fix-warning-about-truncating-conversion.patch
@@ -1,0 +1,25 @@
+From 239664bf18fc2bc093d8dbaa1fb0a0307651897f Mon Sep 17 00:00:00 2001
+From: Moinak Bhattacharyya <moinakb001@gmail.com>
+Date: Mon, 7 Nov 2022 03:40:23 -0600
+Subject: [PATCH] Fix warning about truncating conversion
+
+---
+ lib/alg-yescrypt-opt.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/alg-yescrypt-opt.c b/lib/alg-yescrypt-opt.c
+index 60a6ccd..dacc73b 100644
+--- a/lib/alg-yescrypt-opt.c
++++ b/lib/alg-yescrypt-opt.c
+@@ -514,7 +514,7 @@ static volatile uint64_t Smask2var = Smask2;
+ #define PWXFORM_SIMD(X) { \
+ 	uint64_t x; \
+ 	FORCE_REGALLOC_1 \
+-	uint32_t lo = x = EXTRACT64(X) & Smask2reg; \
++	uint32_t lo = (uint32_t)(x = EXTRACT64(X) & Smask2reg); \
+ 	FORCE_REGALLOC_2 \
+ 	uint32_t hi = x >> 32; \
+ 	X = _mm_mul_epu32(HI32(X), X); \
+-- 
+2.38.1
+

--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
     inherit (nixosTests) login shadow;
   };
 
+  patches = [ ./0001-Fix-warning-about-truncating-conversion.patch ];
+
   meta = with lib; {
     description = "Extended crypt library for descrypt, md5crypt, bcrypt, and others";
     homepage = "https://github.com/besser82/libxcrypt/";


### PR DESCRIPTION


###### Description of changes

Unnecessary warning when compiling libxcrypt with AVX support leads to build failures with Werror. Simple cleanup. Adding patch until next release.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
