### PR TITLE
[22.05] element-{web,desktop}: 1.11.13 -> 1.11.14

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "lib/electron-main.js",
-  "version": "1.11.13",
+  "version": "1.11.14",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {
@@ -53,6 +53,7 @@
     "@babel/core": "^7.18.10",
     "@babel/preset-env": "^7.18.10",
     "@babel/preset-typescript": "^7.18.6",
+    "@electron/notarize": "^1.2.3",
     "@types/auto-launch": "^5.0.1",
     "@types/counterpart": "^0.18.1",
     "@types/detect-libc": "^1.0.0",
@@ -70,10 +71,9 @@
     "chokidar": "^3.5.2",
     "detect-libc": "^1.0.3",
     "electron": "^20",
-    "electron-builder": "22.11.4",
-    "electron-builder-squirrel-windows": "22.11.4",
+    "electron-builder": "^23.6.0",
+    "electron-builder-squirrel-windows": "^23.6.0",
     "electron-devtools-installer": "^3.1.1",
-    "electron-notarize": "^1.0.0",
     "eslint": "7.18.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-import": "^2.25.4",
@@ -134,13 +134,9 @@
     },
     "win": {
       "target": [
-        "squirrel",
-        "msi"
+        "squirrel"
       ],
       "sign": "scripts/electron_winSign"
-    },
-    "msi": {
-      "perMachine": true
     },
     "directories": {
       "output": "dist"

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.11.13",
-  "desktopSrcHash": "E8jpv7cJf8qdR4I3n7id5hUysAiMVvwyqUqHzGnVUJE=",
-  "desktopYarnHash": "1scp9y2lmah3n20f1kpc9paspd3qgslg129diis7g11cz4h0wyi5",
-  "webHash": "1nm2vbqv8gpqzi3wsf0zzy5q13vxwdkfhxk4l6k5k47gmd2g6smp"
+  "version": "1.11.14",
+  "desktopSrcHash": "91WCtb+ylVz9gSqOHb5GuSC1YZjDS3M8gdFIZYVls3c=",
+  "desktopYarnHash": "1ng9fwpwxsw91bzgd2kb2pdq927rkjv5rrrkmszvn55bj6ry7sqi",
+  "webHash": "06bv2qbbd7zj8987a6ah3bxdnr0qcxrimlns16shk1ciawd0c81d"
 }


### PR DESCRIPTION

###### Description of changes
ChangeLog web: https://github.com/vector-im/element-web/releases/tag/v1.11.14 ChangeLog desktop: https://github.com/vector-im/element-desktop/releases/tag/v1.11.14

Backport of 1eb380d489517996794d0852cb5a389a144b4fee (#200301).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
