### PR TITLE
flopoco: init at 4.1.3

### DIFF
--- a/pkgs/applications/science/electronics/flopoco/default.nix
+++ b/pkgs/applications/science/electronics/flopoco/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "The FloPoCo arithmetic core generator";
-    homepage = "http://flopoco.org";
+    homepage = "https://flopoco.org/";
     license = licenses.unfree;
     platforms = platforms.unix;
     maintainers = with maintainers; [ wegank ];

--- a/pkgs/applications/science/electronics/flopoco/default.nix
+++ b/pkgs/applications/science/electronics/flopoco/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchpatch
+, cmake
+, installShellFiles
+, bison
+, boost
+, flex
+, gmp
+, libxml2
+, mpfi
+, mpfr
+, scalp
+, sollya
+, wcpg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "flopoco";
+  version = "4.1.3";
+
+  src = fetchFromGitLab {
+    owner = pname;
+    repo = pname;
+    # flopoco-4.1.3 is not tagged on GitLab
+    rev = "67598298207c9f3261c35679c8a5966480c4343c";
+    sha256 = "sha256-0jRjg4/qciqBcjsi6BTbKO4VJkcoEzpC98wFkUOIGbI=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-clang-error-sin-cos.patch";
+      url = "https://gitlab.com/flopoco/flopoco/-/commit/de3aa60ad19333952c176c2a2e51f12653ca736b.patch";
+      postFetch = ''
+        substituteInPlace $out \
+          --replace 'FixSinCosCORDIC.hpp' 'CordicSinCos.hpp'
+      '';
+      sha256 = "sha256-BlamA/MZuuqqvGYto+jPeQPop6gwva0y394Odw8pdwg=";
+    })
+    (fetchpatch {
+      name = "fix-clang-error-atan2.patch";
+      url = "https://gitlab.com/flopoco/flopoco/-/commit/a3ffe2436c1b59ee0809b3772b74f2d43c6edb99.patch";
+      sha256 = "sha256-dSYcufLHDL0p1V1ghmy6X6xse5f6mjUqckaVqLZnTaA=";
+    })
+  ];
+
+  postPatch = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
+    sed -i "s/-pg//g" {,src/Apps/TaMaDi/}CMakeLists.txt
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bison
+    cmake
+    installShellFiles
+  ];
+
+  buildInputs = [
+    boost
+    flex
+    gmp
+    libxml2
+    mpfi
+    mpfr
+    scalp
+    sollya
+    wcpg
+  ];
+
+  postBuild = ''
+    ./flopoco BuildAutocomplete
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 flopoco $out/bin/flopoco
+    cp bin* fp* ieee* longacc* $out/bin/
+    installShellCompletion --bash flopoco_autocomplete
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The FloPoCo arithmetic core generator";
+    homepage = "http://flopoco.org";
+    license = licenses.unfree;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ wegank ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36052,6 +36052,8 @@ with pkgs;
 
   flatcam = callPackage ../applications/science/electronics/flatcam { };
 
+  flopoco = callPackage ../applications/science/electronics/flopoco { };
+
   fparser = callPackage ../applications/science/electronics/fparser { };
 
   geda = callPackage ../applications/science/electronics/geda {


### PR DESCRIPTION
###### Description of changes

FloPoCo is a generator of arithmetic cores (Floating-Point Cores, but not only) for FPGAs (but not only).

https://flopoco.org

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
