### PR TITLE
mfc465cn[lpr,cupswrapper]: init at 1.0.1-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10751,6 +10751,12 @@
     githubId = 301903;
     name = "Chip Collier";
   };
+  phrogg = {
+    name = "Phil Roggenbuck";
+    email = "nixpkgs@phrogg.de";
+    github = "phrogg";
+    githubId = 1367949;
+  };
   phryneas = {
     email = "mail@lenzw.de";
     github = "phryneas";

--- a/pkgs/misc/cups/drivers/brother/mfc465cncupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfc465cncupswrapper/default.nix
@@ -1,0 +1,82 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, makeWrapper
+, coreutils
+, gnugrep
+, gnused
+, mfc465cnlpr
+, pkgsi686Linux
+, psutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mfc465cncupswrapper";
+  version = "1.0.1-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006134/${pname}-${version}.i386.deb";
+    sha256 = "59a62ed3cf10f1565c08ace55832bd48bd5034f7067662870edf7ff3bf0cb76a";
+  };
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    lpr=${mfc465cnlpr}/usr/local/Brother/Printer/mfc465cn
+    dir=$out/usr/local/Brother/Printer/mfc465cn
+    interpreter=${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2
+    patchelf --set-interpreter "$interpreter" "$dir/cupswrapper/brcupsconfpt1"
+    substituteInPlace $dir/cupswrapper/cupswrappermfc465cn \
+      --replace "mkdir -p /usr" ": # mkdir -p /usr" \
+      --replace '/''${printer_model}' "/mfc465cn" \
+      --replace 'br''${printer_model}' "brmfc465cn" \
+      --replace 'brlpdwrapper''${printer_model}' "brlpdwrappermfc465cn" \
+      --replace 'filter''${printer_model}' "filtermfc465cn" \
+      --replace ' ''${printer_name}' " MFC465CN" \
+      --replace ' ''${device_name}' " MFC-465CN" \
+      --replace '(''${device_name}' "(MFC-465CN" \
+      --replace ':''${device_name}' ":MFC-465CN" \
+      --replace '/''${device_name}' "/MFC-465CN" \
+      --replace 'BR''${pcfilename}' "BR465" \
+      --replace '/''${device_model}' "/Printer" \
+      --replace '/usr/lib64/cups/filter/brlpdwrappermfc465cn' "$out/lib/cups/filter/brlpdwrappermfc465cn" \
+      --replace '/usr/local/Brother/Printer/mfc465cn/lpd/filtermfc465cn' "$lpr/lpd/filtermfc465cn" \
+      --replace '/usr/share/ppd/brmfc465cn.ppd' "$dir/cupswrapper/brmfc465.ppd" \
+      --replace '/usr/share/cups/model/brmfc465cn.ppd' "$dir/cupswrapper/brmfc465.ppd" \
+      --replace '/usr/lib/cups/filter/brlpdwrappermfc465cn' "$out/usr/lib/cups/filter/brlpdwrappermfc465cn" \
+      --replace 'nup="psnup' "nup=\"${psutils}/bin/psnup" \
+      --replace '/usr/bin/psnup' "${psutils}/bin/psnup" \
+      --replace '/usr/local/Brother/Printer/mfc465cn/cupswrapper/brcupsconfpt1' "$dir/cupswrapper/brcupsconfpt1" \
+      --replace '/usr/local/Brother/Printer/mfc465cn/inf' "$lpr/inf"
+    # Create the PPD file from the cupswrapper file
+    sed -n '/ENDOFPPDFILE1/,/ENDOFPPDFILE1/p' "$dir/cupswrapper/cupswrappermfc465cn" | head -n -1 | tail -n +2 > $dir/cupswrapper/brmfc465.ppd
+    sed -n '/ENDOFPPDFILE_END/,/ENDOFPPDFILE_END/p' "$dir/cupswrapper/cupswrappermfc465cn" | head -n -1 | tail -n +2 >> $dir/cupswrapper/brmfc465.ppd
+    chmod 644 $dir/cupswrapper/brmfc465.ppd
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+    ln $dir/cupswrapper/cupswrappermfc465cn $out/lib/cups/filter
+    ln $dir/cupswrapper/brmfc465.ppd $out/share/cups/model
+    sed -n '/!ENDOFWFILTER!/,/!ENDOFWFILTER!/p' "$dir/cupswrapper/cupswrappermfc465cn" | sed '1 br; b; :r s/.*/printer_model=mfc465cn; cat <<!ENDOFWFILTER!/'  | bash > $out/lib/cups/filter/brlpdwrappermfc465cn
+    sed -i "/#! \/bin\/sh/a PATH=${lib.makeBinPath [ coreutils gnused gnugrep ]}:\$PATH" $out/lib/cups/filter/brlpdwrappermfc465cn
+    chmod 755 $out/lib/cups/filter/brlpdwrappermfc465cn
+    '';
+
+  meta = with lib; {
+    description = "Brother MFC-465CN CUPS wrapper driver";
+    homepage = "http://www.brother.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ phrogg ];
+  };
+}

--- a/pkgs/misc/cups/drivers/brother/mfc465cnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfc465cnlpr/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, makeWrapper
+, coreutils
+, file
+, gawk
+, ghostscript
+, gnused
+, pkgsi686Linux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mfc465cnlpr";
+  version = "1.0.1-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006132/${pname}-${version}.i386.deb";
+    sha256 = "cfe0289510bf36bee6014286ea78b1ebc6bbb948dbfd3aee02f0664a7743f99b";
+  };
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    dir=$out/usr/local/Brother/Printer/mfc465cn
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $dir/lpd/brmfc465cnfilter
+    wrapProgram $dir/inf/setupPrintcapij \
+      --prefix PATH : ${lib.makeBinPath [
+        coreutils
+      ]}
+    substituteInPlace $dir/lpd/filtermfc465cn \
+      --replace "BR_PRT_PATH=" "BR_PRT_PATH=\"$dir/\" #"
+    wrapProgram $dir/lpd/filtermfc465cn \
+      --prefix PATH : ${lib.makeBinPath [
+        coreutils
+        file
+        ghostscript
+        gnused
+      ]}
+    substituteInPlace $dir/lpd/psconvertij2 \
+      --replace '`which gs`' "${ghostscript}/bin/gs"
+    wrapProgram $dir/lpd/psconvertij2 \
+      --prefix PATH : ${lib.makeBinPath [
+        gnused
+        gawk
+      ]}
+    chmod -R a+w $dir/inf/
+  '';
+
+  meta = with lib; {
+    description = "Brother MFC-465CN LPR printer driver";
+    homepage = "http://www.brother.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ phrogg ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37116,6 +37116,9 @@ with pkgs;
 
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };
 
+  mfc465cncupswrapper = callPackage ../misc/cups/drivers/brother/mfc465cncupswrapper { };
+  mfc465cnlpr = callPackage ../misc/cups/drivers/brother/mfc465cnlpr { };
+
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
   mfcj470dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj470dwlpr { };
 


### PR DESCRIPTION
###### Description of changes

This package consists of the driver as well as the cupswrapper for the MFC-465CN printer by brother: https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfc5460cn_all&os=128

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
