### PR TITLE
dillong: init at unstable-2021-12-13

### DIFF
--- a/pkgs/applications/networking/browsers/dillong/default.nix
+++ b/pkgs/applications/networking/browsers/dillong/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, which
+, fltk
+, mbedtls
+}:
+
+stdenv.mkDerivation {
+  pname = "dillong";
+  version = "unstable-2021-12-13";
+
+  src = fetchFromGitHub {
+    owner = "w00fpack";
+    repo = "dilloNG";
+    rev = "2804e6e9074b840de3084abb80473983f8e49f5b";
+    hash = "sha256-JSBd8Lgw3I20Es/jQHBtybnLd0iAcs16TqOrOxGPGiU=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    which
+  ];
+
+  buildInputs = [
+    fltk
+    mbedtls
+  ];
+
+  # The start_page and home settings refer to /usr.
+  # We can't change /usr to $out because dillorc is copied to the home directory
+  # on first launch, so the paths would quickly become outdated.
+  # So we just comment them out, and let dillong use the defaults.
+  postPatch = ''
+    substituteInPlace dillorc \
+      --replace "start_page=" "#start_page=" \
+      --replace "home=" "#home="
+  '';
+
+  configureFlags = [ "--enable-ssl=yes" ];
+
+  # Workaround build failure on -fno-common toolchains:
+  #   ld: main.o:/build/dillo-3.0.5/dpid/dpid.h:64: multiple definition of `sock_set';
+  #     dpid.o:/build/dillo-3.0.5/dpid/dpid.h:64: first defined here
+  NIX_CFLAGS_COMPILE = "-fcommon";
+
+  meta = with lib; {
+    description = "Fork of Dillo, a lightweight web browser";
+    homepage = "https://github.com/w00fpack/dilloNG";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18496,6 +18496,8 @@ with pkgs;
     fltk = fltk13;
   };
 
+  dillong = callPackage ../applications/networking/browsers/dillong { };
+
   directfb = callPackage ../development/libraries/directfb { };
 
   discordchatexporter-cli = callPackage ../tools/backup/discordchatexporter-cli { };


### PR DESCRIPTION
###### Description of changes

Fork of Dillo, a lightweight web browser
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
