### PR TITLE
itd: init at 0.0.9

### DIFF
--- a/pkgs/applications/misc/itd/default.nix
+++ b/pkgs/applications/misc/itd/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, buildGoModule
+, fetchFromGitea
+}:
+
+buildGoModule rec {
+  pname = "itd";
+  version = "0.0.9";
+
+  # https://gitea.arsenm.dev/Arsen6331/itd/tags
+  src = fetchFromGitea {
+    domain = "gitea.arsenm.dev";
+    owner = "Arsen6331";
+    repo = "itd";
+    rev = "v${version}";
+    hash = "sha256-FefffF8YIEcB+eglifNWuuK7H5A1YXyxxZOXz1a8HfY=";
+  };
+
+  vendorHash = "sha256-LFzrpKQQ4nFoK4vVTzJDQ5OGDe1y5BSfXPX+FRVunjQ=";
+
+  preBuild = ''
+    echo r${version} > version.txt
+  '';
+
+  subPackages = [
+    "."
+    "cmd/itctl"
+  ];
+
+  postInstall = ''
+    install -Dm644 itd.toml $out/etc/itd.toml
+  '';
+
+  meta = with lib; {
+    description = "itd is a daemon to interact with the PineTime running InfiniTime";
+    homepage = "https://gitea.arsenm.dev/Arsen6331/itd";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mindavi raphaelr ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2768,6 +2768,8 @@ with pkgs;
 
   itch = callPackage ../games/itch {};
 
+  itd = callPackage ../applications/misc/itd { };
+
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };
 
   leetcode-cli = callPackage ../applications/misc/leetcode-cli { };


### PR DESCRIPTION
Note that (in my experience) the itd.toml file appears to be required for this to work.

###### Description of changes

Init itd at 0.0.9, 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested that the application works, including connecting to a pinetime device, reading out sensors and uploading new firmware and resources (the main reason to package this application is due to resource upload being supported by ITD, while it isn't (yet) in gadgetbridge).

There's some funky behavior on the pinetime, but nothing much to worry about, I think (step count being wrong, mainly). Updating firmware worked mostly fine, other than the pinetime not rebooting after the firmware update (but I give it a good chance that's just a bug in the software, nothing to do with the packaging here).

I disabled the GUI build for now, it could probably easily be enabled by adding some dependencies, haven't tried that. Since I don't care too much about running this for long, I also haven't done anything with the systemd service definition.

ITD stands for InfiniTime Daemon, I think.