### PR TITLE
python310Packages.pytest-xdist: 2.5.0 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/pytest-forked/default.nix
+++ b/pkgs/development/python-modules/pytest-forked/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     description = "Run tests in isolated forked subprocesses";
     homepage = "https://github.com/pytest-dev/pytest-forked";

--- a/pkgs/development/python-modules/pytest-forked/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-forked/setup-hook.sh
@@ -1,0 +1,25 @@
+pytestForkedHook() {
+    pytestFlagsArray+=(
+        "--forked"
+    )
+
+    # Using --forked on darwin leads to crashes when fork safety is
+    # enabled. This often happens when urllib tries to request proxy
+    # settings on MacOS through `urllib.request.getproxies()`
+    # - https://github.com/python/cpython/issues/77906
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+    fi
+}
+
+# the flags should be added before pytestCheckHook runs so
+# until we have dependency mechanism in generic builder, we need to use this ugly hack.
+
+if [ -z "${dontUsePytestForked-}" ] && [ -z "${dontUsePytestCheck-}" ]; then
+    if [[ " ${preDistPhases:-} " =~ " pytestCheckPhase " ]]; then
+        preDistPhases+=" "
+        preDistPhases="${preDistPhases/ pytestCheckPhase / pytestForkedHook pytestCheckPhase }"
+    else
+        preDistPhases+=" pytestForkedHook"
+    fi
+fi

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -7,32 +7,47 @@
 , filelock
 , execnet
 , pytest
-, pytest-forked
 , psutil
-, pexpect
+, setproctitle
 }:
 
 buildPythonPackage rec {
   pname = "pytest-xdist";
-  version = "2.5.0";
+  version = "3.1.0";
   disabled = pythonOlder "3.6";
+
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-RYDeyj/wTdsqxT66Oddstd1e3qwFDLb7x2iw3XErTt8=";
+    hash = "sha256-QP2481RJIcXfzUhqwIDOIocOcdgs7W0uePqXwq3dSAw=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
   buildInputs = [
     pytest
   ];
-  checkInputs = [ pytestCheckHook filelock pexpect ];
-  propagatedBuildInputs = [ execnet pytest-forked psutil ];
+
+  propagatedBuildInputs = [
+    execnet
+  ];
+
+  checkInputs = [
+    filelock
+    pytestCheckHook
+  ];
+
+  passthru.optional-dependencies = {
+    psutil = [ psutil ];
+    setproctitle = [ setproctitle ];
+  };
 
   pytestFlagsArray = [
     # pytest can already use xdist at this point
     "--numprocesses=$NIX_BUILD_CORES"
-    "--forked"
   ];
 
   # access file system

--- a/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
@@ -1,16 +1,7 @@
 pytestXdistHook() {
     pytestFlagsArray+=(
         "--numprocesses=$NIX_BUILD_CORES"
-        "--forked"
     )
-
-    # Using --forked on darwin leads to crashes when fork safety is
-    # enabled. This often happens when urllib tries to request proxy
-    # settings on MacOS through `urllib.request.getproxies()`
-    # - https://github.com/python/cpython/issues/77906
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-    fi
 }
 
 # the flags should be added before pytestCheckHook runs so


### PR DESCRIPTION
Should we add a setup hook to pytest-forked instead?

###### Description of changes
https://github.com/pytest-dev/pytest-xdist/blob/v3.1.0/CHANGELOG.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
