### PR TITLE
recoll: 1.32.7 -> 1.33.2

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -35,11 +35,11 @@
 
 mkDerivation rec {
   pname = "recoll";
-  version = "1.32.7";
+  version = "1.33.2";
 
   src = fetchurl {
     url = "https://www.lesbonscomptes.com/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-ygim9LsLUZv5FaBiqbeq3E80NHPMHweJVwggjWYzfbo=";
+    sha256 = "sha256-ql4VHiblIn8uihUbF1htPnpvjw0qMxdzW8HLGlUrZW0=";
   };
 
   configureFlags = [ "--enable-recollq" "--disable-webkit" "--without-systemd" ]

--- a/pkgs/applications/search/recoll/fix-datadir.patch
+++ b/pkgs/applications/search/recoll/fix-datadir.patch
@@ -1,13 +1,13 @@
 diff --git a/utils/rclutil.cpp b/utils/rclutil.cpp
-index 60ff5fb..4a59ccc 100644
+index 6bafc119..d997cd17 100644
 --- a/utils/rclutil.cpp
 +++ b/utils/rclutil.cpp
 @@ -279,7 +279,7 @@ const string& path_pkgdatadir()
          "a subfolder of the installation directory. \n"
          "Please set the RECOLL_DATADIR environment variable to point to it\n"
          "(e.g. setx RECOLL_DATADIR \"C:/Program Files (X86)/Recoll/Share)\"\n";
--#elif defined(__APPLE__) && !defined(MACPORTS) && !defined(HOMEBREW)
-+#elif defined(__APPLE__) && !defined(MACPORTS) && !defined(HOMEBREW) && !defined(NIXPKGS)
-     uint32_t size = 0;
-     _NSGetExecutablePath(nullptr, &size);
-     char *path= (char*)malloc(size+1);
+-#elif defined(__APPLE__) && defined(RECOLL_AS_MAC_BUNDLE)
++#elif defined(__APPLE__) && defined(RECOLL_AS_MAC_BUNDLE) && defined(NIXPKGS)
+     // The package manager builds (Macports, Homebrew, Nixpkgs ...) all arrange to set a proper
+     // compiled value for RECOLL_DATADIR. We can't do this when building a native bundle with
+     // QCreator, in which case we use the executable location.


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[The changelog notes](https://www.lesbonscomptes.com/recoll/pages/release-1.33.html) including notes for its patch releases.

I updated the patch but I don't have a MacOS box to test it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
