### PR TITLE
gobject-introspection: use wrapper.nix for the native package too

### DIFF
--- a/pkgs/applications/window-managers/i3/i3ipc-glib.nix
+++ b/pkgs/applications/window-managers/i3/i3ipc-glib.nix
@@ -4,7 +4,6 @@
 }:
 
 stdenv.mkDerivation rec {
-
   pname = "i3ipc-glib";
   version = "1.0.1";
 
@@ -15,10 +14,10 @@ stdenv.mkDerivation rec {
     sha256 = "01fzvrbnzcwx0vxw29igfpza9zwzp2s7msmzb92v01z0rz0y5m0p";
   };
 
-  nativeBuildInputs = [ autoreconfHook which pkg-config ];
+  strictDeps = true;
+  nativeBuildInputs = [ autoreconfHook which pkg-config gtk-doc gobject-introspection ];
 
-  buildInputs = [ libxcb json-glib gtk-doc xorgproto gobject-introspection ];
-
+  buildInputs = [ libxcb json-glib xorgproto ];
 
   preAutoreconf = ''
     gtkdocize

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -138,14 +138,6 @@ stdenv.mkDerivation (finalAttrs: {
     rm $out/lib/libregress-1.0${stdenv.targetPlatform.extensions.sharedLibrary}
   '';
 
-  # add self to buildInputs to avoid needing to add gobject-introspection to buildInputs in addition to nativeBuildInputs
-  # builds use target-pkg-config to look for gobject-introspection instead of just looking for binaries in $PATH
-  # wrapper uses depsTargetTargetPropagated so ignore it
-  preFixup = lib.optionalString (!lib.hasSuffix "-wrapped" finalAttrs.pname) ''
-    mkdir -p $dev/nix-support
-    echo "$out" > $dev/nix-support/propagated-target-target-deps
-  '';
-
   setupHook = ./setup-hook.sh;
 
   passthru = {

--- a/pkgs/development/libraries/gobject-introspection/wrapper.nix
+++ b/pkgs/development/libraries/gobject-introspection/wrapper.nix
@@ -9,50 +9,96 @@
 # to build, run
 # `nix build ".#pkgsCross.aarch64-multiplatform.buildPackages.gobject-introspection"`
 
+# a comment for both depsTargetTargetPropagated's
+# add self to buildInputs to avoid needing to add gobject-introspection to buildInputs in addition to nativeBuildInputs
+# builds use target-pkg-config to look for gobject-introspection instead of just looking for binaries in $PATH
+
 let
-  # ensure that `.override` works when gobject-introspection == gobject-introspection-wrapped
+  # ensure that `.override` works
   args = builtins.removeAttrs _args [ "buildPackages" "targetPackages" "gobject-introspection-unwrapped" ];
   # passing this stdenv to `targetPackages...` breaks due to splicing not working in `.override``
   argsForTarget = builtins.removeAttrs args [ "stdenv" ];
+
+  overridenUnwrappedGir = gobject-introspection-unwrapped.override args;
+  # if we have targetPackages.gobject-introspection then propagate that
+  overridenTargetUnwrappedGir =
+    if targetPackages ? gobject-introspection-unwrapped
+    then targetPackages.gobject-introspection-unwrapped.override argsForTarget
+    else overridenUnwrappedGir;
 in
 
-(gobject-introspection-unwrapped.override args).overrideAttrs (previousAttrs: {
-  pname = "gobject-introspection-wrapped";
-  depsTargetTargetPropagated = [ gobject-introspection-unwrapped ];
-  postFixup = (previousAttrs.postFixup or "") + ''
-    mv $dev/bin/g-ir-compiler $dev/bin/.g-ir-compiler-wrapped
-    mv $dev/bin/g-ir-scanner $dev/bin/.g-ir-scanner-wrapped
+# wrap both pkgsCrossX.buildPackages.gobject-introspection and {pkgs,pkgsSomethingExecutableOnBuildSystem).buildPackages.gobject-introspection
+if (!stdenv.hostPlatform.canExecute stdenv.targetPlatform) && stdenv.targetPlatform.emulatorAvailable buildPackages
+then
+  stdenv.mkDerivation
+    (builtins.removeAttrs overridenUnwrappedGir.drvAttrs [ "name" ] # so we can get a fresh name generated from the pname
+      // {
+      pname = "gobject-introspection-wrapped";
+      passthru = overridenUnwrappedGir.passthru // {
+        unwrapped = overridenUnwrappedGir;
+      };
+      phases = [ "fixupPhase" ]; # don't remove, it is valid to set phases here.
+      dontStrip = true;
+      depsTargetTargetPropagated = [ overridenTargetUnwrappedGir ];
+      postFixup = ''
+        ${lib.concatMapStrings (output: ''
+          mkdir -p ${"$" + "${output}"}
+          ${lib.getExe buildPackages.xorg.lndir} ${gobject-introspection-unwrapped.${output}} ${"$" + "${output}"}
+        '') gobject-introspection-unwrapped.outputs}
 
-    (
-      export bash="${buildPackages.bash}"
-      export emulator=${lib.escapeShellArg (stdenv.targetPlatform.emulator buildPackages)}
-      export emulatorwrapper="$dev/bin/g-ir-scanner-qemuwrapper"
-      export buildlddtree="${buildPackages.pax-utils}/bin/lddtree"
+        cp $dev/bin/g-ir-compiler $dev/bin/.g-ir-compiler-wrapped
+        cp $dev/bin/g-ir-scanner $dev/bin/.g-ir-scanner-wrapped
 
-      export targetgir="${lib.getDev (targetPackages.gobject-introspection-unwrapped.override argsForTarget)}"
+        (
+          rm "$dev/bin/g-ir-compiler"
+          rm "$dev/bin/g-ir-scanner"
+          export bash="${buildPackages.bash}"
+          export emulator=${lib.escapeShellArg (stdenv.targetPlatform.emulator buildPackages)}
+          export emulatorwrapper="$dev/bin/g-ir-scanner-qemuwrapper"
+          export buildlddtree="${buildPackages.pax-utils}/bin/lddtree"
 
-      substituteAll "${./wrappers/g-ir-compiler.sh}" "$dev/bin/g-ir-compiler"
-      substituteAll "${./wrappers/g-ir-scanner.sh}" "$dev/bin/g-ir-scanner"
-      substituteAll "${./wrappers/g-ir-scanner-lddwrapper.sh}" "$dev/bin/g-ir-scanner-lddwrapper"
-      substituteAll "${./wrappers/g-ir-scanner-qemuwrapper.sh}" "$dev/bin/g-ir-scanner-qemuwrapper"
-      chmod +x $dev/bin/g-ir-*
-    )
-  ''
-  # when cross-compiling and using the wrapper then when a package looks up the g_ir_X
-  # variable with pkg-config they'll get the host version which can't be run
-  # override the variable to use the absolute path to g_ir_X in PATH which can be run
-  + ''
-    cat >> $dev/nix-support/setup-hook <<-'EOF'
-      override-pkg-config-gir-variables() {
-        PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_SCANNER="$(type -p g-ir-scanner)"
-        PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_COMPILER="$(type -p g-ir-compiler)"
-        PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_GENERATE="$(type -p g-ir-generate)"
-        export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_SCANNER
-        export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_COMPILER
-        export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_GENERATE
-      }
+          export targetgir="${lib.getDev overridenTargetUnwrappedGir}"
 
-      preConfigureHooks+=(override-pkg-config-gir-variables)
-    EOF
-  '';
-})
+          substituteAll "${./wrappers/g-ir-compiler.sh}" "$dev/bin/g-ir-compiler"
+          substituteAll "${./wrappers/g-ir-scanner.sh}" "$dev/bin/g-ir-scanner"
+          substituteAll "${./wrappers/g-ir-scanner-lddwrapper.sh}" "$dev/bin/g-ir-scanner-lddwrapper"
+          substituteAll "${./wrappers/g-ir-scanner-qemuwrapper.sh}" "$dev/bin/g-ir-scanner-qemuwrapper"
+          chmod +x $dev/bin/g-ir-compiler
+          chmod +x $dev/bin/g-ir-scanner*
+        )
+      ''
+      # when cross-compiling and using the wrapper then when a package looks up the g_ir_X
+      # variable with pkg-config they'll get the host version which can't be run
+      # override the variable to use the absolute path to g_ir_X in PATH which can be run
+      + ''
+        cat >> $dev/nix-support/setup-hook <<-'EOF'
+          override-pkg-config-gir-variables() {
+            PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_SCANNER="$(type -p g-ir-scanner)"
+            PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_COMPILER="$(type -p g-ir-compiler)"
+            PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_GENERATE="$(type -p g-ir-generate)"
+            export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_SCANNER
+            export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_COMPILER
+            export PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_GENERATE
+          }
+
+          preConfigureHooks+=(override-pkg-config-gir-variables)
+        EOF
+      '';
+    })
+else
+  stdenv.mkDerivation (builtins.removeAttrs overridenUnwrappedGir.drvAttrs [ "name" ] # so we can get a fresh name generated from the pname
+    // {
+    pname = "gobject-introspection-wrapped";
+    passthru = overridenUnwrappedGir.passthru // {
+      unwrapped = overridenUnwrappedGir;
+    };
+    phases = [ "fixupPhase" ]; # don't remove, it is valid to set phases here.
+    dontStrip = true;
+    depsTargetTargetPropagated = [ overridenTargetUnwrappedGir ];
+    postFixup = ''
+      ${lib.concatMapStrings (output: ''
+        mkdir -p ${"$" + "${output}"}
+        ${lib.getExe buildPackages.xorg.lndir} ${gobject-introspection-unwrapped.${output}} ${"$" + "${output}"}
+      '') gobject-introspection-unwrapped.outputs}
+    '';
+  })

