### PR TITLE
nanodbc: 2.13.0 -> 2.14.0 and fix build

### DIFF
--- a/pkgs/development/libraries/nanodbc/default.nix
+++ b/pkgs/development/libraries/nanodbc/default.nix
@@ -1,15 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, cmake, unixODBC }:
+{ lib, stdenv, fetchFromGitHub, catch2, cmake, unixODBC }:
 
 stdenv.mkDerivation rec {
   pname = "nanodbc";
-  version = "2.13.0";
+  version = "2.14.0";
 
   src = fetchFromGitHub {
     owner = "nanodbc";
     repo = "nanodbc";
     rev = "v${version}";
-    sha256 = "1q80p7yv9mcl4hyvnvcjdr70y8nc940ypf368lp97vpqn5yckkgm";
+    hash = "sha256-dVUOwA7LfLqcQq2nc6OAha0krmgTy5RUHupBVrNdo4g=";
   };
+
+  postPatch = ''
+    cp ${catch2}/include/catch2/catch.hpp test/catch/catch.hpp
+  '';
 
   nativeBuildInputs = [ cmake ];
 
@@ -19,15 +23,6 @@ stdenv.mkDerivation rec {
     [ "-DBUILD_STATIC_LIBS=ON" ]
   else
     [ "-DBUILD_SHARED_LIBS=ON" ];
-
-  # fix compilation on macOS
-  # https://github.com/nanodbc/nanodbc/issues/274
-  # remove after the next version update
-  postUnpack = if stdenv.isDarwin then ''
-    mv $sourceRoot/VERSION $sourceRoot/VERSION.txt
-    substituteInPlace $sourceRoot/CMakeLists.txt \
-       --replace 'file(STRINGS VERSION' 'file(STRINGS VERSION.txt'
-  '' else "";
 
   meta = with lib; {
     homepage = "https://github.com/nanodbc/nanodbc";


### PR DESCRIPTION
###### Description of changes

Package update fixes a missing include; [Changelog](https://github.com/nanodbc/nanodbc/releases/tag/v2.14.0)

Also use our catch2 version instead of the version included in their repo because the tests don't build with their older version.

Reverse dependency `irods` is still broken for [an unrelated reason](https://github.com/irods/irods/issues/6158).

ZHF: #199919

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
