### PR TITLE
r3ctl: init at a82cb5b3123224e706835407f21acea9dc7ab0f0

### DIFF
--- a/pkgs/tools/misc/r3ctl/default.nix
+++ b/pkgs/tools/misc/r3ctl/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, qt5
+, qtbase
+, qtsvg
+, qtx11extras
+, qttools
+, qtwebsockets
+, qtmultimedia
+, fetchFromGitHub
+}:
+
+qt5.mkDerivation rec {
+  pname = "r3ctl";
+  version = "a82cb5b3123224e706835407f21acea9dc7ab0f0";
+
+  src = fetchFromGitHub {
+    owner = "0xfeedc0de64";
+    repo = "r3ctl";
+    rev = "a82cb5b3123224e706835407f21acea9dc7ab0f0";
+    sha256 = "5/L8jvEDJGJzsuAxPrctSDS3d8lbFX/+f52OVyGQ/RY=";
+  };
+
+  buildPhase = ''
+    qmake .
+    make
+  '';
+
+  postInstall = ''
+    mv bin $out
+  '';
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qttools
+    qtmultimedia
+    qtwebsockets
+  ];
+
+  meta = with lib; {
+    description = "A cmdline tool to control the r3 hackerspace lights";
+    homepage = "https://github.com/0xfeedc0de64/r3ctl";
+    maintainers = with maintainers; [ mkg20001 ];
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -560,6 +560,8 @@ with pkgs;
 
   riot-redis = callPackage ../development/tools/riot-redis { };
 
+  r3ctl = qt5.callPackage ../tools/misc/r3ctl { };
+
   ptouch-print = callPackage ../misc/ptouch-print { };
 
   demoit = callPackage ../servers/demoit { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a new tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- x ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

// cc @0xFEEDC0DE64
