### PR TITLE
gi-docgen: 2022.1 → 2022.2

### DIFF
--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -66,14 +66,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     desktop-file-utils
-    (gi-docgen.overrideAttrs (attrs: {
-      patches = attrs.patches ++ [
-        (fetchpatch {
-          url = "https://gitlab.gnome.org/GNOME/gi-docgen/-/commit/f4ff4787cce962b705fb2588b31f2988c5063c13.patch";
-          sha256 = "11VGFFb2PLVxnX/qUQdLPLfhGQWx4sf4apBP7R2JWjA=";
-        })
-      ];
-    }))
+    gi-docgen
     gobject-introspection
     meson
     ninja

--- a/pkgs/development/tools/documentation/gi-docgen/default.nix
+++ b/pkgs/development/tools/documentation/gi-docgen/default.nix
@@ -1,33 +1,21 @@
 { lib
-, fetchFromGitLab
-, fetchpatch
+, fetchurl
 , meson
 , ninja
 , python3
+, gnome
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gi-docgen";
-  version = "2022.1";
+  version = "2022.2";
 
   format = "other";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.gnome.org";
-    owner = "GNOME";
-    repo = pname;
-    rev = version;
-    sha256 = "35pL/2TQRVgPfAcfOGCLlSP1LIh4r95mFC+UoXQEEHo=";
+  src = fetchurl {
+    url = "mirror://gnome/sources/gi-docgen/${lib.versions.major version}/gi-docgen-${version}.tar.xz";
+    sha256 = "JlQ5ENdqedYvZnEihWkqO2KnXzHQfLvupG7sfjTmOlQ=";
   };
-
-  patches = [
-    # Fix gnome-builder build
-    # https://gitlab.gnome.org/GNOME/gi-docgen/-/merge_requests/161
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gi-docgen/-/commit/0524047ada3e6a5572c43dd36201ebe589d08095.patch";
-      sha256 = "1P+i7v1sMULOd0w8K363Mssj+tBJ2wiSmE7DlztvCbw=";
-    })
-  ];
 
   depsBuildBuild = [
     python3
@@ -54,6 +42,12 @@ python3.pkgs.buildPythonApplication rec {
     substituteInPlace $out/nix-support/propagated-build-inputs \
       --replace "${python3}" ""
   '';
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = "gi-docgen";
+    };
+  };
 
   meta = with lib; {
     description = "Documentation generator for GObject-based libraries";


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/GNOME/gi-docgen/-/tags/2022.2

Switch to GNOME mirror and add update script.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
