### PR TITLE
Fzf: init module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -25,7 +25,9 @@
     <itemizedlist spacing="compact">
       <listitem>
         <para>
-          Create the first release note entry in this section!
+          <link xlink:href="https://github.com/junegunn/fzf">fzf</link>,
+          a command line fuzzyfinder. Available as
+          <link linkend="opt-programs.fzf.fuzzyCompletion">programs.fzf</link>.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -14,7 +14,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- [fzf](https://github.com/junegunn/fzf), a command line fuzzyfinder. Available as [programs.fzf](#opt-programs.fzf.fuzzyCompletion).
 
 ## Backward Incompatibilities {#sec-release-23.05-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -165,6 +165,7 @@
   ./programs/flexoptix-app.nix
   ./programs/freetds.nix
   ./programs/fuse.nix
+  ./programs/fzf.nix
   ./programs/gamemode.nix
   ./programs/geary.nix
   ./programs/git.nix

--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -1,0 +1,37 @@
+{pkgs, config, lib, ...}:
+with lib;
+let
+  cfg = config.programs.fzf;
+in {
+  options = {
+    programs.fzf = {
+      fuzzyCompletion = mkOption {
+        type = types.bool;
+        description = lib.mdDoc "Whether to use fzf for fuzzy completion";
+        default = false;
+        example = true;
+      };
+      keybindings = mkOption {
+        type = types.bool;
+        description = lib.mdDoc "Whether to set up fzf keybindings";
+        default = false;
+        example = true;
+      };
+    };
+  };
+  config = {
+    environment.systemPackages = optional (cfg.keybindings || cfg.fuzzyCompletion) pkgs.fzf;
+    programs.bash.interactiveShellInit = optionalString cfg.fuzzyCompletion ''
+      source ${pkgs.fzf}/share/fzf/completion.bash
+    '' + optionalString cfg.keybindings ''
+      source ${pkgs.fzf}/share/fzf/key-bindings.bash
+    '';
+
+    programs.zsh.interactiveShellInit = optionalString cfg.fuzzyCompletion ''
+      source ${pkgs.fzf}/share/fzf/completion.zsh
+    '' + optionalString cfg.keybindings ''
+      source ${pkgs.fzf}/share/fzf/key-bindings.zsh
+    '';
+  };
+  meta.maintainers = with maintainers; [ laalsaas ];
+}

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -1,5 +1,12 @@
-{ lib, buildGoModule, fetchFromGitHub, writeText, runtimeShell, ncurses, perl }:
-
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, writeText
+, runtimeShell
+, installShellFiles
+, ncurses
+, perl
+}:
 buildGoModule rec {
   pname = "fzf";
   version = "0.35.1";
@@ -15,7 +22,7 @@ buildGoModule rec {
 
   outputs = [ "out" "man" ];
 
-  fishHook = writeText "load-fzf-keybindings.fish" "fzf_key_bindings";
+  nativeBuildInputs = [ installShellFiles ];
 
   buildInputs = [ ncurses ];
 
@@ -38,22 +45,19 @@ buildGoModule rec {
       --replace " perl -n " " ${perl}/bin/perl -n "
   '';
 
-  preInstall = ''
-    mkdir -p $out/share/fish/{vendor_functions.d,vendor_conf.d}
-    cp shell/key-bindings.fish $out/share/fish/vendor_functions.d/fzf_key_bindings.fish
-    cp ${fishHook} $out/share/fish/vendor_conf.d/load-fzf-key-bindings.fish
-  '';
-
   postInstall = ''
-    cp bin/fzf-tmux $out/bin
+    install bin/fzf-tmux $out/bin
 
-    mkdir -p $man/share/man
-    cp -r man/man1 $man/share/man
+    installManPage man/man1/fzf.1 man/man1/fzf-tmux.1
 
-    mkdir -p $out/share/vim-plugins/${pname}
-    cp -r plugin $out/share/vim-plugins/${pname}
+    install -D plugin/* -t $out/share/vim-plugins/${pname}/plugin
 
-    cp -R shell $out/share/fzf
+    # Install shell integrations
+    install -D shell/* -t $out/share/fzf/
+    install -D shell/key-bindings.fish $out/share/fish/vendor_functions.d/fzf_key_bindings.fish
+    mkdir -p $out/share/fish/vendor_conf.d
+    echo fzf_key_bindings > $out/share/fish/vendor_conf.d/load-fzf-key-bindings.fish
+
     cat <<SCRIPT > $out/bin/fzf-share
     #!${runtimeShell}
     # Run this script to find the fzf shared folder where all the shell


### PR DESCRIPTION
###### Description of changes
Add fzf module to automatically source completion and keybindings in global {bash,zsh}rc. No fish, since this is already done by the package. cleanup the package a bit.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [xJ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
