### PR TITLE
pkgsStatic.libxslt: fix build

### DIFF
--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -11,7 +11,7 @@
 , libxcrypt
 , libgcrypt
 , cryptoSupport ? false
-, pythonSupport ? true
+, pythonSupport ? libxml2.pythonSupport
 , gnome
 }:
 


### PR DESCRIPTION
Make default value of "pythonSupport" to depend configuration of libxml2, which
only builds python support when shared libraries are enabled. This way libxslt
can be built on pkgsStatic platform (albeit without python support) instead of
refusing to build due "meta.broken". That allows to build statically some
packages that depend on libxslt, but don't necessary need python support.
