### PR TITLE
libsegfault: init unstable-2022-11-13

### DIFF
--- a/pkgs/development/libraries/libsegfault/default.nix
+++ b/pkgs/development/libraries/libsegfault/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, ninja
+, boost
+, libbacktrace
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libsegfault";
+  version = "unstable-2022-11-13";
+
+  src = fetchFromGitHub {
+    owner = "jonathanpoelen";
+    repo = "libsegfault";
+    rev = "8bca5964613695bf829c96f7a3a14dbd8304fe1f";
+    sha256 = "vKtY6ZEkyK2K+BzJCSo30f9MpERpPlUnarFIlvJ1Giw=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    boost
+    libbacktrace
+  ];
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Implementation of libSegFault.so with Boost.stracktrace";
+    homepage = "https://github.com/jonathanpoelen/libsegfault";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21394,6 +21394,8 @@ with pkgs;
 
   libsecret = callPackage ../development/libraries/libsecret { };
 
+  libsegfault = callPackage ../development/libraries/libsegfault { };
+
   libserdes = callPackage ../development/libraries/libserdes { };
 
   libserialport = callPackage ../development/libraries/libserialport { };


### PR DESCRIPTION
Can be used as follows to get the backtrace on crash during tests:

```nix
preCheck = ''
  export LD_PRELOAD=${libsegfault}/lib/libsegfault.so
  export SEGFAULT_SIGNALS=all
'';
```

https://github.com/jonathanpoelen/libsegfault

