### PR TITLE
litebrowser, litehtml: init

### DIFF
--- a/pkgs/applications/networking/browsers/litebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/litebrowser/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, gtk3
+, gtkmm3
+, curl
+, poco
+, gumbo # litehtml dependency
+}:
+
+stdenv.mkDerivation {
+  pname = "litebrowser";
+  version = "unstable-2022-10-31";
+
+  src = fetchFromGitHub {
+    owner = "litehtml";
+    repo = "litebrowser-linux";
+    rev = "4654f8fb2d5e2deba7ac6223b6639341bd3b7eba";
+    hash = "sha256-SvW1AOxLBLKqa+/2u2Zn+/t33ZzQHmqlcLRl6z0rK9U=";
+    fetchSubmodules = true; # litehtml submodule
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    gtkmm3
+    curl
+    poco
+    gumbo
+  ];
+
+  cmakeFlags = [
+    "-DEXTERNAL_GUMBO=ON"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 litebrowser $out/bin/litebrowser
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple browser based on the litehtml engine";
+    homepage = "https://github.com/litehtml/litebrowser-linux";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/development/libraries/litehtml/default.nix
+++ b/pkgs/development/libraries/litehtml/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gumbo
+}:
+
+stdenv.mkDerivation rec {
+  pname = "litehtml";
+  version = "0.6";
+
+  src = fetchFromGitHub {
+    owner = "litehtml";
+    repo = "litehtml";
+    rev = "v${version}";
+    hash = "sha256-9571d3k8RkzEpMWPuIejZ7njLmYstSwFUaSqT3sk6uQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gumbo
+  ];
+
+  cmakeFlags = [
+    "-DEXTERNAL_GUMBO=ON"
+  ];
+
+  meta = with lib; {
+    description = "Fast and lightweight HTML/CSS rendering engine";
+    homepage = "http://www.litehtml.com/";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29946,6 +29946,8 @@ with pkgs;
 
   lingot = callPackage ../applications/audio/lingot { };
 
+  litebrowser = callPackage ../applications/networking/browsers/litebrowser { };
+
   littlegptracker = callPackage ../applications/audio/littlegptracker {
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21086,6 +21086,8 @@ with pkgs;
 
   liquidfun = callPackage ../development/libraries/liquidfun { };
 
+  litehtml = callPackage ../development/libraries/litehtml { };
+
   live555 = callPackage ../development/libraries/live555 { };
 
   log4cpp = callPackage ../development/libraries/log4cpp { };


### PR DESCRIPTION
###### Description of changes

A simple web browser
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
