### PR TITLE
nc4nix: unstable-2022-08-06 -> unstable-2022-11-12

### DIFF
--- a/pkgs/development/tools/nc4nix/default.nix
+++ b/pkgs/development/tools/nc4nix/default.nix
@@ -5,21 +5,21 @@
 
 buildGoModule rec {
   pname = "nc4nix";
-  version = "unstable-2022-08-06";
+  version = "unstable-2022-11-12";
 
   src = fetchFromGitLab {
-    domain = "git.helsinki.tools";
-    owner = "helsinki-systems";
+    domain = "git.project-insanity.org";
+    owner = "onny";
     repo = "nc4nix";
-    rev = "91d92e8c339862fe81fb066fd370da7757042367";
-    sha256 = "sha256-8ggYOc+w3oiY2B0Ned5B26/ZNco2vCdvScC+Ms+gOWo=";
+    rev = "d7f55a42b5ca0d02382349c6ec776eefe6079703";
+    sha256 = "sha256-MfMW2B+udXV/lQPGUBFuAE7jwmy4D1M+CYkCuJ088aM=";
   };
 
   vendorSha256 = "sha256-uhINWxFny/OY7M2vV3ehFzP90J6Z8cn5IZHWOuEg91M=";
 
   meta = with lib; {
     description = "Packaging helper for Nextcloud apps";
-    homepage = "https://git.helsinki.tools/helsinki-systems/nc4nix";
+    homepage = "https://git.project-insanity.org/onny/nc4nix";
     license = licenses.unfree;
     maintainers = with maintainers; [ onny ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
