### PR TITLE
libmtp: improve cross-compilation support

### DIFF
--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -35,9 +35,11 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ libusb1 ];
 
-  preConfigure = "./autogen.sh";
+  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
   configureFlags = [ "--with-udev=${placeholder "out"}/lib/udev" ];
+
+  configurePlatforms = [ "build" "host" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes

It still doesn't build, but it gets further now.
Also added configurePlatforms explicitly, not strictly needed for cross, but might help catch issues with cross earlier in some cases.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux (cross-compiling still fails, but gets a lot further) ❌
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

TBH I am not sure how much value this adds, fine with closing if this doesn't help anyone. Figured that it might be nice if the build gets further whenever someone else dives in this.
