### PR TITLE
gfal2: init at 2.22.2; gfal2-python: init at 1.12.2; gfal2-util: init at 1.8.1

### DIFF
--- a/pkgs/by-name/gf/gfal2-util/package.nix
+++ b/pkgs/by-name/gf/gfal2-util/package.nix
@@ -1,0 +1,2 @@
+{ python3Packages }:
+with python3Packages; toPythonApplication gfal2-util

--- a/pkgs/by-name/gf/gfal2/package.nix
+++ b/pkgs/by-name/gf/gfal2/package.nix
@@ -1,0 +1,129 @@
+{ lib
+, stdenv
+, callPackage
+, fetchFromGitHub
+  # Native build inputs
+, cmake
+, pkg-config
+  # General build inputs
+, glib
+, gtest
+, json_c
+, openldap
+  # Plugin build inputs
+, cryptopp
+, davix-copy
+, dcap
+, libssh2
+, libuuid
+, pugixml
+, xrootd
+  # For enablePluginStatus.https only
+, gsoap
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gfal2";
+  version = "2.22.2";
+
+  src = fetchFromGitHub {
+    owner = "cern-fts";
+    repo = "gfal2";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-xcM29mZRUrnSE0//rHMaJFgPBeT6E4WdB9tCFa/y5+g=";
+  };
+
+  passthru.enablePluginStatus = {
+    # TODO: Change back to `true` once dcap is fixed on Darwin.
+    dcap = !dcap.meta.broken;
+    file = true;
+    gridftp = false;
+    # davix-copy's dependency gsoap is currently only available on Linux.
+    # TODO: Change back to `true` once gsoap is fixed on Darwin.
+    http = lib.meta.availableOn stdenv.hostPlatform gsoap;
+    lfc = false;
+    # Break because of redundant `-luuid`. This needs to be fixed from the gfal2 upstream.
+    # TODO: Change back to `true` once fixed.
+    mock = !stdenv.isDarwin;
+    rfio = false;
+    sftp = true;
+    srm = false;
+    xrootd = true;
+  };
+
+  passthru.tests = (
+    # Enable only one plugin in each test case,
+    # to ensure that they gets their dependency when invoked separately.
+    lib.listToAttrs
+      (map
+        (pluginName: lib.nameValuePair
+          "gfal2-${pluginName}"
+          (finalAttrs.finalPackage.overrideAttrs (previousAttrs: {
+            passthru = previousAttrs.passthru // {
+              enablePluginStatus = lib.mapAttrs (n: v: n == pluginName) previousAttrs.passthru.enablePluginStatus;
+            };
+          })))
+        (lib.filter (lib.flip lib.getAttr finalAttrs.passthru.enablePluginStatus) (lib.attrNames finalAttrs.passthru.enablePluginStatus))
+      )
+  ) // {
+    # Disable all plugins in this test case.
+    gfal2-minimal = finalAttrs.finalPackage.overrideAttrs (previousAttrs: {
+      passthru.enablePluginStatus = lib.mapAttrs (n: v: false) previousAttrs.passthru.enablePluginStatus;
+    });
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = lib.unique (
+    [
+      glib
+      json_c
+      # gfal2 version older than 2.21.1 fails to see openldap 2.5+
+      # and will complain
+      # bin/ld: cannot find -lldap_r: No such file or directory
+      # See https://github.com/cern-fts/gfal2/blob/aa24462bb67e259e525f26fb5feb97050a8c5c61/RELEASE-NOTES
+      openldap
+      pugixml # Optional, for MDS Cache.
+    ]
+    ++ lib.optionals finalAttrs.passthru.enablePluginStatus.dcap [ dcap ]
+    ++ lib.optionals finalAttrs.passthru.enablePluginStatus.http [ cryptopp davix-copy ]
+    ++ lib.optionals finalAttrs.passthru.enablePluginStatus.mock [ libuuid ]
+    ++ lib.optionals finalAttrs.passthru.enablePluginStatus.sftp [ libssh2 ]
+    ++ lib.optionals finalAttrs.passthru.enablePluginStatus.xrootd [ xrootd libuuid ]
+  );
+
+  cmakeFlags = (
+    map
+      (pluginName: "-DPLUGIN_${lib.toUpper pluginName}=${lib.toUpper (lib.boolToString finalAttrs.passthru.enablePluginStatus.${pluginName})}")
+      (lib.attrNames finalAttrs.passthru.enablePluginStatus)
+  )
+  ++ [ "-DSKIP_TESTS=${lib.toUpper (lib.boolToString (!finalAttrs.doCheck))}" ]
+  ++ lib.optionals finalAttrs.doCheck [ "-DGTEST_INCLUDE_DIR=${gtest.dev}/include" ]
+  ++ lib.optionals finalAttrs.passthru.enablePluginStatus.http [ "-DCRYPTOPP_INCLUDE_DIRS=${cryptopp.dev}/include/cryptopp" ]
+  ++ lib.optionals finalAttrs.passthru.enablePluginStatus.xrootd [ "-DXROOTD_INCLUDE_DIR=${xrootd.dev}/include/xrootd" ]
+  ;
+
+  doCheck = stdenv.hostPlatform.isLinux;
+
+  checkInputs = [
+    gtest
+  ];
+
+  meta = with lib; {
+    description = "Multi-protocol data management library by CERN";
+    longDescription = ''
+      GFAL (Grid File Access Library )
+      is a C library providing an abstraction layer of
+      the grid storage system complexity.
+      The complexity of the grid is hidden from the client side
+      behind a simple common POSIX API.
+    '';
+    homepage = "https://github.com/cern-fts/gfal2";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ShamrockLee ];
+    mainProgram = "gfal2";
+  };
+})

