### PR TITLE
miniaudio: unstable-2020-04-20 -> 0.11.11

### DIFF
--- a/pkgs/development/libraries/miniaudio/default.nix
+++ b/pkgs/development/libraries/miniaudio/default.nix
@@ -4,13 +4,15 @@
 }:
 stdenv.mkDerivation rec {
   pname = "miniaudio";
-  version = "unstable-2020-04-20";
+  version = "0.11.11";
 
   src = fetchFromGitHub {
     owner = "mackron";
     repo = "miniaudio";
-    rev = "4d813cfe23c28db165cce6785419fee9d2399766";
-    sha256 = "sha256-efZLZTmkLtvcysd25olDE/QqunU5YTYwSVmUZXPKGIY=";
+    rev = "a0dc1037f99a643ff5fad7272cd3d6461f2d63fa";
+    # upstream does not maintain tags:
+    # https://github.com/mackron/miniaudio/issues/273#issuecomment-783861269
+    hash = "sha256-jOvDZk76hDvZ1RQ9O34kVeW0n95BT9+BE6fNhdekI5s=";
   };
 
   installPhase = ''
@@ -19,9 +21,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Single header audio playback and capture library written in C.";
+    description = "Single header audio playback and capture library written in C";
     homepage = "https://github.com/mackron/miniaudio";
-    license = licenses.unlicense;
+    changelog = "https://github.com/mackron/miniaudio/blob/${src.rev}/CHANGES.md";
+    license = with licenses; [ unlicense /* or */ mit0 ];
     maintainers = [ maintainers.jansol ];
     platforms = platforms.all;
   };

--- a/pkgs/development/python-modules/miniaudio/default.nix
+++ b/pkgs/development/python-modules/miniaudio/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "miniaudio";
-  version = "1.53";
+  version = "1.54";
 
   disabled = pythonOlder "3.6";
 
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "irmen";
     repo = "pyminiaudio";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-TB4V41GN48Q2ocsDM1uIyRziY+y8njRNoPxZpTqk+Tk=";
+    hash = "sha256-Xy1O9/oeEM0fjuipCFxL2nknH6/bEVGIraByOlQ/CHs=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
closes https://github.com/NixOS/nixpkgs/pull/201031