### PR TITLE
jhead: patches for CVE-2022-41751

### DIFF
--- a/pkgs/tools/graphics/jhead/default.nix
+++ b/pkgs/tools/graphics/jhead/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, libjpeg }:
+{ lib, stdenv, fetchFromGitHub, libjpeg, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "jhead";
@@ -10,6 +10,38 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0zgh36486cpcnf7xg6dwf7rhz2h4gpayqvdk8hmrx6y418b2pfyf";
   };
+
+  patches = [
+    # Just a spelling/whitespace change, but makes it easier to apply the rest.
+    (fetchpatch {
+      url = "https://github.com/Matthias-Wandel/jhead/commit/8384c6fd2ebfb8eb8bd96616343e73af0e575131.patch";
+      sha256 = "sha256-f3FOIqgFr5QPAsBjvUVAOf1CAqw8pNAVx+pZZuMjq3c=";
+      includes = [ "jhead.c" ];
+    })
+    (fetchpatch {
+      url = "https://github.com/Matthias-Wandel/jhead/commit/63aff8e9bd8c970fedf87f0ec3a1f3368bf2421e.patch";
+      sha256 = "sha256-jyhGdWuwd/eP5uuS8uLYiTJZJdxxLYdsvl0jnQC+Y5c=";
+      includes = [ "jhead.c" ];
+    })
+
+    # Fixes around CVE-2022-41751
+    (fetchpatch {
+      url = "https://github.com/Matthias-Wandel/jhead/commit/6985da52c9ad4f5f6c247269cb5508fae34a971c.patch";
+      sha256 = "sha256-8Uw0Udr9aZEMrD/0zS498MVw+rJqpFukvjb7FgzjgT4=";
+    })
+    (fetchpatch {
+      url = "https://github.com/Matthias-Wandel/jhead/commit/3fe905cf674f8dbac8a89e58cee1b4850abf9530.patch";
+      sha256 = "sha256-5995EV/pOktZc45c7fLl+oQqyutRDQJl3eNutR1JGJo=";
+    })
+    (fetchpatch {
+      url = "https://github.com/joachim-reichel/jhead/commit/ec67262b8e5a4b05d8ad6898a09f1dc3fc032062.patch";
+      sha256 = "sha256-a3KogIV45cRNthJSPygIRw1m2KBJZJSIGSWfsr7FWs4=";
+    })
+    (fetchpatch {
+      url = "https://github.com/joachim-reichel/jhead/commit/65de38cb68747c6f8397608b56b58ce15271a1fe.patch";
+      sha256 = "sha256-xf0d2hxW4rVZwffrYJVVFQ3cDMOcPoGbCdrrQKxf16M=";
+    })
+  ];
 
   buildInputs = [ libjpeg ];
 


### PR DESCRIPTION

###### Description of changes
See https://nvd.nist.gov/vuln/detail/CVE-2022-41751
Also relevant: https://github.com/Matthias-Wandel/jhead/issues/60

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
