### PR TITLE
turbo: init at 1.7.0

### DIFF
--- a/pkgs/tools/misc/turbo/default.nix
+++ b/pkgs/tools/misc/turbo/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, git
+, nodejs
+, protobuf
+, protoc-gen-go
+, protoc-gen-go-grpc
+, rustPlatform
+, pkg-config
+, openssl
+, extra-cmake-modules
+, fontconfig
+, go
+}:
+let
+  version = "1.7.0";
+  src = fetchFromGitHub {
+    owner = "vercel";
+    repo = "turbo";
+    rev = "v${version}";
+    sha256 = "YTuEv2S3jNV2o7HJML+P6OMazgwgRhUPnd/zaTWfDWs=";
+  };
+
+  go-turbo = buildGoModule rec {
+    inherit src version;
+    pname = "go-turbo";
+    modRoot = "cli";
+
+    vendorSha256 = "Kx/CLFv23h2TmGe8Jwu+S3QcONfqeHk2fCW1na75c0s=";
+
+    nativeBuildInputs = [
+      git
+      nodejs
+      protobuf
+      protoc-gen-go
+      protoc-gen-go-grpc
+    ];
+
+    preBuild = ''
+      make compile-protos
+    '';
+
+    preCheck = ''
+      # Some tests try to run mkdir $HOME
+      HOME=$TMP
+
+      # Test_getTraversePath requires that source is a git repo
+      # pwd: /build/source/cli
+      pushd ..
+      git config --global init.defaultBranch main
+      git init
+      popd
+    '';
+
+  };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "turbo";
+  inherit src version;
+  cargoBuildFlags = [
+    "--package"
+    "turbo"
+  ];
+  RELEASE_TURBO_CLI = "true";
+
+  cargoSha256 = "ENw6NU3Fedd+OJEEWgL8A54aowNqjn3iv7rxlr+/4ZE=";
+  RUSTC_BOOTSTRAP = 1;
+  nativeBuildInputs = [
+    pkg-config
+    extra-cmake-modules
+  ];
+  buildInputs = [
+    openssl
+    fontconfig
+  ];
+
+  postInstall = ''
+    ln -s ${go-turbo}/bin/turbo $out/bin/go-turbo
+  '';
+
+  # Browser tests time out with chromium and google-chrome
+  doCheck = false;
+
+  meta = with lib; {
+    description = "High-performance build system for JavaScript and TypeScript codebases";
+    homepage = "https://turbo.build/";
+    maintainers = with maintainers; [ dlip ];
+    license = licenses.mpl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12783,6 +12783,8 @@ with pkgs;
 
   tuptime = callPackage ../tools/system/tuptime { };
 
+  turbo = callPackage ../tools/misc/turbo { };
+
   turses = callPackage ../applications/networking/instant-messengers/turses { };
 
   tutanota-desktop = callPackage ../applications/networking/mailreaders/tutanota-desktop { };


### PR DESCRIPTION
###### Description of changes

Adds Turbo v1.7.0 https://turbo.build/

###### Things done

I have tested a simple monorepo setup. You can either not install turbo in npm or export this environment varible to override the binary:

```
export TURBO_BINARY_PATH="${pkgs.turbo}/bin/turbo"
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
