### PR TITLE
python311Packages.pyext: fix build for python 3.11

### DIFF
--- a/pkgs/development/python-modules/pyext/default.nix
+++ b/pkgs/development/python-modules/pyext/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch }:
 
 buildPythonPackage {
     pname = "pyext";
@@ -6,11 +6,19 @@ buildPythonPackage {
 
     # Latest release not on Pypi or tagged since 2015
     src = fetchFromGitHub {
-      owner = "kirbyfan64";
+      owner = "refi64";
       repo = "PyExt";
       rev = "1e018b12752ceb279f11aee123ed773d63dcec7e";
       sha256 = "16km897ng6lgjs39hv83xragdxh0mhyw6ds0qkm21cyci1k5m1vm";
     };
+
+    patches = [
+      (fetchpatch {
+        name = "fix-for-python-3.11.patch";
+        url = "https://github.com/refi64/PyExt/commit/01dd1c68ec3a44379179b602633a0aecb52c5633.patch";
+        hash = "sha256-kaqWYOR/Ool9Htjr3n4mHq5fxICkXXFGa2tBa33OfIk=";
+      })
+    ];
 
     # Has no test suite
     doCheck = false;


### PR DESCRIPTION
###### Description of changes

Pull in patch from https://github.com/refi64/PyExt/pull/2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
