### PR TITLE
Draft: cargo-deb: 1.30.0 -> 1.41.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-deb/default.nix
+++ b/pkgs/development/tools/rust/cargo-deb/default.nix
@@ -5,6 +5,7 @@
 , rust
 , libiconv
 , Security
+, dpkg
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,6 +20,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
+  nativeBuildInputs = [ dpkg ];
 
   cargoSha256 = "sha256-PJLKEcbWlGqfi7RxWO4mwxByMD/qeK0MWy+r61WSKzo=";
 

--- a/pkgs/development/tools/rust/cargo-deb/default.nix
+++ b/pkgs/development/tools/rust/cargo-deb/default.nix
@@ -9,18 +9,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deb";
-  version = "1.30.0";
+  version = "1.41.0";
 
   src = fetchFromGitHub {
-    owner = "mmstick";
+    owner = "kornelski";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-rAmG6Aj0D9dHVueh1BN1Chhit+XFhqGib1WTvMDy0LI=";
+    sha256 = "sha256-2N7KFkR0HZHvEO6ud88MyvPi4epyq0ISMXz+RPWNDoQ=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
 
-  cargoSha256 = "sha256-MEpyEdjLWNZvqE7gJLvQ169tgmJRzec4vqQI9fF3xr8=";
+  cargoSha256 = "sha256-PJLKEcbWlGqfi7RxWO4mwxByMD/qeK0MWy+r61WSKzo=";
 
   preCheck = ''
     substituteInPlace tests/command.rs \
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Generate Debian packages from information in Cargo.toml";
-    homepage = "https://github.com/mmstick/cargo-deb";
+    homepage = "https://github.com/kornelski/cargo-deb";
     license = licenses.mit;
     # test failures:
     #   control::tests::generate_scripts_generates_maintainer_scripts_for_unit


### PR DESCRIPTION
###### Description of changes

* Updated to current version `1.41.0`
* The project has been moved from https://github.com/mmstick/cargo-deb to https://github.com/kornelski/cargo-deb
* New `nativeBuildInput` `dpkg` was added

## TODO

- [ ] Test fails with

```
dpkg-shlibdeps: error: no dependency information found for /nix/store/ynn1by1qdl16q6qwwh2h7zkgrn36c6i8-glibc-2.35-163/lib/libgcc_s.so.1 (used by /tmp/nix-build-cargo-deb-1.41.0.drv-0/source/target/x86_64-unknown-linux-gnu/release/deps/cargo_deb-240611d9afdc3838)
Hint: check if the library actually comes from a package.
```

[`dpkg-shlibdeps`](https://www.man7.org/linux/man-pages/man1/dpkg-shlibdeps.1.html) tries to find Debian packages for the shared libraries a binary links against. I think this fails since Nix uses different paths for shared libraries. I'm not sure if this can be fixed at all. At this point I'm stuck and am not sure how to continue fixing this package...

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



ZHF: #199919
