### PR TITLE
hugegraph: init at 1.0.0

### DIFF
--- a/pkgs/development/tools/protoc-gen-grpc-java/Makefile
+++ b/pkgs/development/tools/protoc-gen-grpc-java/Makefile
@@ -1,0 +1,44 @@
+# Adapted from https://github.com/grpc/grpc-web/blob/master/javascript/net/grpc/web/generator/Makefile
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CXX ?= g++
+CPPFLAGS += -pthread
+CXXFLAGS += -std=c++11
+LDFLAGS += -lprotoc -lprotobuf -lpthread -ldl
+PREFIX ?= /usr/local
+MIN_MACOS_VERSION := 10.7 # Supports OS X Lion
+STATIC ?= yes
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=$(MIN_MACOS_VERSION)
+else ifeq ($(UNAME_S),Linux)
+  ifeq ($(STATIC),yes)
+    LDFLAGS += -static
+  endif
+endif
+
+all: protoc-gen-grpc-java
+
+protoc-gen-grpc-java: java_plugin.o java_generator.o
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+install: protoc-gen-grpc-java
+	mkdir -p $(PREFIX)/bin
+	install protoc-gen-grpc-java $(PREFIX)/bin/protoc-gen-grpc-java
+
+clean:
+	rm -f *.o protoc-gen-grpc-java

--- a/pkgs/development/tools/protoc-gen-grpc-java/default.nix
+++ b/pkgs/development/tools/protoc-gen-grpc-java/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, protobuf
+}:
+
+stdenv.mkDerivation rec {
+  pname = "protoc-gen-grpc-java";
+  version = "1.53.0";
+
+  src = fetchFromGitHub {
+    owner = "grpc";
+    repo = "grpc-java";
+    rev = "v${version}";
+    hash = "sha256-AenN9gQa/ppwRZfl8cXAmmVYy2IhIz6MemA1MJmrge0=";
+  };
+
+  sourceRoot = "source/compiler/src/java_plugin/cpp";
+
+  postPatch = ''
+    cp ${./Makefile} Makefile
+  '';
+
+  strictDeps = true;
+
+  buildInputs = [ protobuf ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "STATIC=no"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/grpc/grpc-java";
+    description = "The Java gRPC implementation. HTTP/2 based RPC";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ners ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/nosql/hugegraph/default.nix
+++ b/pkgs/servers/nosql/hugegraph/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, hugegraph-unwrapped
+, makeWrapper
+, jdk
+}:
+
+stdenv.mkDerivation {
+  pname = "hugegraph";
+  inherit (hugegraph-unwrapped) version meta;
+
+  src = hugegraph-unwrapped;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/hugegraph
+    cp -r $src/lib $src/conf $src/scripts $out/share/hugegraph
+
+    # Adapted from hugegraph-unwrapped.out/bin/hugegraph-server.sh
+    LIB=$out/share/hugegraph/lib
+    # Add the slf4j-log4j12 binding
+    CP=$(find -L $LIB -name 'log4j-slf4j-impl*.jar' | sort | tr '\n' ':')
+    # Add the jars in lib that start with "hugegraph"
+    CP="$CP":$(find -L $LIB -name 'hugegraph*.jar' | sort | tr '\n' ':')
+    # Add the remaining jars in lib.
+    CP="$CP":$(find -L $LIB -name '*.jar' \
+                    \! -name 'hugegraph*' \
+                    \! -name 'log4j-slf4j-impl*.jar' | sort | tr '\n' ':')
+
+    makeWrapper ${jdk}/bin/java $out/bin/hugegraph-server \
+      --add-flags "-classpath $CP com.baidu.hugegraph.dist.HugeGraphServer"
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/servers/nosql/hugegraph/unwrapped.nix
+++ b/pkgs/servers/nosql/hugegraph/unwrapped.nix
@@ -1,0 +1,99 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, maven
+, jdk11
+, protobuf
+}:
+
+let
+  pname = "hugegraph-unwrapped";
+  version = "1.0.0";
+  hash = "sha256-NXO/4z1/smKDtJ54LWMUBYAaeQSo9DLE5muZ/nEglvw=";
+  outputHash = "sha256-5b2tH7JV+GZBVhR4hPGhBcffJph3P5djbo9zz/Mx4hc=";
+  swaggerUiVersion = "4.15.5";
+  fetchedMavenDeps = { pname, src, version, ... }: stdenv.mkDerivation {
+    pname = "${pname}-maven-deps";
+    inherit src version;
+
+    nativeBuildInputs = [
+      (maven.override { jdk = jdk11; })
+      jdk11
+      protobuf
+    ];
+
+    postPatch = ''
+      sed -i 's|<protocArtifact>.*</protocArtifact>|<protocExecutable>${protobuf}/bin/protoc</protocExecutable>|g' hugegraph-core/pom.xml
+      sed -i '/wget /d' hugegraph-dist/pom.xml
+      sed -i '/tar zxvf /d' hugegraph-dist/pom.xml
+      cp -r ${fetchFromGitHub {
+        owner = "swagger-api";
+        repo = "swagger-ui";
+        rev = "v${swaggerUiVersion}";
+        hash = "sha256-cadQhmgOdIGhuH2YCN+6D00KN4vfXrAE1PeyUsC0ppw=";
+      }} hugegraph-dist/swagger-ui-${swaggerUiVersion}
+      chmod +w -R hugegraph-dist/swagger-ui-${swaggerUiVersion}
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      mvn package -Dmaven.repo.local=$out -DskipTests
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      find $out -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+    dontConfigure = true;
+    outputHashMode = "recursive";
+    inherit outputHash;
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "incubator-hugegraph";
+    rev = "${version}";
+    inherit hash;
+  };
+  fetchedMavenDeps = fetchedMavenDeps finalAttrs;
+
+  inherit (finalAttrs.fetchedMavenDeps) nativeBuildInputs postPatch;
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+    mvn package --offline -Dmaven.repo.local=${finalAttrs.fetchedMavenDeps} -DskipTests
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # we don't know what the name of the bin directory is:
+    #  - when using a binary release, it will be 'hugegraph-<version>'
+    #  - when built from unstable source code, it will be 'apache-hugegraph-incubating-<version>'
+    mv $(ls -d *hugegraph*/bin | xargs dirname | head -n1) $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A graph database with high performance and scalability";
+    homepage = "https://hugegraph.apache.org/";
+    mainProgram = "hugegraph-server";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ners ];
+  };
+})

