### PR TITLE
tic80: init at 1.0.2164

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3134,6 +3134,12 @@
     githubId = 6754950;
     name = "David Armstrong Lewis";
   };
+  davidcromp = {
+    email = "davidcrompton1192@gmail.com";
+    github = "DavidCromp";
+    githubId = 10701143;
+    name = "David Crompton";
+  };
   davidrusu = {
     email = "davidrusu.me@gmail.com";
     github = "davidrusu";

--- a/pkgs/development/tools/tic80/default.nix
+++ b/pkgs/development/tools/tic80/default.nix
@@ -19,14 +19,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    ruby
+  ] ++ lib.optionals stdenv.isDarwin [
+    xcbuild
   ];
 
-  buildInputs = [
-    # Ruby support!
-    ruby
-  ] ++ lib.optional stdenv.isDarwin ([
-    xcbuild
-  ] ++ [
+  buildInputs = lib.optionals stdenv.isDarwin [
     AVFoundation
     AudioUnit
     Cocoa
@@ -34,7 +32,7 @@ stdenv.mkDerivation rec {
     CoreServices
     ForceFeedback
     OpenGL
-  ]);
+  ];
 
   postInstall =
     if stdenv.isDarwin then ''

--- a/pkgs/development/tools/tic80/default.nix
+++ b/pkgs/development/tools/tic80/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ruby
+, xcbuild
+, AVFoundation
+, AudioUnit
+, Cocoa
+, CoreAudio
+, CoreServices
+, ForceFeedback
+, OpenGL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tic-80";
+
+  version = "1.0.2164";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    # Ruby support!
+    ruby
+  ] ++ lib.optional stdenv.isDarwin ([
+    xcbuild
+  ] ++ [
+    AVFoundation
+    AudioUnit
+    Cocoa
+    CoreAudio
+    CoreServices
+    ForceFeedback
+    OpenGL
+  ]);
+
+  postInstall =
+    if stdenv.isDarwin then ''
+      cp -r bin $out/
+    '' else "";
+
+  src = fetchFromGitHub {
+    owner = "nesbox";
+    repo = "TIC-80";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "SnaAhdYoblxKlzTSyfcnvY6u7X6aIJIYWZAXtL2IIXc=";
+  };
+
+  meta = with lib; {
+    description = "TIC-80 is a free and open source fantasy computer for making, playing and sharing tiny games.";
+    homepage = "https://tic80.com";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/tools/tic80/default.nix
+++ b/pkgs/development/tools/tic80/default.nix
@@ -34,10 +34,9 @@ stdenv.mkDerivation rec {
     OpenGL
   ];
 
-  postInstall =
-    if stdenv.isDarwin then ''
-      cp -r bin $out/
-    '' else "";
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    cp -r bin $out
+  '';
 
   src = fetchFromGitHub {
     owner = "nesbox";

--- a/pkgs/development/tools/tic80/default.nix
+++ b/pkgs/development/tools/tic80/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "TIC-80 is a free and open source fantasy computer for making, playing and sharing tiny games.";
+    description = "TIC-80 is a free and open source fantasy computer for making, playing and sharing tiny games";
     homepage = "https://tic80.com";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/development/tools/tic80/default.nix
+++ b/pkgs/development/tools/tic80/default.nix
@@ -15,7 +15,6 @@
 
 stdenv.mkDerivation rec {
   pname = "tic-80";
-
   version = "1.0.2164";
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/tic80/default.nix
+++ b/pkgs/development/tools/tic80/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     homepage = "https://tic80.com";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ davidcromp ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32181,6 +32181,10 @@ with pkgs;
 
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
 
+  tic80 = callPackage ../development/tools/tic80 {
+    inherit (darwin.apple_sdk.frameworks) AVFoundation AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL;
+  };
+
   ticpp = callPackage ../development/libraries/ticpp { };
 
   ticker = callPackage ../applications/misc/ticker { };


### PR DESCRIPTION
###### Description of changes

Created TIC-80 package, as requested by #200260.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
