### PR TITLE
{montserrat,b612}: fix build

### DIFF
--- a/pkgs/data/fonts/b612/default.nix
+++ b/pkgs/data/fonts/b612/default.nix
@@ -1,19 +1,24 @@
 { lib, fetchFromGitHub }:
 
-let
-  version = "1.008";
+fetchFromGitHub rec {
   pname = "b612";
-in fetchFromGitHub {
-  name = "${pname}-font-${version}";
+  version = "1.008";
+
   owner = "polarsys";
   repo = "b612";
   rev = version;
+
   postFetch = ''
-    tar xf $downloadedFile --strip=1
-    mkdir -p $out/share/fonts/truetype/${pname}
-    cp fonts/ttf/*.ttf $out/share/fonts/truetype/${pname}
+    mkdir -p $out/share/fonts/truetype
+
+    mv $out/fonts/ttf/*.ttf $out/share/fonts/truetype
+
+    shopt -s extglob dotglob
+    rm -rf $out/!(share)
+    shopt -u extglob dotglob
   '';
-  sha256 = "0r3lana1q9w3siv8czb3p9rrb5d9svp628yfbvvmnj7qvjrmfsiq";
+
+  hash = "sha256-aJ3XzWQauPsWwEDAHT2rD9a8RvLv1kqU3krFXprmypk=";
 
   meta = with lib; {
     homepage = "http://b612-font.com/";

--- a/pkgs/data/fonts/b612/default.nix
+++ b/pkgs/data/fonts/b612/default.nix
@@ -21,7 +21,7 @@ fetchFromGitHub rec {
   hash = "sha256-aJ3XzWQauPsWwEDAHT2rD9a8RvLv1kqU3krFXprmypk=";
 
   meta = with lib; {
-    homepage = "http://b612-font.com/";
+    homepage = "https://b612-font.com/";
     description = "Highly legible font family for use on aircraft cockpit screens";
     longDescription = ''
       B612 is the result of a research project initiated by Airbus. The font

--- a/pkgs/data/fonts/montserrat/default.nix
+++ b/pkgs/data/fonts/montserrat/default.nix
@@ -1,21 +1,25 @@
 { lib, fetchFromGitHub }:
 
-let
+fetchFromGitHub rec {
   pname = "montserrat";
   version = "7.222";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
+
   owner = "JulietaUla";
   repo = pname;
   rev = "v${version}";
   sha256 = "sha256-MeNnc1e5X5f0JyaLY6fX22rytHkvL++eM2ygsdlGMv0=";
 
   postFetch = ''
-    tar xf $downloadedFile --strip 1
-    install -Dm 444 fonts/otf/*.otf -t $out/share/fonts/otf
-    install -Dm 444 fonts/ttf/*.ttf -t $out/share/fonts/ttf
-    install -Dm 444 fonts/webfonts/*.woff -t $out/share/fonts/woff
-    install -Dm 444 fonts/webfonts/*.woff2 -t $out/share/fonts/woff2
+    mkdir -p $out/share/fonts/{otf,ttf,woff,woff2}
+
+    mv $out/fonts/otf/*.otf $out/share/fonts/otf
+    mv $out/fonts/ttf/*.ttf $out/share/fonts/ttf
+    mv $out/fonts/webfonts/*.woff $out/share/fonts/woff
+    mv $out/fonts/webfonts/*.woff2 $out/share/fonts/woff2
+
+    shopt -s extglob dotglob
+    rm -rf $out/!(share)
+    shopt -u extglob dotglob
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Fixes needed after #173430

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @drupol, we've talked about this in #nix:nixos.org recently