### PR TITLE
lib/types: add `descriptionClass` for `path`

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -478,6 +478,7 @@ rec {
 
     path = mkOptionType {
       name = "path";
+      descriptionClass = "noun";
       check = x: isCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
       merge = mergeEqualOption;
     };


### PR DESCRIPTION
Avoids `list of ((path) or string)`