### PR TITLE
vscode-extensions.contextmapper.context-mapper-vscode-extension: init…

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/contextmapper.context-mapper-vscode-extension/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/contextmapper.context-mapper-vscode-extension/default.nix
@@ -1,0 +1,36 @@
+{ graphviz
+, jre
+, lib
+, makeWrapper
+, vscode-utils
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension rec {
+  mktplcRef = {
+    name = "context-mapper-vscode-extension";
+    publisher = "contextmapper";
+    version = "6.7.0";
+    sha256 = "sha256-vlDVqn1Je0eo5Nf2gyotSvhIa07tWCINe79RZSyMzcA=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    graphviz
+  ];
+
+  postInstall = ''
+    wrapProgram $out/share/vscode/extensions/contextmapper.context-mapper-vscode-extension/lsp/bin/context-mapper-lsp \
+      --set JAVA_HOME "${jre}"
+  '';
+
+  meta = {
+    description = "A VSCode extension for Context Mapper";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=${mktplcRef.publisher}.${mktplcRef.name}";
+    homepage = "https://github.com/ContextMapper/vscode-extension";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.rhoriguchi ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -669,6 +669,8 @@ let
         };
       };
 
+      contextmapper.context-mapper-vscode-extension = callPackage ./contextmapper.context-mapper-vscode-extension { };
+
       coolbear.systemd-unit-file = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "coolbear";


### PR DESCRIPTION
###### Description of changes

There seems to be an upstream bug but highlighting works as intended.

```console
2023-03-25 13:42:43.571 [error] Error: Header must provide a Content-Length property.
    at StreamMessageReader.onData (/nix/store/3a214qn7d93pnl90gxk57035bii028lj-vscode-extension-contextmapper-context-mapper-vscode-extension-6.7.0/share/vscode/extensions/contextmapper.context-mapper-vscode-extension/node_modules/vscode-jsonrpc/lib/messageReader.js:163:27)
    at Socket.<anonymous> (/nix/store/3a214qn7d93pnl90gxk57035bii028lj-vscode-extension-contextmapper-context-mapper-vscode-extension-6.7.0/share/vscode/extensions/contextmapper.context-mapper-vscode-extension/node_modules/vscode-jsonrpc/lib/messageReader.js:148:18)
    at Socket.emit (node:events:526:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
```

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
