### PR TITLE
yarn2nix: add easy yarn & nodejs pkg overrides

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
@@ -2,7 +2,7 @@
 , nodejs ? pkgs.nodejs
 , yarn ? pkgs.yarn
 , allowAliases ? pkgs.config.allowAliases
-}:
+}@inputs:
 
 let
   inherit (pkgs) stdenv lib fetchurl linkFarm callPackage git rsync makeWrapper runCommandLocal;
@@ -70,6 +70,8 @@ in rec {
     offlineCache ? importOfflineCache yarnNix,
     yarnFlags ? [ ],
     ignoreScripts ? true,
+    nodejs ? inputs.nodejs,
+    yarn ? inputs.yarn.override { nodejs = nodejs; },
     pkgConfig ? {},
     preBuild ? "",
     postBuild ? "",
@@ -169,6 +171,8 @@ in rec {
     src,
     packageJSON ? src + "/package.json",
     yarnLock ? src + "/yarn.lock",
+    nodejs ? inputs.nodejs,
+    yarn ? inputs.yarn.override { nodejs = nodejs; },
     packageOverrides ? {},
     ...
   }@attrs:
@@ -226,7 +230,7 @@ in rec {
         inherit name;
         value = mkYarnPackage (
           builtins.removeAttrs attrs ["packageOverrides"]
-          // { inherit src packageJSON yarnLock packageResolutions workspaceDependencies; }
+          // { inherit src packageJSON yarnLock nodejs yarn packageResolutions workspaceDependencies; }
           // lib.attrByPath [name] {} packageOverrides
         );
       })
@@ -241,6 +245,8 @@ in rec {
     yarnLock ? src + "/yarn.lock",
     yarnNix ? mkYarnNix { inherit yarnLock; },
     offlineCache ? importOfflineCache yarnNix,
+    nodejs ? inputs.nodejs,
+    yarn ? inputs.yarn.override { nodejs = nodejs; },
     yarnFlags ? [ ],
     yarnPreBuild ? "",
     yarnPostBuild ? "",
@@ -268,7 +274,7 @@ in rec {
         preBuild = yarnPreBuild;
         postBuild = yarnPostBuild;
         workspaceDependencies = workspaceDependenciesTransitive;
-        inherit packageJSON pname version yarnLock offlineCache yarnFlags pkgConfig packageResolutions;
+        inherit packageJSON pname version yarnLock offlineCache nodejs yarn yarnFlags pkgConfig packageResolutions;
       };
 
       publishBinsFor_ = unlessNull publishBinsFor [pname];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Projects often require a specific major version of NodeJS, and sometimes a specific yarn version. Since yarn2nix utilities are accessed from nixpkgs now, there is no simple way to override versions of nodejs and yarn without complex solutions like an overlay.

This adds `yarn` and `nodejs` as optional attribute arguments to `mkYarnModules`, `mkYarnPackage`, and `mkYarnWorkspace`. They default to the same versions that are currently being used, and the nodejs input to yarn is overridden so that it will match if only `nodejs` is overridden by the user.

These arguments will also cascade from `mkYarnWorkspace` -> `mkYarnPackage` -> `mkYarnModules`, making per-package overrides very simple.

See an example of a build error that could be fixed much more easily with this change [here](https://github.com/Smona/nixpkgs-upstream/commit/24e5bf4c94fa318afa5ec35a0f5ce23f1e9eb3b7).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
