### PR TITLE
python310Packages.trustme: Fix enabled tests on darwin

### DIFF
--- a/pkgs/development/python-modules/trustme/default.nix
+++ b/pkgs/development/python-modules/trustme/default.nix
@@ -21,9 +21,10 @@ buildPythonPackage rec {
   };
 
   checkInputs = [
-    pyopenssl
     service-identity
     pytestCheckHook
+  ] ++ lib.optionals (!stdenv.isDarwin && !stdenv.isAarch64) [
+    pyopenssl
   ];
 
   propagatedBuildInputs = [
@@ -38,6 +39,11 @@ buildPythonPackage rec {
   disabledTests = lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
     "test_pyopenssl_end_to_end"
   ];
+
+  postPatch = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    substituteInPlace "tests/test_trustme.py" \
+      --replace "import OpenSSL.SSL" ""
+  '';
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
As indicated in #175875, `pyopenssl` does not support aarch64-darwin. In
 #115226, the only test that required `pyopenssl` was disabled on
`aarch64-darwin` — but unfortunately the package doesn’t build. This
commit makes two changes.

###### Description of changes

1.  The `pyopenssl` dependency is no longer pulled in on
    `aarch64-darwin`. The derivation is thereby no longer marked broken.

2.  The test suite is patched so that `OpenSSL.SSL` is no longer
    imported; this was only used by the disabled test. As a result
    the test suite runs (and succeeds).

@catern (thanks!)

###### Things done

I tested a downstream package (`datasette`), which works.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - **and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)**
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).