### PR TITLE
python3.pkgs.pylpsd: init at 0.1.4

### DIFF
--- a/pkgs/development/python-modules/pylpsd/default.nix
+++ b/pkgs/development/python-modules/pylpsd/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, numpy
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "pylpsd";
+  version = "0.1.4";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-evPL9vF75S8ATkFwzQjh4pLI/aXGXWwoypCb24nXAN8=";
+  };
+
+  # Tests fail and there are none
+  doCheck = false;
+  pythonImportsCheck = [
+    "pylpsd"
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+  ];
+
+  meta = with lib; {
+    description = "Python implementation of the LPSD algorithm for computing power spectral density with logarithmically spaced points.";
+    homepage = "https://github.com/bleykauf/py-lpsd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8042,6 +8042,8 @@ self: super: with self; {
 
   pylsp-mypy = callPackage ../development/python-modules/pylsp-mypy { };
 
+  pylpsd = callPackage ../development/python-modules/pylpsd { };
+
   PyLTI = callPackage ../development/python-modules/pylti { };
 
   pylutron = callPackage ../development/python-modules/pylutron { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
