### PR TITLE
dxvk: 1.10.3 -> 2.0

### DIFF
--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Vulkan Header files and API registry";
     homepage    = "https://www.lunarg.com";
-    platforms   = platforms.unix;
+    platforms   = platforms.unix ++ platforms.windows;
     license     = licenses.asl20;
     maintainers = [ maintainers.ralith ];
   };

--- a/pkgs/misc/dxvk/default.nix
+++ b/pkgs/misc/dxvk/default.nix
@@ -22,11 +22,15 @@ stdenvNoCC.mkDerivation (finalAttrs:
     # platforms diverge (due to the need for Darwin-specific patches that would fail to apply).
     # Should that happen, set `darwin` to the last working `rev` and `hash`.
     srcs = rec {
-      darwin = { inherit (default) rev hash version; };
-      default = {
+      darwin = {
         rev = "v${finalAttrs.version}";
         hash = "sha256-T93ZylxzJGprrP+j6axZwl2d3hJowMCUOKNjIyNzkmE=";
         version = "1.10.3";
+      };
+      default = {
+        rev = "v${finalAttrs.version}";
+        hash = "sha256-mboVLdPgZMzmqyeF0jAloEz6xqfIDiY/X98e7l2KZnw=";
+        version = "2.0";
       };
     };
   in
@@ -60,10 +64,12 @@ stdenvNoCC.mkDerivation (finalAttrs:
 
     installPhase = ''
       mkdir -p $out/bin $bin $lib
+      # Replace both basedir forms to support both DXVK 2.0 and older versions.
       substitute setup_dxvk.sh $out/bin/setup_dxvk.sh \
         --subst-var-by mcfgthreads32 "${pkgsCross.mingw32.windows.mcfgthreads}" \
         --subst-var-by mcfgthreads64 "${pkgsCross.mingwW64.windows.mcfgthreads}" \
-        --replace 'basedir=$(dirname "$(readlink -f $0)")' "basedir=$bin"
+        --replace 'basedir=$(dirname "$(readlink -f $0)")' "basedir=$bin" \
+        --replace 'basedir="$(dirname "$(readlink -f "$0")")"' "basedir=$bin"
       chmod a+x $out/bin/setup_dxvk.sh
       declare -A dxvks=( [x32]=${dxvk32} [x64]=${dxvk64} )
       for arch in "''${!dxvks[@]}"; do

--- a/pkgs/misc/dxvk/dxvk.nix
+++ b/pkgs/misc/dxvk/dxvk.nix
@@ -7,17 +7,30 @@
 , windows
 , src
 , version
+, spirv-headers
+, vulkan-headers
 , dxvkPatches
 }:
 
+let
+  # DXVK 2.0+ no longer vendors certain dependencies. This derivation also needs to build on Darwin,
+  # which does not currently support DXVK 2.0, so adapt conditionally for this situation.
+  isDxvk2 = lib.versionAtLeast version "2.0";
+in
 stdenv.mkDerivation {
   pname = "dxvk";
   inherit src version;
 
   nativeBuildInputs = [ glslang meson ninja ];
-  buildInputs = [ windows.pthreads ];
+  buildInputs = [ windows.pthreads ]
+    ++ lib.optionals isDxvk2 [ spirv-headers vulkan-headers ];
 
   patches = dxvkPatches;
+
+  preConfigure = lib.optionalString isDxvk2 ''
+    ln -s ${lib.getDev spirv-headers}/include include/spirv/include
+    ln -s ${lib.getDev vulkan-headers}/include include/vulkan/include
+  '';
 
   mesonFlags =
     let


### PR DESCRIPTION
###### Description of changes

Creating this as a draft PR until after the 22.11 release.

DXVK 2.0 release notes: https://github.com/doitsujin/dxvk/releases/tag/v2.0

DXVK is pinned to 1.10.3 on Darwin because MoltenVK does not support Vulkan 1.3 or enough extensions for DXVK 2.0 to work with it. Alas, it’s not as easy anymore as just lying about extension support.

I was able to build and test that the `setup_dxvk.sh` script still works. Unfortunately, I do not have access to any Linux machines with capable GPUs to test the functionality beyond that.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
