### PR TITLE
srvc: fix build on darwin, set meta.mainProgram

### DIFF
--- a/pkgs/applications/version-management/srvc/default.nix
+++ b/pkgs/applications/version-management/srvc/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform, stdenv, Security }:
+{ lib, rustPlatform, fetchFromGitHub, stdenv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "srvc";
@@ -13,6 +13,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-nJM7/w4awbCZQysUOSTO6bfsBXO3agJRdp1RyRZhtUY=";
 
+  # remove timeouts in tests to make them less flaky
+  patches = [ ./tests-no-timeout.patch ];
+
   buildInputs = lib.optionals stdenv.isDarwin [
     Security
   ];
@@ -22,5 +25,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/insilica/rs-srvc";
     license = licenses.asl20;
     maintainers = with maintainers; [ john-shaffer ];
+    mainProgram = "sr";
   };
 }

--- a/pkgs/applications/version-management/srvc/tests-no-timeout.patch
+++ b/pkgs/applications/version-management/srvc/tests-no-timeout.patch
@@ -1,0 +1,36 @@
+--- a/tests/common/mod.rs
++++ b/tests/common/mod.rs
+@@ -1,15 +1,13 @@
+ #![allow(dead_code)]
+ 
+ use std::path::PathBuf;
+-use std::time::Duration;
+ 
+ use assert_cmd::Command;
+ #[cfg(unix)]
+ use rexpect::session::PtySession;
+ 
+-pub fn cmd(timeout_millis: u64) -> Command {
++pub fn cmd(_: u64) -> Command {
+     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+-    cmd.timeout(Duration::from_millis(timeout_millis));
+     cmd.env_remove("RUST_BACKTRACE");
+     cmd
+ }
+@@ -19,14 +17,14 @@ pub fn spawn(
+     dir: &str,
+     args: Vec<&str>,
+     timestamp_override: u64,
+-    timeout_millis: u64,
++    _: u64,
+ ) -> Result<PtySession, rexpect::errors::Error> {
+     let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_sr"));
+     cmd.args(args);
+     cmd.current_dir(dir);
+     cmd.env("SR_TIMESTAMP_OVERRIDE", timestamp_override.to_string());
+     cmd.env_remove("RUST_BACKTRACE");
+-    Ok(rexpect::session::spawn_command(cmd, Some(timeout_millis))?)
++    rexpect::session::spawn_command(cmd, None)
+ }
+ 
+ pub fn remove_sink(dir: &str) -> Result<(), std::io::Error> {


### PR DESCRIPTION
###### Description of changes

ZHF #199919

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
