### PR TITLE
ocamlPackages.camlidl: 1.05 → 1.11; mlgmpidl: 1.2.12 → 1.2.15

### DIFF
--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -1,17 +1,18 @@
-{ stdenv, lib, fetchFromGitHub, perl, ocaml, findlib, camlidl, gmp, mpfr }:
+{ stdenv, lib, fetchFromGitHub, perl, ocaml, findlib, camlidl, gmp, mpfr, bigarray-compat }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-mlgmpidl";
-  version = "1.2.12";
+  version = "1.2.15";
   src = fetchFromGitHub {
     owner = "nberth";
     repo = "mlgmpidl";
     rev = version;
-    sha256 = "17xqiclaqs4hmnb92p9z6z9a1xfr31vcn8nlnj8ykk57by31vfza";
+    sha256 = "sha256-85wy5eVWb5qdaa2lLDcfqlUTIY7vnN3nGMdxoj5BslU=";
   };
 
   nativeBuildInputs = [ perl ocaml findlib camlidl ];
   buildInputs = [ gmp mpfr ];
+  propagatedBuildInputs = [ bigarray-compat ];
 
   strictDeps = true;
 
@@ -19,6 +20,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--gmp-prefix ${gmp.dev}"
     "--mpfr-prefix ${mpfr.dev}"
+    "-disable-profiling"
   ];
 
   postConfigure = ''

--- a/pkgs/development/tools/ocaml/camlidl/default.nix
+++ b/pkgs/development/tools/ocaml/camlidl/default.nix
@@ -1,16 +1,17 @@
-{ lib, stdenv, fetchurl, ocaml, writeText }:
+{ lib, stdenv, fetchFromGitHub, ocaml, writeText }:
 
-let
-  pname = "camlidl";
-  webpage = "https://caml.inria.fr/pub/old_caml_site/camlidl/";
-in
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.03")
+  "camlidl is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
-  version = "1.05";
+  pname = "ocaml${ocaml.version}-camlidl";
+  version = "1.11";
 
-  src = fetchurl {
-    url = "http://caml.inria.fr/pub/old_caml_site/distrib/bazar-ocaml/${pname}-${version}.tar.gz";
-    sha256 = "0483cs66zsxsavcllpw1qqvyhxb39ddil3h72clcd69g7fyxazl5";
+  src = fetchFromGitHub {
+    owner = "xavierleroy";
+    repo = "camlidl";
+    rev = "camlidl111";
+    sha256 = "sha256-8m0zem/6nvpEJtjJNP/+vafeVLlMvNQGdl8lyf/OeBg=";
   };
 
   nativeBuildInputs = [ ocaml ];
@@ -21,10 +22,10 @@ stdenv.mkDerivation rec {
   preBuild = ''
     mv config/Makefile.unix config/Makefile
     substituteInPlace config/Makefile --replace BINDIR=/usr/local/bin BINDIR=$out
-    substituteInPlace config/Makefile --replace OCAMLLIB=/usr/local/lib/ocaml OCAMLLIB=$out/lib/ocaml/${ocaml.version}/site-lib/camlidl
-    substituteInPlace config/Makefile --replace CPP=/lib/cpp CPP=${stdenv.cc}/bin/cpp
-    substituteInPlace config/Makefile --replace "OCAMLC=ocamlc -g" "OCAMLC=ocamlc -g -warn-error -31"
+    substituteInPlace config/Makefile --replace 'OCAMLLIB=$(shell $(OCAMLC) -where)' OCAMLLIB=$out/lib/ocaml/${ocaml.version}/site-lib/camlidl
+    substituteInPlace config/Makefile --replace CPP=cpp CPP=${stdenv.cc}/bin/cpp
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/camlidl/caml
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/camlidl/stublibs
   '';
 
   postInstall = ''
@@ -40,15 +41,14 @@ stdenv.mkDerivation rec {
   '';
 
   setupHook = writeText "setupHook.sh" ''
-    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${name}/"
     export NIX_CFLAGS_COMPILE+=" -isystem $1/lib/ocaml/${ocaml.version}/site-lib/camlidl"
     export NIX_LDFLAGS+=" -L $1/lib/ocaml/${ocaml.version}/site-lib/camlidl"
   '';
 
   meta = {
     description = "A stub code generator and COM binding for Objective Caml";
-    homepage = webpage;
-    license = "LGPL";
+    homepage = "https://xavierleroy.org/camlidl/";
+    license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.roconnor ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
