### PR TITLE
pre-commit-hooks: fix conditional dependency on tomli

### DIFF
--- a/pkgs/development/python-modules/pre-commit-hooks/default.nix
+++ b/pkgs/development/python-modules/pre-commit-hooks/default.nix
@@ -6,7 +6,7 @@
 , pytestCheckHook
 , pythonOlder
 , ruamel-yaml
-, toml
+, tomli
 }:
 
 buildPythonPackage rec {
@@ -25,8 +25,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     ruamel-yaml
-    toml
-  ];
+  ] ++ (if (pythonOlder "3.11") then [tomli] else []);
 
   checkInputs = [
     git

--- a/pkgs/development/python-modules/pre-commit-hooks/default.nix
+++ b/pkgs/development/python-modules/pre-commit-hooks/default.nix
@@ -25,7 +25,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     ruamel-yaml
-  ] ++ (if (pythonOlder "3.11") then [tomli] else []);
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ];
 
   checkInputs = [
     git


### PR DESCRIPTION


###### Description of changes
As seen in https://github.com/pre-commit/pre-commit-hooks/commit/fc88f3fa495385e6b367f7c4c8cf10940ad053da, upstream changed their dependency from `toml` to `tomli>=1.1.0;python_version<"3.11"`.

Without this patch, running `check-toml` from this package fails with:

```
Traceback (most recent call last):
  File "/nix/store/06qpfmlgkhxakgjs8g7gk5jlkczij0m6-python3.10-pre-commit-hooks-4.3.0/bin/.check-toml-wrapped", line 6, in <module>
    from pre_commit_hooks.check_toml import main
  File "/nix/store/06qpfmlgkhxakgjs8g7gk5jlkczij0m6-python3.10-pre-commit-hooks-4.3.0/lib/python3.10/site-packages/pre_commit_hooks/check_toml.py", line 10, in <module>
    import tomli as tomllib
ModuleNotFoundError: No module named 'tomli'
```

See https://github.com/pre-commit/pre-commit-hooks/issues/833.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

@kalbasit
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
