### PR TITLE
nixos/power-management: use systemd-sleep features instead of units

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -43,6 +43,8 @@ in
             Commands executed when the machine powers up.  That is,
             they're executed both when the system first boots and when
             it resumes from suspend or hibernation.
+            `$GOAL` contains either `suspend`, `hibernate`, `hybrid-sleep`, `suspend-then-hibernate` or `off`.
+            `$SYSTEMD_SLEEP_ACTION` is identical to `$GOAL` except when `$GOAL` is `suspend-then-hibernate` where it refines it by either `suspend`, `hibernate`, or `suspend-after-failed-hibernate`.
           '';
       };
 
@@ -57,6 +59,8 @@ in
             Commands executed when the machine powers down.  That is,
             they're executed both when the system shuts down and when
             it goes to suspend or hibernation.
+            `$GOAL` contains either `suspend`, `hibernate`, `hybrid-sleep`, `suspend-then-hibernate` or `off`.
+            `$SYSTEMD_SLEEP_ACTION` is identical to `$GOAL` except when `$GOAL` is `suspend-then-hibernate` where it refines it by either `suspend`, `hibernate`, or `suspend-after-failed-hibernate`.
           '';
       };
 
@@ -68,39 +72,46 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-
-    systemd.targets.post-resume = {
-      description = "Post-Resume Actions";
-      requires = [ "post-resume.service" ];
-      after = [ "post-resume.service" ];
-      wantedBy = [ "sleep.target" ];
-      unitConfig.StopWhenUnneeded = true;
+    # this file will be executed by system-sleep.service
+    environment.etc."systemd/system-sleep/nixos-sleep.sh".source = pkgs.writeShellScript "nixos-sleep.sh" ''
+      set +e
+      export GOAL="$2"
+      if [[ "$2" = "off" ]]; then
+        export SYSTEMD_SLEEP_ACTION=off
+      fi
+      case "$1" in
+        pre)
+          ${cfg.powerDownCommands}
+          ;;
+        post)
+          ${cfg.powerUpCommands}
+          case "$SYSTEMD_SLEEP_ACTION" in
+            suspend|suspend-after-failed-hibernate)
+              ${cfg.resumeCommands}
+              ;;
+            *)
+          esac
+          ;;
+        *)
+          echo "/etc/systemd/system-sleep/nixos-sleep.sh called with unexpected argument $@"
+        esac
+    '';
+    # system-suspend.service and co do not handle bootup and poweroff
+    systemd.services.bootup-commands = {
+      after = [ "multi-user.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = [ "/etc/systemd/system-sleep/nixos-sleep.sh post off" ];
+        Type = "oneshot";
+      };
     };
-
-    # Service executed before suspending/hibernating.
-    systemd.services.pre-sleep =
-      { description = "Pre-Sleep Actions";
-        wantedBy = [ "sleep.target" ];
-        before = [ "sleep.target" ];
-        script =
-          ''
-            ${cfg.powerDownCommands}
-          '';
-        serviceConfig.Type = "oneshot";
+    systemd.services.poweroff-commands = rec {
+      before = wantedBy;
+      wantedBy = [ "halt.target" "poweroff.target" "reboot.target" ];
+      serviceConfig = {
+        ExecStart = [ "/etc/systemd/system-sleep/nixos-sleep.sh pre off" ];
+        Type = "oneshot";
       };
-
-    systemd.services.post-resume =
-      { description = "Post-Resume Actions";
-        after = [ "suspend.target" "hibernate.target" "hybrid-sleep.target" "suspend-then-hibernate.target" ];
-        script =
-          ''
-            /run/current-system/systemd/bin/systemctl try-restart --no-block post-resume.target
-            ${cfg.resumeCommands}
-            ${cfg.powerUpCommands}
-          '';
-        serviceConfig.Type = "oneshot";
-      };
-
+    };
   };
-
 }


### PR DESCRIPTION
Fixes a deadlock where post-resume.target has After=post-resume.service and post-resume.service runs systemctl try-restart post-resume.target the systemctl call cannot complete if post-resume.target was already queued at that time.

cc @flokli, see https://github.com/NixOS/nixpkgs/pull/199352 for context. Draft until this has release notes, will have to wait until 22.11 is released.

Has a number of problems:
- contrary to what the doc of the options suggest, I have the impression that powerDown and powerUpCommands are not run on boot up/shutdown in the current module.
- systemd-sleep does not handle bootup and shutdown, so I have to use units. but I don't know how to have a unit start at bootup but not on nixos-rebuild.
- I didn't test absolutely all circumstances where those should be called.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