--- a/pkgs/development/python-modules/gfal2-python/default.nix
+++ b/pkgs/development/python-modules/gfal2-python/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, pkg-config
+, boost
+, gfal2
+, glib
+, pythonAtLeast
+  # For tests
+, gfal2-util ? null
+}:
+buildPythonPackage rec {
+  pname = "gfal2-python";
+  version = "1.12.2";
+  src = fetchFromGitHub {
+    owner = "cern-fts";
+    repo = "gfal2-python";
+    rev = "v${version}";
+    hash = "sha256-Xk+gLTrqfWb0kGB6QhnM62zAHVFb8rRAqCIBxn0V824=";
+  };
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    boost
+    gfal2
+    glib
+  ];
+  # We don't want setup.py to (re-)execute cmake in buildPhase
+  # Besides, this package is totally handled by CMake, which means no additional configuration is needed.
+  dontConfigure = true;
+  pythonImportsCheck = [
+    "gfal2"
+  ];
+  passthru = {
+    inherit gfal2;
+    tests = {
+      inherit gfal2-util;
+    }
+    // lib.optionalAttrs (gfal2-util != null) gfal2-util.tests or { };
+  };
+  meta = with lib; {
+    description = "Python binding for gfal2";
+    homepage = "https://github.com/cern-fts/gfal2-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ShamrockLee ];
+    # It currently fails to build against Python 3.12 or later,
+    # complaining CMake faililng to find Python include path, library path and site package path.
+    broken = pythonAtLeast "3.12";
+  };
+}

