### PR TITLE
libsForQt5.mauiPackages: 2.1.2 -> 2.2.0

### DIFF
--- a/pkgs/applications/maui/booth.nix
+++ b/pkgs/applications/maui/booth.nix
@@ -1,0 +1,52 @@
+{ lib
+, mkDerivation
+, cmake
+, extra-cmake-modules
+, kcoreaddons
+, ki18n
+, kirigami2
+, mauikit
+, mauikit-filebrowsing
+, qtgraphicaleffects
+, qtmultimedia
+, qtquickcontrols2
+, gst_all_1
+}:
+
+mkDerivation {
+  pname = "booth";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcoreaddons
+    ki18n
+    kirigami2
+    mauikit
+    mauikit-filebrowsing
+    qtgraphicaleffects
+    qtmultimedia
+    qtquickcontrols2
+  ] ++ (with gst_all_1; [
+    gst-plugins-bad
+    gst-plugins-base
+    gst-plugins-good
+    gstreamer
+  ]);
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+    )
+  '';
+
+  meta = with lib; {
+    description = "Camera application";
+    homepage = "https://invent.kde.org/maui/booth";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ milahu ];
+  };
+}

--- a/pkgs/applications/maui/default.nix
+++ b/pkgs/applications/maui/default.nix
@@ -70,6 +70,7 @@ let
       mauiman = callPackage ./mauiman.nix { };
 
       # applications
+      booth = callPackage ./booth.nix { };
       buho = callPackage ./buho.nix { };
       clip = callPackage ./clip.nix { };
       communicator = callPackage ./communicator.nix { };

--- a/pkgs/applications/maui/default.nix
+++ b/pkgs/applications/maui/default.nix
@@ -14,7 +14,7 @@ See also `pkgs/applications/kde` as this is what this is based on.
 
 # Updates
 
-1. Update the URL in `callPackage ./fetch.sh`.
+1. Update the URL in `./fetch.sh`.
 2. Run `callPackage ./maintainers/scripts/fetch-kde-qt.sh pkgs/applications/maui`
    from the top of the Nixpkgs tree.
 3. Use `nixpkgs-review wip` to check that everything builds.
@@ -67,6 +67,7 @@ let
       mauikit-filebrowsing = callPackage ./mauikit-filebrowsing.nix { };
       mauikit-imagetools = callPackage ./mauikit-imagetools.nix { };
       mauikit-texteditor = callPackage ./mauikit-texteditor.nix { };
+      mauiman = callPackage ./mauiman.nix { };
 
       # applications
       buho = callPackage ./buho.nix { };

--- a/pkgs/applications/maui/fetch.sh
+++ b/pkgs/applications/maui/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/maui/ -A '*-2.1.2.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/maui/ -A '*.tar.xz' )

--- a/pkgs/applications/maui/mauikit.nix
+++ b/pkgs/applications/maui/mauikit.nix
@@ -6,6 +6,7 @@
 , kcoreaddons
 , ki18n
 , knotifications
+, mauiman
 , qtbase
 , qtquickcontrols2
 , qtx11extras
@@ -24,6 +25,7 @@ mkDerivation {
     kcoreaddons
     ki18n
     knotifications
+    mauiman
     qtquickcontrols2
     qtx11extras
   ];

