### PR TITLE
treewide: adjust cubeb dependencies

### DIFF
--- a/pkgs/applications/emulators/citra/generic.nix
+++ b/pkgs/applications/emulators/citra/generic.nix
@@ -17,7 +17,7 @@
 , enableQt ? true, qtbase, qtmultimedia, wrapQtAppsHook
 , enableQtTranslation ? enableQt, qttools
 , enableWebService ? true
-, enableCubeb ? true, libpulseaudio
+, enableCubeb ? true, cubeb
 , enableFfmpegAudioDecoder ? true
 , enableFfmpegVideoDumper ? true
 , ffmpeg_4
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableQt [ qtbase qtmultimedia ]
     ++ lib.optional enableSdl2 SDL2
     ++ lib.optional enableQtTranslation qttools
-    ++ lib.optional enableCubeb libpulseaudio
+    ++ lib.optionals enableCubeb cubeb.passthru.backendLibs
     ++ lib.optional (enableFfmpegAudioDecoder || enableFfmpegVideoDumper) ffmpeg_4
     ++ lib.optional useDiscordRichPresence rapidjson
     ++ lib.optional enableFdk fdk_aac;
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
   # Fixes https://github.com/NixOS/nixpkgs/issues/171173
   postInstall = lib.optionalString (enableCubeb && enableSdl2) ''
     wrapProgram "$out/bin/citra" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio ]}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath cubeb.passthru.backendLibs}
   '';
 
   meta = with lib; {

--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -4,10 +4,10 @@
 , SDL2
 , cmake
 , copyDesktopItems
+, cubeb
 , curl
 , extra-cmake-modules
 , libXrandr
-, libpulseaudio
 , makeDesktopItem
 , mesa # for libgbm
 , ninja
@@ -48,7 +48,6 @@ stdenv.mkDerivation {
   buildInputs = [
     SDL2
     curl
-    libpulseaudio
     libXrandr
     mesa
     qtbase
@@ -58,7 +57,8 @@ stdenv.mkDerivation {
   ++ lib.optionals enableWayland [
     qtwayland
     wayland
-  ];
+  ]
+  ++ cubeb.passthru.backendLibs;
 
   cmakeFlags = [
     "-DUSE_DRMKMS=ON"
@@ -100,7 +100,7 @@ stdenv.mkDerivation {
   '';
 
   qtWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio vulkan-loader ]}"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([ vulkan-loader ] ++ cubeb.passthru.backendLibs)}"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/emulators/pcsx2/default.nix
+++ b/pkgs/applications/emulators/pcsx2/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , lib
 , stdenv
+, cubeb
 , curl
 , ffmpeg
 , fmt
@@ -10,7 +11,6 @@
 , libaio
 , libbacktrace
 , libpcap
-, libpulseaudio
 , libsamplerate
 , libXrandr
 , libzip
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
     libaio
     libbacktrace
     libpcap
-    libpulseaudio
     libsamplerate
     libXrandr
     libzip
@@ -85,7 +84,8 @@ stdenv.mkDerivation rec {
     vulkan-loader
     wayland
     xz
-  ];
+  ]
+  ++ cubeb.passthru.backendLibs;
 
   installPhase = ''
     mkdir -p $out/bin
@@ -98,11 +98,10 @@ stdenv.mkDerivation rec {
   '';
 
   qtWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([
       ffmpeg # It's loaded with dlopen. They plan to change it https://github.com/PCSX2/pcsx2/issues/8624
-      libpulseaudio
       vulkan-loader
-    ]}"
+    ] ++ cubeb.passthru.backendLibs)}"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/emulators/rpcs3/default.nix
+++ b/pkgs/applications/emulators/rpcs3/default.nix
@@ -2,9 +2,8 @@
 , qtbase, qtquickcontrols, qtmultimedia, openal, glew, vulkan-headers, vulkan-loader, libpng
 , ffmpeg, libevdev, libusb1, zlib, curl, wolfssl, python3, pugixml, faudio, flatbuffers
 , sdl2Support ? true, SDL2
-, pulseaudioSupport ? true, libpulseaudio
+, cubebSupport ? true, cubeb
 , waylandSupport ? true, wayland
-, alsaSupport ? true, alsa-lib
 }:
 
 let
@@ -66,8 +65,7 @@ stdenv.mkDerivation {
     qtbase qtquickcontrols qtmultimedia openal glew vulkan-headers vulkan-loader libpng ffmpeg
     libevdev zlib libusb1 curl wolfssl python3 pugixml faudio flatbuffers
   ] ++ lib.optional sdl2Support SDL2
-    ++ lib.optional pulseaudioSupport libpulseaudio
-    ++ lib.optional alsaSupport alsa-lib
+    ++ lib.optionals cubebSupport cubeb.passthru.backendLibs
     ++ lib.optional waylandSupport wayland;
 
   postInstall = ''


### PR DESCRIPTION
###### Description of changes

Many emulators use `cubeb` (a library that automatically selects the audio backend) in order to output audio, which is often vendored and can't be replaced.
Despite that, it still requires having the audio libraries as dependencies, but in many packages only `libpulseaudio` was put in. Cubeb supports many more backends, and this PR adds them in.

Tested DuckStation, PCSX2 and Citra.
Cannot test RPCS3, so if anyone can test it...

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
