### PR TITLE
byacc: 20220128 -> 20221106

### DIFF
--- a/pkgs/development/tools/parsing/byacc/default.nix
+++ b/pkgs/development/tools/parsing/byacc/default.nix
@@ -1,15 +1,20 @@
-{ lib, stdenv, fetchurl }:
+{ lib
+, stdenv
+, fetchurl
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "byacc";
-  version = "20220128";
+  version = "20221106";
 
   src = fetchurl {
-    urls = [
-      "ftp://ftp.invisible-island.net/byacc/${pname}-${version}.tgz"
+    urls = let
+      inherit (finalAttrs) pname version;
+    in [
       "https://invisible-mirror.net/archives/byacc/${pname}-${version}.tgz"
+      "ftp://ftp.invisible-island.net/byacc/${pname}-${version}.tgz"
     ];
-    sha256 = "sha256-QsGAXMUpMU5qdjJv4bM+gMcIYqRLAUdNo2Li99stdJw=";
+    hash = "sha256-qJm+Inu8rJz3cA99u1qElGiPH58GF7UQdi2urOR7nRI=";
   };
 
   configureFlags = [
@@ -23,9 +28,22 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Berkeley YACC";
     homepage = "https://invisible-island.net/byacc/byacc.html";
+    description = "Berkeley YACC";
+    longDescription = ''
+      Berkeley Yacc (byacc) is generally conceded to be the best yacc variant
+      available. In contrast to bison, it is written to avoid dependencies upon
+      a particular compiler.
+
+      Byacc was written around 1990 by Robert Corbett who is the original author
+      of bison. Byacc is noted in Lex & Yacc by John Levine et al (O'Reilly,
+      1992) for its compatibility with the original yacc program.
+
+      Nowadays byacc is maintained by Thomas E. Dickey.
+    '';
+    changelog = "https://invisible-island.net/byacc/CHANGES.html";
     license = licenses.publicDomain;
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Also, add AndersonTorres as maintainer.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