--- a/pkgs/development/python-modules/gfal2-util/default.nix
+++ b/pkgs/development/python-modules/gfal2-util/default.nix
@@ -1,0 +1,103 @@
+{ lib
+, buildPythonPackage
+, callPackage
+, fetchFromGitHub
+, runCommandLocal
+  # Build inputs
+, gfal2-python
+  # For tests
+, xrootd # pkgs.xrootd
+}:
+(buildPythonPackage rec {
+  pname = "gfal2-util";
+  version = "1.8.1";
+  src = fetchFromGitHub {
+    owner = "cern-fts";
+    repo = "gfal2-util";
+    rev = "v${version}";
+    hash = "sha256-3JbJgKD17aYkrB/aaww7IQU8fLFrTCh868KWlLPxmlk=";
+  };
+
+  # Replace the ad-hoc python executable finding
+  # and change the shebangs from `#!/bin/sh` to `#!/usr/bin/env python`
+  # for fixup phase to work correctly.
+  postPatch = ''
+    for script in src/gfal-*; do
+      patch "$script" ${./gfal-util-script.patch}
+    done
+  '';
+
+  propagatedBuildInputs = [
+    gfal2-python
+  ];
+
+  pythonImportsCheck = [
+    "gfal2_util"
+  ];
+
+  meta = with lib; {
+    description = "CLI for gfal2";
+    homepage = "https://github.com/cern-fts/gfal2-utils";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}).overrideAttrs (finalAttrs: previousAttrs: lib.recursiveUpdate previousAttrs {
+  passthru = {
+    inherit (gfal2-python) gfal2;
+
+    fetchGfal2 = lib.makeOverridable (callPackage ./fetchgfal2.nix { gfal2-util = finalAttrs.finalPackage; });
+
+    # With these functionality tests, it should be safe to merge version bumps once all the tests are passed.
+    tests =
+      let
+        # Use the the bin output hash of gfal2-util as version to ensure that
+        # the test gets rebuild everytime gfal2-util gets rebuild
+        versionFODTests = finalAttrs.version + "-" + lib.substring (lib.stringLength builtins.storeDir + 1) 32 "${self}";
+        self = finalAttrs.finalPackage;
+      in
+      lib.optionalAttrs gfal2-python.gfal2.enablePluginStatus.xrootd (
+        let
+          # Test against a real-world dataset from CERN Open Data
+          # borrowed from `xrootd.tests`.
+          urlTestFile = xrootd.tests.test-xrdcp.url;
+          hashTestFile = xrootd.tests.test-xrdcp.outputHash;
+          urlTestDir = dirOf urlTestFile;
+        in
+        {
+          test-copy-file-xrootd = finalAttrs.passthru.fetchGfal2 {
+            url = urlTestFile;
+            hash = hashTestFile;
+            extraGfalCopyFlags = [ "--verbose" ];
+            pname = "gfal2-util-test-copy-file-xrootd";
+            version = versionFODTests;
+            allowSubstitutes = false;
+          };
+
+          test-copy-dir-xrootd = finalAttrs.passthru.fetchGfal2 {
+            url = urlTestDir;
+            hash = "sha256-vOahIhvx1oE9sfkqANMGUvGeLHS737wyfYWo4rkvrxw=";
+            recursive = true;
+            extraGfalCopyFlags = [ "--verbose" ];
+            pname = "gfal2-util-test-copy-dir-xrootd";
+            version = versionFODTests;
+            allowSubstitutes = false;
+          };
+
+          test-ls-dir-xrootd = (runCommandLocal "test-gfal2-util-ls-dir-xrootd" { } ''
+            set -eu -o pipefail
+            gfal-ls "$url" | grep "$baseNameExpected" | tee "$out"
+          '').overrideAttrs (finalAttrs: previousAttrs: {
+            pname = previousAttrs.name;
+            version = versionFODTests;
+            name = "${finalAttrs.pname}-${finalAttrs.version}";
+            nativeBuildInputs = [ self ];
+            url = urlTestDir;
+            baseNameExpected = baseNameOf urlTestFile;
+            outputHashMode = "flat";
+            outputHashAlgo = "sha256";
+            outputHash = builtins.hashString finalAttrs.outputHashAlgo (finalAttrs.baseNameExpected + "\n");
+          });
+        }
+      );
+  };
+})

--- a/pkgs/development/python-modules/gfal2-util/fetchgfal2.nix
+++ b/pkgs/development/python-modules/gfal2-util/fetchgfal2.nix
@@ -1,0 +1,48 @@
+{ lib
+, runCommandLocal
+, gfal2-util
+}:
+
+# `url` and `urls` should only be overriden via `<pkg>.override`, but not `<pkg>.overrideAttrs`.
+{ name ? ""
+, pname ? ""
+, version ? ""
+, urls ? [ ]
+, url ? if urls == [ ] then abort "Expect either non-empty `urls` or `url`" else lib.head urls
+, hash ? lib.fakeHash
+, recursive ? false
+, intermediateDestUrls ? [ ]
+, extraGfalCopyFlags ? [ ]
+, allowSubstitutes ? true
+}:
+
+(runCommandLocal name { } ''
+  for u in "''${urls[@]}"; do
+    gfal-copy "''${gfalCopyFlags[@]}" "$u" "''${intermediateDestUrls[@]}" "$out"
+    ret="$?"
+    (( ret )) && break
+  done
+  if (( ret )); then
+    echo "gfal-copy failed trying to download from any of the urls" >&2
+    exit "$ret"
+  fi
+'').overrideAttrs (finalAttrs: previousAttrs:
+{
+  __structuredAttrs = true;
+  inherit allowSubstitutes;
+  nativeBuildInputs = [ gfal2-util ];
+  outputHashAlgo = null;
+  outputHashMode = if finalAttrs.recursive then "recursive" else "flat";
+  outputHash = hash;
+  inherit url;
+  urls = if urls == [ ] then lib.singleton url else urls;
+  gfalCopyFlags = extraGfalCopyFlags
+  ++ lib.optional finalAttrs.recursive "--recursive"
+  ;
+  inherit recursive intermediateDestUrls;
+} // (if (pname != "" && version != "") then {
+  inherit pname version;
+  name = "${finalAttrs.pname}-${finalAttrs.version}";
+} else {
+  name = if (name != "") then name else (baseNameOf url);
+}))

