### PR TITLE
jacoco: init at 0.8.8

### DIFF
--- a/pkgs/development/tools/analysis/jacoco/default.nix
+++ b/pkgs/development/tools/analysis/jacoco/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchzip
+, makeWrapper
+, jre
+}:
+
+stdenv.mkDerivation rec {
+  pname = "jacoco";
+  version = "0.8.8";
+
+  src = fetchzip {
+    url = "https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/${version}/jacoco-${version}.zip";
+    stripRoot = false;
+    sha256 = "sha256-NfXkMAFG1yMj1o06Hlhg9+B4RzL0I36fAGjZx3IC+NQ=";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $doc/share/doc $out/bin
+
+    cp -r doc $doc/share/doc/jacoco
+    install -Dm444 lib/* -t $out/share/java
+
+    makeWrapper ${jre}/bin/java $out/bin/jacoco \
+      --add-flags "-jar $out/share/java/jacococli.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A free code coverage library for Java";
+    homepage = "https://jacoco.org/jacoco";
+    license = licenses.epl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17211,6 +17211,8 @@ with pkgs;
 
   itstool = callPackage ../development/tools/misc/itstool { };
 
+  jacoco = callPackage ../development/tools/analysis/jacoco { };
+
   inherit (callPackage ../development/tools/build-managers/jam { })
     jam
     ftjam;


### PR DESCRIPTION
###### Description of changes

I tried building from source with `javaPackages.mavenfod` but kept running into errors and hash mismatches, so I gave up and switched to `fetchzip`

https://github.com/jacoco/jacoco

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
