### PR TITLE
qMasterPassword: 1.2.3 -> 1.2.4

### DIFF
--- a/pkgs/applications/misc/qMasterPassword/default.nix
+++ b/pkgs/applications/misc/qMasterPassword/default.nix
@@ -1,6 +1,18 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, qtbase, qmake, qttools, libX11, libXtst, openssl, libscrypt }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, libX11
+, libXtst
+, qmake
+, qtbase
+, qttools
+, qtwayland
+, openssl
+, libscrypt
+, wrapQtAppsHook
+}:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qMasterPassword";
   version = "1.2.4";
 
@@ -11,8 +23,8 @@ mkDerivation rec {
     sha256 = "sha256-VQ1ZkXaZ5sUbtWa/GreTr5uXvnZ2Go6owJ2ZBK25zns=";
   };
 
-  buildInputs = [ qtbase libX11 libXtst openssl libscrypt ];
-  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [ qtbase qtwayland libX11 libXtst openssl libscrypt ];
+  nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
 
   # Upstream install is mostly defunct. It hardcodes target.path and doesn't
   # install anything but the binary.
@@ -46,7 +58,7 @@ mkDerivation rec {
     '';
     homepage = "https://github.com/bkueng/qMasterPassword";
     license = licenses.gpl3;
-    maintainers = [ maintainers.tadeokondrak ];
+    maintainers = with lib.maintainers; [ tadeokondrak ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/qMasterPassword/default.nix
+++ b/pkgs/applications/misc/qMasterPassword/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "qMasterPassword";
-  version = "1.2.3";
+  version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "bkueng";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-eUJD9FoGaDzADKm3wZHs5Bhdt7RoM1WTTVNP6xUV7gs=";
+    sha256 = "sha256-VQ1ZkXaZ5sUbtWa/GreTr5uXvnZ2Go6owJ2ZBK25zns=";
   };
 
   buildInputs = [ qtbase libX11 libXtst openssl libscrypt ];

--- a/pkgs/applications/misc/qMasterPassword/default.nix
+++ b/pkgs/applications/misc/qMasterPassword/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/bkueng/qMasterPassword";
     license = licenses.gpl3;
-    maintainers = with lib.maintainers; [ tadeokondrak ];
+    maintainers = with lib.maintainers; [ tadeokondrak teutat3s ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36997,7 +36997,7 @@ with pkgs;
     gtk2 = gtk2-x11;
   };
 
-  qMasterPassword = libsForQt5.callPackage ../applications/misc/qMasterPassword { };
+  qMasterPassword = qt6Packages.callPackage ../applications/misc/qMasterPassword { };
 
   qtrvsim = libsForQt5.callPackage ../applications/science/computer-architecture/qtrvsim { };
 


### PR DESCRIPTION
###### Description of changes
https://github.com/bkueng/qMasterPassword/compare/v1.2.3...v1.2.4

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
