### PR TITLE
nitter: patch source version/rev/url into about

### DIFF
--- a/pkgs/servers/nitter/default.nix
+++ b/pkgs/servers/nitter/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , nimPackages
 , nixosTests
+, substituteAll
 }:
 
 nimPackages.buildNimPackage rec {
@@ -14,6 +15,15 @@ nimPackages.buildNimPackage rec {
     rev = "138826fb4fbdec73fc6fee2e025fda88f7f2fb49";
     hash = "sha256-fdzVfzmEFIej6Kb/K9MQyvbN8aN3hO7RetHL53cD59k=";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./nitter-version.patch;
+      inherit version;
+      inherit (src) rev;
+      url = builtins.replaceStrings [ "archive" ".tar.gz" ] [ "commit" "" ] src.url;
+    })
+  ];
 
   buildInputs = with nimPackages; [
     flatty

--- a/pkgs/servers/nitter/nitter-version.patch
+++ b/pkgs/servers/nitter/nitter-version.patch
@@ -1,0 +1,17 @@
+diff --git a/src/views/about.nim b/src/views/about.nim
+index e7e8de9..54a6050 100644
+--- a/src/views/about.nim
++++ b/src/views/about.nim
+@@ -3,10 +3,8 @@ import os, strformat
+ import karax/[karaxdsl, vdom]
+ 
+ const
+-  date = staticExec("git show -s --format=\"%cd\" --date=format:\"%Y.%m.%d\"")
+-  hash = staticExec("git show -s --format=\"%h\"")
+-  link = "https://github.com/zedeus/nitter/commit/" & hash
+-  version = &"{date}-{hash}"
++  link = "@url@"
++  version = "@version@-@rev@"
+ 
+ var aboutHtml: string
+ 


### PR DESCRIPTION
###### Description of changes

As it stands, the Nitter in Nixpkgs isn't able to display the source date/revision in the about page.
This small patch injects the package `version`, and `rev`/`url` from `src` into the about page so it'll display properly.

For the sake of keeping it simple, I kept `version` wholesale instead of removing `unstable-`, however if that would be preferred, I can include it since it is pretty trivial to do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
