### PR TITLE
Fix for darwin build.

### DIFF
--- a/pkgs/applications/science/logic/surelog/default.nix
+++ b/pkgs/applications/science/logic/surelog/default.nix
@@ -7,19 +7,32 @@
 , libuuid
 , openjdk11
 , gperftools
+, flatbuffers
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   pname = "surelog";
-  version = "1.40";
+  version = "1.45";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-5nhJilFIJJDCnJUEUgyPNtWSQUgWcvM6LDFgFatAl/k=";
+    hash = "sha256-/SSKcEIhmWDOKN4v3djWTwZ5/nQvR8ibflzSVFDt/rM=";
     fetchSubmodules = true;
   };
+
+  # This prevents race conditions in unit tests that surface since we run
+  # ctest in parallel.
+  # This patch can be removed with the next version of surelog
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/chipsalliance/Surelog/commit/9a54efbd156becf65311a4272104810f36041fa6.patch";
+      sha256 = "sha256-rU1Z/0wlVTgnPLqTN/87n+gI1iJ+6k/+sunVVd0ulhQ=";
+      name = "parallel-test-running.patch";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -34,6 +47,11 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libuuid
     gperftools
+    flatbuffers
+  ];
+
+  cmakeFlags = [
+    "-DSURELOG_USE_HOST_FLATBUFFERS=On"
   ];
 
   doCheck = true;

--- a/pkgs/applications/science/logic/uhdm/default.nix
+++ b/pkgs/applications/science/logic/uhdm/default.nix
@@ -3,19 +3,34 @@
 , fetchFromGitHub
 , cmake
 , python3
+, gtest
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   pname = "UHDM";
-  version = "0.9.1.40";
+  version = "1.45";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-CliKU2WM8B9012aDcS/mTyIf+JcsVsc4uRRi9+FRWbM=";
+    hash = "sha256-mxQRmI8yUUrSUYa4kUT9URgfqYvuz3V9e1IGjtiHyhc=";
     fetchSubmodules = true;
   };
+
+  # Add ability to use local googletest provided from nix instead of
+  # the version from the submodule in third_party/. The third_party/ version
+  # is slightly older and does not work with our hydra Darwin builds that needs
+  # to set a particular temp directory.
+  # This patch allows to choose UHDM_USE_HOST_GTEST=On in the cflags.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/chipsalliance/UHDM/commit/ad60fdb65a7c49fdc8ee3fffdca791f9364af4f5.patch";
+      sha256 = "sha256-IkwnepWWmBychJ0mu+kaddUEc9jkldIRq+GyJkhrO8A=";
+      name = "allow-local-gtest.patch";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -23,6 +38,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     (python3.withPackages (p: with p; [ orderedmultidict ]))
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DUHDM_USE_HOST_GTEST=On"
   ];
 
   doCheck = true;
@@ -31,12 +51,6 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mv $out/lib/uhdm/* $out/lib/
     rm -rf $out/lib/uhdm
-  '';
-
-  prePatch = ''
-    substituteInPlace CMakeLists.txt --replace \
-    'capnp compile' \
-    'capnp compile --src-prefix=''${GENDIR}/..'
   '';
 
   meta = {

--- a/pkgs/development/compilers/yosys/plugins/symbiflow.nix
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow.nix
@@ -9,16 +9,17 @@
 , yosys-symbiflow
 , uhdm
 , surelog
+, flatbuffers
 }: let
 
   src = fetchFromGitHub {
     owner  = "chipsalliance";
     repo   = "yosys-f4pga-plugins";
-    rev    = "27208ce08200a5e89e3bd4f466bc68824df38c32";
-    hash   = "sha256-S7txjzlIp+idWIfp/DDOznluA3aMFfosMUt5dvi+g44=";
+    rev    = "e23ff6db487da9ceea576c53ac33853566c3a84e";
+    hash   = "sha256-HJ4br6lQwRrcnkLgV3aecr3T3zcPzA11MfxhRjwIb0I=";
   };
 
-  version = "2022.09.27";
+  version = "2022.11.07";
 
   # Supported symbiflow plugins.
   #
@@ -60,6 +61,7 @@ in lib.genAttrs plugins (plugin: stdenv.mkDerivation (rec {
   patches = lib.optional ( plugin == "ql-qlf" ) ./symbiflow-pmgen.patch;
 
   preBuild = ''
+    export LDFLAGS="-L${flatbuffers}/lib"
     mkdir -p ql-qlf-plugin/pmgen
   ''
   + lib.optionalString ( plugin == "ql-qlf" ) ''
@@ -68,8 +70,8 @@ in lib.genAttrs plugins (plugin: stdenv.mkDerivation (rec {
 
   # Providing a symlink avoids the need for patching the test makefile
   postUnpack = ''
-    mkdir -p source/third_party/googletest/googletest/build/
-    ln -s ${static_gtest}/lib source/third_party/googletest/googletest/build/lib
+    mkdir -p source/third_party/googletest/build/
+    ln -s ${static_gtest}/lib source/third_party/googletest/build/lib
   '';
 
   makeFlags = [


### PR DESCRIPTION
Related: #199919 as this is fixing the Darwin build.

###### Description of changes

Update Surelog/UHDM to latest 1.45, which uses the googletest version that can deal with temporary directories on Darwin (the current 1.12.x  [works with environment variables](https://github.com/google/googletest/commit/5e6a533680fc8292c31f31664d80c48440d4a526) on _all_ platforms to determine temp-dir, while previous versions did not and, on Darwin, just assumed `/tmp` which did not work in the nix build environment)

Update corresponding f4pga plugin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) (using **ofborg**)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable (check phase of affected packages on all platforms ran)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
