### PR TITLE
mucommander: 0.9.3-3 -> 1.1.0-1

### DIFF
--- a/pkgs/applications/file-managers/mucommander/default.nix
+++ b/pkgs/applications/file-managers/mucommander/default.nix
@@ -1,86 +1,109 @@
-{ lib, stdenv, fetchFromGitHub, gradle_6, perl, makeWrapper, jdk11, gsettings-desktop-schemas }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, gradle_7
+, perl
+, makeWrapper
+, writeText
+, jdk11
+, gsettings-desktop-schemas
+}:
 
 let
-  version = "0.9.3-3";
+  version = "1.1.0-1";
 
   src = fetchFromGitHub {
     owner = "mucommander";
     repo = "mucommander";
     rev = version;
-    sha256 = "1zhglsx3b5k6np3ppfkkrqz9wg0j7ip598xxfgn75gjl020w0can";
+    sha256 = "sha256-sCBbY3aBSuJmyOuy36pg8X2jX6hXwW8SW2UzYyp/isM=";
   };
 
   postPatch = ''
     # there is no .git anyway
     substituteInPlace build.gradle \
-      --replace "git = org.ajoberstar.grgit.Grgit.open(file('.'))"  "" \
-      --replace "revision = git.head().id"                          "revision = 'abcdefgh'" \
-      --replace "proguard.enabled =" "// proguard.enabled =" \
-      --replace "version = '0.9.4'" "version = '${version}'"
-
-    # disable gradle plugins with native code and their targets
-    perl -i.bak1 -pe "s#(^\s*id '.+' version '.+'$)#// \1#" build.gradle
-    perl -i.bak2 -pe "s#(.*)#// \1# if /^(buildscript|task portable|task nsis|task proguard|task tgz|task\(afterEclipseImport\)|launch4j|macAppBundle|buildRpm|buildDeb|shadowJar)/ ... /^}/" build.gradle
-
-    # fix source encoding
-    find . -type f -name build.gradle \
-      -exec perl -i.bak3 -pe "s#(repositories\.jcenter\(\))#
-                                \1
-                                compileJava.options.encoding = 'UTF-8'
-                                compileTestJava.options.encoding = 'UTF-8'
-                               #" {} \;
+      --replace "git = grgit.open(dir: project.rootDir)" "" \
+      --replace "id 'org.ajoberstar.grgit' version '3.1.1'" "" \
+      --replace "revision = git.head().id" "revision = '${version}'"
   '';
 
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {
     pname = "mucommander-deps";
     inherit version src postPatch;
-    nativeBuildInputs = [ gradle_6 perl ];
+    nativeBuildInputs = [ gradle_7 perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
-      gradle --no-daemon build
+      gradle --no-daemon tgz
     '';
     # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    # reproducible by sorting
     installPhase = ''
       find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | LC_ALL=C sort \
         | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
         | sh
+      # copy maven-metadata.xml for commons-codec
+      # thankfully there is only one xml
+      cp $GRADLE_USER_HOME/caches/modules-2/resources-2.1/*/*/maven-metadata.xml $out/commons-codec/commons-codec/maven-metadata.xml
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "1v5a76pvk7llbyv2rg50wlxc2wf468l2cslz1vi20aihycbyky7j";
+    outputHash = "sha256-15ThPkvcmOfa5m/HMJzjrOOUi/BYbd57p5bBfj5/3n4=";
   };
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation rec {
   pname = "mucommander";
   inherit version src postPatch;
-  nativeBuildInputs = [ gradle_6 perl makeWrapper ];
+  nativeBuildInputs = [ gradle_7 perl makeWrapper ];
+
+  # Point to our local deps repo
+  gradleInit = writeText "init.gradle" ''
+    logger.lifecycle 'Replacing Maven repositories with ${deps}...'
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${deps}' }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          maven { url '${deps}' }
+        }
+      }
+    }
+  '';
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)
 
-    # point to offline repo
-    find . -type f -name build.gradle \
-      -exec perl -i.bak3 -pe "s#repositories\.jcenter\(\)#
-                                repositories { mavenLocal(); maven { url '${deps}' } }
-                               #" {} \;
-
-    gradle --offline --no-daemon distTar
+    gradle --offline --init-script ${gradleInit} --no-daemon tgz
   '';
 
   installPhase = ''
-    mkdir $out
-    tar xvf build/distributions/mucommander-${version}.tar --directory=$out --strip=1
-    wrapProgram $out/bin/mucommander \
+    mkdir -p $out/share/mucommander
+    tar xvf build/distributions/mucommander-*.tgz --directory=$out/share/mucommander
+
+    makeWrapper $out/share/mucommander/mucommander.sh $out/bin/mucommander \
       --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name} \
       --set JAVA_HOME ${jdk11}
   '';
 
   meta = with lib; {
-    homepage = "http://www.mucommander.com/";
+    homepage = "https://www.mucommander.com/";
     description = "Cross-platform file manager";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ jiegec ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/mucommander/mucommander/releases/tag/1.1.0-1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
