### PR TITLE
lvm2: 2.03.16 -> 2.03.17, 2.02.187 -> 2.02.188

### DIFF
--- a/pkgs/os-specific/linux/lvm2/2_02.nix
+++ b/pkgs/os-specific/linux/lvm2/2_02.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "2.02.187";
-  sha256 = "sha256-Dg1SGoY6XbJEDy4edie6grcCc65KsLvhMIUdsNWOWvE=";
+  version = "2.02.188";
+  sha256 = "sha256-cQHosIFq135DkP7ZdJoJAhS6UgBhzQg0N4ceGeUMyb0=";
 }

--- a/pkgs/os-specific/linux/lvm2/2_02.nix
+++ b/pkgs/os-specific/linux/lvm2/2_02.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
   version = "2.02.188";
-  sha256 = "sha256-cQHosIFq135DkP7ZdJoJAhS6UgBhzQg0N4ceGeUMyb0=";
+  hash = "sha256-cQHosIFq135DkP7ZdJoJAhS6UgBhzQg0N4ceGeUMyb0=";
 }

--- a/pkgs/os-specific/linux/lvm2/2_03.nix
+++ b/pkgs/os-specific/linux/lvm2/2_03.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
   version = "2.03.16";
-  sha256 = "sha256-5mHs4VtdiNir45pMHh2y9D4YlvAZlIu5iw4V13doB4Y=";
+  hash = "sha256-5mHs4VtdiNir45pMHh2y9D4YlvAZlIu5iw4V13doB4Y=";
 }

--- a/pkgs/os-specific/linux/lvm2/2_03.nix
+++ b/pkgs/os-specific/linux/lvm2/2_03.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "2.03.16";
-  hash = "sha256-5mHs4VtdiNir45pMHh2y9D4YlvAZlIu5iw4V13doB4Y=";
+  version = "2.03.17";
+  hash = "sha256-cobPqWUYKMWJOJUJVGMzuNqWXfqEoaTIqz5oGkf6uuc=";
 }

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -1,4 +1,4 @@
-{ version, sha256 }:
+{ version, hash }:
 
 { lib, stdenv
 , fetchpatch
@@ -28,8 +28,11 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    url = "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${version}.tgz";
-    inherit sha256;
+    urls = [
+      "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${version}.tgz"
+      "ftp://sourceware.org/pub/lvm2/LVM2.${version}.tgz"
+    ];
+    inherit hash;
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
     "--bindir=${placeholder "bin"}/bin"
     "--sbindir=${placeholder "bin"}/bin"
     "--libdir=${placeholder "lib"}/lib"
+    "--with-libexecdir=${placeholder "lib"}/libexec"
   ] ++ lib.optional enableCmdlib "--enable-cmdlib"
   ++ lib.optionals enableDmeventd [
     "--enable-dmeventd"


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).