### PR TITLE
urdfdom: 1.0.4 -> 3.1.0

### DIFF
--- a/pkgs/development/libraries/urdfdom/default.nix
+++ b/pkgs/development/libraries/urdfdom/default.nix
@@ -3,25 +3,20 @@
 
 stdenv.mkDerivation rec {
   pname = "urdfdom";
-  version = "1.0.4";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "ros";
     repo = pname;
     rev = version;
-    sha256 = "0wambq06d7dvja25zcv4agc055q9rmf3xkrnxy8lsf4nic7ra2rr";
+    hash = "sha256-9MJnify4zcDBSZVJZCN/XupN5xax+U4PLee54gVVw3Q=";
   };
 
   patches = [
-    # Fix CMake saying console-bridge 1.0 is incompatible
-    (fetchpatch {
-      url = "https://github.com/ros/urdfdom/commit/6faba176d41cf39114785a3e029013f941ed5a0e.patch";
-      sha256 = "1pn9hcg5wkkc7y28sbkxvffqxgvazzsp3g1xmz6h055v4f9ikjbs";
-    })
     # Fix CMake relative install dir assumptions (https://github.com/ros/urdfdom/pull/142)
     (fetchpatch {
-      url = "https://github.com/ros/urdfdom/commit/707c97c3d1f739ba0ab6e93e1bf7cd01d68a8c07.patch";
-      sha256 = "10bv7sv7gfy6lj8z5bkw7v291y12fbrrxsiqxqjxg4i65rfg92ng";
+      url = "https://github.com/ros/urdfdom/commit/cbe6884d267779463bb444be851f6404e692cc0a.patch";
+      hash = "sha256-1gTRKIGqiSRion76bGecSfFJSBskYUJguUIa6ePIiX4=";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

Update urdfdom to the latest version.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
