### PR TITLE
ocamlPackages.js_of_ocaml-ocamlbuild: 4.0.0 → 5.0

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
@@ -1,26 +1,24 @@
-{ lib, buildDunePackage, fetchFromGitHub
+{ lib, buildDunePackage, fetchurl
 , ocamlbuild
 }:
 
 buildDunePackage rec {
   pname = "js_of_ocaml-ocamlbuild";
-  version = "4.0.0";
+  version = "5.0";
 
   minimalOCamlVersion = "4.02";
 
-  src = fetchFromGitHub {
-    owner = "ocsigen";
-    repo = pname;
-    rev = "852302c8f35b946e2ec275c529a79e46d8749be6";
-    sha256 = "sha256:03ayvakvbh4wi4dwcgd7r9y8ka8cv3d59hb81yk2dxyd94bln145";
+  src = fetchurl {
+    url = "https://github.com/ocsigen/js_of_ocaml-ocamlbuild/releases/download/${version}/js_of_ocaml-ocamlbuild-${version}.tbz";
+    sha256 = "sha256-qlm8vxzie8sqPrd6iiwf8X6d2+DyQOOhmMoc67ChwHs=";
   };
 
   propagatedBuildInputs = [ ocamlbuild ];
 
   meta = {
     description = "An ocamlbuild plugin to compile to JavaScript";
+    homepage = "https://github.com/ocsigen/js_of_ocaml-ocamlbuild";
     license = lib.licenses.lgpl2Only;
     maintainers = [ lib.maintainers.vbgl ];
-    inherit (src.meta) homepage;
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/ocsigen/js_of_ocaml-ocamlbuild/blob/5.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
