### PR TITLE
sublime4: 4126 -> 4142

### DIFF
--- a/pkgs/applications/editors/sublime/4/packages.nix
+++ b/pkgs/applications/editors/sublime/4/packages.nix
@@ -5,9 +5,9 @@ let
 in
   {
     sublime4 = common {
-      buildVersion = "4126";
-      x64sha256 = "sha256-XGTlNMzgAy5U08cCjo1rO97yjz/SiiYkSjYKLOdUUKE=";
-      aarch64sha256 = "0gmnxyczj2wk9dilhkpa6gi2fkvbic6smyiimd3lq0s7ilbarm0a";
+      buildVersion = "4142";
+      x64sha256 = "JrFL17trcsUcS/bYbSbMhTnSMyla6AkoMII2lt2nAwY=";
+      aarch64sha256 = "r6bxOYXVA2RAo8prdBQ7/gSNKFPmwDW5osblIE0azT4=";
     } {};
 
     sublime4-dev = common {


### PR DESCRIPTION
###### Description of changes

Changelog at https://www.sublimetext.com/download

###### Things done

Built and tested.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
