### PR TITLE
NetBox avoid usage of base dir for dynamic content, fix LDAP configuration

### DIFF
--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -46,11 +46,10 @@ let
     installPhase = old.installPhase + ''
       ln -s ${configFile} $out/opt/netbox/netbox/netbox/configuration.py
     '' + optionalString cfg.enableLdap ''
-      ln -s ${ldapConfigPath} $out/opt/netbox/netbox/netbox/ldap_config.py
+      ln -s ${cfg.ldapConfigPath} $out/opt/netbox/netbox/netbox/ldap_config.py
     '';
   })).override {
-    plugins = ps: ((cfg.plugins ps)
-      ++ optionals cfg.enableLdap [ ps.django-auth-ldap ]);
+    inherit (cfg) plugins;
   };
   netboxManageScript = with pkgs; (writeScriptBin "netbox-manage" ''
     #!${stdenv.shell}
@@ -143,6 +142,8 @@ in {
   };
 
   config = mkIf cfg.enable {
+    services.netbox.plugins = mkIf cfg.enableLdap (ps: [ ps.django-auth-ldap ]);
+
     services.redis.servers.netbox.enable = true;
 
     services.postgresql = {

--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -9,6 +9,10 @@ let
     name = "configuration.py";
     text = ''
       STATIC_ROOT = '${staticDir}'
+      MEDIA_ROOT = '${cfg.dataDir}/media'
+      REPORTS_ROOT = '${cfg.dataDir}/reports'
+      SCRIPTS_ROOT = '${cfg.dataDir}/scripts'
+
       ALLOWED_HOSTS = ['*']
       DATABASE = {
         'NAME': 'netbox',


### PR DESCRIPTION
###### Description of changes

Previously, NetBox would try to store media content in the Nix store, without success. Scripts and reports also were looked for in the Nix store. This PR changes this behavior by setting the various paths under `dataDir`.

This PR also fixes the LDAP configuration, which wasn't working. Right now it's working as expected, though we don't have a NixOS test for it yet.

This PR should be backwards compatible.

I'll try and do another PR so that we can have a more RFC42-style RFC, and maybe add a NixOS test for the LDAP configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
