### PR TITLE
qt5/qtwayland: fix popups being placed outside the screen

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -1,4 +1,4 @@
-{ qtModule, qtbase, qtquickcontrols, wayland, pkg-config }:
+{ qtModule, qtbase, qtquickcontrols, wayland, pkg-config, fetchpatch }:
 
 qtModule {
   pname = "qtwayland";
@@ -11,5 +11,13 @@ qtModule {
     # wrapped executables from `wrapQtAppsHook` (see comment in patch for further
     # context).  Beware: shared among different Qt5 versions.
     ./qtwayland-app_id.patch
+    # Backport of https://codereview.qt-project.org/c/qt/qtwayland/+/388338
+    # Pulled from Fedora as they modified it to not apply to KDE as Plasma 5.x
+    # doesn't behave properly with the patch applied. See the discussion at
+    # https://invent.kde.org/qt/qt/qtwayland/-/merge_requests/39 for details
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/qt5-qtwayland/raw/46376bb00d4c3dd3db2e82ad7ca5301ce16ea4ab/f/0080-Client-set-constraint-adjustments-for-popups-in-xdg.patch";
+      sha256 = "sha256-XP+noYCk8fUdA0ItCqMjV7lSXDlNdB7Az9q7NRpupHc=";
+    })
   ];
 }


### PR DESCRIPTION
###### Description of changes

QT 5 did not set layout constraints on their popups. This causes some compositors like GNOME to place the popups partially outside the screen. This change backports the corresponding fix, but with an exclusion for KDE as its current version does not work well with layout constraints.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
