### PR TITLE
gtkcord4: init at 0.0.6

### DIFF
--- a/pkgs/applications/audio/gtkcord4/default.nix
+++ b/pkgs/applications/audio/gtkcord4/default.nix
@@ -1,0 +1,47 @@
+{ buildGoModule
+, cairo
+, fetchFromGitHub
+, gdk-pixbuf
+, glib
+, gobject-introspection
+, graphene
+, gtk4
+, lib
+, pango
+, pkg-config
+}:
+
+buildGoModule rec {
+  pname = "gtkcord4";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "diamondburned";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-uEG1pAHMQT+C/E5rKByflvL0NNkC8SeSPMAXanzvhE4=";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    gdk-pixbuf
+    glib
+    graphene
+    gtk4
+    pango
+  ];
+
+  vendorHash = "sha256-QZSjSk1xu5ZcrNEra5TxnUVvlQWb5/h31fm5Nc7WMoI=";
+
+  meta = with lib; {
+    description = "GTK4 Discord client in Go, attempt #4.";
+    homepage = "https://github.com/diamondburned/gtkcord4";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28325,6 +28325,8 @@ with pkgs;
 
   gspeech = callPackage ../applications/audio/gspeech { };
 
+  gtkcord4 = callPackage ../applications/audio/gtkcord4 {};
+
   haruna = libsForQt5.callPackage ../applications/video/haruna { };
 
   hdrmerge = libsForQt5.callPackage ../applications/graphics/hdrmerge { };


### PR DESCRIPTION
Fixes #96936

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
