### PR TITLE
vowpal-wabbit: 9.0.1 -> 9.6.0

### DIFF
--- a/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
+++ b/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-iSsxpeTRZjIhZaYBeoKLHl9j1aBIXWjONmAInmKvU/I=";
   };
-  
+
   patches = [
     (fetchpatch {
       url = "https://github.com/VowpalWabbit/vowpal_wabbit/commit/0cb410dfc885ca1ecafd1f8a962b481574fb3b82.patch";

--- a/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
+++ b/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Fix x86_64-linux build by adding missing include
+    # https://github.com/VowpalWabbit/vowpal_wabbit/pull/4275
     (fetchpatch {
       url = "https://github.com/VowpalWabbit/vowpal_wabbit/commit/0cb410dfc885ca1ecafd1f8a962b481574fb3b82.patch";
       sha256 = "sha256-bX3eJ+vMTEMAo3EiESQTDryBP0h2GtnMa/Fz0rTeaNY=";

--- a/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
+++ b/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/VowpalWabbit/vowpal_wabbit/commit/0cb410dfc885ca1ecafd1f8a962b481574fb3b82.patch";
-      sha256 = "798246d976932a6e278d071fdff0bff57ba994a3aef58926bbf4e0bf6fa09690";
+      sha256 = "sha256-bX3eJ+vMTEMAo3EiESQTDryBP0h2GtnMa/Fz0rTeaNY=";
     })
   ];
 

--- a/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
+++ b/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
@@ -10,6 +10,13 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-iSsxpeTRZjIhZaYBeoKLHl9j1aBIXWjONmAInmKvU/I=";
   };
+  
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/VowpalWabbit/vowpal_wabbit/commit/0cb410dfc885ca1ecafd1f8a962b481574fb3b82.patch";
+      sha256 = "798246d976932a6e278d071fdff0bff57ba994a3aef58926bbf4e0bf6fa09690";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
+++ b/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, boost, eigen, rapidjson, spdlog, zlib }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, boost, eigen, rapidjson, spdlog, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "vowpal-wabbit";

--- a/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
+++ b/pkgs/applications/science/machine-learning/vowpal-wabbit/default.nix
@@ -1,42 +1,35 @@
-{ lib, stdenv, fetchFromGitHub, cmake, boost, flatbuffers, rapidjson, spdlog, zlib }:
+{ lib, stdenv, fetchFromGitHub, cmake, boost, eigen, rapidjson, spdlog, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "vowpal-wabbit";
-  version = "9.0.1";
+  version = "9.6.0";
 
   src = fetchFromGitHub {
     owner = "VowpalWabbit";
     repo = "vowpal_wabbit";
     rev = version;
-    sha256 = "sha256-ZUurY2bmTKKIW4GR4oiIpLxb6DSRUNJI/EyNSOu9D9c=";
+    sha256 = "sha256-iSsxpeTRZjIhZaYBeoKLHl9j1aBIXWjONmAInmKvU/I=";
   };
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
     boost
-    flatbuffers
+    eigen
     rapidjson
     spdlog
     zlib
   ];
 
-  # -DBUILD_TESTS=OFF is set as both it saves time in the build and the default
-  # cmake flags appended by the builder include -DBUILD_TESTING=OFF for which
-  # this is the equivalent flag.
-  # Flatbuffers are an optional feature.
-  # BUILD_FLATBUFFERS=ON turns it on. This will still consume Flatbuffers as a
-  # system dependency
   cmakeFlags = [
     "-DVW_INSTALL=ON"
-    "-DBUILD_TESTS=OFF"
     "-DBUILD_JAVA=OFF"
     "-DBUILD_PYTHON=OFF"
-    "-DUSE_LATEST_STD=ON"
     "-DRAPIDJSON_SYS_DEP=ON"
     "-DFMT_SYS_DEP=ON"
     "-DSPDLOG_SYS_DEP=ON"
-    "-DBUILD_FLATBUFFERS=ON"
+    "-DVW_BOOST_MATH_SYS_DEP=ON"
+    "-DVW_EIGEN_SYS_DEP=ON"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Replaces #199878

- flatbuffers removed as a dep as the upstream doesn't support installing with flatbuffer support currently and this is an experimental feature
- BUILD_TESTS workaround removed as upstream now properly understands BUILD_TESTING
- `eigen` is a new dependency in this release
- Removed `USE_LATEST_STD` as it was causing an ICE in clang when building on an m1 macbook and it is not strictly necessary for the package

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
