### PR TITLE
mdbook-open-on-gh: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/tools/text/mdbook-open-on-gh/default.nix
+++ b/pkgs/tools/text/mdbook-open-on-gh/default.nix
@@ -1,26 +1,17 @@
-{ lib, rustPlatform, fetchFromGitHub, fetchpatch }:
+{ lib, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook-open-on-gh";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "badboy";
     repo = pname;
-    rev = "2.2.0";
-    hash = "sha256-x7ESuXoF5dYnJZpgDyYliVixCG4w/VX/Vhm3VqxsiEI=";
+    rev = version;
+    hash = "sha256-omQTyJ7XKRBjX8jyWLONajAYnwr93nElrwDLdvs2MxM=";
   };
 
-  cargoPatches = [
-    # https://github.com/badboy/mdbook-open-on-gh/pull/7
-    (fetchpatch {
-      name = "update-mdbook-for-rust-1.64.patch";
-      url = "https://github.com/badboy/mdbook-open-on-gh/commit/bd20601bfcec144c9302b1ba1a1aff4b95b334d9.patch";
-      hash = "sha256-3Df9Q3sqCpZzqCN9fi+wdeWjLUW4XdywIS3QUjsDE9g=";
-    })
-  ];
-
-  cargoHash = "sha256-N0RwengTWk4luPIecIxzbFReGi+PtE77FJalPq1CdbA=";
+  cargoHash = "sha256-57KcqALWbiGtp6HWSN42gZ0St38oHu3inZ0TT77j7go=";
 
   meta = with lib; {
     description = "mdbook preprocessor to add a open-on-github link on every page";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
