### PR TITLE
slock: 1.4 → 1.5

### DIFF
--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -4,14 +4,13 @@
 # https://git.suckless.org/slock/tree/config.def.h
 , conf ? null }:
 
-with lib;
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "slock";
-  version = "1.4";
+  version = "1.5";
 
   src = fetchurl {
-    url = "https://dl.suckless.org/tools/slock-${version}.tar.gz";
-    sha256 = "0sif752303dg33f14k6pgwq2jp1hjyhqv6x4sy3sj281qvdljf5m";
+    url = "https://dl.suckless.org/tools/slock-${finalAttrs.version}.tar.gz";
+    hash = "sha256-ruHj+/aid/tiWjg4BzuXm2SD57rKTOgvVt4f8ZLbDk0=";
   };
 
   buildInputs = [ xorgproto libX11 libXext libXrandr libxcrypt ];
@@ -20,13 +19,13 @@ stdenv.mkDerivation rec {
 
   postPatch = "sed -i '/chmod u+s/d' Makefile";
 
-  preBuild = optionalString (conf != null) ''
+  preBuild = lib.optionalString (conf != null) ''
     cp ${writeText "config.def.h" conf} config.def.h
   '';
 
   makeFlags = [ "CC:=$(CC)" ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://tools.suckless.org/slock";
     description = "Simple X display locker";
     longDescription = ''
@@ -36,4 +35,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes
[Changelog](https://git.suckless.org/slock/)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
