### PR TITLE
rml: init at 1.09.07

### DIFF
--- a/pkgs/development/compilers/rml/default.nix
+++ b/pkgs/development/compilers/rml/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, ocamlPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rml";
+  version = "1.09.07";
+
+  src = fetchFromGitHub {
+    owner = "reactiveml";
+    repo = pname;
+    rev = "${pname}-${version}-2021-07-26";
+    hash = "sha256-UFqXQBeIQMSV4O439j9s06p1hh7xA98Tu79FsjK9PIY=";
+  };
+
+  nativeBuildInputs = with ocamlPackages; [
+    ocaml
+  ];
+
+  buildInputs = with ocamlPackages; [
+    num
+  ];
+
+  configureFlags = [ "--prefix" "${placeholder "out"}" ];
+
+  dontAddPrefix = true;
+
+  meta = with lib; {
+    description = "ReactiveML: a programming language for implementing interactive systems";
+    homepage = "https://rml.lri.fr";
+    license = with licenses; [ qpl lgpl21Plus ];
+    maintainers = with maintainers; [ wegank ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14928,6 +14928,8 @@ with pkgs;
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
+  rml = callPackage ../development/compilers/rml { };
+
   composable_kernel = callPackage ../development/libraries/composable_kernel {
     inherit (llvmPackages) openmp;
   };


### PR DESCRIPTION
###### Description of changes

ReactiveML is a general purpose programming language extended with concurrency constructs to ease the programming of interactive systems.

https://rml.lri.fr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
