### PR TITLE
vcsh: 2.0.4 → 2.0.5

### DIFF
--- a/pkgs/applications/version-management/vcsh/default.nix
+++ b/pkgs/applications/version-management/vcsh/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "vcsh";
-  version = "2.0.4";
+  version = "2.0.5";
 
   src = fetchurl {
     url = "https://github.com/RichiH/vcsh/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-W/Ql2J9HTDQPu0el34mHVzqe85KGWLPph2sHyuEzPPI=";
+    sha256 = "0bf3gacbyxw75ksd8y6528kgk7mqx6grz40gfiffxa2ghsz1xl01";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Upstream release only removes a bashism from the configure script. It updates CI and other bits too, but nothing that should relate to the build. See [upstream release notes](https://github.com/RichiH/vcsh/releases/tag/v2.0.5).