--- a/pkgs/applications/maui/mauiman.nix
+++ b/pkgs/applications/maui/mauiman.nix
@@ -1,0 +1,27 @@
+{ lib
+, mkDerivation
+, cmake
+, extra-cmake-modules
+, kconfig
+, kcoreaddons
+, ki18n
+, knotifications
+, qtbase
+, qtquickcontrols2
+, qtx11extras
+}:
+
+mkDerivation {
+  pname = "mauiman";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  meta = with lib; {
+    homepage = "https://invent.kde.org/maui/mauiman";
+    description = "Maui Manager Library. Server and public library API";
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/applications/maui/srcs.nix
+++ b/pkgs/applications/maui/srcs.nix
@@ -3,116 +3,148 @@
 { fetchurl, mirror }:
 
 {
-  buho = {
-    version = "2.1.2";
+  bonsai = {
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/buho/2.1.2/buho-2.1.2.tar.xz";
-      sha256 = "0xc623w1zp0yh929b8h6mf9r4frnfabd30634ba43x4ac12jk7g8";
-      name = "buho-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/bonsai/1.0.0/bonsai-2.2.0.tar.xz";
+      sha256 = "0gpqdj30brqv9nsiis93w9lad4xn7d301gxncj04pcpybmbksg4r";
+      name = "bonsai-2.2.0.tar.xz";
+    };
+  };
+  booth = {
+    version = "1.0.0";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/booth/1.0.0/booth-1.0.0.tar.xz";
+      sha256 = "0cdn3vkbf1mlq32akz86mdyjfrq661h4jrfmp1x62ih63930hix2";
+      name = "booth-1.0.0.tar.xz";
+    };
+  };
+  buho = {
+    version = "2.2.0";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/buho/2.2.0/buho-2.2.0.tar.xz";
+      sha256 = "1jj9kygh5b88ksg22969zlsrbgps6z7z2n77g6ldqzvg8mmh2cwr";
+      name = "buho-2.2.0.tar.xz";
     };
   };
   clip = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/clip/2.1.2/clip-2.1.2.tar.xz";
-      sha256 = "168lz2qi4y56pwfwyzqnhwz4lgh2763w260l860527aw049crv4z";
-      name = "clip-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/clip/2.2.0/clip-2.2.0.tar.xz";
+      sha256 = "0ggymdscd7c942vvii3mswkq84lkygdcbvpg3s2lhqaqxpivy96z";
+      name = "clip-2.2.0.tar.xz";
     };
   };
   communicator = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/communicator/2.1.2/communicator-2.1.2.tar.xz";
-      sha256 = "0m7axdjpl7s9cz6fcaj4kwr9wdxybwdb76k9rz5yigyy35vigcfi";
-      name = "communicator-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/communicator/2.2.0/communicator-2.2.0.tar.xz";
+      sha256 = "0njyjzf8w2aamrj1yajjw7551dc72db9m0iv14mnb0gcd9pphni7";
+      name = "communicator-2.2.0.tar.xz";
     };
   };
   index-fm = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/index/2.1.2/index-fm-2.1.2.tar.xz";
-      sha256 = "1yawnzx51h6yrlnivbwz9d7481k382pzg3jnczrajfjnv7ir29dn";
-      name = "index-fm-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/index/2.2.0/index-fm-2.2.0.tar.xz";
+      sha256 = "0v39sfdqb21669cx96nd78vprwaxsvg3cpp3lly43n09nv6gkw41";
+      name = "index-fm-2.2.0.tar.xz";
     };
   };
   mauikit = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit/2.1.2/mauikit-2.1.2.tar.xz";
-      sha256 = "1n5p8107lwa4m5gbwlcqmmdlyw15vjaq0dfaz5zal733s6rq2gm7";
-      name = "mauikit-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit/2.2.0/mauikit-2.2.0.tar.xz";
+      sha256 = "05bvgwl1yfbfrlxhl6ngvkdk34rg4y12fsrddm8f19b6dkvjzxq2";
+      name = "mauikit-2.2.0.tar.xz";
     };
   };
   mauikit-accounts = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-accounts/2.1.2/mauikit-accounts-2.1.2.tar.xz";
-      sha256 = "00nc54gi34r8z6cwa0h8490gd0w01a245rh2g4d9fvbkrybwg7sk";
-      name = "mauikit-accounts-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-accounts/2.2.0/mauikit-accounts-2.2.0.tar.xz";
+      sha256 = "1wc67mhhmxq0dq1g10338zm52kx274yry2ja34kagva3qkbhbb2i";
+      name = "mauikit-accounts-2.2.0.tar.xz";
     };
   };
   mauikit-filebrowsing = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-filebrowsing/2.1.2/mauikit-filebrowsing-2.1.2.tar.xz";
-      sha256 = "09pfjr449mkf27ywmwsvflzq0dgaiprw8b2lcms3m5ad7i6jvvyq";
-      name = "mauikit-filebrowsing-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-filebrowsing/2.2.0/mauikit-filebrowsing-2.2.0.tar.xz";
+      sha256 = "1377mgkx1q66jzdlra87airqkmkl9cfj6n5xw1my1nihxcjq9bz1";
+      name = "mauikit-filebrowsing-2.2.0.tar.xz";
     };
   };
   mauikit-imagetools = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-imagetools/2.1.2/mauikit-imagetools-2.1.2.tar.xz";
