### PR TITLE
syncthingtray: Fix Nix wrapped path in autostart desktop generation

### DIFF
--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , lib
 , fetchFromGitHub
+, substituteAll
 , qtbase
 , qtwebengine
 , qtdeclarative
@@ -30,6 +31,17 @@ mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-uhVRO9aiYJbUmwDp1+LIYF3wNBbVduVpTtVzaS0oUMU=";
   };
+
+  patches = [
+    # Fix Exec= path in runtime-generated
+    # ~/.config/autostart/syncthingtray.desktop file - this is required because
+    # we are wrapping the executable. We can't use `substituteAll` because we
+    # can't use `${placeholder "out"}` because that will produce the $out of
+    # the patch derivation itself, and not of syncthing's "out" placeholder.
+    # Hence we use a C definition with NIX_CFLAGS_COMPILE
+    ./use-nix-path-in-autostart.patch
+  ];
+  NIX_CFLAGS_COMPILE = "-DEXEC_NIX_PATH=\"${placeholder "out"}/bin/syncthingtray\"";
 
   buildInputs = [
     qtbase

--- a/pkgs/applications/misc/syncthingtray/use-nix-path-in-autostart.patch
+++ b/pkgs/applications/misc/syncthingtray/use-nix-path-in-autostart.patch
@@ -1,0 +1,13 @@
+diff --git i/widgets/settings/settingsdialog.cpp w/widgets/settings/settingsdialog.cpp
+index 4deff1f..16845b5 100644
+--- i/widgets/settings/settingsdialog.cpp
++++ w/widgets/settings/settingsdialog.cpp
+@@ -802,7 +802,7 @@ bool setAutostartEnabled(bool enabled)
+         desktopFile.write("[Desktop Entry]\n"
+                           "Name=" APP_NAME "\n"
+                           "Exec=\"");
+-        desktopFile.write(qEnvironmentVariable("APPIMAGE", QCoreApplication::applicationFilePath()).toUtf8().data());
++        desktopFile.write(qEnvironmentVariable("APPIMAGE", EXEC_NIX_PATH).toUtf8().data());
+         desktopFile.write("\" qt-widgets-gui --single-instance\nComment=" APP_DESCRIPTION "\n"
+                           "Icon=" PROJECT_NAME "\n"
+                           "Type=Application\n"


### PR DESCRIPTION
Fixes #199596.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
