### PR TITLE
honeycomb-refinery: init at 1.19.0

### DIFF
--- a/pkgs/servers/tracing/honeycomb/refinery/0001-add-NO_REDIS_TEST-env-var-that-disables-Redis-requir.patch
+++ b/pkgs/servers/tracing/honeycomb/refinery/0001-add-NO_REDIS_TEST-env-var-that-disables-Redis-requir.patch
@@ -1,0 +1,37 @@
+From 301de689a1f7fae8ee6d0d5bbbe155a351b1b927 Mon Sep 17 00:00:00 2001
+From: Jade Lovelace <jadel@mercury.com>
+Date: Wed, 9 Nov 2022 11:02:02 -0800
+Subject: [PATCH] add NO_REDIS_TEST env-var that disables Redis-requiring tests
+
+---
+ internal/peer/peers_test.go | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/internal/peer/peers_test.go b/internal/peer/peers_test.go
+index 5ec7f81..c64b1b4 100644
+--- a/internal/peer/peers_test.go
++++ b/internal/peer/peers_test.go
+@@ -2,6 +2,7 @@ package peer
+ 
+ import (
+ 	"context"
++	"os"
+ 	"testing"
+ 	"time"
+ 
+@@ -26,6 +27,12 @@ func TestNewPeers(t *testing.T) {
+ 		t.Errorf("received %T expected %T", i, &filePeers{})
+ 	}
+ 
++	// Allow skipping test requiring redis, since Nix builds without redis
++	// available
++	if os.Getenv("NO_REDIS_TEST") != "" {
++		t.Skip("Skipping redis-requiring test");
++	}
++
+ 	c = &config.MockConfig{
+ 		GetPeerListenAddrVal: "0.0.0.0:8081",
+ 		PeerManagementType:   "redis",
+-- 
+2.37.1
+

--- a/pkgs/servers/tracing/honeycomb/refinery/default.nix
+++ b/pkgs/servers/tracing/honeycomb/refinery/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "honeycomb-refinery";
+  version = "1.19.0";
+
+  src = fetchFromGitHub {
+    owner = "honeycombio";
+    repo = "refinery";
+    rev = "v${version}";
+    hash = "sha256-SU9JbyUuBMqPw4XcoF5s8CgBn7+V/rHBAwpXJk373jg=";
+  };
+
+  NO_REDIS_TEST = true;
+
+  patches = [
+    # Allows turning off the one test requiring a Redis service during build.
+    # We could in principle implement that, but it's significant work to little
+    # payoff.
+    ./0001-add-NO_REDIS_TEST-env-var-that-disables-Redis-requir.patch
+  ];
+
+  excludedPackages = [ "cmd/test_redimem" ];
+
+  ldflags = [ "-s" "-w" "-X main.BuildID=${version}" ];
+
+  vendorHash = "sha256-0M05JGLdmKivRTN8ZdhAm+JtXTlYAC31wFS82g3NenI=";
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/honeycomb/refinery";
+    description = "A tail-sampling proxy for OpenTelemetry";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lf- ];
+    mainProgram = "refinery";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -502,6 +502,8 @@ with pkgs;
 
   hobbes = callPackage ../development/tools/hobbes { stdenv = gcc10StdenvCompat; };
 
+  honeycomb-refinery = callPackage ../servers/tracing/honeycomb/refinery { };
+
   html5validator = python3Packages.callPackage ../applications/misc/html5validator { };
 
   buildcatrust = with python3.pkgs; toPythonApplication buildcatrust;


### PR DESCRIPTION
###### Description of changes

This is a tail sampling proxy for OpenTelemetry, which collects full traces in-memory, then makes sampling decisions, finally sending traces out if they were chosen to be sampled.

https://github.com/honeycombio/refinery

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
