### PR TITLE
adguardhome: 0.107.16 -> 0.107.18

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,23 +1,23 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-rVc1ad8qwXfEuqZUrTsdzSQHUit3j8PQp3B0dD6FrcQ=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-XzM+ZAlpT33AQd7etCXZQos9Ifg7oM9DkzncP+EBvoo=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.18/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-GaeTdv467dVfSk2YuILmi2KphMfFYfLdpNI+dVx/UoU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-9pMZVSqU6Rqet73Lg/JBzX1PWmR9nxUSmKD6E4fAxSw=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.18/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-6fXU2vU3MgveWZhgrphOeczDc1GUBv7ZUehPF8+GUdY=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-AVFQpruoScSTFpsK3+7e1hXaJaKlK5dQ+8uga5+dHRY=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.18/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-6rUC0R0bGS4omX9bybShk78mFaNRjUUkQqczZE2Wz5M=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-ncVQc8zJy9i8TNmDIjLQh58I3gIfTLgDwctBFD1HR2I=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.18/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-3cowMi081TIx65dgzBP+YkIj4IBwyK1Yd/gn2zL9kOI=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.16/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-tzc67MHg6idLW5b69zLZw/76tP6YEMlWNPosrsD4uTA=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.18/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.16";
+  version = "0.107.18";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/AdguardTeam/AdGuardHome";
     description = "Network-wide ads & trackers blocking DNS server";
     platforms = builtins.attrNames sources;
-    maintainers = with maintainers; [ numkem iagoq ];
+    maintainers = with maintainers; [ numkem iagoq rhoriguchi ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.gpl3Only;
   };


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

