### PR TITLE
cinnamon.cinnamon-gsettings-overrides: Override gnome-terminal settin…

### DIFF
--- a/pkgs/desktops/cinnamon/cinnamon-gsettings-overrides/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-gsettings-overrides/default.nix
@@ -2,6 +2,7 @@
 , runCommand
 , nixos-artwork
 , glib
+, gnome
 , gtk3
 , gsettings-desktop-schemas
 , extraGSettingsOverrides ? ""
@@ -35,9 +36,20 @@ let
     cinnamon-session
     cinnamon-settings-daemon
     cinnamon-common
+    gnome.gnome-terminal
     gtk3
   ] ++ extraGSettingsOverridePackages;
 
+  gsettingsOverrides = ''
+    # Use Fedora's default to make text readable and
+    # restore ununified menu.
+    # https://github.com/NixOS/nixpkgs/issues/200017
+    [org.gnome.Terminal.Legacy.Settings]
+    theme-variant='dark'
+    unified-menu=false
+
+    ${extraGSettingsOverrides}
+  '';
 in
 
 # TODO: Having https://github.com/NixOS/nixpkgs/issues/54150 would supersede this
@@ -53,7 +65,7 @@ runCommand "cinnamon-gsettings-overrides" { preferLocalBuild = true; }
     chmod -R a+w "$data_dir"
 
     cat - > "$schema_dir/nixos-defaults.gschema.override" <<- EOF
-    ${extraGSettingsOverrides}
+    ${gsettingsOverrides}
     EOF
 
     ${glib.dev}/bin/glib-compile-schemas --strict "$schema_dir"


### PR DESCRIPTION
…gs with Fedora's default

See #200017 for motivation.

Closes #200017

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
