### PR TITLE
erigon: module: better secret management

### DIFF
--- a/nixos/modules/services/blockchain/ethereum/erigon.nix
+++ b/nixos/modules/services/blockchain/ethereum/erigon.nix
@@ -13,13 +13,13 @@ in {
     services.erigon = {
       enable = mkEnableOption (lib.mdDoc "Ethereum implementation on the efficiency frontier");
 
-      group = mkOption {
-        type = types.str;
-        default = "ethereum";
+      secretJwtPath = mkOption {
+        type = types.path;
         description = lib.mdDoc ''
-          Group of the user running the lighthouse process. This is used to share the jwt
-          secret with the execution layer.
+          Path to the secret jwt used for the http api authentication.
         '';
+        default = "";
+        example = "config.age.secrets.ERIGON_JWT.path";
       };
 
       settings = mkOption {
@@ -64,19 +64,6 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users = {
-      users.erigon = {
-        name = "erigon";
-        group = cfg.group;
-        description = "Erigon user";
-        home = "/var/lib/erigon";
-        isSystemUser = true;
-      };
-      groups = mkIf (cfg.group == "ethereum") {
-        ethereum = {};
-      };
-    };
-
     # Default values are the same as in the binary, they are just written here for convenience.
     services.erigon.settings = {
       datadir = mkDefault "/var/lib/erigon";
@@ -98,9 +85,9 @@ in {
       after = [ "network.target" ];
 
       serviceConfig = {
-        ExecStart = "${pkgs.erigon}/bin/erigon --config ${configFile}";
-        User = "erigon";
-        Group = cfg.group;
+        LoadCredential = "ERIGON_JWT:${cfg.secretJwtPath}";
+        ExecStart = "${pkgs.erigon}/bin/erigon --config ${configFile} --authrpc.jwtsecret=%d/ERIGON_JWT";
+        DynamicUser = true;
         Restart = "on-failure";
         StateDirectory = "erigon";
         CapabilityBoundingSet = "";

--- a/nixos/modules/services/blockchain/ethereum/lighthouse.nix
+++ b/nixos/modules/services/blockchain/ethereum/lighthouse.nix
@@ -57,15 +57,6 @@ in {
               '';
             };
 
-            group = mkOption {
-              type = types.str;
-              default = "ethereum";
-              description = lib.mdDoc ''
-                Group of the user running the lighthouse process. This is used to share the jwt
-                secret with the execution layer.
-              '';
-            };
-
             execution = {
               address = mkOption {
                 type = types.str;
@@ -221,19 +212,6 @@ in {
 
   config = mkIf (cfg.beacon.enable || cfg.validator.enable) {
 
-    users = {
-      users.lighthouse-beacon = {
-        name = "lighthouse-beacon";
-        group = cfg.beacon.group;
-        description = "Lighthouse beacon node user";
-        home = "${cfg.beacon.dataDir}";
-        isSystemUser = true;
-      };
-      groups = mkIf (cfg.beacon.group == "ethereum") {
-        ethereum = {};
-      };
-    };
-
     environment.systemPackages = [ pkgs.lighthouse ] ;
 
     networking.firewall = mkIf cfg.beacon.enable {
@@ -259,14 +237,14 @@ in {
           --network ${cfg.network} \
           --datadir ${cfg.beacon.dataDir}/${cfg.network} \
           --execution-endpoint http://${cfg.beacon.execution.address}:${toString cfg.beacon.execution.port} \
-          --execution-jwt ${cfg.beacon.execution.jwtPath} \
+          --execution-jwt ''${CREDENTIALS_DIRECTORY}/LIGHTHOUSE_JWT \
           ${lib.optionalString cfg.beacon.http.enable '' --http --http-address ${cfg.beacon.http.address} --http-port ${toString cfg.beacon.http.port}''} \
           ${lib.optionalString cfg.beacon.metrics.enable '' --metrics --metrics-address ${cfg.beacon.metrics.address} --metrics-port ${toString cfg.beacon.metrics.port}''} \
           ${cfg.extraArgs} ${cfg.beacon.extraArgs}
       '';
       serviceConfig = {
-        User = "lighthouse-beacon";
-        Group = cfg.beacon.group;
+        LoadCredential = "LIGHTHOUSE_JWT:${cfg.beacon.execution.jwtPath}";
+        DynamicUser = true;
         Restart = "on-failure";
         StateDirectory = "lighthouse-beacon";
         NoNewPrivileges = true;


### PR DESCRIPTION
###### Description of changes

An update for security and better management of erigon and lighthouse.
Those both use DynamicUser now.
They also use LoadCredentials for the secret instead of letting the user define manually it's secret.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
