### PR TITLE
arangod: tidy maintainers, preConfigure

### DIFF
--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -50,16 +50,16 @@ gcc10Stdenv.mkDerivation rec {
   dontFixCmake = true;
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
-  preConfigure = ''
-    patchShebangs utils
-  '';
-
   postPatch = ''
     sed -ie 's!/bin/echo!echo!' 3rdParty/V8/gypfiles/*.gypi
 
     # with nixpkgs, it has no sense to check for a version update
     substituteInPlace js/client/client.js --replace "require('@arangodb').checkAvailableVersions();" ""
     substituteInPlace js/server/server.js --replace "require('@arangodb').checkAvailableVersions();" ""
+  '';
+
+  preConfigure = ''
+    patchShebangs utils
   '';
 
   cmakeFlags = [

--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -49,7 +49,10 @@ gcc10Stdenv.mkDerivation rec {
   # prevent failing with "cmake-3.13.4/nix-support/setup-hook: line 10: ./3rdParty/rocksdb/RocksDBConfig.cmake.in: No such file or directory"
   dontFixCmake = true;
   NIX_CFLAGS_COMPILE = "-Wno-error";
-  preConfigure = "patchShebangs utils";
+
+  preConfigure = ''
+    patchShebangs utils
+  '';
 
   postPatch = ''
     sed -ie 's!/bin/echo!echo!' 3rdParty/V8/gypfiles/*.gypi
@@ -76,6 +79,6 @@ gcc10Stdenv.mkDerivation rec {
     description = "A native multi-model database with flexible data models for documents, graphs, and key-values";
     license = licenses.asl20;
     platforms = [ "x86_64-linux" ];
-    maintainers = [ maintainers.flosse maintainers.jsoo1 ];
+    maintainers = with maintainers; [ flosse jsoo1 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Missed code review feedback.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).