### PR TITLE
nixos/lib/testing-python: remove unused `with pkgs;`

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -9,9 +9,6 @@
   # Modules to add to each VM
 , extraConfigurations ? [ ]
 }:
-
-with pkgs;
-
 let
   nixos-lib = import ./default.nix { inherit (pkgs) lib; };
 in


### PR DESCRIPTION
###### Description of changes

This with statement has no users anymore and can safely be removed.


