### PR TITLE
ruby: Make reproducible

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -188,7 +188,7 @@ let
             ''
           }
           # Remove unnecessary external intermediate files created by gems
-          extMakefiles=$(find $out/lib/ruby/gems -name Makefile)
+          extMakefiles=$(find $out/${passthru.gemPath} -name Makefile)
           for makefile in $extMakefiles; do
             make -C "$(dirname "$makefile")" distclean
           done

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -192,6 +192,7 @@ let
           for makefile in $extMakefiles; do
             make -C "$(dirname "$makefile")" distclean
           done
+          find "$out/${passthru.gemPath}" -name gem_make.out -delete
           # Bundler tries to create this directory
           mkdir -p $out/nix-support
           cat > $out/nix-support/setup-hook <<EOF


### PR DESCRIPTION
Bundled gems that have native extensions have a gem_make.out file that is the build log for the native extension. That file contains random filenames. Since this file is not needed, simply remove it.

With this change, ruby, ruby_3_0, and ruby_3_1 builds are reproducible, at least on x86_64-linux. I tested basic functionality of the two affected bundled gems as well (on ruby_3_1), and, unsurprisingly, seemed fine.

Example `diff -ur` from `nix build --rebuild --keep-failed .#ruby_3_1`, before this change:

```diff
diff -ur /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/debug-1.4.0/gem_make.out /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2.check/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/debug-1.4.0/gem_make.out
--- /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/debug-1.4.0/gem_make.out	1969-12-31 19:00:01.000000000 -0500
+++ /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2.check/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/debug-1.4.0/gem_make.out	1969-12-31 19:00:01.000000000 -0500
@@ -3,12 +3,12 @@
 creating Makefile

 current directory: /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug
-make DESTDIR\= sitearchdir\=./.gem.20221028-31660-a79mlv sitelibdir\=./.gem.20221028-31660-a79mlv clean
+make DESTDIR\= sitearchdir\=./.gem.20221109-31667-zllvs sitelibdir\=./.gem.20221109-31667-zllvs clean
 make[1]: Entering directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug'
 make[1]: Leaving directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug'

 current directory: /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug
-make DESTDIR\= sitearchdir\=./.gem.20221028-31660-a79mlv sitelibdir\=./.gem.20221028-31660-a79mlv
+make DESTDIR\= sitearchdir\=./.gem.20221109-31667-zllvs sitelibdir\=./.gem.20221109-31667-zllvs
 make[1]: Entering directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug'
 compiling debug.c
 compiling iseq_collector.c
@@ -16,7 +16,7 @@
 make[1]: Leaving directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug'

 current directory: /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug
-make DESTDIR\= sitearchdir\=./.gem.20221028-31660-a79mlv sitelibdir\=./.gem.20221028-31660-a79mlv install
+make DESTDIR\= sitearchdir\=./.gem.20221109-31667-zllvs sitelibdir\=./.gem.20221109-31667-zllvs install
 make[1]: Entering directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug'
-/nix/store/xq4g38m5ppg78z7bzfxyy2s8ii693k74-coreutils-9.1/bin/install -c -m 0755 debug.so ./.gem.20221028-31660-a79mlv/debug
+/nix/store/xq4g38m5ppg78z7bzfxyy2s8ii693k74-coreutils-9.1/bin/install -c -m 0755 debug.so ./.gem.20221109-31667-zllvs/debug
 make[1]: Leaving directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.4.0/ext/debug'
diff -ur /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/rbs-2.1.0/gem_make.out /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2.check/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/rbs-2.1.0/gem_make.out
--- /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/rbs-2.1.0/gem_make.out	1969-12-31 19:00:01.000000000 -0500
+++ /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2.check/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/rbs-2.1.0/gem_make.out	1969-12-31 19:00:01.000000000 -0500
@@ -3,12 +3,12 @@
 creating Makefile

 current directory: /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension
-make DESTDIR\= sitearchdir\=./.gem.20221028-31660-cv0bgw sitelibdir\=./.gem.20221028-31660-cv0bgw clean
+make DESTDIR\= sitearchdir\=./.gem.20221109-31667-7spnp3 sitelibdir\=./.gem.20221109-31667-7spnp3 clean
 make[1]: Entering directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension'
 make[1]: Leaving directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension'

 current directory: /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension
-make DESTDIR\= sitearchdir\=./.gem.20221028-31660-cv0bgw sitelibdir\=./.gem.20221028-31660-cv0bgw
+make DESTDIR\= sitearchdir\=./.gem.20221109-31667-7spnp3 sitelibdir\=./.gem.20221109-31667-7spnp3
 make[1]: Entering directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension'
 compiling constants.c
 compiling lexer.c
@@ -23,7 +23,7 @@
 make[1]: Leaving directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension'

 current directory: /nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension
-make DESTDIR\= sitearchdir\=./.gem.20221028-31660-cv0bgw sitelibdir\=./.gem.20221028-31660-cv0bgw install
+make DESTDIR\= sitearchdir\=./.gem.20221109-31667-7spnp3 sitelibdir\=./.gem.20221109-31667-7spnp3 install
 make[1]: Entering directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension'
-/nix/store/xq4g38m5ppg78z7bzfxyy2s8ii693k74-coreutils-9.1/bin/install -c -m 0755 rbs_extension.so ./.gem.20221028-31660-cv0bgw
+/nix/store/xq4g38m5ppg78z7bzfxyy2s8ii693k74-coreutils-9.1/bin/install -c -m 0755 rbs_extension.so ./.gem.20221109-31667-7spnp3
 make[1]: Leaving directory '/nix/store/m9xczrqsh4chvg4b9z3sl4y93s0jqlbg-ruby-3.1.2/lib/ruby/gems/3.1.0/gems/rbs-2.1.0/ext/rbs_extension'
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
