### PR TITLE
python3.pkgs.myhdl: init at unstable-2022-04-26

### DIFF
--- a/pkgs/development/python-modules/asyncserial/default.nix
+++ b/pkgs/development/python-modules/asyncserial/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+}:
+
+buildPythonPackage rec {
+  pname = "asyncserial";
+  version = "unstable-2022-06-10";
+
+  src = fetchFromGitHub {
+    owner = "m-labs";
+    repo = "asyncserial";
+    rev = "446559fec892a556876b17d17f182ae9647d5952";
+    hash = "sha256-WExmgh55sTH2w7wV3i96J1F1FN7L5rX3L/Ayvt2Kw/g=";
+  };
+
+  propagatedBuildInputs = [
+    pyserial
+  ];
+
+  pythonImportsCheck = [ "asyncserial" ];
+
+  meta = with lib; {
+    description = "asyncio support for pyserial";
+    homepage = "https://github.com/m-labs/asyncserial";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/migen/default.nix
+++ b/pkgs/development/python-modules/migen/default.nix
@@ -7,14 +7,13 @@
 
 buildPythonPackage rec {
   pname = "migen";
-  version = "unstable-2021-09-14";
-  disabled = pythonOlder "3.3";
+  version = "unstable-2022-09-02";
 
   src = fetchFromGitHub {
     owner = "m-labs";
     repo = "migen";
-    rev = "a5bc262560238f93ceaad423820eb06843326274";
-    sha256 = "32UjaIam/B7Gx6XbPcR067LcXfokJH2mATG9mU38a6o=";
+    rev = "639e66f4f453438e83d86dc13491b9403bbd8ec6";
+    hash = "sha256-IPyhoFZLhY8d3jHB8jyvGdbey7V+X5eCzBZYSrJ18ec=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/misoc/default.nix
+++ b/pkgs/development/python-modules/misoc/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, asyncserial
+, jinja2
+, migen
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "misoc";
+  version = "unstable-2022-10-08";
+
+  src = fetchFromGitHub {
+    owner = "m-labs";
+    repo = "misoc";
+    rev = "6a7c670ab6120b8136f652c41d907eb0fb16ed54";
+    hash = "sha256-dLDp0xg5y5b443hD7vbJFobHxbhtnj68RdZnQ7ckgp4=";
+  };
+
+  propagatedBuildInputs = [
+    pyserial
+    asyncserial
+    jinja2
+    migen
+  ];
+
+  checkInputs = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "misoc" ];
+
+  meta = with lib; {
+    description = "The original high performance and small footprint system-on-chip based on Migen";
+    homepage = "https://github.com/m-labs/misoc";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/myhdl/default.nix
+++ b/pkgs/development/python-modules/myhdl/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, verilog
+, ghdl
+, pytest
+, pytest-xdist
+}:
+
+buildPythonPackage rec {
+  pname = "myhdl";
+  # The stable version is from 2019 and it doesn't pass tests
+  version = "unstable-2022-04-26";
+  # The pypi src doesn't contain the ci script used in checkPhase
+  src = fetchFromGitHub {
+    owner = "myhdl";
+    repo = "myhdl";
+    rev = "1a4f5cd4e9de2e7bbf1053c3c2bc9526b5cc524a";
+    hash = "sha256-Tgoem88Y6AhlCKVhMm0Khg6GPcrEktYOqV8xcMaNkl4=";
+  };
+
+  checkInputs = [
+    pytest
+    pytest-xdist
+    verilog
+    ghdl
+  ];
+  passthru = {
+    # If using myhdl as a dependency, use these if needed and not ghdl and
+    # verlog from all-packages.nix
+    inherit ghdl verilog;
+  };
+  checkPhase = ''
+    runHook preCheck
+
+    for target in {core,iverilog,ghdl}; do
+      env CI_TARGET="$target" bash ./scripts/ci.sh
+    done;
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "A free, open-source package for using Python as a hardware description and verification language.";
+    homepage = "http://www.myhdl.org/";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5722,6 +5722,8 @@ self: super: with self; {
 
   misaka = callPackage ../development/python-modules/misaka { };
 
+  misoc = callPackage ../development/python-modules/misoc { };
+
   mistletoe = callPackage ../development/python-modules/mistletoe { };
 
   mistune = callPackage ../development/python-modules/mistune { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -682,6 +682,8 @@ self: super: with self; {
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };
 
+  asyncserial = callPackage ../development/python-modules/asyncserial { };
+
   asyncsleepiq = callPackage ../development/python-modules/asyncsleepiq { };
 
   asyncssh = callPackage ../development/python-modules/asyncssh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5949,6 +5949,10 @@ self: super: with self; {
 
   mygpoclient = callPackage ../development/python-modules/mygpoclient { };
 
+  myhdl = callPackage ../development/python-modules/myhdl {
+    inherit (pkgs) ghdl verilog;
+  };
+
   myhome = callPackage ../development/python-modules/myhome { };
 
   myjwt = callPackage ../development/python-modules/myjwt { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