--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -70,6 +70,13 @@ stdenv.mkDerivation rec {
     dbus
   ];
 
+  postPatch = ''
+    # https://gitlab.gnome.org/GNOME/gtksourceview/-/merge_requests/295
+    # build: drop unnecessary vapigen check
+    substituteInPlace meson.build \
+      --replace "if generate_vapi" "if false"
+  '';
+
   # Broken by PCRE 2 bump in GLib.
   # https://gitlab.gnome.org/GNOME/gtksourceview/-/issues/283
   doCheck = false;

--- a/pkgs/development/libraries/gtksourceview/5.x.nix
+++ b/pkgs/development/libraries/gtksourceview/5.x.nix
@@ -74,6 +74,13 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
   ];
 
+  postPatch = ''
+    # https://gitlab.gnome.org/GNOME/gtksourceview/-/merge_requests/295
+    # build: drop unnecessary vapigen check
+    substituteInPlace meson.build \
+      --replace "if generate_vapi" "if false"
+  '';
+
   doCheck = stdenv.isLinux;
 
   checkPhase = ''

--- a/pkgs/development/libraries/keybinder3/default.nix
+++ b/pkgs/development/libraries/keybinder3/default.nix
@@ -13,14 +13,25 @@ stdenv.mkDerivation rec {
     sha256 = "196ibn86j54fywfwwgyh89i9wygm4vh7ls19fn20vrnm6ijlzh9r";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+  strictDeps = true;
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkg-config
+    gnome.gnome-common
+    gtk-doc
+    gobject-introspection
+  ];
   buildInputs = [
-    gnome.gnome-common gtk-doc gtk3
-    libX11 libXext libXrender gobject-introspection
+    gtk3 libX11 libXext libXrender
   ];
 
   preConfigure = ''
