### PR TITLE
mautrix-discord: init at unstable-2022-11-04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11821,6 +11821,13 @@
     githubId = 521306;
     name = "Rob Glossop";
   };
+  robin = {
+    name = "Robin";
+    email = "robin@robin.town";
+    matrix = "@robin:robin.town";
+    github = "robintown";
+    githubId = 48614497;
+  };
   roblabla = {
     email = "robinlambertz+dev@gmail.com";
     github = "roblabla";

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -399,6 +399,12 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://go.mau.fi/mautrix-discord/">mautrix-discord</link>
+          Matrix to Discord hybrid puppeting/relaybot bridge.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://troglobit.com/projects/merecat/">merecat</link>,
           a small and easy HTTP server based on thttpd. Available as
           <link linkend="opt-services.merecat.enable">services.merecat</link>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -134,6 +134,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [expressvpn](https://www.expressvpn.com), the CLI client for ExpressVPN. Available as [services.expressvpn](#opt-services.expressvpn.enable).
 
+- [mautrix-discord](https://go.mau.fi/mautrix-discord/) Matrix to Discord hybrid puppeting/relaybot bridge.
+
 - [merecat](https://troglobit.com/projects/merecat/), a small and easy HTTP server based on thttpd. Available as [services.merecat](#opt-services.merecat.enable)
 
 - [go-autoconfig](https://github.com/L11R/go-autoconfig), IMAP/SMTP autodiscover server. Available as [services.go-autoconfig](#opt-services.go-autoconfig.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -541,6 +541,7 @@
   ./services/matrix/appservice-irc.nix
   ./services/matrix/conduit.nix
   ./services/matrix/dendrite.nix
+  ./services/matrix/mautrix-discord.nix
   ./services/matrix/mautrix-facebook.nix
   ./services/matrix/mautrix-telegram.nix
   ./services/matrix/mjolnir.nix

--- a/nixos/modules/services/matrix/mautrix-discord.nix
+++ b/nixos/modules/services/matrix/mautrix-discord.nix
@@ -1,0 +1,131 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mautrix-discord;
+  dataDir = "/var/lib/mautrix-discord";
+  registrationFile = "${dataDir}/discord-registration.yaml";
+  settingsFormat = pkgs.formats.yaml { };
+  settingsFile = settingsFormat.generate "mautrix-discord-config.yaml" cfg.settings;
+  runtimeSettingsFile = "${dataDir}/config.yaml";
+in {
+  options = {
+    services.mautrix-discord = {
+      enable = mkEnableOption (mdDoc "Matrix to Discord hybrid puppeting/relaybot bridge");
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.mautrix-discord;
+        defaultText = literalExpression "pkgs.mautrix-discord";
+        description = mdDoc ''
+          The mautrix-discord package to use.
+        '';
+      };
+
+      settings = mkOption rec {
+        apply = recursiveUpdate default;
+        inherit (settingsFormat) type;
+        default = {
+          homeserver = {
+            software = "standard";
+          };
+
+          appservice = rec {
+            database = {
+              type = "sqlite3";
+              uri = "file:${dataDir}/mautrix-discord.db";
+            };
+            port = 8080;
+            address = "http://localhost:${toString port}";
+          };
+
+          bridge = {
+            permissions."*" = "relay";
+            double_puppet_server_map = {};
+            login_shared_secret_map = {};
+          };
+
+          logging = {
+            directory = "";
+            file_name_format = ""; # Disable file logging
+            file_date_format = "2006-01-02";
+            file_mode = 384;
+            timestamp_format = "Jan _2, 2006 15:04:05";
+            print_level = "warn";
+            print_json = false;
+            file_json = false;
+          };
+        };
+        description = mdDoc ''
+          Bridge configuration as a Nix attribute set.
+
+          Configuration options should match those described in
+          [example-config.yaml](https://github.com/mautrix/discord/blob/main/example-config.yaml).
+        '';
+      };
+
+      serviceDependencies = mkOption {
+        type = with types; listOf str;
+        default = optional config.services.matrix-synapse.enable "matrix-synapse.service";
+        defaultText = literalExpression ''
+          optional config.services.matrix-synapse.enable "matrix-synapse.service"
+        '';
+        description = mdDoc ''
+          List of Systemd services to require and wait for when starting the application service.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.mautrix-discord = {
+      description = "Matrix to Discord hybrid puppeting/relaybot bridge";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ] ++ cfg.serviceDependencies;
+      after = [ "network-online.target" ] ++ cfg.serviceDependencies;
+
+      preStart = ''
+        # Generate the appservice's registration file if absent
+        if [ ! -f '${registrationFile}' ]; then
+          ${cfg.package}/bin/mautrix-discord \
+            --config '${settingsFile}' \
+            --registration '${registrationFile}' \
+            --generate-registration
+        fi
+
+        old_umask=$(umask)
+        umask 0177
+        # Extract the AS and HS tokens from the registration and add them to the settings file
+        ${pkgs.yq}/bin/yq -y ".appservice.as_token = $(${pkgs.yq}/bin/yq .as_token ${registrationFile}) | .appservice.hs_token = $(${pkgs.yq}/bin/yq .hs_token ${registrationFile})" ${settingsFile} > ${runtimeSettingsFile}
+        umask $old_umask
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+
+        DynamicUser = true;
+        PrivateTmp = true;
+        WorkingDirectory = cfg.package;
+        StateDirectory = baseNameOf dataDir;
+        UMask = "0027";
+
+        ExecStart = ''
+          ${cfg.package}/bin/mautrix-discord \
+            --config ${runtimeSettingsFile} \
+            --no-update
+        '';
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ robin ];
+}

--- a/nixos/tests/matrix/mautrix-discord.nix
+++ b/nixos/tests/matrix/mautrix-discord.nix
@@ -1,0 +1,154 @@
+import ../make-test-python.nix ({ pkgs, ... }:
+  let
+    homeserverUrl = "http://homeserver:8008";
+  in
+  {
+    name = "mautrix-discord";
+    meta.maintainers = pkgs.mautrix-discord.meta.maintainers;
+
+    nodes = {
+      homeserver = { pkgs, ... }: {
+        # We'll switch to this once the registration is copied into place
+        specialisation.running.configuration = {
+          services.matrix-synapse = {
+            enable = true;
+            settings = {
+              database.name = "sqlite3";
+              app_service_config_files = [ "/discord-registration.yaml" ];
+
+              enable_registration = true;
+
+              # don't use this in production, always use some form of verification
+              enable_registration_without_verification = true;
+
+              listeners = [ {
+                # The default but tls=false
+                bind_addresses = [
+                  "0.0.0.0"
+                ];
+                port = 8008;
+                resources = [ {
+                  "compress" = true;
+                  "names" = [ "client" ];
+                } {
+                  "compress" = false;
+                  "names" = [ "federation" ];
+                } ];
+                tls = false;
+                type = "http";
+              } ];
+            };
+          };
+
+          networking.firewall.allowedTCPPorts = [ 8008 ];
+        };
+      };
+
+      bridge = { pkgs, ... }: {
+        services.mautrix-discord = {
+          enable = true;
+
+          settings = {
+            homeserver = {
+              address = homeserverUrl;
+              domain = "homeserver";
+            };
+
+            appservice = {
+              address = "http://bridge:8009";
+              port = 8009;
+            };
+
+            bridge.permissions."@alice:homeserver" = "user";
+          };
+        };
+
+        networking.firewall.allowedTCPPorts = [ 8009 ];
+      };
+
+      client = { pkgs, ... }: {
+        environment.systemPackages = [
+          (pkgs.writers.writePython3Bin "do_test"
+          {
+            libraries = [ pkgs.python3Packages.matrix-nio ];
+            flakeIgnore = [
+              # We don't live in the dark ages anymore.
+              # Languages like Python that are whitespace heavy will overrun
+              # 79 characters..
+              "E501"
+            ];
+          } ''
+              import sys
+              import functools
+              import asyncio
+
+              from nio import AsyncClient, RoomMessageNotice, RoomCreateResponse, RoomInviteResponse
+
+
+              async def message_callback(matrix: AsyncClient, msg: str, _r, e):
+                  print("Received matrix text message: ", e)
+                  assert msg in e.body
+                  exit(0)  # Success!
+
+
+              async def run(homeserver: str):
+                  matrix = AsyncClient(homeserver)
+                  response = await matrix.register("alice", "foobar")
+                  print("Matrix register response: ", response)
+
+                  # Open a DM with the bridge bot
+                  response = await matrix.room_create()
+                  print("Matrix create room response:", response)
+                  assert isinstance(response, RoomCreateResponse)
+                  room_id = response.room_id
+
+                  response = await matrix.room_invite(room_id, "@discordbot:homeserver")
+                  assert isinstance(response, RoomInviteResponse)
+
+                  callback = functools.partial(
+                      message_callback, matrix, "Hello, I'm a Discord bridge bot."
+                  )
+                  matrix.add_event_callback(callback, RoomMessageNotice)
+
+                  print("Waiting for matrix message...")
+                  await matrix.sync_forever(timeout=30000)
+
+
+              if __name__ == "__main__":
+                  asyncio.run(run(sys.argv[1]))
+            ''
+          )
+        ];
+      };
+    };
+
+    testScript = ''
+      import pathlib
+      import os
+
+      start_all()
+
+      with subtest("start the bridge"):
+          bridge.wait_for_unit("mautrix-discord.service")
+
+      with subtest("copy the registration file"):
+          bridge.copy_from_vm("/var/lib/mautrix-discord/discord-registration.yaml")
+          homeserver.copy_from_host(
+              str(pathlib.Path(os.environ.get("out", os.getcwd())) / "discord-registration.yaml"), "/"
+          )
+          homeserver.succeed("chmod 444 /discord-registration.yaml")
+
+      with subtest("start the homeserver"):
+          homeserver.succeed(
+              "/run/current-system/specialisation/running/bin/switch-to-configuration test >&2"
+          )
+
+          homeserver.wait_for_unit("matrix-synapse.service")
+          homeserver.wait_for_open_port(8008)
+          # Bridge only opens the port after it contacts the homeserver
+          bridge.wait_for_open_port(8009)
+
+      with subtest("ensure messages can be exchanged"):
+          client.succeed("do_test ${homeserverUrl} >&2")
+    '';
+  })

--- a/pkgs/servers/mautrix-discord/default.nix
+++ b/pkgs/servers/mautrix-discord/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub, olm }:
+
+buildGoModule rec {
+  pname = "mautrix-discord";
+  version = "unstable-2022-11-04";
+
+  src = fetchFromGitHub {
+    owner = "mautrix";
+    repo = "discord";
+    rev = "f53975cc91e3c643a722adf0d3e0dfb98d0127a2";
+    hash = "sha256-xUALcN5oQfwC6gmOeygCkOAXJrJzNitBxHRFAKKgFvE=";
+  };
+
+  buildInputs = [ olm ];
+
+  vendorHash = "sha256-yday2mSnPwuhXWkCG4XY7qoBl3DXHcSvzBoZbjgYz/c=";
+
+  ldflags = [ "-s" "-w" ]; # https://github.com/NixOS/nixpkgs/issues/177698
+
+  doCheck = false; # No tests available
+
+  meta = with lib; {
+    homepage = "https://go.mau.fi/mautrix-discord";
+    description = "Matrix to Discord hybrid puppeting/relaybot bridge";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ robin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8607,6 +8607,8 @@ with pkgs;
 
   matrix-corporal = callPackage ../servers/matrix-corporal { };
 
+  mautrix-discord = callPackage ../servers/mautrix-discord { };
+
   mautrix-facebook = callPackage ../servers/mautrix-facebook { };
 
   mautrix-signal = recurseIntoAttrs (callPackage ../servers/mautrix-signal { });


### PR DESCRIPTION
mautrix-discord is a puppeting Discord bridge for Matrix, similar to mx-puppet-discord. Its main advantage over the latter is that mx-puppet-discord is effectively no longer maintained, so the original maintainer has suggested that users move to this bridge instead.

###### Description of changes

This adds a package and NixOS module for mautrix-discord.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
