### PR TITLE
mastodon: seperate localDomain from hosting and add webDomain cfg

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -236,6 +236,7 @@ in {
         example = "social.example.org";
         type = lib.types.str;
         default = cfg.localDomain;
+        defaultText = lib.literalexpression "localDomain";
       };
 
       secretKeyBaseFile = lib.mkOption {

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -229,7 +229,9 @@ in {
         description = lib.mdDoc ''
           The web domain serving your Mastodon instance. If different to
           localDomain then a manual web-finger 301 redirect must be
-          configured. See https://docs.joinmastodon.org/admin/config/
+          configured. Study https://docs.joinmastodon.org/admin/config/ before configuring
+          as this value cannot be changed once other servers federate
+          with you.
         '';
         example = "social.example.org";
         type = lib.types.str;

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -222,6 +222,7 @@ in {
         description = lib.mdDoc "The web domain serving your Mastodon instance. If different to localDomain then a manual web-finger 301 redirect must be configured. See https://docs.joinmastodon.org/admin/config/";
         example = "social.example.org";
         type = lib.types.str;
+        default = cfg.localDomain;
       };
 
       secretKeyBaseFile = lib.mkOption {

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -229,9 +229,9 @@ in {
         description = lib.mdDoc ''
           The web domain serving your Mastodon instance. If different to
           localDomain then a manual web-finger 301 redirect must be
-          configured. Study https://docs.joinmastodon.org/admin/config/ before configuring
-          as this value cannot be changed once other servers federate
-          with you.
+          configured. Study https://docs.joinmastodon.org/admin/config/ 
+          before configuring as this value cannot be changed once other
+          servers federate with you.
         '';
         example = "social.example.org";
         type = lib.types.str;

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -213,13 +213,24 @@ in {
       };
 
       localDomain = lib.mkOption {
-        description = lib.mdDoc "The domain serving your Mastodon instance. If webDomain is configured to host the application on a subdomain then enable pretty @username@example.com style usernames on your domain root is possible";
+        description = lib.mdDoc ''
+          The domain serving your Mastodon instance. If webDomain is configured
+          to host the application on a subdomain then enable pretty
+          @username@example.com style usernames on your domain root is possible.
+          Study https://docs.joinmastodon.org/admin/config/ before configuring
+          as this value cannot be changed once other servers federate
+          with you.
+        '';
         example = "example.org";
         type = lib.types.str;
       };
 
       webDomain = lib.mkOption {
-        description = lib.mdDoc "The web domain serving your Mastodon instance. If different to localDomain then a manual web-finger 301 redirect must be configured. See https://docs.joinmastodon.org/admin/config/";
+        description = lib.mdDoc ''
+          The web domain serving your Mastodon instance. If different to
+          localDomain then a manual web-finger 301 redirect must be
+          configured. See https://docs.joinmastodon.org/admin/config/
+        '';
         example = "social.example.org";
         type = lib.types.str;
         default = cfg.localDomain;

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -236,7 +236,7 @@ in {
         example = "social.example.org";
         type = lib.types.str;
         default = cfg.localDomain;
-        defaultText = lib.literalexpression "localDomain";
+        defaultText = lib.literalExpression "localDomain";
       };
 
       secretKeyBaseFile = lib.mkOption {

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -219,7 +219,7 @@ in {
       };
 
       webDomain = lib.mkOption {
-        description = lib.mdDoc "The web domain serving your Mastodon instance. If different to localDomain then a web-finger 301 redirect must be configured. See https://docs.joinmastodon.org/admin/config/";
+        description = lib.mdDoc "The web domain serving your Mastodon instance. If different to localDomain then a manual web-finger 301 redirect must be configured. See https://docs.joinmastodon.org/admin/config/";
         example = "social.example.org";
         type = lib.types.str;
       };

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -213,7 +213,7 @@ in {
       };
 
       localDomain = lib.mkOption {
-        description = lib.mdDoc "The domain serving your Mastodon instance. Configure with example.com here to enable pretty @username@example.com style usernames";
+        description = lib.mdDoc "The domain serving your Mastodon instance. If webDomain is configured to host the application on a subdomain then enable pretty @username@example.com style usernames on your domain root is possible";
         example = "example.org";
         type = lib.types.str;
       };

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -26,6 +26,7 @@ let
     DB_PORT = toString(cfg.database.port);
     DB_NAME = cfg.database.name;
     LOCAL_DOMAIN = cfg.localDomain;
+    WEB_DOMAIN = cfg.webDomain;
     SMTP_SERVER = cfg.smtp.host;
     SMTP_PORT = toString(cfg.smtp.port);
     SMTP_FROM_ADDRESS = cfg.smtp.fromAddress;
@@ -213,6 +214,12 @@ in {
 
       localDomain = lib.mkOption {
         description = lib.mdDoc "The domain serving your Mastodon instance.";
+        example = "example.org";
+        type = lib.types.str;
+      };
+
+      webDomain = lib.mkOption {
+        description = lib.mdDoc "The web domain serving your Mastodon instance.";
         example = "social.example.org";
         type = lib.types.str;
       };
@@ -637,7 +644,7 @@ in {
     services.nginx = lib.mkIf cfg.configureNginx {
       enable = true;
       recommendedProxySettings = true; # required for redirections to work
-      virtualHosts."${cfg.localDomain}" = {
+      virtualHosts."${cfg.webDomain}" = {
         root = "${cfg.package}/public/";
         forceSSL = true; # mastodon only supports https
         enableACME = true;

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -219,7 +219,7 @@ in {
       };
 
       webDomain = lib.mkOption {
-        description = lib.mdDoc "The web domain serving your Mastodon instance.";
+        description = lib.mdDoc "The web domain serving your Mastodon instance. If different to localDomain then a web-finger 301 redirect must be configured. See https://docs.joinmastodon.org/admin/config/";
         example = "social.example.org";
         type = lib.types.str;
       };

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -213,7 +213,7 @@ in {
       };
 
       localDomain = lib.mkOption {
-        description = lib.mdDoc "The domain serving your Mastodon instance.";
+        description = lib.mdDoc "The domain serving your Mastodon instance. Configure with example.com here to enable pretty @username@example.com style usernames";
         example = "example.org";
         type = lib.types.str;
       };


### PR DESCRIPTION
###### Description of changes

Opening up early for discussion -> please note that I have **NOT** tested this change.

- I launched `fediverse.ghuntley.com` as `@ghuntley@fediverse.ghuntley.com` but it looked ugly.
- Upon studying [the documentation](https://docs.joinmastodon.org/admin/config/) I learned that _it is indeed_ possible to do `@ghuntley@ghuntley.com` if I configure a webfinger 301.
- Currently localDomain and web-serving is coupled in nixpkgs leading people to make mistakes similar to the one I made. 
- I am proposing that we remove this coupling to ensure others don't make the same mistake again.

Related https://twitter.com/GeoffreyHuntley/status/1591026513629319169


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
