### PR TITLE
root: enable davix and ssl support

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -5,6 +5,7 @@
 , makeWrapper
 , cmake
 , git
+, davix
 , ftgl
 , gl2ps
 , glew
@@ -22,6 +23,7 @@
 , lz4
 , xz
 , openblas
+, openssl
 , pcre
 , nlohmann_json
 , pkg-config
@@ -66,6 +68,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper cmake pkg-config git ];
   buildInputs = [
+    davix
     ftgl
     gl2ps
     glew
@@ -80,6 +83,7 @@ stdenv.mkDerivation rec {
     xz
     gsl
     openblas
+    openssl
     xxHash
     libAfterImage
     giflib
@@ -140,7 +144,7 @@ stdenv.mkDerivation rec {
     "-Dcastor=OFF"
     "-Dchirp=OFF"
     "-Dclad=OFF"
-    "-Ddavix=OFF"
+    "-Ddavix=ON"
     "-Ddcache=OFF"
     "-Dfail-on-missing=ON"
     "-Dfftw3=OFF"
@@ -164,7 +168,7 @@ stdenv.mkDerivation rec {
     "-Drfio=OFF"
     "-Droot7=OFF"
     "-Dsqlite=OFF"
-    "-Dssl=OFF"
+    "-Dssl=ON"
     "-Dtmva=ON"
     "-Dvdt=OFF"
     "-Dwebgui=OFF"


### PR DESCRIPTION
This patch enables CERN ROOT to open file urls with scheme `davs://` and `https://`. The above two functionality of the updated `root` package are tested on CERN LXPLUS.

The inclusion of `openssl` in buildInputs will increase neither the closure size nor the rebuild frequency, since `python3`, which depends on `openssl`, is already a dependency.

This simple change significantly increases the usability of the `root` package toward remote file access.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`) (Tested on CERN LXPLUS.)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
