### PR TITLE
julia: refresh patches, disable failing Zlib_jll version test

### DIFF
--- a/pkgs/development/compilers/julia/patches/1.8/0001-skip-symlink-system-libraries.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0001-skip-symlink-system-libraries.patch
@@ -1,4 +1,4 @@
-From f342b6bfab5eee9c7fea9ddc8804d9a5ff6953eb Mon Sep 17 00:00:00 2001
+From 1faa30525c9671ffd3a08901896b521a040d7e5c Mon Sep 17 00:00:00 2001
 From: Nick Cao <nickcao@nichi.co>
 Date: Tue, 20 Sep 2022 18:42:08 +0800
 Subject: [PATCH 1/4] skip symlink system libraries
@@ -8,7 +8,7 @@ Subject: [PATCH 1/4] skip symlink system libraries
  1 file changed, 2 deletions(-)
 
 diff --git a/base/Makefile b/base/Makefile
-index 23a9c40..12f92aa 100644
+index 23a9c4011..12f92aa05 100644
 --- a/base/Makefile
 +++ b/base/Makefile
 @@ -181,7 +181,6 @@ $$(build_private_libdir)/$$(libname_$2):
@@ -28,5 +28,5 @@ index 23a9c40..12f92aa 100644
  endif
  
 -- 
-2.37.2
+2.38.1
 

--- a/pkgs/development/compilers/julia/patches/1.8/0002-skip-building-doc.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0002-skip-building-doc.patch
@@ -1,4 +1,4 @@
-From 6a7723be33261cdc302e0f7bdb37fb50d30cc5fc Mon Sep 17 00:00:00 2001
+From 05c008dcabaf94f5623f2f7e267005eef0a8c5fc Mon Sep 17 00:00:00 2001
 From: Nick Cao <nickcao@nichi.co>
 Date: Tue, 20 Sep 2022 18:42:31 +0800
 Subject: [PATCH 2/4] skip building doc
@@ -8,7 +8,7 @@ Subject: [PATCH 2/4] skip building doc
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index d38311d..a775d36 100644
+index d38311dce..a775d36e1 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -227,7 +227,7 @@ define stringreplace
@@ -21,5 +21,5 @@ index d38311d..a775d36 100644
  	@$(MAKE) $(QUIET_MAKE) all
  else
 -- 
-2.37.2
+2.38.1
 

--- a/pkgs/development/compilers/julia/patches/1.8/0003-skip-failing-tests.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0003-skip-failing-tests.patch
@@ -1,4 +1,4 @@
-From a57c582eabc4703ed627b32f7f11893db9676fb6 Mon Sep 17 00:00:00 2001
+From 756d4e977f8f224e20effa82c612e5a9cc14d82e Mon Sep 17 00:00:00 2001
 From: Nick Cao <nickcao@nichi.co>
 Date: Tue, 20 Sep 2022 18:42:59 +0800
 Subject: [PATCH 3/4] skip failing tests
@@ -8,7 +8,7 @@ Subject: [PATCH 3/4] skip failing tests
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/test/Makefile b/test/Makefile
-index 24e137a..0e82acf 100644
+index 24e137a5b..c17ccea8a 100644
 --- a/test/Makefile
 +++ b/test/Makefile
 @@ -23,7 +23,7 @@ default:
@@ -16,10 +16,10 @@ index 24e137a..0e82acf 100644
  $(TESTS):
  	@cd $(SRCDIR) && \
 -	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
-+	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --skip LibGit2_jll --skip MozillaCACerts_jll --skip NetworkOptions --skip nghttp2_jll $@)
++	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --skip LibGit2_jll --skip MozillaCACerts_jll --skip NetworkOptions --skip nghttp2_jll --skip Zlib_jll $@)
  
  $(addprefix revise-, $(TESTS)): revise-% :
  	@cd $(SRCDIR) && \
 -- 
-2.37.2
+2.38.1
 

--- a/pkgs/development/compilers/julia/patches/1.8/0004-ignore-absolute-path-when-loading-library.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0004-ignore-absolute-path-when-loading-library.patch
@@ -1,4 +1,4 @@
-From a60100f06f48fbb4697aced65175bf3d41185e3e Mon Sep 17 00:00:00 2001
+From c0e587f4c50bd7bedfe6e5102e9b47c9704fac9b Mon Sep 17 00:00:00 2001
 From: Nick Cao <nickcao@nichi.co>
 Date: Tue, 20 Sep 2022 18:43:15 +0800
 Subject: [PATCH 4/4] ignore absolute path when loading library
@@ -8,7 +8,7 @@ Subject: [PATCH 4/4] ignore absolute path when loading library
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/cli/loader_lib.c b/cli/loader_lib.c
-index 0301b6e..5cbda61 100644
+index 0301b6eed..5cbda61af 100644
 --- a/cli/loader_lib.c
 +++ b/cli/loader_lib.c
 @@ -50,9 +50,7 @@ static void * load_library(const char * rel_path, const char * src_dir, int err)
@@ -23,5 +23,5 @@ index 0301b6e..5cbda61 100644
  #if defined(_OS_WINDOWS_)
      wchar_t wpath[2*JL_PATH_MAX + 1] = {0};
 -- 
-2.37.2
+2.38.1
 


### PR DESCRIPTION
###### Description of changes
ZHF: #199919
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
