### PR TITLE
nixos/tests: add ROCm and amdvlk tests

### DIFF
--- a/pkgs/build-support/make-impure-test.nix
+++ b/pkgs/build-support/make-impure-test.nix
@@ -1,0 +1,96 @@
+/* Create tests that run in the nix sandbox with additional access to selected host paths
+
+  This is for example useful for testing hardware where a tests needs access to
+  /sys and optionally more.
+
+  The following example shows a test that accesses the GPU:
+
+  Example:
+    makeImpureTest {
+      name = "opencl";
+      testedPackage = "mypackage"; # Or testPath = "mypackage.impureTests.opencl.testDerivation"
+
+      sandboxPaths = [ "/sys" "/dev/dri" ]; # Defaults to ["/sys"]
+      prepareRunCommands = ""; # (Optional) Setup for the runScript
+      nixFlags = []; # (Optional) nix-build options for the runScript
+
+      testScript = "...";
+    }
+
+  Save as `test.nix` next to a package and reference it from the package:
+    passthru.impureTests = { opencl = callPackage ./test.nix {}; };
+
+  `makeImpureTest` will return here a script that contains the actual nix-build command including all necessary sandbox flags.
+
+  It can be executed like this:
+    $(nix-build -A mypackage.impureTests)
+
+  Rerun an already cached test:
+    $(nix-build -A mypackage.impureTests) --check
+*/
+{ lib
+, stdenv
+, writeShellScript
+
+, name
+, testedPackage ? null
+, testPath ? "${testedPackage}.impureTests.${name}.testDerivation"
+, sandboxPaths ? [ "/sys" ]
+, prepareRunCommands ? ""
+, nixFlags ? [ ]
+, testScript
+, ...
+} @ args:
+
+let
+  sandboxPathsTests = builtins.map (path: "[[ ! -e '${path}' ]]") sandboxPaths;
+  sandboxPathsTest = lib.concatStringsSep " || " sandboxPathsTests;
+  sandboxPathsList = lib.concatStringsSep " " sandboxPaths;
+
+  testDerivation = stdenv.mkDerivation (lib.recursiveUpdate
+    {
+      name = "test-run-${name}";
+
+      requiredSystemFeatures = [ "nixos-test" ];
+
+      buildCommand = ''
+        mkdir -p $out
+
+        if ${sandboxPathsTest}; then
+          echo 'Run this test as *root* with `--option extra-sandbox-paths '"'${sandboxPathsList}'"'`'
+          exit 1
+        fi
+
+        # Run test
+        ${testScript}
+      '';
+
+      passthru.runScript = runScript;
+    }
+    (builtins.removeAttrs args [
+      "lib"
+      "stdenv"
+      "writeShellScript"
+
+      "name"
+      "testedPackage"
+      "testPath"
+      "sandboxPaths"
+      "prepareRunCommands"
+      "nixFlags"
+      "testScript"
+    ])
+  );
+
+  runScript = writeShellScript "run-script-${name}" ''
+    set -euo pipefail
+
+    ${prepareRunCommands}
+
+    sudo nix-build --option extra-sandbox-paths '${sandboxPathsList}' ${lib.escapeShellArgs nixFlags} -A ${testPath} "$@"
+  '';
+in
+# The main output is the run script, inject the derivation for the actual test
+runScript.overrideAttrs (old: {
+  passthru = { inherit testDerivation; };
+})

--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, callPackage
 , lib
 , fetchRepoProject
 , writeScript
