### PR TITLE
superd: init at 0.7

### DIFF
--- a/pkgs/misc/superd/default.nix
+++ b/pkgs/misc/superd/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+, installShellFiles
+, scdoc
+}:
+
+buildGoModule rec {
+  pname = "superd";
+  version = "0.7";
+
+  src = fetchFromSourcehut {
+    owner = "~craftyguy";
+    repo = pname;
+    rev = version;
+    hash = "sha256-XSB6qgepWhus15lOP9GzbiNoOCSsy6xLij7ic3LFs1E=";
+  };
+
+  vendorHash = "sha256-Oa99U3THyWLjH+kWMQAHO5QAS2mmtY7M7leej+gnEqo=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    scdoc
+  ];
+
+  postBuild = ''
+    make doc
+  '';
+
+  postInstall = ''
+    installManPage superd.1 superd.service.5 superctl.1
+    installShellCompletion --bash completions/bash/superctl
+    installShellCompletion --zsh completions/zsh/superctl
+  '';
+
+  meta = with lib; {
+    description = "Unprivileged user service supervisor";
+    homepage = "https://sr.ht/~craftyguy/superd/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ chuangzhu wentam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36962,6 +36962,8 @@ with pkgs;
 
   stork = callPackage ../applications/misc/stork { };
 
+  superd = callPackage ../misc/superd { };
+
   oclgrind = callPackage ../development/tools/analysis/oclgrind { };
 
   opkg = callPackage ../tools/package-management/opkg { };


### PR DESCRIPTION
###### Description of changes

Unprivileged user service supervisor. Upstream-ed from [here](https://github.com/wentam/sxmo-nix/blob/main/pkgs/superd/default.nix) and [here](https://github.com/chuangzhu/nixpkgs-sxmo/blob/master/superd.nix). This is a dependency of [sxmo](https://sxmo.org/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-linux.pkgsCross.aarch64-multiplatform
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