--- a/pkgs/servers/nosql/janusgraph/unwrapped.nix
+++ b/pkgs/servers/nosql/janusgraph/unwrapped.nix
@@ -1,0 +1,102 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, maven
+, jdk11
+, protobuf
+, protoc-gen-grpc-java
+, unzip
+}:
+
+let
+  pname = "janusgraph-unwrapped";
+  version = "1.0.0-rc2";
+  hash = "sha256-T9SBswO3u0WZfytYTlEqXCrt5Qzb+ATPJ5vnbRCk5GE=";
+  outputHash = "sha256-oUfivy2o1Jvtdrb4xKBhXzenipRvC8ZLciGQnk/8qGs=";
+  fetchedMavenDeps = { pname, src, version, ... }: stdenv.mkDerivation {
+    pname = "${pname}-maven-deps";
+    inherit src version;
+
+    nativeBuildInputs = [
+      (maven.override { jdk = jdk11; })
+      jdk11
+      protobuf
+      protoc-gen-grpc-java
+    ];
+
+    postPatch = ''
+      sed -i 's|<protocArtifact>.*</protocArtifact>|<protocExecutable>${protobuf}/bin/protoc</protocExecutable>|g; /<pluginArtifact>/d' janusgraph-grpc/pom.xml
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      mvn package \
+        -Dmaven.repo.local=$out \
+        -Pjanusgraph-release \
+        -Dmaven.test.failure.ignore=true \
+        -Dgpg.skip=true \
+        -Dadditionalparam=-Xdoclint:none \
+        -DadditionalJOption=-Xdoclint:none
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      find $out -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+    dontConfigure = true;
+    outputHashMode = "recursive";
+    inherit outputHash;
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
+  src = fetchFromGitHub {
+    owner = "JanusGraph";
+    repo = "janusgraph";
+    rev = "v${version}";
+    inherit hash;
+  };
+  fetchedMavenDeps = fetchedMavenDeps finalAttrs;
+
+  inherit (finalAttrs.fetchedMavenDeps) postPatch;
+
+  nativeBuildInputs = finalAttrs.fetchedMavenDeps.nativeBuildInputs ++ [ unzip ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+    mvn package \
+        --offline \
+        -Dmaven.repo.local=${finalAttrs.fetchedMavenDeps} \
+        -Pjanusgraph-release \
+        -Dgpg.skip=true \
+        -DskipTests=true \
+        -Dmaven.test.failure.ignore=true
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    unzip -q janusgraph-dist/target/janusgraph-full-*.zip -d $out
+    f=("$out"/*) && mv "$out"/*/* "$out" && rmdir "''${f[@]}"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An open-source, distributed graph database";
+    homepage = "https://janusgraph.org/";
+    mainProgram = "janusgraph-server";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ners ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25265,6 +25265,9 @@ with pkgs;
 
   https-dns-proxy = callPackage ../servers/dns/https-dns-proxy { };
 
+  hugegraph-unwrapped = callPackage ../servers/nosql/hugegraph/unwrapped.nix { };
+  hugegraph = callPackage ../servers/nosql/hugegraph { };
+
   hydron = callPackage ../servers/hydron { };
 
   hyprspace = callPackage ../applications/networking/hyprspace {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25304,6 +25304,7 @@ with pkgs;
 
   janus-gateway = callPackage ../servers/janus-gateway { };
 
+  janusgraph-unwrapped = callPackage ../servers/nosql/janusgraph/unwrapped.nix { };
   janusgraph = callPackage ../servers/nosql/janusgraph { };
 
   jboss = callPackage ../servers/http/jboss { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -621,6 +621,8 @@ with pkgs;
 
   protoc-gen-grpc-web = callPackage ../development/tools/protoc-gen-grpc-web { };
 
+  protoc-gen-grpc-java = callPackage ../development/tools/protoc-gen-grpc-java { };
+
   protoc-gen-connect-go = callPackage ../development/tools/protoc-gen-connect-go { };
 
   protoc-gen-rust = callPackage ../development/tools/protoc-gen-rust { };


### PR DESCRIPTION
###### Description of changes

This PR introduces a new package, Apache HugeGraph. HugeGraph has no binary releases and has to be built from source.

I've also provided a from-source derivation for JanusGraph, another Java NoSQL package that I maintain. This required the introduction of grpc-java. The rationale is that JanusGraph is built very similarly to HugeGraph unstable, so the two can be reviewed side by side.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
