### PR TITLE
linuxPackages.nvidia_x11_beta: 515.43.04 -> 525.53

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -153,7 +153,7 @@ installPhase() {
 
     if [ -n "$firmware" ]; then
         # Install the GSP firmware
-        install -Dm644 firmware/gsp.bin $firmware/lib/firmware/nvidia/$version/gsp.bin
+        install -Dm644 -t $firmware/lib/firmware/nvidia/$version firmware/gsp*.bin
     fi
 
     # All libs except GUI-only are installed now, so fixup them.

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -45,11 +45,11 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "515.43.04";
-    sha256_64bit = "sha256-PodaTTUOSyMW8rtdtabIkSLskgzAymQyfToNlwxPPcc=";
-    openSha256 = "sha256-1bAr5dWZ4jnY3Uo2JaEz/rhw2HuW9LZ5bACmA1VG068=";
-    settingsSha256 = "sha256-j47LtP6FNTPfiXFh9KwXX8vZOQzlytA30ZfW9N5F2PY=";
-    persistencedSha256 = "sha256-hULBy0wnVpLH8I0L6O9/HfgvJURtE2whpXOgN/vb3Wo=";
+    version = "525.53";
+    sha256_64bit = "sha256-dLsJcfBPHd3TxGQciRcG+5bo3lLiL2B55Q3nbTpRaH8=";
+    openSha256 = "sha256-XA5RY+dQZv+dTHF7rm/bXnPZLj1G75PJKSTfREpuKag=";
+    settingsSha256 = "sha256-N3+EOm2D2NSmD/cai+Pm2z5WHmV+GEJVr9KTQv/7j88=";
+    persistencedSha256 = "sha256-AhB6zetbejQzajg76+hqpbfv3OzftueXGpviepH/xss=";
   });
 
   # Vulkan developer beta driver


### PR DESCRIPTION
###### Description of changes

- Release highlights since `520.56.06`:
  - Added support for the following GPUs:
    - GeForce RTX 3050
    - GeForce RTX 3070 Ti Laptop GPU
    - GeForce RTX 3080 Ti Laptop GPU
    - GeForce RTX 3090 Ti
    - RTX A500 Laptop GPU
    - RTX A1000 Embedded GPU
    - RTX A2000 Embedded GPU
    - RTX A1000 Laptop GPU
    - RTX A2000 8GB Laptop GPU
    - RTX A3000 12GB Laptop GPU
    - RTX A4500 Embedded GPU
    - RTX A4500 Laptop GPU
    - RTX A5500 Laptop GPU
    - T550 Laptop GPU
    - NVIDIA GeForce MX550
    - NVIDIA GeForce MX570
    - NVIDIA GeForce RTX 2050
    - NVIDIA PG509-210
    - GeForce RTX 3050 OEM
  - Fixed a bug which caused Dynamic Boost to not engage on certain Ampere GPU based notebooks.
  - Added support for Dynamic Boost on notebooks with AMD CPUs.
  - Fixed a bug that resulted in stutter when moving windows in GNOME.
  - Added support for the EGL_MESA_platform_surfaceless extension.
  - Updated the nvidia-settings control panel to prevent the creation of display layouts that exceed hardware size limitations when using the SLI Mosaic configuration page, and to display a warning if such a layout is created manually in the Display Configuration page.
  - Removed the hard dependency on GTK 2 when building nvidia-settings from source. nvidia-settings may now be built with support for GTK 2 only, GTK 3 only, or both GTK 2 and GTK 3.
  - Updated the open kernel modules to support Quadro Sync, Stereo, rotation in X11, and YUV 4:2:0 on Turing.
  - Updated an error message that nvidia-installer displays when kernel header files cannot be found to print full paths for the missing files.
  - Updated nvidia-installer to use “command -v” in place of depending on “which” to determine the availability and location of certain tools.
  - Fixed a bug that caused nvidia-settings to find incorrect fan speed ranges on some GPUs. Lower-level layers of the driver protected the hardware from programming incorrect fan speeds, so the symptom was only incorrect reporting. Now, reporting in nvidia-settings matches what actually gets programmed in hardware.
  - Turing and later: fixed possible excessive GPU power draw on an idle X11 or Wayland desktop when driving high resolutions or refresh rates.
  - Fixed an issue where HDMI audio output was not working in some cases, especially with high display refresh rates (120Hz, 100Hz, etc.) using Fixed Rate Link (FRL) transmission mode.

- Changed (https://github.com/NVIDIA/open-gpu-kernel-modules/releases/tag/525.53)
  - GSP firmware is now distributed as multiple firmware files: this release has gsp_tu10x.bin and gsp_ad10x.bin replacing gsp.bin from previous releases.
    - Each file is named after a GPU architecture and supports GPUs from one or more architectures. This allows GSP firmware to better leverage each architecture's capabilities.
    - The .run installer will continue to install firmware to /lib/firmware/nvidia/<version> and the nvidia.ko kernel module will load the appropriate firmware for each GPU at runtime.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