-      sha256 = "1830x8xwyjs7bj0qi63pl1dk5h2qi6f84mki1schviddddq5cv6j";
-      name = "mauikit-imagetools-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-imagetools/2.2.0/mauikit-imagetools-2.2.0.tar.xz";
+      sha256 = "07clir651sfi4c9awv0jnq4pck2cfzfv0fdkwcapl6hh0zq9qvpr";
+      name = "mauikit-imagetools-2.2.0.tar.xz";
     };
   };
   mauikit-texteditor = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-texteditor/2.1.2/mauikit-texteditor-2.1.2.tar.xz";
-      sha256 = "19z9qry56h2624kdx5xnfjzd3spv5shc87p2m6ix33x9mmrf92p1";
-      name = "mauikit-texteditor-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-texteditor/2.2.0/mauikit-texteditor-2.2.0.tar.xz";
+      sha256 = "0x1cblydgqkhcy86x6yd8dipwhy9l5d7xlmk5igh5dllnzvcaicq";
+      name = "mauikit-texteditor-2.2.0.tar.xz";
+    };
+  };
+  mauiman = {
+    version = "1.0.0";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/mauiman/1.0.0/mauiman-1.0.0.tar.xz";
+      sha256 = "1risxzgjg684c8zwmwl03ihfrxx44lbb4j43v8z3wnjkq7p44w82";
+      name = "mauiman-1.0.0.tar.xz";
     };
   };
   nota = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/nota/2.1.2/nota-2.1.2.tar.xz";
-      sha256 = "11z1mw6yhwin3wj19gj9495az4p40yjkwrn0nb6i8h9b0nh44pn7";
-      name = "nota-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/nota/2.2.0/nota-2.2.0.tar.xz";
+      sha256 = "1nr8craafima1khkcxv47v1868yfwykjzaczlmmqmjha7bm1dlbd";
+      name = "nota-2.2.0.tar.xz";
     };
   };
   pix = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/pix/2.1.2/pix-2.1.2.tar.xz";
-      sha256 = "0ycpazi267pl4l178i34lwzc0ssjklp0indz79r7mcfpr1vicz1s";
-      name = "pix-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/pix/2.2.0/pix-2.2.0.tar.xz";
+      sha256 = "0nghp69ax73yf0wybd724a3lgbj7jiiznnmwp67n2ls74q8yrwwy";
+      name = "pix-2.2.0.tar.xz";
     };
   };
   shelf = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/shelf/2.1.2/shelf-2.1.2.tar.xz";
-      sha256 = "0f3781l8wfbpj0irmri0zkp3ia3qlik4aaq3w6qk97xjv24d98xh";
-      name = "shelf-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/shelf/2.2.0/shelf-2.2.0.tar.xz";
+      sha256 = "028ll3pi4h3jxgilsf4s5ic2rq0z9q8kh9pram9dsjvgz24p7g0c";
+      name = "shelf-2.2.0.tar.xz";
     };
   };
   station = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/station/2.1.2/station-2.1.2.tar.xz";
-      sha256 = "0lrw7rf8i277nl9bwyx5sc05bswgll00k1jzad1i69rwdfiy9ghg";
-      name = "station-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/station/2.2.0/station-2.2.0.tar.xz";
+      sha256 = "0za3jh5clkx8xf436vzs83nrsw5fyna4wcy73ihlf3xbra0358v1";
+      name = "station-2.2.0.tar.xz";
+    };
+  };
+  strike = {
+    version = "2.2.0";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/strike/1.0.0/strike-2.2.0.tar.xz";
+      sha256 = "159l1i0mi3q5avcg45aq5ixz8wjfryhip61h9gynxr1m77qdpfnc";
+      name = "strike-2.2.0.tar.xz";
     };
   };
   vvave = {
-    version = "2.1.2";
+    version = "2.2.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/vvave/2.1.2/vvave-2.1.2.tar.xz";
-      sha256 = "14b6b034899vyvvhzl2jqifqq715lb26dnw3d5wxzxhdplfd7pdf";
-      name = "vvave-2.1.2.tar.xz";
+      url = "${mirror}/stable/maui/vvave/2.2.0/vvave-2.2.0.tar.xz";
+      sha256 = "0qnwklc875j6g2rg610dmvcizg3m4q80fhjk4c3i1xzn8dybbg5s";
+      name = "vvave-2.2.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Description of changes
https://mauikit.org/blog/maui-2-2-0-release/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @NixOS/qt-kde 