### PR TITLE
aaxtomp3: init at 1.3

### DIFF
--- a/pkgs/applications/audio/aaxtomp3/default.nix
+++ b/pkgs/applications/audio/aaxtomp3/default.nix
@@ -1,0 +1,56 @@
+{ coreutils
+, fetchFromGitHub
+, ffmpeg
+, findutils
+, gnugrep
+, gnused
+, jq
+, lame
+, lib
+, makeWrapper
+, mediainfo
+, mp4v2
+, stdenv
+}:
+let
+  runtimeInputs = [
+    coreutils
+    ffmpeg
+    findutils
+    gnugrep
+    gnused
+    jq
+    lame
+    mediainfo
+    mp4v2
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "aaxtomp3";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "krumpetpirate";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-7a9ZVvobWH/gPxa3cFiPL+vlu8h1Dxtcq0trm3HzlQg=";
+  };
+
+  dontBuild = false;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -Dm755 AAXtoMP3 $out/bin/aaxtomp3
+    wrapProgram $out/bin/aaxtomp3 --prefix PATH : ${lib.makeBinPath runtimeInputs}
+    install -Dm755 interactiveAAXtoMP3 $out/bin/interactiveaaxtomp3
+    wrapProgram $out/bin/interactiveaaxtomp3 --prefix PATH : ${lib.makeBinPath runtimeInputs}
+  '';
+
+  meta = with lib; {
+    description = "Convert Audible's .aax filetype to MP3, FLAC, M4A, or OPUS";
+    homepage = "https://krumpetpirate.github.io/AAXtoMP3";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27124,6 +27124,8 @@ with pkgs;
 
   aacgain = callPackage ../applications/audio/aacgain { };
 
+  aaxtomp3 = callPackage ../applications/audio/aaxtomp3 {};
+
   abcde = callPackage ../applications/audio/abcde {
     inherit (python3Packages) eyeD3;
   };


### PR DESCRIPTION

###### Description of changes

Fixes #197312

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
