### PR TITLE
wtwitch: init at 2.6.0

### DIFF
--- a/pkgs/tools/video/wtwitch/default.nix
+++ b/pkgs/tools/video/wtwitch/default.nix
@@ -1,0 +1,73 @@
+{ bash
+, coreutils-prefixed
+, curl
+, fetchFromGitHub
+, gnused
+, gnugrep
+, installShellFiles
+, jq
+, lib
+, makeWrapper
+, mplayer
+, mpv
+, ncurses
+, procps
+, scdoc
+, stdenv
+, streamlink
+, sudo
+, vlc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wtwitch";
+  version = "2.6.0";
+
+  src = fetchFromGitHub {
+    owner = "krathalan";
+    repo = pname;
+    rev = version;
+    hash = "sha256-KkuXZOquihY3IRVp4FM+AdN3kYi0MqmrXFuNmydTpio=";
+  };
+
+  # hardcode SCRIPT_NAME because #150841
+  postPatch = ''
+    substituteInPlace src/wtwitch --replace 'readonly SCRIPT_NAME="''${0##*/}"' 'readonly SCRIPT_NAME="wtwitch"'
+  '';
+
+  buildPhase = ''
+    scdoc < src/wtwitch.1.scd > wtwitch.1
+  '';
+
+  nativeBuildInputs = [ scdoc installShellFiles makeWrapper ];
+
+  installPhase = ''
+    installManPage wtwitch.1
+    installShellCompletion --cmd wtwitch \
+      --bash src/wtwitch-completion.bash \
+      --zsh src/_wtwitch
+    install -Dm755 src/wtwitch $out/bin/wtwitch
+    wrapProgram $out/bin/wtwitch \
+      --set-default LANG en_US.UTF-8 \
+      --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.isLinux [ vlc ] ++ [
+        bash
+        coreutils-prefixed
+        curl
+        gnused
+        gnugrep
+        jq
+        mplayer
+        mpv
+        procps
+        streamlink
+      ])}
+  '';
+
+  meta = with lib; {
+    description = "Terminal user interface for Twitch";
+    homepage = "https://github.com/krathalan/wtwitch";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ urandom ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1499,6 +1499,8 @@ with pkgs;
     wine = wineWowPackages.staging;
   };
 
+  wtwitch = callPackage ../tools/video/wtwitch {};
+
   wwcd = callPackage ../tools/misc/wwcd { };
 
   writedisk = callPackage ../tools/misc/writedisk { };


### PR DESCRIPTION


###### Description of changes
Fixes #184685
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