@@ -101,6 +102,8 @@ in stdenv.mkDerivation rec {
     hash="$(nix to-base64 $(nix-build -A amdvlk 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true))"
     setHash "$hash"
   '';
+
+  passthru.impureTests = { amdvlk = callPackage ./test.nix {}; };
 
   meta = with lib; {
     description = "AMD Open Source Driver For Vulkan";

--- a/pkgs/development/libraries/amdvlk/test.nix
+++ b/pkgs/development/libraries/amdvlk/test.nix
@@ -1,0 +1,49 @@
+{ lib, makeImpureTest, coreutils, amdvlk, vulkan-tools }:
+makeImpureTest {
+  name = "amdvlk";
+  testedPackage = "amdvlk";
+
+  sandboxPaths = [ "/sys" "/dev/dri" ];
+
+  nativeBuildInputs = [ vulkan-tools ];
+
+  VK_ICD_FILENAMES = "${amdvlk}/share/vulkan/icd.d/amd_icd64.json";
+  XDG_RUNTIME_DIR = "/tmp";
+
+  # AMDVLK needs access to /dev/dri/card0 (or another card), but normally it is rw-rw----
+  # Change the permissions to be rw for everyone
+  prepareRunCommands = ''
+    function reset_perms()
+    {
+      # Reset permissions to previous state
+      for card in /dev/dri/card*; do
+        sudo ${coreutils}/bin/chmod "0''${cardPerms[$card]}" $card
+      done
+    }
+
+    # Save permissions on /dev/dri/card*
+    declare -A cardPerms
+    for card in /dev/dri/card*; do
+      cardPerms[$card]=$(stat -c "%a" $card)
+    done
+
+    sudo ${coreutils}/bin/chmod o+rw /dev/dri/card*
+    trap reset_perms EXIT
+  '';
+
+  testScript = ''
+    # Check that there is at least one card with write-access
+    if ! ls -l /dev/dri/card* | cut -b8-9 | grep -q rw; then
+      echo 'AMDVLK needs rw access to /dev/dri/card0 or a fitting card, please run `sudo chmod o+rw /dev/dri/card*`'
+      exit 1
+    fi
+
+    vulkaninfo --summary
+    echo "Checking version"
+    vulkaninfo --summary | grep '= ${amdvlk.version}'
+  '';
+
+  meta = with lib.maintainers; {
+    maintainers = [ Flakebi ];
+  };
+}

--- a/pkgs/development/libraries/rocm-opencl-icd/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-icd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rocm-opencl-runtime }:
+{ lib, callPackage, stdenv, rocm-opencl-runtime }:
 
 stdenv.mkDerivation rec {
   pname = "rocm-opencl-icd";
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/etc/OpenCL/vendors
     echo "${rocm-opencl-runtime}/lib/libamdocl64.so" > $out/etc/OpenCL/vendors/amdocl64.icd
   '';
+
+  passthru.impureTests = { rocm-opencl = callPackage ./test.nix {}; };
 
   meta = with lib; {
     description = "OpenCL ICD definition for AMD GPUs using the ROCm stack";

--- a/pkgs/development/libraries/rocm-opencl-icd/test.nix
+++ b/pkgs/development/libraries/rocm-opencl-icd/test.nix
@@ -1,0 +1,19 @@
+{ lib, makeImpureTest, clinfo, rocm-opencl-icd, rocm-smi }:
+makeImpureTest {
+  name = "rocm-opencl";
+  testedPackage = "rocm-opencl-icd";
+
+  nativeBuildInputs = [ clinfo rocm-smi ];
+
+  OCL_ICD_VENDORS = "${rocm-opencl-icd}/etc/OpenCL/vendors/";
+
+  testScript = ''
+    # Test fails if the number of platforms is 0
+    clinfo | grep -E 'Number of platforms * [1-9]'
+    rocm-smi | grep -A1 GPU
+  '';
+
+  meta = with lib; {
+    maintainers = teams.rocm.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -945,6 +945,8 @@ with pkgs;
 
   makeAutostartItem = callPackage ../build-support/make-startupitem { };
 
+  makeImpureTest = callPackage ../build-support/make-impure-test.nix;
+
   makeInitrd = callPackage ../build-support/kernel/make-initrd.nix; # Args intentionally left out
 
   makeInitrdNG = callPackage ../build-support/kernel/make-initrd-ng.nix;


### PR DESCRIPTION
###### Description of changes

Testing ROCm and other software like amdvlk is slightly more difficult, because it needs hardware like GPUs to run on.
This PR adds some infrastructure – `make-test-hardware.nix` analogous to `make-test-python.nix` – that makes it easy to write such tests and run them by giving access to the host hardware into the nix build sandbox.

The tests added here are very basic and are meant more for demonstration of how it works (and smoke testing that nothing fundamental is broken).

The added tests can be run with
```bash
$(nix-build -A rocm-opencl-icd.impureTests)
$(nix-build -A amdvlk.impureTests)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->