### PR TITLE
kismet: 2020-09-R2 -> 2022-08-R1

### DIFF
--- a/pkgs/applications/networking/sniffers/kismet/default.nix
+++ b/pkgs/applications/networking/sniffers/kismet/default.nix
@@ -1,36 +1,43 @@
-{ lib, stdenv, fetchurl, pkg-config, libpcap, pcre, libnl, zlib, libmicrohttpd
-, sqlite, protobuf, protobufc, libusb1, libcap, binutils, elfutils
-, withNetworkManager ? false, glib, networkmanager
-, withPython ? false, python3
-, withSensors ? false, lm_sensors}:
-
-# couldn't get python modules to build correctly,
-# waiting for some other volunteer to fix it
-assert !withPython;
+{ lib
+, stdenv
+, binutils
+, elfutils
+, fetchurl
+, glib
+, libcap
+, libmicrohttpd
+, libnl
+, libpcap
+, libusb1
+, libwebsockets
+, lm_sensors
+, networkmanager
+, pcre
+, pkg-config
+, openssl
+, protobuf
+, protobufc
+, python3
+, sqlite
+, withNetworkManager ? false
+, withPython ? true
+, withSensors ? false
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "kismet";
-  version = "2020-09-R2";
+  version = "2022-08-R1";
 
   src = fetchurl {
     url = "https://www.kismetwireless.net/code/${pname}-${version}.tar.xz";
-    sha256 = "1n6y6sgqf50bng8n0mhs2r1w0ak14mv654sqay72a78wh2s7ywzg";
+    hash = "sha256-IUnM6sVSZQhlP00C3PemlOPaPcAAojcqHuS/mYgnl4E=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [
-    libpcap pcre libmicrohttpd libnl zlib sqlite protobuf protobufc
-    libusb1 libcap binutils elfutils
-  ] ++ lib.optionals withNetworkManager [ networkmanager glib ]
-    ++ lib.optional withSensors lm_sensors
-    ++ lib.optional withPython (python3.withPackages(ps: [ ps.setuptools ps.protobuf
-                                                                  ps.numpy ps.pyserial ]));
-
-  configureFlags = []
-    ++ lib.optional (!withNetworkManager) "--disable-libnm"
-    ++ lib.optional (!withPython) "--disable-python-tools"
-    ++ lib.optional (!withSensors) "--disable-lmsensors";
+  postPatch = ''
+    substituteInPlace Makefile.in \
+      --replace "-m 4550" ""
+  '';
 
   postConfigure = ''
     sed -e 's/-o $(INSTUSR)//' \
@@ -40,12 +47,58 @@ stdenv.mkDerivation rec {
         -i Makefile
   '';
 
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ lib.optionals withPython [
+    python3
+  ];
+
+  buildInputs = [
+    binutils
+    elfutils
+    libcap
+    libmicrohttpd
+    libnl
+    libpcap
+    openssl
+    libusb1
+    libwebsockets
+    pcre
+    protobuf
+    protobufc
+    sqlite
+    zlib
+  ] ++ lib.optionals withNetworkManager [
+    networkmanager
+    glib
+  ] ++ lib.optional withSensors [
+    lm_sensors
+  ];
+
+  propagatedBuildInputs = [
+  ] ++ lib.optional withPython (python3.withPackages (ps: [
+    ps.numpy
+    ps.protobuf
+    ps.pyserial
+    ps.setuptools
+    ps.websockets
+  ]));
+
+  configureFlags = [
+  ] ++ lib.optional (!withNetworkManager) [
+    "--disable-libnm"
+  ] ++ lib.optional (!withPython) [
+    "--disable-python-tools"
+  ] ++ lib.optional (!withSensors) [
+    "--disable-lmsensors"
+  ];
+
   enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Wireless network sniffer";
     homepage = "https://www.kismetwireless.net/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes
https://www.kismetwireless.net/release/kismet-2022-08-R1/

Python modules are now enabled but like the SUID parts, both parts will most likely need some adjustments as this is the first Kismet update for two years.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