-    ./autogen.sh --prefix="$out"
+    # NOCONFIGURE fixes 'If you meant to cross compile, use `--host'.'
+    NOCONFIGURE=1 ./autogen.sh --prefix="$out"
+    substituteInPlace ./configure \
+      --replace "dummy pkg-config" 'dummy ''${ac_tool_prefix}pkg-config'
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/libwnck/default.nix
+++ b/pkgs/development/libraries/libwnck/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , fetchpatch
 , meson
+, mesonEmulatorHook
 , ninja
 , pkg-config
 , gtk-doc
@@ -50,6 +51,8 @@ stdenv.mkDerivation rec {
     gtk-doc
     docbook_xsl
     docbook_xml_dtd_412
+  ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    mesonEmulatorHook
   ];
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19174,8 +19174,7 @@ with pkgs;
   gns3-gui = gns3Packages.guiStable;
   gns3-server = gns3Packages.serverStable;
 
-  gobject-introspection = if (!stdenv.hostPlatform.canExecute stdenv.targetPlatform) && stdenv.targetPlatform.emulatorAvailable buildPackages
-    then callPackage ../development/libraries/gobject-introspection/wrapper.nix { } else gobject-introspection-unwrapped;
+  gobject-introspection = callPackage ../development/libraries/gobject-introspection/wrapper.nix { };
 
   gobject-introspection-unwrapped = callPackage ../development/libraries/gobject-introspection {
     nixStoreDir = config.nix.storeDir or builtins.storeDir;


### PR DESCRIPTION
so we can propagate the dev output

during the build of i3ipc-glib with strictDeps enabled i noticed that
gobject-introspection was not being detected and it was due to
gobject-introspection path not being in the PKG_CONFIG_PATH variable

this commit makes gobject-introspection get detected when build==host

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
