### PR TITLE
apgdiff: init at 2.7.0

### DIFF
--- a/pkgs/development/tools/database/apgdiff/default.nix
+++ b/pkgs/development/tools/database/apgdiff/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, makeWrapper
+, jre
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  version = "2.7.0";
+  pname = "apgdiff";
+
+  src = fetchurl {
+    url = "https://github.com/fordfrog/apgdiff/raw/release_${finalAttrs.version}/releases/apgdiff-${finalAttrs.version}.jar";
+    sha256 = "sha256-6OempDmedl6LOwP/s5y0hOIxGDWHd7qM7/opW3UwQ+I=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildCommand = ''
+    install -Dm644 $src $out/lib/apgdiff.jar
+
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/apgdiff \
+      --argv0 apgdiff \
+      --add-flags "-jar $out/lib/apgdiff.jar"
+  '';
+
+  meta = with lib; {
+    description = "Another PostgreSQL diff tool";
+    homepage = "https://apgdiff.com";
+    license = licenses.mit;
+    inherit (jre.meta) platforms;
+    sourceProvenance = sourceTypes.binaryBytecode;
+    maintainers = [ maintainers.misterio77 ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16203,6 +16203,8 @@ with pkgs;
 
   anybadge = with python3Packages; toPythonApplication anybadge;
 
+  apgdiff = callPackage ../development/tools/database/apgdiff { };
+
   apkg = callPackage ../tools/package-management/apkg { };
 
   augeas = callPackage ../tools/system/augeas { };


### PR DESCRIPTION
###### Description of changes

Adds [`apgdiff`](https://apgdiff.com/), a tool for diffing PostgreSQL schemas.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
