### PR TITLE
nixpkgs/doc: fix admonition syntax

### DIFF
--- a/doc/builders/images/portableservice.section.md
+++ b/doc/builders/images/portableservice.section.md
@@ -15,7 +15,7 @@ This allows using Nix to build images which can be run on many recent Linux dist
 The primary tool for interacting with Portable Services is `portablectl`,
 and they are managed by the `systemd-portabled` system service.
 
-:::{.note}
+::: {.note}
 Portable services are supported starting with systemd 239 (released on 2018-06-22).
 :::
 
@@ -37,7 +37,7 @@ dependencies of the two derivations in the `units` list.
 `units` must be a list of derivations, and their names must be prefixed with the service name (`"demo"` in this case).
 Otherwise `systemd-portabled` will ignore them.
 
-:::{.Note}
+::: {.note}
 The `.raw` file extension of the image is required by the portable services specification.
 :::
 
@@ -76,6 +76,6 @@ portablectl attach demo_1.0.raw
 systemctl enable --now demo.socket
 systemctl enable --now demo.service
 ```
-:::{.Note}
+::: {.note}
 See the [man page](https://www.freedesktop.org/software/systemd/man/portablectl.html) of `portablectl` for more info on its usage.
 :::

--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -489,7 +489,7 @@ Preferred source hash type is sha256. There are several ways to get it.
    
    in the package expression, attempt build and extract correct hash from error messages.
 
-   :::{.warning}
+   ::: {.warning}
    You must use one of these four fake hashes and not some arbitrarily-chosen hash.
    
    See [](#sec-source-hashes-security).


### PR DESCRIPTION
Match admonition syntax in

https://nixos.org/manual/nixpkgs/unstable/#chap-contributing

followup from #200089

cc @anka-213 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
