### PR TITLE
bazel_5: 5.2.0 -> 5.3.2

### DIFF
--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -234,11 +234,13 @@ let
     fetchAttrs = {
       sha256 =
         if cudaSupport then
-          "sha256-Z9GDWGv+1YFyJjudyshZfeRJsKShoA1kIbNR3h3GxPQ="
-        else if stdenv.isDarwin then
-          "sha256-i3wiJHD4+pgTvDMhnYiQo9pdxxKItgYnc4/4wGt2NXM="
-        else
-          "sha256-liRxmjwm0OmVMfgoGXx+nGBdW2fzzP/d4zmK6A59HAM=";
+          "sha256-FO3mvxr+c3kWOhIRRdJ0gBOHrPr2LKrtjZvYaPp8Xu0="
+        else {
+          x86_64-linux = "sha256-s4fJhjxr9Nj8EMfNFoKDE68AVN7ETsvuuCZ4bJVS1Eo=";
+          aarch64-linux = "sha256-MgkQ8BwIP77dwbYyEyb59WUcOE7jWthHcDJZFNceS4o=";
+          x86_64-darwin = "sha256-xF36ctkzH/LGvKhrcrqVDz5tUqFnYsFaOzjf3aJUTtU=";
+          aarch64-darwin = "sha256-/C6HUTHvRd+3LL4repJWWQq+2UXgO5za4xXZhhNxNrM=";
+        }.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -372,11 +372,11 @@ let
     fetchAttrs = {
       sha256 = {
       x86_64-linux = if cudaSupport
-        then "sha256-SudzMTxfifKJJso6haCgOD2dXeAhYSXHA2nzq1ErTHg="
-        else "sha256-bwZwK24DlUevN5gIdKmBkq1dJpn0i2H4hq+IN77BzjE=";
-      aarch64-linux = "sha256-ZbCNZSHF9of+KGTNEqFdKQ44MVNto/rTyo2XEsKXISg=";
-      x86_64-darwin = "sha256-ZfZQjLdqo8VVlfKfkdolvSHQvKe4IbQSLc/4cNzHr3E=";
-      aarch64-darwin = "sha256-u+ODHAZDlGe06PUWId4sNKyl60vhAPMd01jMm2EvN8E=";
+        then "sha256-8J3tVd32KKSN9H7kpwj8VhtxHkAJPmogMvxNXcNauf4="
+        else "sha256-Ay28HmBvAsH+jOYO1V5mL7OUfkRwP3BQ/Rm9A1gNh4I=";
+      aarch64-linux = "sha256-FKz6SRmS5E/BJ1WqIjRiVKGfgedmRG6ip/eAmn6LdcQ=";
+      x86_64-darwin = "sha256-GnDlloMOPSEX66hLPrVCKJmKBJ8dUTp7nG/XF0fVESc=";
+      aarch64-darwin = "sha256-36pg8Vywm7+h5vWcoEeW4Ab9gZ39Mtx6aVFIV4L2cjA=";
       }.${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
     };
 

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -81,7 +81,7 @@ buildBazelPackage rec {
       rm -rf $bazelOut/external/com_google_protobuf
     '';
 
-    sha256 = "sha256-R+Hc9ldYcKgAXETKr2+Hk7IrjJ93WkrjyJ1SQRoM9V4=";
+    sha256 = "sha256-AiSUwoa0JKChSSPSi1EWTpUKQggmOsjLB6fRMCAgUyE=";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -26,12 +26,12 @@
 }:
 
 let
-  version = "5.2.0";
+  version = "5.3.2";
   sourceRoot = ".";
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "sha256-ggqU27FAce1tjCZs8MCA7LJlpe6mUwdXlInEZiwtWCo=";
+    hash = "sha256-OICtkZWS0ePkDFBvE7Ms0KLibxKdh8troXDxgB19e4I=";
   };
 
   # Update with `eval $(nix-build -A bazel_5.updater)`,

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -83,8 +83,8 @@ buildBazelPackage rec {
 
   fetchAttrs = {
     sha256 = {
-      x86_64-linux = "sha256-zEebnLFGLUy6UR5Uf2f6s23s6tXYccp5SHzTcldDKwQ=";
-      aarch64-linux = "sha256-UfowJD9uUBimRbIaSq2US6BpEVDDqSLchSDJ1k0Cfwk=";
+      x86_64-linux = "sha256-MRkh00f7FyCdelOObkS0lBnOoyh2Nku9CP+kk9K8A/8=";
+      aarch64-linux = "sha256-t4TTVUt/L+JmLeVdN1v0eFzi8s0kF1mMoQEktPpp9iQ=";
     }.${stdenv.system} or (throw "unsupported system ${stdenv.system}");
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16745,7 +16745,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
-  buildBazelPackage = callPackage ../build-support/build-bazel-package { };
+  buildBazelPackage = darwin.apple_sdk_11_0.callPackage ../build-support/build-bazel-package { };
 
   bear = callPackage ../development/tools/build-managers/bear { };
 


### PR DESCRIPTION
###### Description of changes

https://blog.bazel.build/2022/08/23/bazel-5.3.html

to supersede https://github.com/NixOS/nixpkgs/pull/187943 and https://github.com/NixOS/nixpkgs/pull/198016

re-reverts https://github.com/NixOS/nixpkgs/pull/199458 with more hash updates: bazel-watcher, jaxlib, tensorflow, envoy. That should be all using `buildBazelPackage` with `bazel_5`. On darwin tensorflow still fails, so replacing hash with explicitly invalid one.

ZHF: #199919 (fixes bazel-watcher on x86_64-darwin)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
