### PR TITLE
fwbuilder: disable blanket `-Werror`

### DIFF
--- a/pkgs/tools/security/fwbuilder/default.nix
+++ b/pkgs/tools/security/fwbuilder/default.nix
@@ -20,6 +20,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-j5HjGcIqq93Ca9OBqEgSotoSXyw+q6Fqxa3hKk1ctwQ=";
   };
 
+  postPatch = ''
+    # Avoid blanket -Werror as it triggers on any minor compiler
+    # warnings like deprecated functions or invalid indentat8ion.
+    # Leave fixing these problems to upstream.
+    substituteInPlace CMakeLists.txt --replace ';-Werror;' ';'
+  '';
+
   nativeBuildInputs = [
     cmake
     wrapQtAppsHook
@@ -29,10 +36,6 @@ stdenv.mkDerivation rec {
     wayland
     wayland-protocols
     qtwayland
-  ];
-
-  NIX_CFLAGS_COMPILE = [
-    "-Wno-error=misleading-indentation"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
`-Werror` flag usually causes build failures due to minor changes in compiler versions. They might be useful for developers themselves but are rarely useful for distributions.

This time the change fixes `fwbuilder` build against newer `libxml2`:

    libfwbuilder/src/fwbuilder/XMLTools.cpp: In static member function 'static void libfwbuilder::XMLTools::initXMLTools()':
    libfwbuilder/src/fwbuilder/XMLTools.cpp:222:18: error: 'int xmlInitMemory()' is deprecated [-Werror=deprecated-declarations]
      222 |     xmlInitMemory();
          |     ~~~~~~~~~~~~~^~

ZFH: https://github.com/NixOS/nixpkgs/issues/199919

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
