### PR TITLE
cargo-generate: 0.16.0 -> 0.17.2

### DIFF
--- a/pkgs/development/tools/rust/cargo-generate/default.nix
+++ b/pkgs/development/tools/rust/cargo-generate/default.nix
@@ -10,19 +10,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-generate";
-  version = "0.16.0";
+  version = "0.17.2";
 
   src = fetchFromGitHub {
     owner = "cargo-generate";
     repo = "cargo-generate";
     rev = "v${version}";
-    sha256 = "sha256-qL5ZbLimpsi/7yuhubHF3/tAouE/5zCWRx4nZG841cU=";
+    sha256 = "sha256-so69T2mDq/nFGiug2zYIX6Z+Dhxk3riV+TkEYTpFrTg=";
   };
 
   # patch Cargo.toml to not vendor libgit2 and openssl
   cargoPatches = [ ./no-vendor.patch ];
 
-  cargoSha256 = "sha256-OB3rjJNxkUKRQPsWRvCniNPfYBgLFV4yXO7dnVvL7wo=";
+  cargoSha256 = "sha256-JRoD6SuGQPJ8HOePXrH3avIY+sW61ErZFOHLafqmxMY=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -39,14 +39,13 @@ rustPlatform.buildRustPackage rec {
   # - favorites_default_to_git_if_not_defined: requires network access to github.com
   # - should_canonicalize: the test assumes that it will be called from the /Users/<project_dir>/ folder on darwin variant.
   checkFlags = [
-      "--skip favorites::favorites_default_to_git_if_not_defined"
-      # Probably git 2.38.1 releated failure
-      # Upstream issue https://github.com/cargo-generate/cargo-generate/issues/777
-      "--skip basics::it_loads_a_submodule"
-    ] ++ lib.optionals stdenv.isDarwin [ "--skip git::utils::should_canonicalize" ];
+    "--skip=favorites::favorites_default_to_git_if_not_defined"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "--skip=git::utils::should_canonicalize"
+  ];
 
   meta = with lib; {
-    description = "cargo, make me a project";
+    description = "A tool to generaet a new Rust project by leveraging a pre-existing git repository as a template";
     homepage = "https://github.com/cargo-generate/cargo-generate";
     changelog = "https://github.com/cargo-generate/cargo-generate/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ asl20 /* or */ mit ];

--- a/pkgs/development/tools/rust/cargo-generate/no-vendor.patch
+++ b/pkgs/development/tools/rust/cargo-generate/no-vendor.patch
@@ -3,9 +3,9 @@
 @@ -10,7 +10,7 @@ include = ["src/**/*", "LICENSE-*", "*.md"]
  
  [dependencies]
- clap = { version = "3.2", features = ["derive", "std"], default-features = false }
--git2 = { version = "0.14", features = ["ssh", "https", "vendored-libgit2", "vendored-openssl"], default-features = false }
-+git2 = { version = "0.14", features = ["ssh", "https"], default-features = false }
+ clap = { version = "4.0", features = ["derive", "std", "help"], default-features = false }
+-git2 = { version = "0.15", features = ["ssh", "https", "vendored-libgit2", "vendored-openssl"], default-features = false }
++git2 = { version = "0.15", features = ["ssh", "https"], default-features = false }
  console = "0.15"
  dialoguer = "0.10"
  dirs = "4.0"


### PR DESCRIPTION
###### Description of changes

https://github.com/cargo-generate/cargo-generate/compare/v0.16.0...v0.17.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
