### PR TITLE
cudaPackages_11_8: fix missing manifest

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/redist/extension.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/extension.nix
@@ -12,6 +12,7 @@ final: prev: let
     "11.5" = ./manifests/redistrib_11.5.2.json;
     "11.6" = ./manifests/redistrib_11.6.2.json;
     "11.7" = ./manifests/redistrib_11.7.0.json;
+    "11.8" = ./manifests/redistrib_11.8.0.json;
   };
 
   # Function to build a single cudatoolkit redist package


### PR DESCRIPTION
A follow-up on https://github.com/NixOS/nixpkgs/pull/194705/
...fixes missing attributes, like `cudaPackages_11_8.libcublas`

P.S. I thought we had decided to update `cudaPackages` to `cudaPackages_11_8` in a separate commit, but it seems we didn't - in the end?

###### Description of changes

Before:
```console
❯ nix eval --impure --expr 'builtins.attrNames (import ./. { config.allowUnfree = true; }).cudaPackages_11_8'
[ "addBuildInputs" "autoAddOpenGLRunpathHook" "callPackage" "cuda-library-samples" "cuda-samples" "cudaMajorMinorVersion" "cudaMajorVersion" "cudaVersion" "cudatoolkit" "cudnn" "cudnn_8_6_0" "cutensor" "lib" "nccl" "newScope" "override" "overrideDerivation" "overrideSco
pe" "overrideScope'" "packages" "pkgs" "tensorrt" ]
```

Now:
```console
❯ nix eval --impure --expr 'builtins.attrNames (import ./. { config.allowUnfree = true; }).cudaPackages_11_8'
[ "addBuildInputs" "autoAddOpenGLRunpathHook" "callPackage" "cuda-library-samples" "cuda-samples" "cudaMajorMinorVersion" "cudaMajorVersion" "cudaVersion" "cuda_cccl" "cuda_compat" "cuda_cudart" "cuda_cuobjdump" "cuda_cupti" "cuda_cuxxfilt" "cuda_demo_suite" "cuda_documentation" "cuda_gdb" "cuda_memcheck" "cuda_nsight" "cuda_nvcc" "cuda_nvdisasm" "cuda_nvml_dev" "cuda_nvprof" "cuda_nvprune" "cuda_nvrtc" "cuda_nvtx" "cuda_nvvp" "cuda_profiler_api" "cuda_sanitizer_api" "cudatoolkit" "cudnn" "cudnn_8_6_0" "cutensor" "fabricmanager" "lib" "libcublas" "libcudla" "libcufft" "libcufile" "libcurand" "libcusolver" "libcusparse" "libnpp" "libnvidia_nscq" "libnvjpeg" "nccl" "newScope" "nsight_compute" "nsight_nvtx" "nsight_systems" "nsight_vse" "nvidia_driver" "nvidia_fs" "override" "overrideDerivation" "overrideScope" "overrideScope'" "packages" "pkgs" "tensorrt" "visual_studio_integration" ]
```


@NixOS/cuda-maintainers 