### PR TITLE
buf: Add patch to make TestCyclicImport deterministic

### DIFF
--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, fetchpatch
 , protobuf
 , git
 , testers
@@ -29,6 +30,11 @@ buildGoModule rec {
     # Remove reliance of tests on file protocol which is disabled in git by default now
     # Rebased upstream change https://github.com/bufbuild/buf/commit/bcaa77f8bbb8f6c198154c7c8d53596da4506dab
     ./buf-tests-dont-use-file-transport.patch
+    # Make TestCyclicImport tests deterministic (see https://github.com/bufbuild/buf/pull/1551)
+    (fetchpatch {
+      url = "https://github.com/bufbuild/buf/commit/75b5ef4c84f5953002dff95a1c66cb82b0e3b06f.patch";
+      sha256 = "sha256-pKF3VXkzttsTTT2r/Z37ug9nnu8gRdkfmv/aTOhAJpw=";
+    })
   ];
 
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -35,6 +35,11 @@ buildGoModule rec {
       url = "https://github.com/bufbuild/buf/commit/75b5ef4c84f5953002dff95a1c66cb82b0e3b06f.patch";
       sha256 = "sha256-pKF3VXkzttsTTT2r/Z37ug9nnu8gRdkfmv/aTOhAJpw=";
     })
+    # Make TestDuplicateSyntheticOneofs check deterministic (see https://github.com/bufbuild/buf/pull/1579)
+    (fetchpatch {
+      url = "https://github.com/bufbuild/buf/commit/9e72aa314e6f02b36793caa5f6068394cbdcb98c.patch";
+      sha256 = "sha256-6NEF3sP1EQ6cQxkH2xRyHxAD0OrXBlQQa05rLK998wo=";
+    })
   ];
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
###### Description of changes

The test were failing on hydra (e.g. https://hydra.nixos.org/build/197933497/nixlog/1):

```
=== CONT  TestCyclicImport
    builder_test.go:270: 
                Error Trace:    /build/source/private/bufpkg/bufimage/bufimagebuild/builder_test.go:400
                                                        /build/source/private/bufpkg/bufimage/bufimagebuild/builder_test.go:270
                Error:          Not equal: 
                                expected: []string{"testdata/cyclicimport/a/a.proto:5:8:cycle found in imports: \"a/a.proto\" -> \"b/b.proto\" -> \"a/a.proto\""}
                                actual  : []string{"testdata/cyclicimport/b/b.proto:5:8:cycle found in imports: \"b/b.proto\" -> \"a/a.proto\" -> \"b/b.proto\""}
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 ([]string) (len=1) {
                                - (string) (len=101) "testdata/cyclicimport/a/a.proto:5:8:cycle found in imports: \"a/a.proto\" -> \"b/b.proto\" -> \"a/a.proto\""
                                + (string) (len=101) "testdata/cyclicimport/b/b.proto:5:8:cycle found in imports: \"b/b.proto\" -> \"a/a.proto\" -> \"b/b.proto\""
                                 }
                Test:           TestCyclicImport
--- FAIL: TestCyclicImport (0.00s)
=== CONT  TestDuplicateSyntheticOneofs
    builder_test.go:280: 
                Error Trace:    /build/source/private/bufpkg/bufimage/bufimagebuild/builder_test.go:400
                                                        /build/source/private/bufpkg/bufimage/bufimagebuild/builder_test.go:280
                Error:          Not equal: 
                                expected: []string{"testdata/duplicatesyntheticoneofs/a1.proto:5:9:symbol \"a.Foo\" already defined at a2.proto:5:9", "testdata/duplicatesyntheticoneofs/a1.proto:6:19:symbol \"a.Foo._bar\" already defined at a2.proto:6:19", "testdata/duplicatesyntheticoneofs/a1.proto:6:19:symbol \"a.Foo.bar\" already defined at a2.proto:6:19"}
                                actual  : []string{"testdata/duplicatesyntheticoneofs/a2.proto:5:9:symbol \"a.Foo\" already defined at a1.proto:5:9", "testdata/duplicatesyntheticoneofs/a2.proto:6:19:symbol \"a.Foo._bar\" already defined at a1.proto:6:19", "testdata/duplicatesyntheticoneofs/a2.proto:6:19:symbol \"a.Foo.bar\" already defined at a1.proto:6:19"}
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,5 +1,5 @@
                                 ([]string) (len=3) {
                                - (string) (len=93) "testdata/duplicatesyntheticoneofs/a1.proto:5:9:symbol \"a.Foo\" already defined at a2.proto:5:9",
                                - (string) (len=100) "testdata/duplicatesyntheticoneofs/a1.proto:6:19:symbol \"a.Foo._bar\" already defined at a2.proto:6:19",
                                - (string) (len=99) "testdata/duplicatesyntheticoneofs/a1.proto:6:19:symbol \"a.Foo.bar\" already defined at a2.proto:6:19"
                                + (string) (len=93) "testdata/duplicatesyntheticoneofs/a2.proto:5:9:symbol \"a.Foo\" already defined at a1.proto:5:9",
                                + (string) (len=100) "testdata/duplicatesyntheticoneofs/a2.proto:6:19:symbol \"a.Foo._bar\" already defined at a1.proto:6:19",
                                + (string) (len=99) "testdata/duplicatesyntheticoneofs/a2.proto:6:19:symbol \"a.Foo.bar\" already defined at a1.proto:6:19"
                                 }
                Test:           TestDuplicateSyntheticOneofs
--- FAIL: TestDuplicateSyntheticOneofs (0.00s)
```

There is an upstream fix, see https://github.com/bufbuild/buf/pull/1551

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
