### PR TITLE
uboot: add Librecomputer CC custom build

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -211,6 +211,47 @@ in {
     '';
   };
 
+  # Flashing instructions:
+  # dd if=u-boot.gxl.sd.bin of=<sdcard> conv=fsync,notrunc bs=512 skip=1 seek=1
+  # dd if=u-boot.gxl.sd.bin of=<sdcard> conv=fsync,notrunc bs=1 count=444
+  ubootLibreTechCC = let
+    firmwareImagePkg = fetchFromGitHub {
+      owner = "LibreELEC";
+      repo = "amlogic-boot-fip";
+      rev = "4369a138ca24c5ab932b8cbd1af4504570b709df";
+      sha256 = "sha256-mGRUwdh3nW4gBwWIYHJGjzkezHxABwcwk/1gVRis7Tc=";
+      meta.license = lib.licenses.unfreeRedistributableFirmware;
+    };
+  in
+  assert stdenv.buildPlatform.system == "x86_64-linux"; # aml_encrypt_gxl is a x86_64 binary
+  buildUBoot {
+    defconfig = "libretech-cc_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = ["u-boot.bin"];
+    postBuild = ''
+      # Copy binary files & tools from LibreELEC/amlogic-boot-fip, and u-boot build to working dir
+      mkdir $out tmp
+      cp ${firmwareImagePkg}/lepotato/{acs.bin,bl2.bin,bl21.bin,bl30.bin,bl301.bin,bl31.img} \
+         ${firmwareImagePkg}/lepotato/{acs_tool.py,aml_encrypt_gxl,blx_fix.sh} \
+         u-boot.bin tmp/
+      cd tmp
+      python3 acs_tool.py bl2.bin bl2_acs.bin acs.bin 0
+
+      bash -e blx_fix.sh bl2_acs.bin zero bl2_zero.bin bl21.bin bl21_zero.bin bl2_new.bin bl2
+      [ -f zero ] && rm zero
+
+      bash -e blx_fix.sh bl30.bin zero bl30_zero.bin bl301.bin bl301_zero.bin bl30_new.bin bl30
+      [ -f zero ] && rm zero
+
+      ./aml_encrypt_gxl --bl2sig --input bl2_new.bin --output bl2.n.bin.sig
+      ./aml_encrypt_gxl --bl3enc --input bl30_new.bin --output bl30_new.bin.enc
+      ./aml_encrypt_gxl --bl3enc --input bl31.img --output bl31.img.enc
+      ./aml_encrypt_gxl --bl3enc --input u-boot.bin --output bl33.bin.enc
+      ./aml_encrypt_gxl --bootmk --output $out/u-boot.gxl \
+        --bl2 bl2.n.bin.sig --bl30 bl30_new.bin.enc --bl31 bl31.img.enc --bl33 bl33.bin.enc
+    '';
+  };
+
   ubootNanoPCT4 = buildUBoot rec {
     rkbin = fetchFromGitHub {
       owner = "armbian";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25939,6 +25939,7 @@ with pkgs;
     ubootCubieboard2
     ubootGuruplug
     ubootJetsonTK1
+    ubootLibreTechCC
     ubootNanoPCT4
     ubootNovena
     ubootOdroidC2


### PR DESCRIPTION
###### Description of changes

Add a new U-boot flavor for LibreComputer's AML-S905X-CC (Le Potato).

SoC's secure boot scheme will verify early boot stages up to and excluding U-boot. Those boot stages come as signed-and-verified binary blobs provided by the vendor.

Proprietary blobs and related tooling are fetched from github.com/LibreELEC/amlogic-boot-fip and used in postBuild along with build output.

Hardware: https://libre.computer/products/aml-s905x-cc/
U-boot doc: https://u-boot.readthedocs.io/en/latest/board/amlogic/libretech-cc.html

Note: I would have preferred to use meson-tools instead of the proprietary tools, but if it's even possible, it's quite obscure to me, and not very documented.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (cross compiled for aarch64-multiplatform)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
