### PR TITLE
fetchgit: make sparseCheckout a list of strings

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -100,10 +100,10 @@ stdenv.mkDerivation {
   name = "hello";
   src = fetchgit {
     url = "https://...";
-    sparseCheckout = ''
-      directory/to/be/included
-      another/directory
-    '';
+    sparseCheckout = [
+      "directory/to/be/included"
+      "another/directory"
+    ];
     sha256 = "0000000000000000000000000000000000000000000000000000";
   };
 }

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -545,6 +545,15 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>fetchgit</literal> fetcher supports sparse
+          checkouts via the <literal>sparseCheckout</literal> option.
+          This used to accept a multi-line string with
+          directories/patterns to check out, but now requires a list of
+          strings.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>openssh</literal> was updated to version 9.1,
           disabling the generation of DSA keys when using
           <literal>ssh-keygen -A</literal> as they are insecure. Also,

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -179,6 +179,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - The `fetchgit` fetcher now uses [cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalscone_mode_handling) by default for sparse checkouts. [Non-cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems) can be enabled by passing `nonConeMode = true`, but note that non-cone mode is deprecated and this option may be removed alongside a future Git update without notice.
 
+- The `fetchgit` fetcher supports sparse checkouts via the `sparseCheckout` option. This used to accept a multi-line string with directories/patterns to check out, but now requires a list of strings.
+
 - `openssh` was updated to version 9.1, disabling the generation of DSA keys when using `ssh-keygen -A` as they are insecure. Also, `SetEnv` directives in `ssh_config` and `sshd_config` are now first-match-wins
 
 - `bsp-layout` no longer uses the command `cycle` to switch to other window layouts, as it got replaced by the commands `previous` and `next`.

--- a/pkgs/applications/misc/nerd-font-patcher/default.nix
+++ b/pkgs/applications/misc/nerd-font-patcher/default.nix
@@ -9,10 +9,10 @@ python3Packages.buildPythonApplication rec {
     owner = "ryanoasis";
     repo = "nerd-fonts";
     rev = "v${version}";
-    sparseCheckout = ''
-      font-patcher
-      /src/glyphs
-    '';
+    sparseCheckout = [
+      "font-patcher"
+      "/src/glyphs"
+    ];
     sha256 = "sha256-boZUd1PM8puc9BTgOwCJpkfk6VMdXLsIyp+fQmW/ZqI=";
   };
 

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -12,10 +12,10 @@
     name = "nix-source";
     url = "https://github.com/NixOS/nix";
     rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
-    sparseCheckout = ''
-      src
-      tests
-    '';
+    sparseCheckout = [
+      "src"
+      "tests"
+    ];
     sha256 = "sha256-g1PHGTWgAcd/+sXHo1o6AjVWCvC6HiocOfMbMh873LQ=";
   };
 
@@ -23,10 +23,10 @@
     name = "nix-source";
     url = "https://github.com/NixOS/nix";
     rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
-    sparseCheckout = ''
-      src
-      tests
-    '';
+    sparseCheckout = [
+      "src"
+      "tests"
+    ];
     nonConeMode = true;
     sha256 = "sha256-FknO6C/PSnMPfhUqObD4vsW4PhkwdmPa9blNzcNvJQ4=";
   };

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -3,7 +3,7 @@
 { owner, repo, rev, name ? "source"
 , fetchSubmodules ? false, leaveDotGit ? null
 , deepClone ? false, private ? false, forceFetchGit ? false
-, sparseCheckout ? ""
+, sparseCheckout ? []
 , githubBase ? "github.com", varPrefix ? null
 , meta ? { }
 , ... # For hash agility
@@ -24,7 +24,7 @@ let
   };
   passthruAttrs = removeAttrs args [ "owner" "repo" "rev" "fetchSubmodules" "forceFetchGit" "private" "githubBase" "varPrefix" ];
   varBase = "NIX${if varPrefix == null then "" else "_${varPrefix}"}_GITHUB_PRIVATE_";
-  useFetchGit = fetchSubmodules || (leaveDotGit == true) || deepClone || forceFetchGit || (sparseCheckout != "");
+  useFetchGit = fetchSubmodules || (leaveDotGit == true) || deepClone || forceFetchGit || !(sparseCheckout == "" || sparseCheckout == []);
   # We prefer fetchzip in cases we don't need submodules as the hash
   # is more stable in that case.
   fetcher = if useFetchGit then fetchgit else fetchzip;

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -71,7 +71,7 @@ let
         owner = "googlefonts";
         repo = "noto-cjk";
         inherit rev sha256;
-        sparseCheckout = "${typeface}/Variable/OTC";
+        sparseCheckout = [ "${typeface}/Variable/OTC" ];
       };
 
       installPhase = ''

--- a/pkgs/data/icons/beauty-line-icon-theme/default.nix
+++ b/pkgs/data/icons/beauty-line-icon-theme/default.nix
@@ -18,9 +18,9 @@ stdenvNoCC.mkDerivation rec {
     owner = "gvolpe";
     repo = pname;
     rev = version;
-    sparseCheckout = ''
-      BeautyLine-V3
-    '';
+    sparseCheckout = [
+      "BeautyLine-V3"
+    ];
     sha256 = "sha256-IkkypAj250+OXbf19TampCnqYsSbJVIjeYlxJoyhpzk=";
   };
 

--- a/pkgs/data/misc/colemak-dh/default.nix
+++ b/pkgs/data/misc/colemak-dh/default.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation rec {
     repo  = "mod-dh";
     rev = "e846a5bd24d59ed15ba70b3a9d5363a38ca51d09";
     sha256  = "sha256-RFOpN+tIMfakb7AZN0ock9eq2mytvL0DWedvQV67+ks=";
-    sparseCheckout = "console";
+    sparseCheckout = [ "console" ];
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/games/itch/default.nix
+++ b/pkgs/games/itch/default.nix
@@ -41,7 +41,7 @@ stdenvNoCC.mkDerivation rec {
         repo = pname;
         rev = "v${version}";
         hash = "sha256-DZBmf8fe0zw5uiQjNKXw8g/vU2hjNDa87z/7XuhyXog=";
-        inherit sparseCheckout;
+        sparseCheckout = [ sparseCheckout ];
       } + sparseCheckout;
 
   nativeBuildInputs = [ copyDesktopItems makeWrapper ];


### PR DESCRIPTION
###### Description of changes

        Then it should really be a list of strings rather than a multiline string.

_Originally posted by @SuperSandro2000 in https://github.com/NixOS/nixpkgs/pull/176950#discussion_r1012358360_

The `sparseCheckout` argument allows the user to specify names or
patterns of files, which Git uses to filter files it should check-out.

Git expects a multi-line string on stdin ("newline-delimited list", see
`git-sparse-checkout(1)`), but within nixpkgs it is more consistent to
use a list of strings instead. The list elements are joined to a
multi-line string only before passing it to the builder script.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages

I successfully built the fetchgit tests: `nix-build -A pkgs.tests.fetchgit` and the outputs looked fine.

- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


###### Open questions

- Should I add an entry to the release notes?
- Instead of a breaking change, should I add a compatibility layer for handling the multi-line string and add deprecation notice?
- Throw an error message if a string is passed instead of a list?
- Should the file/pattern list/array be passed to the `builder.sh` and concatenated to multi-line string in bash, or should the current approach concatenating strings in default.nix be kept?
- Should the current separated commits of this PR be squashed into a single commit?
