### PR TITLE
sqlcl: init at 22.3.1

### DIFF
--- a/pkgs/development/tools/database/sqlcl/default.nix
+++ b/pkgs/development/tools/database/sqlcl/default.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, makeWrapper, requireFile, unzip, jdk }:
+
+let
+  version = "22.3.1";
+  fileVersion = "1032109-01";
+in
+  stdenv.mkDerivation {
+
+  inherit version;
+  pname = "sqlcl";
+
+  src = requireFile rec {
+    url = "https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/download/";
+    name = "V${fileVersion}.zip";
+    message = ''
+      This Nix expression requires that ${name} already be part of the store. To
+      obtain it you need to
+
+      - navigate to ${url}
+      - make sure that it says "Version ${version}" above the list of downloads
+        - if it does not, click on the "Previous Version" link below the
+          download and repeat until the version is correct. This is necessary
+          because as the time of this writing there exists no permanent link
+          for the current version yet.
+          Also consider updating this package yourself (you probably just need
+          to change the `version` variable and update the sha256 to the one of
+          the new file) or opening an issue at the nixpkgs repo.
+      - click "Download"
+      - sign in or create an oracle account if neccessary
+      - on the next page, click the "${name}" link
+
+      and then add the file to the Nix store using either:
+
+        nix-store --add-fixed sha256 ${name}
+
+      or
+
+        nix-prefetch-url --type sha256 file:///path/to/${name}
+    '';
+    sha256 = "0yqj8m2zwl8m7zxrzjnbl2rqnl2imn5h1bfpnmklp03nkakbzjbn";
+  };
+
+  nativeBuildInputs = [ makeWrapper unzip ];
+
+  unpackCmd = "unzip $curSrc";
+
+  installPhase = ''
+    mkdir -p $out/libexec
+    mv * $out/libexec/
+
+    makeWrapper $out/libexec/bin/sql $out/bin/sqlcl \
+      --set JAVA_HOME ${jdk.home} \
+      --chdir "$out/libexec/bin"
+  '';
+
+  meta = with lib; {
+    description = "Oracle's Oracle DB CLI client";
+    longDescription = ''
+      Oracle SQL Developer Command Line (SQLcl) is a free command line
+      interface for Oracle Database. It allows you to interactively or batch
+      execute SQL and PL/SQL. SQLcl provides in-line editing, statement
+      completion, and command recall for a feature-rich experience, all while
+      also supporting your previously written SQL*Plus scripts.
+    '';
+    homepage = "https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ misterio77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16864,6 +16864,8 @@ with pkgs;
 
   libsigrokdecode = callPackage ../development/tools/libsigrokdecode { };
 
+  sqlcl = callPackage ../development/tools/database/sqlcl { };
+
   sigrok-firmware-fx2lafw = callPackage ../development/tools/sigrok-firmware-fx2lafw { };
 
   cli11 = callPackage ../development/tools/misc/cli11 { };


### PR DESCRIPTION
###### Description of changes

[Oracle SQL Developer Command Line (SQLcl)](https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/) is a free (of charge) command line interface for Oracle Database. It allows you to interactively or batch execute SQL and PL/SQL.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
