### PR TITLE
codeowners: narrower responsibilities for fricklerhandwerk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,11 +49,16 @@
 /pkgs/build-support/writers @lassulus @Profpatsch
 
 # Nixpkgs documentation
-/doc @fricklerhandwerk
 /maintainers/scripts/db-to-md.sh @jtojnar @ryantm
 /maintainers/scripts/doc @jtojnar @ryantm
+
+/doc/* @fricklerhandwerk
 /doc/build-aux/pandoc-filters @jtojnar
-/doc/contributing/contributing-to-documentation.chapter.md @jtojnar
+/doc/builders/trivial-builders.chapter.md @fricklerhandwerk
+/doc/contributing/ @fricklerhandwerk
+/doc/contributing/contributing-to-documentation.chapter.md @jtojnar @fricklerhandwerk
+/doc/stdenv @fricklerhandwerk
+/doc/using @fricklerhandwerk
 
 # NixOS Internals
 /nixos/default.nix          @nbp @infinisil


### PR DESCRIPTION
the number of pull requests against documentation is too high to handle
on the side, and getting assigned as reviewer for all of them sends the
wrong message to authors.