### PR TITLE
btcd: init at 0.23.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -69,6 +69,12 @@
       fingerprint = "F466 A548 AD3F C1F1 8C88  4576 8702 7528 B006 D66D";
     }];
   };
+  _0xB10C = {
+    email = "nixpkgs@b10c.me";
+    name = "0xB10C";
+    github = "0xb10c";
+    githubId = 19157360;
+  };
   _0xbe7a = {
     email = "nix@be7a.de";
     name = "Bela Stoyan";

--- a/pkgs/applications/blockchains/btcd/default.nix
+++ b/pkgs/applications/blockchains/btcd/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "btcd";
+  version = "0.23.3";
+
+  src = fetchFromGitHub {
+    owner = "btcsuite";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-LdK68Ianiyrs+HVMwrkiX2ruCWKkdpuY8ylxhNbm9qI=";
+  };
+
+  vendorSha256 = "sha256-3w8rb0sfAIFCXqPXOKb4QwoLd7WsbFv3phu/rJCEjeY=";
+
+  subPackages = [ "." "cmd/*" ];
+
+  preCheck = ''
+    DIR="github.com/btcsuite/btcd/"
+    # TestCreateDefaultConfigFile requires the sample-btcd.conf in $DIR
+    mkdir -p $DIR
+    cp sample-btcd.conf $DIR
+  '';
+
+  meta = with lib; {
+    description = "An alternative full node bitcoin implementation written in Go (golang)";
+    homepage = "https://github.com/btcsuite/btcd";
+    license = licenses.isc;
+    maintainers = with maintainers; [ _0xB10C ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33395,6 +33395,8 @@ with pkgs;
     inherit (darwin) autoSignDarwinBinariesHook;
   };
 
+  btcd = callPackage ../applications/blockchains/btcd { };
+
   cgminer = callPackage ../applications/blockchains/cgminer { };
 
   chia = callPackage ../applications/blockchains/chia { };


### PR DESCRIPTION
###### Description of changes

`btcd` is a bitcoin implementation written in Go. See [github.com/btcsuite/btcd](https://github.com/btcsuite/btcd).

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested: via btcd unit tests
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
