### PR TITLE
systemd: 251.7 -> 251.8

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -122,7 +122,7 @@ assert withHomed -> withCryptsetup;
 let
   wantCurl = withRemote || withImportd;
   wantGcrypt = withResolved || withImportd;
-  version = "251.7";
+  version = "251.8";
 
   # Bump this variable on every (major) version change. See below (in the meson options list) for why.
   # command:
@@ -139,7 +139,7 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "sha256-Sa5diyNFyYtREo1xSCcufAW83ZZGZvueoDVuQ2r8wno=";
+    sha256 = "sha256-kao0xJwwJc4zUyaK5yxyGip4E6ADak98iVv5E8Hw0zk=";
   };
 
   # On major changes, or when otherwise required, you *must* reformat the patches,


### PR DESCRIPTION
```
git log --oneline v251.7..v251.8
ae8b249af4 test: fstab-generator: adjust PATH for fsck
03514a9f64 man: add note that network-generator is not a generator
8c8a423821 condition: Check that subsystem is enabled in ConditionSecurity=tpm2
9243b88b55 test: wait for loop device to be removed
f5c2be99bc test: wait for the lodev to get properly initialized
8cfe979030 test: disable LSan in the ASan env wrapper
db00a62be8 test: introduce a simple environment file for test service
fd082f335e test: lower the # of mpath devices to 16
d17a45340b test: make TEST-64 a bit more ASan friendly
a51cc9e578 test: don't wrap binaries built with ASan
e176dca593 test: drop all LD_PRELOAD-related ASan workarounds
9fba4cdf61 test: set $ASAN_RT_PATH along with $LD_PRELOAD to the ASan runtime DSO
4fbf69fd1b semaphore: remove the Semaphore repositories recursively
6258394c1e test: wrap `ls` and `stat` to make it work w/ sanitizers in specific cases
db14b371df test: create an ASan wrapper for `getent` and `su`
1027d3d633 test: always wrap useradd/userdel when running w/ ASan
65ab7b0950 Revert "Support -D_FORTIFY_SOURCE=3 by using __builtin_dynamic_object_size."
f994276068 test: make TEST-63 more reliable on slower machines
68b4f10f82 test: use PBKDF2 with capped iterations instead of Argon2
1f32ec761c hashmap: use assert_se() to make clang happy
94a25aa6d5 coredump: drop an unused variable
5f09fa4d5e network: drop an unused variable
a29ddb989b machine: drop an unused variable
9a71cd3bf6 sd-journal: drop an unused variable
ae0537f18f ci: reenable validation of GH Actions files
6e92f64ca4 ci: temporarily disable validation of GH Action files
6cd1b11d02 cryptsetup: fix build with -Db_ndebug=true
0ab5e9fe98 test: wrap binaries using systemd DSOs when running w/ ASan
6d4ae5a7cd test: make the virt detection quiet
024ee3def9 test: check for other hypervisors as well
520be40734 test-mountpoint-util: support running on a mount namespace with another mount on /proc
2cd4aed358 test-mountpoint-util: use log_info()
c7b66dbe2a test-mountpoint-util: fix NULL arg to %s
4e49c726ad test: drop redundant log message
b57ef0c672 build(deps): bump meson from 0.63.2 to 0.63.3 in /.github/workflows
8c80564405 build(deps): bump ninja from 1.10.2.3 to 1.10.2.4 in /.github/workflows
70e90da84b build(deps): bump meson from 0.63.1 to 0.63.2 in /.github/workflows
489c00dee5 build(deps): bump meson from 0.63.0 to 0.63.1 in /.github/workflows
08e85ad43d build(deps): bump meson from 0.62.2 to 0.63.0 in /.github/workflows
b0619c9c55 build(deps): bump meson from 0.62.0 to 0.62.2 in /.github/workflows
d982169592 build(deps): bump systemd/mkosi
9d4af5fea1 mkosi: libbpf0 -> libbpf1
3abf9f08f1 mkosi: Switch to Fedora 37
18f9fbab08 mkosi: update to latest commit
5403b727a7 mkosi: Use SourceFileTransfer=mount
9744c04ffd mkosi: Drop kernel-modules-extra from Fedora config
ab2f7a9b9e mkosi: install fdisk for test-loop-block
17acdca99d mkosi: Set ExtraSearchPaths=build/ by default
420e782904 mkosi: update to latest commit
43ef15c752 mkosi: add back packages removed from OpenSUSE build
9a94aa1d88 mkosi: disable isc-dhcp-server again
d1785c462f mkosi: Ensure we build all features/components in mkosi
6712396da3 meson: Downgrade efi-ld warning
66309ee674 ci: Add mold to build tests
86c25ca937 ci: build with clang-15; drop clang-12
28457b030e mkosi: Drop workarounds
abecb21561 mkosi: Update to latest commit
d9eaf39930 mkosi: Update to latest commit
619b36b22c mkosi: Don't use InstallDirectory by default
cdf3fd312a mkosi: Use mkosi.output/ as output directory by default
b8a746e89b mkosi: Add package libfdisk to Ubuntu dependencies (#24211)
0e518f3639 ci: set a timeout for each mkosi stage
5e79cf977c mkosi: Update to latest
edef8edf0b mkosi: Update to latest commit
a0402d3ab6 mkosi: Update to latest commit
081168fa19 mkosi: Build against Fedora rawhide as well
a38a0504ec mkosi: Remove usage of deprecated option names/sections
47404f1802 mkosi: Changes to allow booting with sanitizers in mkosi
db1281e12e mkosi: Update Ubuntu config to 22.04
ca8dc691fe mkosi: Install xxd in images
f12a6945c6 ci: limit which env variables we pass through `sudo`
7e24ac6d77 mkosi: update to latest main
a46ba01e79 mkosi: Update to latest release
7ef1d71895 mkosi: Pull in fix that solves action mirror issue
d3d90ae66b mkosi: Update CI to mkosi 13
9bf797be2c ci: build systemd with clang with -Dmode=release --optimization=2
9e88b3a5e1 ci: bump gcc in the "build test" workflow
dcbc64db61 ci: prefer the distro llvm version if available
ccd81889d4 ci: bump GH Actions to Ubuntu Jammy where applicable
b8fbf21526 kernel-install/90-loaderentry: do not add multiple systemd.machine_id options
fe5e692bfc tests: minor simplification in test-execute
a94fe70bbe tests: make test-execute pass on openSUSE
4a65c1674b firstboot: fix segfault when --locale-messages= is passed without --locale=
c3b22515b9 test: introduce sanity coverage for auxiliary utils
c61e4377d7 udev: add safe guard for setting by-id symlink
2f4fdaaecc udev: drop redundant call of usb_id and assignment of ID_USB_INTERFACE_NUM
491924940f udev: first set properties based on usb subsystem
293c006789 test: further extend systemctl's sanity coverage
f48e6576a2 test: add a couple of sanity tests for systemctl
3d5e379808 test: rename TEST-26-SETENV to TEST-26-SYSTEMCTL
a34afc4197 namespace: Add hidepid/subset support check
2ac138a5b6 coverage: Mark _coverage__exit as noreturn
9952c228a9 parse_hwdb: allow negative value for EVDEV_ABS_ properties
7b6fa1d3e6 test: add a couple of sanity tests for journalctl
cf21555d6d sd-device-monitor: dynamically allocate receive buffer
ee42e84968 man: use the correct 'Markers' property name for marking units
45090f3418 core: fix memleak in GetUnitFileLinks method
7eefd2fbb7 network: forcibly reconfigure all interfaces after sleep
66fa6110ba resolved: fix typo in feature level table
2f8f1d9e4a network: skip to reassign master ifindex if already set
d94f197818 resolved: fix copypasta in resolved varlink API
b61fcaca1b udev: always create device symlinks for USB disks
6fc2f387af man: Add documentation for AssertCredential= (#25178)
c339e8d71b man: document reboot --poweroff exception
91b8491e97 network: allow 0 for table number
3f94f03389 network: Table= also accepts table name
bdd84e82e5 analyze: add --image= + --root= to --help text
23d66a03de meson: Fix build with --optimization=plain
98a45608c4 manager: allow transient units to have drop-ins
228cd82d2c manager: reformat boolean expression in unit_is_pristine()
````

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
