### PR TITLE
astc-encoder: 3.6 -> 4.2.0

### DIFF
--- a/pkgs/tools/graphics/astc-encoder/default.nix
+++ b/pkgs/tools/graphics/astc-encoder/default.nix
@@ -1,5 +1,5 @@
 { lib
-, gccStdenv
+, stdenv
 , fetchFromGitHub
 , cmake
 , simdExtensions ? null
@@ -8,7 +8,7 @@
 with rec {
   # SIMD instruction sets to compile for. If none are specified by the user,
   # an appropriate one is selected based on the detected host system
-  isas = with gccStdenv.hostPlatform;
+  isas = with stdenv.hostPlatform;
     if simdExtensions != null then lib.toList simdExtensions
     else if avx2Support then [ "AVX2" ]
     else if sse4_1Support then [ "SSE41" ]
@@ -16,7 +16,7 @@ with rec {
     else if isAarch64 then [ "NEON" ]
     else [ "NONE" ];
 
-  archFlags = lib.optionals gccStdenv.hostPlatform.isAarch64 [ "-DARCH=aarch64" ];
+  archFlags = lib.optionals stdenv.hostPlatform.isAarch64 [ "-DARCH=aarch64" ];
 
   # CMake Build flags for the selected ISAs. For a list of flags, see
   # https://github.com/ARM-software/astc-encoder/blob/main/Docs/Building.md
@@ -24,12 +24,12 @@ with rec {
 
   # The suffix of the binary to link as 'astcenc'
   mainBinary = builtins.replaceStrings
-    [ "AVX2" "SSE41"  "SSE2" "NEON" "NONE" ]
-    [ "avx2" "sse4.1" "sse2" "neon" "none" ]
+    [ "AVX2" "SSE41"  "SSE2" "NEON" "NONE" "NATIVE" ]
+    [ "avx2" "sse4.1" "sse2" "neon" "none" "native" ]
     ( builtins.head isas );
 };
 
-gccStdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "astc-encoder";
   version = "4.2.0";
 
@@ -43,7 +43,7 @@ gccStdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = isaFlags ++ archFlags ++ [
-    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
   ];
 
   # Set a fixed build year to display within help output (otherwise, it would be 1980)
@@ -52,9 +52,8 @@ gccStdenv.mkDerivation rec {
       --replace 'string(TIMESTAMP astcencoder_YEAR "%Y")' 'set(astcencoder_YEAR "2022")'
   '';
 
-  # Link binaries into environment and provide 'astcenc' link
+  # Provide 'astcenc' link to main executable
   postInstall = ''
-    mv $out/astcenc $out/bin
     ln -s $out/bin/astcenc-${mainBinary} $out/bin/astcenc
   '';
 
@@ -73,6 +72,6 @@ gccStdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.asl20;
     maintainers = with maintainers; [ dasisdormax ];
-    broken = !gccStdenv.is64bit;
+    broken = !stdenv.is64bit;
   };
 }

--- a/pkgs/tools/graphics/astc-encoder/default.nix
+++ b/pkgs/tools/graphics/astc-encoder/default.nix
@@ -31,13 +31,13 @@ with rec {
 
 gccStdenv.mkDerivation rec {
   pname = "astc-encoder";
-  version = "3.6";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "ARM-software";
     repo = "astc-encoder";
     rev = version;
-    sha256 = "sha256-TzVO2xQOuE87h8j4UwkpnAaFwkvy5dZge8zDNR/mVf0=";
+    sha256 = "sha256-zE0rXCmRz3z1P1wLm8aO7iQ/Yf1TJeEZqz9fB0Shsz4=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Description of changes

- Version update from version 3.6 to 4.2.0. Upstream changelog:
  - https://github.com/ARM-software/astc-encoder/releases
  - The versions 3.7, 4.0.0, 4.1.0 are skipped
- Fix macOS build, finally ...
  - by switching back to the regular stdenv and using the "RelWithDebInfo" build settings

Closes #174408

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux (cross-compile only)
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
