### PR TITLE
fead: init at 0.1.3

### DIFF
--- a/pkgs/applications/misc/fead/default.nix
+++ b/pkgs/applications/misc/fead/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromSourcehut, python3, help2man }:
+
+stdenv.mkDerivation rec {
+  pname = "fead";
+  version = "0.1.3";
+
+  src = fetchFromSourcehut {
+    owner = "~cnx";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-cW0GxyvC9url2QAAWD0M2pR4gBiPA3eeAaw77TwMV/0=";
+  };
+
+  nativeBuildInputs = [ help2man ];
+  buildInputs = [ python3 ];
+
+  # Needed for man page generation in build phase
+  postPatch = ''
+    patchShebangs src/fead.py
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  # Already done in postPatch phase
+  dontPatchShebangs = true;
+
+  # The package has no tests.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Advert generator from web feeds";
+    homepage = "https://git.sr.ht/~cnx/fead";
+    license = licenses.agpl3Plus;
+    changelog = "https://git.sr.ht/~cnx/fead/refs/${version}";
+    maintainers = with maintainers; [ McSinyx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7357,6 +7357,8 @@ with pkgs;
 
   fdk-aac-encoder = callPackage ../applications/audio/fdkaac { };
 
+  fead = callPackage ../applications/misc/fead { };
+
   feedgnuplot = callPackage ../tools/graphics/feedgnuplot { };
 
   fbcat = callPackage ../tools/misc/fbcat { };


### PR DESCRIPTION
###### Description of changes

Fead is a more scalable implementation of openring.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).