### PR TITLE
webp-pixbuf-loader: 0.0.6 -> 0.0.7

### DIFF
--- a/pkgs/development/libraries/webp-pixbuf-loader/default.nix
+++ b/pkgs/development/libraries/webp-pixbuf-loader/default.nix
@@ -18,17 +18,17 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "webp-pixbuf-loader";
-  version = "0.0.6";
+  version = "0.0.7";
 
   src = fetchFromGitHub {
     owner = "aruiz";
     repo = "webp-pixbuf-loader";
     rev = version;
-    sha256 = "sha256-dcdydWYrXZJjo4FxJtvzGzrQLOs87/BmxshFZwsT2ws=";
+    sha256 = "sha256-Za5/9YlDRqF5oGI8ZfLhx2ZT0XvXK6Z0h6fu5CGvizc=";
   };
 
   nativeBuildInputs = [
-    gdk-pixbuf
+    gdk-pixbuf.dev
     meson
     ninja
     pkg-config
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgdk_pixbuf_query_loaders_path=${gdk-pixbuf.dev}/bin/gdk-pixbuf-query-loaders"
     "-Dgdk_pixbuf_moduledir=${placeholder "out"}/${moduleDir}"
   ];
 
@@ -51,13 +50,11 @@ stdenv.mkDerivation rec {
       --replace "@bindir@/gdk-pixbuf-thumbnailer" "$out/bin/webp-thumbnailer"
   '';
 
-  preInstall = ''
-    # environment variables controlling loaders.cache generation by gdk-pixbuf-query-loaders
-    export GDK_PIXBUF_MODULE_FILE="$out/${loadersPath}"
-    export GDK_PIXBUF_MODULEDIR="$out/${moduleDir}"
-  '';
-
   postInstall = ''
+    GDK_PIXBUF_MODULE_FILE="$out/${loadersPath}" \
+    GDK_PIXBUF_MODULEDIR="$out/${moduleDir}" \
+    gdk-pixbuf-query-loaders --update-cache
+
     # It assumes gdk-pixbuf-thumbnailer can find the webp loader in the loaders.cache referenced by environment variable, breaking containment.
     # So we replace it with a wrapped executable.
     mkdir -p "$out/bin"
@@ -71,7 +68,5 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;
     maintainers = teams.gnome.members ++ [ maintainers.cwyc ];
-    # meson.build:16:0: ERROR: Program or command 'gcc' not found or not executable
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes
Updates package.
Includes changes to build procedure because upstream was restructured to leave loaders.cache generation to the distribution.

Changelog: https://github.com/aruiz/webp-pixbuf-loader/releases/tag/0.0.7
`meson improvements and BSD compatibility`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
