### PR TITLE
emacs.pkgs.ada-mode: fix build for version 7.3.1

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -69,7 +69,7 @@ self: let
                 then null
                 else super.project;
       # Compilation instructions for the Ada executables:
-      # https://www.nongnu.org/ada-mode/ada-mode.html#Ada-executables
+      # https://www.nongnu.org/ada-mode/
       ada-mode = super.ada-mode.overrideAttrs (old: {
         # actually unpack source of ada-mode and wisi
         # which are both needed to compile the tools
@@ -85,15 +85,18 @@ self: let
         nativeBuildInputs = [
           buildPackages.gnat
           buildPackages.gprbuild
-          buildPackages.lzip
+          buildPackages.dos2unix
+          buildPackages.re2c
         ];
 
         buildInputs = [
           pkgs.gnatcoll-xref
         ];
 
-        preInstall = ''
+        buildPhase = ''
+          runHook preBuild
           ./build.sh -j$NIX_BUILD_CORES
+          runHook postBuild
         '';
 
         postInstall = (old.postInstall or "") + "\n" + ''


### PR DESCRIPTION
Fixes breakage to ada-mode introduced in #200190.

ada-mode recently gained a Makefile [1] which is intended for compiling it in the ELPA worktree. Building from the ELPA release tarball still needs to be done via build.sh, so we need to overwrite buildPhase to ignore the Makefile (previously it'd just do nothing).

Additionally some new build tools are needed and lzip can be removed (as we no longer fetch an archived version of wisi from ELPA).

[1]: https://git.savannah.gnu.org/cgit/emacs/elpa.git/commit/Makefile?h=externals/ada-mode&id=d5428433e39f3de7168fdc891127a2dcff849904

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
