### PR TITLE
python3Packages.python-lsp-server: add missing setuptools

### DIFF
--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -57,7 +57,6 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [
-    setuptools
     setuptools-scm
   ];
 
@@ -66,6 +65,7 @@ buildPythonPackage rec {
     jedi
     pluggy
     python-lsp-jsonrpc
+    setuptools # `pkg_resources`imported in pylsp/config/config.py
     ujson
   ];
 
@@ -142,6 +142,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "pylsp"
+    "pylsp.python_lsp"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Error on start
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/j354wmsca9xkgnygj22605p6z7msharm-python3.10-python-lsp-server-1.6.0/lib/python3.10/site-packages/pylsp/python_lsp.py", line 16, in <module>
    from .config import config
  File "/nix/store/j354wmsca9xkgnygj22605p6z7msharm-python3.10-python-lsp-server-1.6.0/lib/python3.10/site-packages/pylsp/config/config.py", line 9, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Introduced in https://github.com/NixOS/nixpkgs/pull/199661

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
