### PR TITLE
firmware-updater: update hashes

### DIFF
--- a/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
@@ -1,13 +1,17 @@
 { lib
 , flutter2
 , fetchFromGitHub
+, stdenv
 }:
 
 flutter2.mkFlutterApp {
   pname = "firmware-updater";
   version = "unstable";
 
-  vendorHash = "sha256-7uOiebGBcX61oUyNCi1h9KldTRTrCfYaHUQSH4J5OoQ=";
+  vendorHash =
+    if stdenv.system == "aarch64-linux"
+    then "sha256-2eleXBlg2jxDDBF5rInyqZa3n14X6UdQn6ND7FTieVA="
+    else "sha256-nPblucEpNCBJYpIqx1My6SWq8CjXYuHDG/uphdcrWjQ=";
 
   src = fetchFromGitHub {
     owner = "canonical";

--- a/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
@@ -10,7 +10,7 @@ flutter2.mkFlutterApp {
 
   vendorHash =
     if stdenv.system == "aarch64-linux"
-    then "sha256-2eleXBlg2jxDDBF5rInyqZa3n14X6UdQn6ND7FTieVA="
+    then "sha256-+ACmcIKXtGtaYBuwc7jY9hEdIS9qxQCbuxRKJQohX5A="
     else "sha256-nPblucEpNCBJYpIqx1My6SWq8CjXYuHDG/uphdcrWjQ=";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Description of changes

Was able to build this package after updating hashes. Hydra failures don't mention hash mismatch, but maybe update will still help.

ZHF: #199919

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