--- a/pkgs/development/python-modules/gfal2-util/gfal-util-script.patch
+++ b/pkgs/development/python-modules/gfal2-util/gfal-util-script.patch
@@ -1,0 +1,19 @@
+--- a/gfal-SCRIPT_NAME	2022-11-17 00:00:00.000000000 +0000
++++ b/gfal-SCRIPT_NAME	2022-11-17 00:00:00.000000000 +0000
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/usr/bin/env python3
+ # -*- coding: utf-8 -*-
+ #
+ # Copyright (c) 2022 CERN
+@@ -15,10 +15,2 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-
+-# Execute script content with first python interpreter found:
+-# * GFAL_PYTHONBIN environment variable
+-# * python on the PATH if import gfal2, gfal2_util succeeds
+-# * python3 on the PATH if import gfal2, gfal2_util succeeds
+-# * python2 on the PATH if import gfal2, gfal2_util succeeds
+-# * /usr/bin/python
+-"exec" "$(  check_interpreter() { unalias $1 2> /dev/null; unset $1; GFAL_PYTHONBIN=$(command -v $1); [ $GFAL_PYTHONBIN ] && $GFAL_PYTHONBIN -c 'import gfal2, gfal2_util' > /dev/null 2>&1 && { echo $GFAL_PYTHONBIN; unset GFAL_PYTHONBIN; }; }; [ $GFAL_PYTHONBIN ] && echo $GFAL_PYTHONBIN || check_interpreter python || check_interpreter python3 || check_interpreter python2 || echo /usr/bin/python )" "-u" "-Wignore" "$0" "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1834,6 +1834,12 @@ with pkgs;
 
   github-copilot-cli = callPackage ../tools/misc/github-copilot-cli { };
 
+  # This is to workaround gfal2-python broken against Python 3.12 or later.
+  # TODO: Remove these lines after solving the breakage.
+  gfal2-util = callPackage ../by-name/gf/gfal2-util/package.nix (lib.optionalAttrs python3Packages.gfal2-python.meta.broken {
+    python3Packages = python311Packages;
+  });
+
   gfshare = callPackage ../tools/security/gfshare { };
 
   gh-actions-cache = callPackage ../tools/misc/gh-actions-cache { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4687,6 +4687,10 @@ self: super: with self; {
 
   gfal2-python = callPackage ../development/python-modules/gfal2-python { };
 
+  gfal2-util = callPackage ../development/python-modules/gfal2-util {
+    inherit (pkgs) xrootd;
+  };
+
   gflags = callPackage ../development/python-modules/gflags { };
 
   gflanguages = callPackage ../development/python-modules/gflanguages { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4685,6 +4685,8 @@ self: super: with self; {
 
   gevent-websocket = callPackage ../development/python-modules/gevent-websocket { };
 
+  gfal2-python = callPackage ../development/python-modules/gfal2-python { };
+
   gflags = callPackage ../development/python-modules/gflags { };
 
   gflanguages = callPackage ../development/python-modules/gflanguages { };


### PR DESCRIPTION
###### Description of changes

Gfal2, Grid File Access Library v2, provides a layer of abstraction and unified (POSIX-like) way to access different kinds of GRID storage systems.

https://dmc-docs.web.cern.ch/dmc-docs/gfal2/gfal2.html

This PR includes the [C library](https://github.com/cern-fts/gfal2) (`gfal2`), its [Python binding](https://github.com/cern-fts/gfal2-python) (`gfal2-python`) and [command-line utilities](https://github.com/cern-fts/gfal2-util) (`gfal2-util`). Now we have `gfal-ls` and `gfal-copy` in Nixpkgs!

~This PR also mark `xrootd` as broken. Due to #169677, the package is not usable.~

Cc: @veprbl

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
