### PR TITLE
heroic: Add optional Wine dependencies

### DIFF
--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -52,6 +52,7 @@ buildFHSUserEnv {
     alsa-lib
     alsa-plugins
     bash
+    cabextract
     cairo
     coreutils
     cups

--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -49,21 +49,26 @@ buildFHSUserEnv {
     ];
   in pkgs: with pkgs; [
     alsa-lib
+    alsa-plugins
     bash
     cairo
     coreutils
     cups
     dbus
+    freealut
     freetype
     fribidi
     giflib
     glib
     gnutls
+    gst_all_1.gst-plugins-base
     gtk3
     lcms2
     libevdev
+    libgcrypt
     libGLU
     libglvnd
+    libgpg-error
     libjpeg
     libkrb5
     libmpeg2
@@ -83,16 +88,19 @@ buildFHSUserEnv {
     libxkbcommon
     libxml2
     mpg123
+    ncurses
     ocl-icd
     openldap
     pipewire
     samba4
     sane-backends
     SDL2
+    sqlite
     udev
     udev
     unixODBC
     util-linux
+    v4l-utils
     vulkan-loader
     wayland
     zlib

--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -12,6 +12,7 @@ buildFHSUserEnv {
 
   targetPkgs = pkgs: with pkgs; [
     heroic-unwrapped
+    gamemode
     curl
     gawk
     gnome.zenity


### PR DESCRIPTION
###### Description of changes
Add optional Wine dependencies following a guide that is strongly recommended by upstream: https://github.com/lutris/docs/blob/master/WineDependencies.md

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).