### PR TITLE
blender: fix on darwin

### DIFF
--- a/pkgs/applications/misc/blender/darwin.patch
+++ b/pkgs/applications/misc/blender/darwin.patch
@@ -1,7 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1832,7 +1832,7 @@ if(WITH_COMPILER_SHORT_FILE_MACRO)
+@@ -1894,7 +1894,7 @@ if(WITH_COMPILER_SHORT_FILE_MACRO)
    ADD_CHECK_CXX_COMPILER_FLAG(CXX_PREFIX_MAP_FLAGS CXX_MACRO_PREFIX_MAP -fmacro-prefix-map=foo=bar)
    if(C_MACRO_PREFIX_MAP AND CXX_MACRO_PREFIX_MAP)
      if(APPLE)
@@ -58,10 +58,10 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
 -    theora theoradec theoraenc vorbis vorbisenc
 -    vorbisfile vpx x264 xvidcore)
 +    swresample swscale)
-   find_package(FFmpeg)
- endif()
- 
-@@ -270,7 +263,6 @@ if(WITH_BOOST)
+   if(EXISTS ${LIBDIR}/ffmpeg/lib/libaom.a)
+     list(APPEND FFMPEG_FIND_COMPONENTS aom)
+   endif()
+@@ -273,7 +266,6 @@ if(WITH_BOOST)
  endif()
  
  if(WITH_INTERNATIONAL OR WITH_CODEC_FFMPEG)
@@ -69,7 +69,7 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
  endif()
  
  if(WITH_PUGIXML)
-@@ -399,7 +391,7 @@ endif()
+@@ -402,7 +394,7 @@ endif()
  
  # CMake FindOpenMP doesn't know about AppleClang before 3.12, so provide custom flags.
  if(WITH_OPENMP)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
