### PR TITLE
mindustry: 126.2 → 140.4

### DIFF
--- a/pkgs/games/mindustry/0001-fix-include-path-for-SDL2-on-linux.patch
+++ b/pkgs/games/mindustry/0001-fix-include-path-for-SDL2-on-linux.patch
@@ -4,13 +4,13 @@ Date: Fri, 8 Jan 2021 04:49:14 +0100
 Subject: [PATCH] fix include path for SDL2 on linux
 
 ---
- .../src/main/java/arc/backend/sdl/jni/SDL.java            | 8 --------
+ .../src/arc/backend/sdl/jni/SDL.java            | 8 --------
  1 file changed, 8 deletions(-)
 
-diff --git a/backends/backend-sdl/src/main/java/arc/backend/sdl/jni/SDL.java b/backends/backend-sdl/src/main/java/arc/backend/sdl/jni/SDL.java
+diff --git a/backends/backend-sdl/src/arc/backend/sdl/jni/SDL.java b/backends/backend-sdl/src/arc/backend/sdl/jni/SDL.java
 index 62d9286a..2853119d 100644
---- a/Arc/backends/backend-sdl/src/main/java/arc/backend/sdl/jni/SDL.java
-+++ b/Arc/backends/backend-sdl/src/main/java/arc/backend/sdl/jni/SDL.java
+--- a/Arc/backends/backend-sdl/src/arc/backend/sdl/jni/SDL.java
++++ b/Arc/backends/backend-sdl/src/arc/backend/sdl/jni/SDL.java
 @@ -8,16 +8,8 @@ import java.nio.*;
  public class SDL{
      /*JNI

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -91,14 +91,14 @@ let
   };
 
   cleanupMindustrySrc = ''
-    pushd Mindustry
+    # Ensure the prebuilt shared objects don't accidentally get shipped
+    rm -r Arc/natives/natives-*/libs/*
+    rm -r Arc/backends/backend-*/libs/*
 
     # Remove unbuildable iOS stuff
-    sed -i '/^project(":ios"){/,/^}/d' build.gradle
-    sed -i '/robo(vm|VM)/d' build.gradle
-    rm ios/build.gradle
-
-    popd
+    sed -i '/^project(":ios"){/,/^}/d' Mindustry/build.gradle
+    sed -i '/robo(vm|VM)/d' Mindustry/build.gradle
+    rm Mindustry/ios/build.gradle
   '';
 
   # fake build to pre-download deps into fixed-output derivation
@@ -134,11 +134,7 @@ assert lib.assertMsg (enableClient || enableServer)
 stdenv.mkDerivation rec {
   inherit pname version unpackPhase patches;
 
-  postPatch = ''
-    # ensure the prebuilt shared objects don't accidentally get shipped
-    rm -r Arc/natives/natives-*/libs/*
-    rm -r Arc/backends/backend-*/libs/*
-  '' + cleanupMindustrySrc;
+  postPatch = cleanupMindustrySrc;
 
   buildInputs = lib.optionals enableClient [
     SDL2

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv
+{ lib, stdenv, fetchurl
 , makeWrapper
 , makeDesktopItem
 , copyDesktopItems
 , fetchFromGitHub
-, gradle_6
+, gradle
 , jdk
 , perl
 
@@ -16,6 +16,11 @@
 , alsa-plugins
 , glew
 
+# for soloud
+, libpulseaudio ? null
+, libjack2 ? null
+
+
 # Make the build version easily overridable.
 # Server and client build versions must match, and an empty build version means
 # any build is allowed, so this parameter acts as a simple whitelist.
@@ -27,30 +32,42 @@
 
 let
   pname = "mindustry";
-  # Note: when raising the version, ensure that all SNAPSHOT versions in
-  # build.gradle are replaced by a fixed version
-  # (the current one at the time of release) (see postPatch).
-  version = "126.2";
+  version = "140.4";
   buildVersion = makeBuildVersion version;
 
   Mindustry = fetchFromGitHub {
     owner = "Anuken";
     repo = "Mindustry";
     rev = "v${version}";
-    sha256 = "URmjmfzQAVVl6erbh3+FVFdN7vGTNwYKPtcrwtt9vkg=";
+    sha256 = "0lfDISvC5dOd76BuPPniPf+8hXWQ/wtreNHN75k2jVA=";
   };
   Arc = fetchFromGitHub {
     owner = "Anuken";
     repo = "Arc";
     rev = "v${version}";
-    sha256 = "pUUak5P9t4RmSdT+/oH/8oo6l7rjIN08XDJ06TcUn8I=";
+    sha256 = "lZ3ACijauUC9jVRq9I/QwX9ozFF/dw+ArEMND+RMItM=";
   };
   soloud = fetchFromGitHub {
     owner = "Anuken";
     repo = "soloud";
-    # this is never pinned in upstream, see https://github.com/Anuken/Arc/issues/39
-    rev = "b33dfc5178fcb2613ee68136f4a4869cadc0b06a";
-    sha256 = "1vf68i3pnsixch37285ib7afkwmlrc05v783395jsdjzj9i67lj3";
+    # This is pinned in Arc's arc-core/build.gradle
+    rev = "v0.9";
+    sha256 = "6KlqOtA19MxeqZttNyNrMU7pKqzlNiA4rBZKp9ekanc=";
+  };
+  freetypeSource = fetchurl {
+    # This is pinned in Arc's extensions/freetype/build.gradle
+    url = "https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.gz";
+    sha256 = "1b4dcngjcly9n80hnyr4d5s6qp8bspabfs7v3h07gb13pdg7kasy";
+  };
+  glewSource = fetchurl {
+    # This is pinned in Arc's backends/backend-sdl/build.gradle
+    url = "https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0.zip";
+    sha256 = "1m702jzfjhdr76cb71qplv6amhw15nnb1h6wbq4mlfbl6y8nl159";
+  };
+  SDLmingwSource = fetchurl {
+    # This is pinned in Arc's backends/backend-sdl/build.gradle
+    url = "https://www.libsdl.org/release/SDL2-devel-2.0.20-mingw.tar.gz";
+    sha256 = "1lbbjxl3a8vdillvv7654m6mp34lfkncvig5a8iwdmjpm214s29q";
   };
 
   patches = [
@@ -81,13 +98,8 @@ let
     sed -i '/robo(vm|VM)/d' build.gradle
     rm ios/build.gradle
 
-    # Pin 'SNAPSHOT' versions
-    sed -i 's/com.github.anuken:packr:-SNAPSHOT/com.github.anuken:packr:034efe51781d2d8faa90370492133241bfb0283c/' build.gradle
-
     popd
   '';
-
-  gradle = (gradle_6.override (old: { java = jdk; }));
 
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {
@@ -113,7 +125,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "+7vSwQT6LwHgKE9DubISznq4G4DgvlnD7WaF1KywBzU=";
+    outputHash = "FbLd3kk/awFz91o8pZcwJTFozwJ7R+RlDOsMRaala5Q=";
   };
 
 in
@@ -124,8 +136,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # ensure the prebuilt shared objects don't accidentally get shipped
-    rm Arc/natives/natives-desktop/libs/libarc*.so
-    rm Arc/backends/backend-sdl/libs/linux64/libsdl-arc*.so
+    rm -r Arc/natives/natives-*/libs/*
+    rm -r Arc/backends/backend-*/libs/*
   '' + cleanupMindustrySrc;
 
   buildInputs = lib.optionals enableClient [
@@ -149,18 +161,29 @@ stdenv.mkDerivation rec {
     export GRADLE_USER_HOME=$(mktemp -d)
 
     # point to offline repo
+    sed -ie "1ipluginManagement { repositories { maven { url '${deps}' } } }; " Mindustry/settings.gradle
     sed -ie "s#mavenLocal()#mavenLocal(); maven { url '${deps}' }#g" Mindustry/build.gradle
     sed -ie "s#mavenCentral()#mavenCentral(); maven { url '${deps}' }#g" Arc/build.gradle
+    sed -ie "s#wget.*freetype.* -O #cp ${freetypeSource} #" Arc/extensions/freetype/build.gradle
+    sed -ie "/curl.*glew/{;s#curl -o #cp ${glewSource} #;s# -L http.*\.zip##;}" Arc/backends/backend-sdl/build.gradle
+    sed -ie "/curl.*sdlmingw/{;s#curl -o #cp ${SDLmingwSource} #;s# -L http.*\.tar.gz##;}" Arc/backends/backend-sdl/build.gradle
 
     pushd Mindustry
   '' + optionalString enableClient ''
+
+    pushd ../Arc
     gradle --offline --no-daemon jnigenBuild -Pbuildversion=${buildVersion}
-    gradle --offline --no-daemon sdlnatives -Pdynamic -Pbuildversion=${buildVersion}
+    gradle --offline --no-daemon jnigenJarNativesDesktop -Pbuildversion=${buildVersion}
     glewlib=${lib.getLib glew}/lib/libGLEW.so
     sdllib=${lib.getLib SDL2}/lib/libSDL2.so
-    patchelf ../Arc/backends/backend-sdl/libs/linux64/libsdl-arc*.so \
+    patchelf backends/backend-sdl/libs/linux64/libsdl-arc*.so \
       --add-needed $glewlib \
       --add-needed $sdllib
+    # Put the freshly-built libraries where the pre-built libraries used to be:
+    cp arc-core/libs/*/* natives/natives-desktop/libs/
+    cp extensions/freetype/libs/*/* natives/natives-freetype-desktop/libs/
+    popd
+
     gradle --offline --no-daemon desktop:dist -Pbuildversion=${buildVersion}
   '' + optionalString enableServer ''
     gradle --offline --no-daemon server:dist -Pbuildversion=${buildVersion}
@@ -173,6 +196,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     makeWrapper ${jdk}/bin/java $out/bin/mindustry \
       --add-flags "-jar $out/share/mindustry.jar" \
+      --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath [libpulseaudio alsa-lib libjack2]} \
       --set ALSA_PLUGIN_DIR ${alsa-plugins}/lib/alsa-lib/
 
     # Retain runtime depends to prevent them from being cleaned up.
@@ -204,7 +228,7 @@ stdenv.mkDerivation rec {
       binaryBytecode  # deps
     ];
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ fgaz ];
+    maintainers = with maintainers; [ chkno fgaz ];
     platforms = platforms.x86_64;
     # Hash mismatch on darwin:
     # https://github.com/NixOS/nixpkgs/pull/105590#issuecomment-737120293

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34400,16 +34400,12 @@ with pkgs;
 
   methane = callPackage ../games/methane { };
 
-  mindustry = callPackage ../games/mindustry {
-    jdk = adoptopenjdk-hotspot-bin-15;
-  };
+  mindustry = callPackage ../games/mindustry { };
   mindustry-wayland = callPackage ../games/mindustry {
-    jdk = adoptopenjdk-hotspot-bin-15;
     glew = glew-egl;
   };
 
   mindustry-server = callPackage ../games/mindustry {
-    jdk = adoptopenjdk-hotspot-bin-15;
     enableClient = false;
     enableServer = true;
   };


### PR DESCRIPTION
###### Description of changes
This is the big update, releasing the last 1.5 years of development out of beta, with the new planet Erekir: https://store.steampowered.com/news/app/1127400/view/3415444546227810671

Also, get back to using the latest Java and gradle versions (as enabled and required by https://github.com/Anuken/Mindustry/issues/5114 )

Also, eliminate more (maybe the last of?) uses of binaries-not-built-here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


This is follow-up from https://github.com/NixOS/nixpkgs/pull/198323

FYI:
Mindustry maintainer @fgaz
Other folks that have done mindustry version bumps @maxhbr @Mindavi