### PR TITLE
emacsPackages.grails: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -47279,20 +47279,20 @@
   "repo": "lifeisfoo/emacs-grails",
   "unstable": {
    "version": [
-    20220407,
-    1847
+    20221110,
+    929
    ],
-   "commit": "350869ecc4f429fc4e26f826d6050d068e724c5d",
-   "sha256": "1zw8hh97jlxjdgi5spsfd40qgahwbcca2cg2wbqyn1pgq4rjdx0i"
+   "commit": "3019f86e555ee94388795a0475cfa213e3897bbb",
+   "sha256": "PpdaJ5ccAEwS7uC7YkDP4++ZexG7goDXsFEcHZhDdJ4="
   },
   "stable": {
    "version": [
     0,
     5,
-    0
+    1
    ],
-   "commit": "350869ecc4f429fc4e26f826d6050d068e724c5d",
-   "sha256": "1zw8hh97jlxjdgi5spsfd40qgahwbcca2cg2wbqyn1pgq4rjdx0i"
+   "commit": "3019f86e555ee94388795a0475cfa213e3897bbb",
+   "sha256": "PpdaJ5ccAEwS7uC7YkDP4++ZexG7goDXsFEcHZhDdJ4="
   }
  },
  {


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes build; 0.5.0 was missing parens. I submitted a patch to fix, which was applied shortly thereafter. The build now succeeds, although there are some warnings.

It also bumps the unstable version to match, since it was pointing at 0.5.0 as well. I wasn't sure if this required a separate commit, but I'm happy to do so if needed.

I also wasn't sure if this sort of surgical update was considered fine, or if maybe I should just submit a full melpa update.

ZHF: #199919

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
