### PR TITLE
super-tiny-icons: init at 2022-11-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5280,6 +5280,16 @@
     github = "gytis-ivaskevicius";
     githubId = 23264966;
   };
+  h7x4 = {
+    name = "h7x4";
+    email = "h7x4@nani.wtf";
+    matrix = "@h7x4:nani.wtf";
+    github = "h7x4";
+    githubId = 14929991;
+    keys = [{
+      fingerprint = "F7D3 7890 228A 9074 40E1  FD48 46B9 228E 814A 2AAC";
+    }];
+  };
   hagl = {
     email = "harald@glie.be";
     github = "hagl";

--- a/pkgs/data/icons/super-tiny-icons/default.nix
+++ b/pkgs/data/icons/super-tiny-icons/default.nix
@@ -1,0 +1,34 @@
+{ pkgs, lib, stdenvNoCC, fetchFromGitHub, }:
+
+stdenvNoCC.mkDerivation {
+  pname = "super-tiny-icons";
+  version = "unstable-2022-11-07";
+
+  src = fetchFromGitHub {
+    owner = "edent";
+    repo = "SuperTinyIcons";
+    rev = "b4d5a3be04c99ec0a309ac9e0d0b21207c237c7d";
+    sha256 = "670ndAuBrZBr7YOTQm2zHJfpiBC56aPk+ZKMneREEoI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons/SuperTinyIcons
+    find $src/images -type d -exec cp -r {} $out/share/icons/SuperTinyIcons/ \;
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Miniscule SVG versions of common logos";
+    longDescription = ''
+      Super Tiny Web Icons are minuscule SVG versions of your favourite logos.
+      The average size is under 568 bytes!
+    '';
+    homepage = "https://github.com/edent/SuperTinyIcons";
+    license = licenses.mit;
+    maintainers = [ maintainers.h7x4 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26839,6 +26839,8 @@ with pkgs;
 
   stix-two = callPackage ../data/fonts/stix-two { };
 
+  super-tiny-icons = callPackage ../data/icons/super-tiny-icons { };
+
   inherit (callPackages ../data/fonts/gdouros { })
     aegan aegyptus akkadian assyrian eemusic maya symbola textfonts unidings;
 


### PR DESCRIPTION
###### Description of changes

Packaged https://github.com/edent/SuperTinyIcons as a standalone icon package.

It is useful for all sorts of modules that uses icons, e.g [`services.jupyter.kernels.<name>.logo64`](https://search.nixos.org/options?channel=22.05&show=services.jupyter.kernels.%3Cname%3E.logo64&from=0&size=50&sort=relevance&type=packages&query=services.jupyter.)

This depends on #199767, because I added my maintainer entry there.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
