### PR TITLE
vmware-workstation: 16.2.3 -> 17.0.0 and support macOS guests

### DIFF
--- a/pkgs/applications/virtualization/vmware-workstation/default.nix
+++ b/pkgs/applications/virtualization/vmware-workstation/default.nix
@@ -26,13 +26,29 @@
 , makeWrapper
 , sqlite
 , enableInstaller ? false
+, enableMacOSGuests ? false, fetchFromGitHub, gnutar, unzip
 }:
 
 let
-  vmware-unpack-env = buildFHSUserEnv rec {
-    name = "vmware-unpack-env";
-    targetPkgs = pkgs: [ zlib ];
+  # macOS - versions
+  fusionVersion = "13.0.0";
+  fusionBuild = "20802013";
+  unlockerVersion = "3.0.4";
+
+  # macOS - ISOs
+  darwinIsoSrc = fetchurl {
+    url = "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/${fusionVersion}/${fusionBuild}/x86/core/com.vmware.fusion.zip.tar";
+    sha256 = "sha256-cSboek+nhkVj8rjdic6yzWQfjXiiLlch6gBWn73BzRU=";
   };
+
+  # macOS - Unlocker
+  unlockerSrc = fetchFromGitHub {
+    owner = "paolo-projects";
+    repo = "unlocker";
+    rev = "${unlockerVersion}";
+    sha256 = "sha256-kpvrRiiygfjQni8z+ju9mPBVqy2gs08Wj4cHxE9eorQ=";
+  };
+
   gdbm3 = gdbm.overrideAttrs (old: rec {
     version = "1.8.3";
 
@@ -46,11 +62,16 @@ let
       cp .libs/libgdbm*.so* $out/lib/
     '';
   });
+
+  vmware-unpack-env = buildFHSUserEnv rec {
+    name = "vmware-unpack-env";
+    targetPkgs = pkgs: [ zlib ];
+  };
 in
 stdenv.mkDerivation rec {
   pname = "vmware-workstation";
-  version = "16.2.3";
-  build = "19376536";
+  version = "17.0.0";
+  build = "20800274";
 
   buildInputs = [
     libxslt
@@ -73,15 +94,35 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ python3 vmware-unpack-env autoPatchelfHook makeWrapper ]
-    ++ lib.optionals enableInstaller [ sqlite bzip2 ];
+    ++ lib.optionals enableInstaller [ sqlite bzip2 ]
+    ++ lib.optionals enableMacOSGuests [ gnutar unzip ];
 
   src = fetchurl {
-    url = "https://download3.vmware.com/software/WKST-1623-LX-New/VMware-Workstation-Full-${version}-${build}.x86_64.bundle";
-    sha256 = "sha256-+JE1KnRfawcaBannIyEr1TNZTF7YXRYYaFMVq0/erbM=";
+    url = "https://download3.vmware.com/software/WKST-1700-LX/VMware-Workstation-Full-${version}-${build}.x86_64.bundle";
+    sha256 = "sha256-kBTocGb1tg5i+dvWmOaPfPUHxrWcX8/obeKqRGR+mRA=";
   };
 
   unpackPhase = ''
     ${vmware-unpack-env}/bin/vmware-unpack-env -c "sh ${src} --extract unpacked"
+
+    ${lib.optionalString enableMacOSGuests ''
+      mkdir -p fusion/
+      tar -xvpf "${darwinIsoSrc}" -C fusion/
+      unzip "fusion/com.vmware.fusion.zip" \
+        "payload/VMware Fusion.app/Contents/Library/isoimages/x86_x64/darwin.iso" \
+        "payload/VMware Fusion.app/Contents/Library/isoimages/x86_x64/darwinPre15.iso" \
+        -d fusion/
+    ''}
+  '';
+
+  patchPhase = lib.optionalString enableMacOSGuests ''
+    cp -R "${unlockerSrc}" unlocker/
+
+    substituteInPlace unlocker/unlocker.py --replace \
+      "/usr/lib/vmware/bin/" "$out/lib/vmware/bin"
+
+    substituteInPlace unlocker/unlocker.py --replace \
+      "/usr/lib/vmware/lib/libvmwarebase.so/libvmwarebase.so" "$out/lib/vmware/lib/libvmwarebase.so/libvmwarebase.so"
   '';
 
   installPhase = ''
@@ -226,6 +267,14 @@ stdenv.mkDerivation rec {
        unpacked/vmware-tools-solaris/solaris.iso \
        $out/lib/vmware/isoimages/
 
+    ${lib.optionalString enableMacOSGuests ''
+      echo "Installing VMWare Tools for MacOS"
+      cp -v \
+       "fusion/payload/VMware Fusion.app/Contents/Library/isoimages/x86_x64/darwin.iso" \
+       "fusion/payload/VMware Fusion.app/Contents/Library/isoimages/x86_x64/darwinPre15.iso" \
+       $out/lib/vmware/isoimages/
+    ''}
+
     ## VMware Player Application
     echo "Installing VMware Player Application"
     unpacked="unpacked/vmware-player-app"
@@ -290,9 +339,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/include/
     cp -r $unpacked/include/* $out/include/
 
-    ## VMware VIX Workstation-16.0.0 Library
-    echo "Installing VMware VIX Workstation-16.0.0 Library"
-    unpacked="unpacked/vmware-vix-lib-Workstation1600"
+    ## VMware VIX Workstation-17.0.0 Library
+    echo "Installing VMware VIX Workstation-17.0.0 Library"
+    unpacked="unpacked/vmware-vix-lib-Workstation1700"
     cp -r $unpacked/lib/* $out/lib/vmware-vix/
 
     ## VMware VProbes component for Linux
@@ -327,6 +376,11 @@ stdenv.mkDerivation rec {
       sed -i -e "s,/usr/local/sbin,/run/vmware/bin," "$out/$lib"
     done
 
+    ${lib.optionalString enableMacOSGuests ''
+      echo "Running VMWare Unlocker to enable macOS Guests"
+      python3 unlocker/unlocker.py
+    ''}
+
     # SUID hack
     wrapProgram $out/lib/vmware/bin/vmware-vmx
     rm $out/lib/vmware/bin/vmware-vmx
@@ -339,6 +393,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ deinferno ];
+    maintainers = with maintainers; [ cawilliamson deinferno ];
   };
 }

--- a/pkgs/os-specific/linux/vmware/default.nix
+++ b/pkgs/os-specific/linux/vmware/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mkubecek";
     repo = "vmware-host-modules";
-    rev = "w${vmware-workstation.version}-k5.18";
-    sha256 = "sha256-sAeCjaSrBXGP5szfCY5CpMrGwzCw4aM67EN+YfA3AWA=";
+    rev = "w${vmware-workstation.version}";
+    sha256 = "sha256-EHMiSmljpUjYuZH6r/0Vk5OVGeyQyNngy0AVJO/48a0=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mkubecek/vmware-host-modules";
     license = licenses.gpl2Only;
     platforms = [ "x86_64-linux" ];
-    broken = (kernel.kernelOlder "5.5" && kernel.isHardened) || kernel.kernelAtLeast "5.19";
+    broken = (kernel.kernelOlder "5.5" && kernel.isHardened);
     maintainers = with maintainers; [ deinferno ];
   };
 }


### PR DESCRIPTION
###### Description of changes

The purpose of this change is to both update VMWare Workstation to v17.0.0 (latest version at this time) and allow macOS guests to be run on top of non-Apple host systems.

This functionality is provided on other distros such as ArchLinux & Gentoo by AUR packages or USE flags in gentoo's case. This will be a useful addition and I am happy to maintain it (and as such have added myself as a maintainer of the package.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC: @deinferno