### PR TITLE
wavebox: 4.11.3->10.114.26-2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4476,6 +4476,15 @@
     githubId = 1516017;
     name = "Ed Cragg";
   };
+  eddsteel = {
+    email = "edd@eddsteel.com";
+    github = "eddsteel";
+    githubId = 206872;
+    name = "Edd Steel";
+    keys = [{
+      fingerprint = "1BE8 48D7 6C7C 4C51 349D  DDCC 3362 0159 D403 85A0";
+    }];
+  };
   edef = {
     email = "edef@edef.eu";
     github = "edef1c";

--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -18,8 +18,7 @@
 }:
 
 let
-  version = "10.108.19-2";
-
+  version = "10.110.26-2";
   desktopItem = makeDesktopItem rec {
     name = "Wavebox";
     exec = "wavebox";
@@ -37,7 +36,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "https://download.wavebox.app/stable/linux/tar/${tarball}";
-    sha256 = "sha256-VI2/qhD5EK3e00lexcsGXt72Vm6ncVNqMkUmGbDATWc=";
+    sha256 = "04fnnqbyq8fd4wh61lwx3j32lilqannblxxkjha0h1qn4qvr9pj9";
   };
 
   # don't remove runtime deps

--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -1,12 +1,12 @@
 { alsa-lib, autoPatchelfHook, fetchurl, gtk3, libnotify
 , makeDesktopItem, makeWrapper, nss, lib, stdenv, udev, xdg-utils
-, xorg
+, xorg, qtbase, wrapQtAppsHook, mesa
 }:
 
 let
   bits = "x86_64";
 
-  version = "4.11.3";
+  version = "10.107.10";
 
   desktopItem = makeDesktopItem rec {
     name = "Wavebox";
@@ -17,25 +17,25 @@ let
     categories = [ "Network" ];
   };
 
-  tarball = "Wavebox_${lib.replaceStrings ["."] ["_"] (toString version)}_linux_${bits}.tar.gz";
+  tarball = "Wavebox_${version}-2.tar.gz";
 
 in stdenv.mkDerivation {
   pname = "wavebox";
   inherit version;
   src = fetchurl {
-    url = "https://github.com/wavebox/waveboxapp/releases/download/v${version}/${tarball}";
-    sha256 = "0z04071lq9bfyrlg034fmvd4346swgfhxbmsnl12m7c2m2b9z784";
+    url = "https://download.wavebox.app/stable/linux/tar/${tarball}";
+    sha256 = "17q72bmq461bh75dwawwfpc7pd73pahx6gm6rd89kb5xgad01dvi";
   };
 
   # don't remove runtime deps
   dontPatchELF = true;
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapQtAppsHook ];
 
   buildInputs = with xorg; [
-    libXdmcp libXScrnSaver libXtst
+    libXdmcp libXScrnSaver libXtst libXdamage libXrandr
   ] ++ [
-    alsa-lib gtk3 nss
+    alsa-lib qtbase nss stdenv.cc.cc.lib gtk3 mesa
   ];
 
   runtimeDependencies = [ (lib.getLib udev) libnotify ];
@@ -52,15 +52,16 @@ in stdenv.mkDerivation {
 
   postFixup = ''
     # make xdg-open overrideable at runtime
-    makeWrapper $out/opt/wavebox/Wavebox $out/bin/wavebox \
+    makeWrapper $out/opt/wavebox/wavebox $out/bin/wavebox \
       --suffix PATH : ${xdg-utils}/bin
   '';
 
   meta = with lib; {
-    description = "Wavebox messaging application";
-    homepage = "https://wavebox.io";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [ rawkode ];
+    description = "Browser application for webapps";
+    homepage = https://wavebox.io;
+    changelog = https://wavebox.io/blog/tag/releases/;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ rawkode eddsteel ];
     platforms = ["x86_64-linux"];
     hydraPlatforms = [];
   };

--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "10.110.26-2";
+  version = "10.114.26-2";
   desktopItem = makeDesktopItem rec {
     name = "Wavebox";
     exec = "wavebox";
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "https://download.wavebox.app/stable/linux/tar/${tarball}";
-    sha256 = "04fnnqbyq8fd4wh61lwx3j32lilqannblxxkjha0h1qn4qvr9pj9";
+    sha256 = "1yk664zgahjg6n98n3kc9avcay0nqwcyq8wq231p7kvd79zazk0r";
   };
 
   # don't remove runtime deps

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34433,7 +34433,7 @@ with pkgs;
 
   viber = callPackage ../applications/networking/instant-messengers/viber { };
 
-  wavebox = callPackage ../applications/networking/instant-messengers/wavebox { };
+  wavebox = libsForQt5.callPackage ../applications/networking/instant-messengers/wavebox { };
 
   sonic-pi = libsForQt5.callPackage ../applications/audio/sonic-pi { };
 


### PR DESCRIPTION
###### Description of changes

Updates wavebox to the latest stable version, and adds me as a maintainer.

Since v4 there have been significant changes, for example moving the core engine to chromium not electron. Also the licensing has changed and the release artifact location has moved. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
