### PR TITLE
python3Packages.jpylyzer: 2.0.1 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/jpylyzer/default.nix
+++ b/pkgs/development/python-modules/jpylyzer/default.nix
@@ -1,25 +1,50 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , buildPythonPackage
 , six
+, lxml
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+let
+  # unclear relationship between test-files version and jpylyzer version.
+  # upstream appears to just always test against the latest version, so
+  # probably worth updating this when package is bumped.
+  testFiles = fetchFromGitHub {
+    owner = "openpreserve";
+    repo = "jpylyzer-test-files";
+    rev = "146cb0029b5ea9d8ef22dc6683cec8afae1cc63a";
+    sha256 = "sha256-uKUau7mYXqGs4dSnXGPnPsH9k81ZCK0aPj5F9HWBMZ8=";
+  };
+
+in buildPythonPackage rec {
   pname = "jpylyzer";
-  version = "2.0.1";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "openpreserve";
     repo = pname;
     rev = version;
-    sha256 = "1cd9klq83g9p4nkg7x78axqid5vcsqzggp431hcfdiixa50yjxjg";
+    sha256 = "sha256-LBVOwjWC/HEvGgoi8WxEdl33M4JrfdHEj1Dk7f1NAiA=";
   };
 
   propagatedBuildInputs = [ six ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [ pytestCheckHook lxml ];
+
+  # don't depend on testFiles on darwin as it may not be extractable due to
+  # weird filenames
+  preCheck = lib.optionalString (!stdenv.isDarwin) ''
+    sed -i '/^testFilesDir = /ctestFilesDir = "${testFiles}"' tests/unit/test_testfiles.py
+  '';
+  disabledTestPaths = lib.optionals stdenv.isDarwin [
+    "tests/unit/test_testfiles.py"
+  ];
+
   pythonImportsCheck = [ "jpylyzer" ];
+
+  disallowedReferences = [ testFiles ];
 
   meta = with lib; {
     description = "JP2 (JPEG 2000 Part 1) image validator and properties extractor";


### PR DESCRIPTION
###### Description of changes

Straightforward bump. This is only a large rebuild because it's used in the tests for `openjpeg` (and basically nowhere else), so for a quick review I suggest just checking `openjpeg` builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
