### PR TITLE
php82: init at 8.2.0rc6

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -141,6 +141,11 @@
       </listitem>
       <listitem>
         <para>
+          PHP 8.2.0 RC 6 is available.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>protonup</literal> has been aliased to and replaced
           by <literal>protonup-ng</literal> due to upstream not
           maintaining it.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -57,6 +57,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   `mod_php` usage we still enable `ZTS` (Zend Thread Safe). This has been a
   common practice for a long time in other distributions.
 
+- PHP 8.2.0 RC 6 is available.
+
 - `protonup` has been aliased to and replaced by `protonup-ng` due to upstream not maintaining it.
 
 - Perl has been updated to 5.36, and its core module `HTTP::Tiny` was patched to verify SSL/TLS certificates by default.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -492,6 +492,7 @@ in {
   php = handleTest ./php {};
   php80 = handleTest ./php { php = pkgs.php80; };
   php81 = handleTest ./php { php = pkgs.php81; };
+  php82 = handleTest ./php { php = pkgs.php82; };
   phylactery = handleTest ./web-apps/phylactery.nix {};
   pict-rs = handleTest ./pict-rs.nix {};
   pinnwand = handleTest ./pinnwand.nix {};

--- a/pkgs/development/interpreters/php/8.2.nix
+++ b/pkgs/development/interpreters/php/8.2.nix
@@ -1,0 +1,61 @@
+{ callPackage, lib, stdenv, fetchurl, ... }@_args:
+
+let
+  hash = "sha256-sbT8sIwle3OugXxqLZO3jKXlrOQsX1iH7WRH8G+nv8Y=";
+
+  base = callPackage ./generic.nix (_args // {
+    version = "8.2.0";
+    phpAttrsOverrides = attrs: attrs // {
+      src = fetchurl {
+        url = "https://downloads.php.net/~sergey/php-8.2.0RC6.tar.xz";
+        inherit hash;
+      };
+    };
+    inherit hash;
+  });
+
+in
+base.withExtensions ({ all, ... }: with all; ([
+  bcmath
+  calendar
+  curl
+  ctype
+  dom
+  exif
+  fileinfo
+  filter
+  ftp
+  gd
+  gettext
+  gmp
+  iconv
+  imap
+  intl
+  ldap
+  mbstring
+  mysqli
+  mysqlnd
+  opcache
+  openssl
+  pcntl
+  pdo
+  pdo_mysql
+  pdo_odbc
+  pdo_pgsql
+  pdo_sqlite
+  pgsql
+  posix
+  readline
+  session
+  simplexml
+  sockets
+  soap
+  sodium
+  sysvsem
+  sqlite3
+  tokenizer
+  xmlreader
+  xmlwriter
+  zip
+  zlib
+]))

--- a/pkgs/development/php-packages/datadog_trace/default.nix
+++ b/pkgs/development/php-packages/datadog_trace/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, curl, fetchFromGitHub, lib, pcre2 }:
+{ buildPecl, curl, fetchFromGitHub, lib, pcre2, php }:
 
 buildPecl rec {
   pname = "ddtrace";
@@ -14,6 +14,7 @@ buildPecl rec {
   buildInputs = [ curl pcre2 ];
 
   meta = with lib; {
+    broken = lib.versionOlder php.version "8.1"; # Broken on PHP older than 8.1.
     description = "Datadog Tracing PHP Client";
     homepage = "https://github.com/DataDog/dd-trace-php";
     license = licenses.apsl20;

--- a/pkgs/development/php-packages/gnupg/default.nix
+++ b/pkgs/development/php-packages/gnupg/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, gpgme, file, gnupg }:
+{ buildPecl, lib, gpgme, file, gnupg, php }:
 
 buildPecl {
   pname = "gnupg";
@@ -29,6 +29,7 @@ buildPecl {
   doCheck = true;
 
   meta = with lib; {
+    broken = lib.versionOlder php.version "8.1"; # Broken on PHP older than 8.1.
     description = "PHP wrapper for GpgME library that provides access to GnuPG";
     license = licenses.bsd3;
     homepage = "https://pecl.php.net/package/gnupg";

--- a/pkgs/development/php-packages/oci8/default.nix
+++ b/pkgs/development/php-packages/oci8/default.nix
@@ -1,12 +1,18 @@
-{ buildPecl, lib, oracle-instantclient }:
+{ buildPecl, lib, oracle-instantclient, php }:
+
 let
-  version = "3.0.1";
-  sha256 = "108ds92620dih5768z19hi0jxfa7wfg5hdvyyvpapir87c0ap914";
+  versionData = if (lib.versionOlder php.version "8.1") then {
+    version = "3.0.1";
+    sha256 = "108ds92620dih5768z19hi0jxfa7wfg5hdvyyvpapir87c0ap914";
+  } else {
+    version = "3.2.1";
+    sha256 = "zyF703DzRZDBhlNFFt/dknmZ7layqhgjG1/ZDN+PEsg=";
+  };
 in
 buildPecl {
   pname = "oci8";
 
-  inherit version sha256;
+  inherit (versionData) version sha256;
 
   buildInputs = [ oracle-instantclient ];
   configureFlags = [ "--with-oci8=shared,instantclient,${oracle-instantclient.lib}/lib" ];

--- a/pkgs/development/php-packages/xdebug/default.nix
+++ b/pkgs/development/php-packages/xdebug/default.nix
@@ -1,10 +1,18 @@
-{ buildPecl, lib }:
+{ buildPecl, lib, php }:
 
+let
+  versionData = if (lib.versionOlder php.version "8.1") then {
+    version = "3.1.6";
+    sha256 = "1lnmrb5kgq8lbhjs48j3wwhqgk44pnqb1yjq4b5r6ysv9l5wlkjm";
+  } else {
+    version = "3.2.0RC2";
+    sha256 = "dQgXDP3Ifg+D0niWxaJ4ec71Vfr8KH40jv6QbxSyY+4=";
+  };
+in
 buildPecl {
   pname = "xdebug";
 
-  version = "3.1.6";
-  sha256 = "1lnmrb5kgq8lbhjs48j3wwhqgk44pnqb1yjq4b5r6ysv9l5wlkjm";
+  inherit (versionData) version sha256;
 
   doCheck = true;
   checkTarget = "test";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15765,6 +15765,16 @@ with pkgs;
   phpExtensions = php.extensions;
   phpPackages = php.packages;
 
+  # Import PHP82 interpreter, extensions and packages
+  php82 = callPackage ../development/interpreters/php/8.2.nix {
+    stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
+    pcre2 = pcre2.override {
+      withJitSealloc = !stdenv.isDarwin;
+    };
+  };
+  php82Extensions = recurseIntoAttrs php82.extensions;
+  php82Packages = recurseIntoAttrs php82.packages;
+
   # Import PHP81 interpreter, extensions and packages
   php81 = callPackage ../development/interpreters/php/8.1.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;


### PR DESCRIPTION
PHP 8.2.0 should be released [the 8th of December](https://wiki.php.net/todo/php82), this PR can either be committed as it is or I can continue to update it until the 8th of December.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
