### PR TITLE
fuse-7z-ng: fix build against modern glibc

### DIFF
--- a/pkgs/tools/filesystems/fuse-7z-ng/default.nix
+++ b/pkgs/tools/filesystems/fuse-7z-ng/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
     rev = "eb5efb1f304c2b7bc2e0389ba06c9bf2ac4b932c";
     sha256 = "17v1gcmg5q661b047zxjar735i4d3508dimw1x3z1pk4d1zjhp3x";
   };
+  patches = [
+    # Drop unused pthread library. pthread_yield()
+    # fails the configure.
+    ./no-pthread.patch
+  ];
 
   nativeBuildInputs = [ pkg-config makeWrapper autoconf automake ];
   buildInputs = [ fuse ];

--- a/pkgs/tools/filesystems/fuse-7z-ng/no-pthread.patch
+++ b/pkgs/tools/filesystems/fuse-7z-ng/no-pthread.patch
@@ -1,0 +1,11 @@
+pthread_yield() is not used by fuse-7z-ng, fails configure.
+--- a/configure.ac
++++ b/configure.ac
+@@ -25,7 +25,6 @@ AC_CHECK_HEADERS([fcntl.h stddef.h string.h unistd.h dlfcn.h dirent.h])
+ AC_CHECK_FUNCS([memset memmove])
+ AC_CHECK_FUNCS([sqrt])
+ 
+-AC_CHECK_LIB([pthread], [pthread_yield],,AC_MSG_ERROR([pthread library not found.]))
+ AC_CHECK_LIB([dl], [dlclose])
+ 
+ PKG_CHECK_MODULES([fuse], [fuse >= 2.8])


### PR DESCRIPTION
Wthout the change configure fails as:

    checking for pthread_yield in -lpthread... no
    configure: error: pthread library not found.

fuze-7z-ng does not use pthread itself. Let's just drop the check.

ZHF: https://github.com/NixOS/nixpkgs/issues/199919
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
