### PR TITLE
mate.caja-extensions: Fix some crash caused by schema path

### DIFF
--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./hardcode-gsettings.patch;
       caja_gsetttings_path = glib.getSchemaPath mate.caja;
-      term_gsetttings_path = glib.getSchemaPath mate.mate-terminal;
+      desktop_gsetttings_path = glib.getSchemaPath mate.mate-desktop;
     })
   ];
 

--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -39,8 +39,8 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./hardcode-gsettings.patch;
-      CAJA_GSETTINGS_PATH = glib.getSchemaPath mate.caja;
-      TERM_GSETTINGS_PATH = glib.getSchemaPath mate.mate-terminal;
+      caja_gsetttings_path = glib.getSchemaPath mate.caja;
+      term_gsetttings_path = glib.getSchemaPath mate.mate-terminal;
     })
   ];
 

--- a/pkgs/desktops/mate/caja-extensions/hardcode-gsettings.patch
+++ b/pkgs/desktops/mate/caja-extensions/hardcode-gsettings.patch
@@ -53,7 +53,7 @@ index e14a9bf..691afab 100644
 +    GSettingsSchemaSource* schema_source;
 +    GSettingsSchema* schema;
 +
-+    schema_source = g_settings_schema_source_new_from_directory("@CAJA_GSETTINGS_PATH@",
++    schema_source = g_settings_schema_source_new_from_directory("@caja_gsetttings_path@",
 +                                                                g_settings_schema_source_get_default(),
 +                                                                TRUE, NULL);
 +    schema = g_settings_schema_source_lookup(schema_source,
@@ -74,7 +74,7 @@ index e14a9bf..691afab 100644
 +    GSettingsSchemaSource* schema_source;
 +    GSettingsSchema* schema;
 +
-+    schema_source = g_settings_schema_source_new_from_directory("@TERM_GSETTINGS_PATH@",
++    schema_source = g_settings_schema_source_new_from_directory("@term_gsetttings_path@",
 +                                                                g_settings_schema_source_get_default(),
 +                                                                TRUE, NULL);
 +    schema = g_settings_schema_source_lookup(schema_source,
@@ -95,7 +95,7 @@ index e14a9bf..691afab 100644
 +    GSettingsSchemaSource* schema_source;
 +    GSettingsSchema* schema;
 +
-+    schema_source = g_settings_schema_source_new_from_directory("@TERM_GSETTINGS_PATH@",
++    schema_source = g_settings_schema_source_new_from_directory("@term_gsetttings_path@",
 +                                                                g_settings_schema_source_get_default(),
 +                                                                TRUE, NULL);
 +    schema = g_settings_schema_source_lookup(schema_source,

--- a/pkgs/desktops/mate/caja-extensions/hardcode-gsettings.patch
+++ b/pkgs/desktops/mate/caja-extensions/hardcode-gsettings.patch
@@ -74,7 +74,7 @@ index e14a9bf..691afab 100644
 +    GSettingsSchemaSource* schema_source;
 +    GSettingsSchema* schema;
 +
-+    schema_source = g_settings_schema_source_new_from_directory("@term_gsetttings_path@",
++    schema_source = g_settings_schema_source_new_from_directory("@desktop_gsetttings_path@",
 +                                                                g_settings_schema_source_get_default(),
 +                                                                TRUE, NULL);
 +    schema = g_settings_schema_source_lookup(schema_source,
@@ -95,7 +95,7 @@ index e14a9bf..691afab 100644
 +    GSettingsSchemaSource* schema_source;
 +    GSettingsSchema* schema;
 +
-+    schema_source = g_settings_schema_source_new_from_directory("@term_gsetttings_path@",
++    schema_source = g_settings_schema_source_new_from_directory("@desktop_gsetttings_path@",
 +                                                                g_settings_schema_source_get_default(),
 +                                                                TRUE, NULL);
 +    schema = g_settings_schema_source_lookup(schema_source,
@@ -155,7 +155,7 @@ index 3119e9f..4f80c88 100644
      filename = g_filename_from_uri(uri, NULL, NULL);
  
 -    settings = g_settings_new (WP_SCHEMA);
-+    schema_source = g_settings_schema_source_new_from_directory("@GSETTINGS_PATH@",
++    schema_source = g_settings_schema_source_new_from_directory("@desktop_gsetttings_path@",
 +                                                                g_settings_schema_source_get_default(),
 +                                                                TRUE, NULL);
 +    schema = g_settings_schema_source_lookup(schema_source,


### PR DESCRIPTION
###### Description of changes

I am experiencing some crash when using the caja right-click menu, e.g:

- Opening an terminal
- Setting image as wallpaper

Here is an sample stack trace:

<details>

```
Process 2484 (.caja-wrapped) of user 1000 dumped core.
    
    Module linux-vdso.so.1 with build-id e348c146fb64178897b9dd047778358cb9473a95
    Module librsvg-2.so.2 without build-id.
    Module libpixbufloader-svg.so without build-id.
    Module libgioremote-volume-monitor.so without build-id.
    Module libcaja-engrampa.so without build-id.
    Module libsynctex.so.2 without build-id.
    Module libatrildocument.so.3 without build-id.
    Module libatril-properties-page.so without build-id.
    Module libcaja-xattr-tags.so without build-id.
    Module libcaja-wallpaper.so without build-id.
    Module libcaja-share.so without build-id.
    Module libcaja-sendto.so without build-id.
    Module libcaja-open-terminal.so without build-id.
    Module libcaja-image-converter.so without build-id.
    Module libcaja-gksu.so without build-id.
    Module libdconfsettings.so without build-id.
    Module libgvfscommon.so without build-id.
    Module libgvfsdbus.so without build-id.
    Module libcap.so.2 without build-id.
    Module libicudata.so.72 without build-id.
    Module libsystemd.so.0 without build-id.
    Module libpcre.so.1 without build-id.
    Module libblkid.so.1 with build-id f4f9ebcbcca3e44b7094b20e2ee71709825f36bb
    Module libGLX.so.0 without build-id.
    Module libXdmcp.so.6 without build-id.
    Module libXau.so.6 without build-id.
    Module libGLdispatch.so.0 without build-id.
    Module libdatrie.so.1 without build-id.
    Module libsqlite3.so.0 with build-id 377f9d7f0fb8f5896be673d87eb739eb7866db92
    Module libjson-glib-1.0.so.0 without build-id.
    Module libicui18n.so.72 without build-id.
    Module libicuuc.so.72 without build-id.
    Module libdbus-1.so.3 without build-id.
    Module libatspi.so.0 without build-id.
    Module libbz2.so.1 without build-id.
    Module libgcc_s.so.1 without build-id.
    Module ld-linux-x86-64.so.2 with build-id db50353a26600bb848b9a5541b1506e0a24cb34b
    Module libstdc++.so.6 without build-id.
    Module libexpat.so.1 without build-id.
    Module libpcre2-8.so.0 without build-id.
    Module libffi.so.8 without build-id.
    Module libselinux.so.1 without build-id.
    Module libmount.so.1 with build-id ed8fa2ae9881fc31bd8f5963397b42c8644f162d
    Module libjpeg.so.62 without build-id.
    Module librt.so.1 with build-id 7c9aae26f0646a27bf0f7c49c914b3258c5fa43e
    Module libGL.so.1 without build-id.
    Module libXrender.so.1 without build-id.
    Module libxcb-render.so.0 without build-id.
    Module libxcb.so.1 without build-id.
    Module libxcb-shm.so.0 without build-id.
    Module libpng16.so.16 without build-id.
    Module libdl.so.2 with build-id 67c430223def0be24c4ae1a4c3985f26566b8831
    Module libEGL.so.1 without build-id.
    Module libpixman-1.so.0 with build-id a4a8d46c6b2f698ceaf6661c79d06700493d31ab
    Module libgraphite2.so.3 without build-id.
    Module libfreetype.so.6 without build-id.
    Module libthai.so.0 without build-id.
    Module libXinerama.so.1 without build-id.
    Module libXcomposite.so.1 without build-id.
    Module libXcursor.so.1 without build-id.
    Module libXext.so.6 without build-id.
    Module libwayland-egl.so.1 with build-id d6b466ff99696870068c564a8ebded6a81cae225
    Module libwayland-cursor.so.0 with build-id 5552be47a749c6825465c9a93d43f69f9701c9de
    Module libwayland-client.so.0 with build-id c3616c06165ba2231464dfdde480b9ae48f92ec7
    Module libxkbcommon.so.0 without build-id.
    Module libXfixes.so.3 without build-id.
    Module libtracker-sparql-3.0.so.0 without build-id.
    Module libatk-bridge-2.0.so.0 without build-id.
    Module libXi.so.6 without build-id.
    Module libepoxy.so.0 without build-id.
    Module libfribidi.so.0 without build-id.
    Module libfontconfig.so.1 without build-id.
    Module libpangoft2-1.0.so.0 without build-id.
    Module libdconf.so.1 without build-id.
    Module libXrandr.so.2 without build-id.
    Module libuuid.so.1 with build-id 4afb95013ebf0ac1452e2fed433ee31f7622723a
    Module libc.so.6 with build-id 2bb226bc600b443958c7566207d0d02f8345e6ea
    Module libpthread.so.0 with build-id 85431f01160c3de171d3baeb3f8cf1c9578dc441
    Module libm.so.6 with build-id b8454b40db819599169f3a948939aed4b3fc7f82
    Module libnotify.so.4 without build-id.
    Module libexempi.so.3 without build-id.
    Module libexif.so.12 without build-id.
    Module libX11.so.6 without build-id.
    Module libglib-2.0.so.0 with build-id b13cd968ce6f5320e45dde1446f3066371403d7c
    Module libgobject-2.0.so.0 with build-id cc0205109407a5b4ace0874f64aee611878a482d
    Module libgio-2.0.so.0 with build-id 9c3d32e1d5dbf7d39ea67d2bb7045fbf51126a85
    Module libgdk_pixbuf-2.0.so.0 with build-id 8f15f562c170a916afff71fb3e34401dd4e20d9e
    Module libcairo.so.2 with build-id 21e308ba73f784934d4eb8cb2efd507151a8d65e
    Module libcairo-gobject.so.2 with build-id df83675e5c22873ce86626535519d51ff3cc513a
    Module libatk-1.0.so.0 without build-id.
    Module libharfbuzz.so.0 without build-id.
    Module libpango-1.0.so.0 without build-id.
    Module libpangocairo-1.0.so.0 without build-id.
    Module libz.so.1 without build-id.
    Module libgdk-3.so.0 with build-id 2cfb8d0f3702bc5c753dbfac0002a0b9c18b5d83
    Module libgtk-3.so.0 with build-id 43ad91b494d9bf2e052ade1c14ed724c2c3030b2
    Module libxml2.so.2 without build-id.
    Module libgailutil-3.so.0 with build-id b0310bb4e6becac07ad73e083cfc37c8d1e63d28
    Module libgthread-2.0.so.0 with build-id 9a1dbe17a3e1ecbb57ebe02680c6ecf262858e3a
    Module libmate-desktop-2.so.17 without build-id.
    Module libgmodule-2.0.so.0 with build-id 5ea22aa96ea6851566bb6ab070a1621683ae4e88
    Module libcaja-extension.so.1 without build-id.
    Module libICE.so.6 without build-id.
    Module libSM.so.6 without build-id.
    Module .caja-wrapped without build-id.
    Stack trace of thread 2484:
    #0  0x00007f6dd9e92d30 g_settings_schema_unref (libgio-2.0.so.0 + 0xf7d30)
    #1  0x00007f6dd4aa48c5 open_terminal_callback (libcaja-open-terminal.so + 0x38c5)
    #2  0x00007f6dd9d515af g_closure_invoke (libgobject-2.0.so.0 + 0x175af)
    #3  0x00007f6dd9d64917 signal_emit_unlocked_R (libgobject-2.0.so.0 + 0x2a917)
    #4  0x00007f6dd9d6b6ba g_signal_emit_valist (libgobject-2.0.so.0 + 0x316ba)
    #5  0x00007f6dd9d6b94f g_signal_emit (libgobject-2.0.so.0 + 0x3194f)
    #6  0x000000000049a2b1 extension_action_callback (.caja-wrapped + 0x9a2b1)
    #7  0x00007f6dd9d515af g_closure_invoke (libgobject-2.0.so.0 + 0x175af)
    #8  0x00007f6dd9d64917 signal_emit_unlocked_R (libgobject-2.0.so.0 + 0x2a917)
    #9  0x00007f6dd9d6b6ba g_signal_emit_valist (libgobject-2.0.so.0 + 0x316ba)
    #10 0x00007f6dd9d6b94f g_signal_emit (libgobject-2.0.so.0 + 0x3194f)
    #11 0x00007f6dda75b711 _gtk_action_emit_activate (libgtk-3.so.0 + 0x38e711)
    #12 0x00007f6dd9d517d9 _g_closure_invoke_va (libgobject-2.0.so.0 + 0x177d9)
    #13 0x00007f6dd9d6b64d g_signal_emit_valist (libgobject-2.0.so.0 + 0x3164d)
    #14 0x00007f6dd9d6b94f g_signal_emit (libgobject-2.0.so.0 + 0x3194f)
    #15 0x00007f6dda715394 gtk_widget_activate (libgtk-3.so.0 + 0x348394)
    #16 0x00007f6dda5dbd86 gtk_menu_shell_activate_item (libgtk-3.so.0 + 0x20ed86)
    #17 0x00007f6dda5dc063 gtk_menu_shell_button_release (libgtk-3.so.0 + 0x20f063)
    #18 0x00007f6dda46aa04 _gtk_marshal_BOOLEAN__BOXEDv (libgtk-3.so.0 + 0x9da04)
    #19 0x00007f6dd9d517d9 _g_closure_invoke_va (libgobject-2.0.so.0 + 0x177d9)
    #20 0x00007f6dd9d6ac56 g_signal_emit_valist (libgobject-2.0.so.0 + 0x30c56)
    #21 0x00007f6dd9d6b94f g_signal_emit (libgobject-2.0.so.0 + 0x3194f)
    #22 0x00007f6dda7125f4 gtk_widget_event_internal.part.0 (libgtk-3.so.0 + 0x3455f4)
    #23 0x00007f6dda5c67e0 propagate_event (libgtk-3.so.0 + 0x1f97e0)
    #24 0x00007f6dda5c823d gtk_main_do_event (libgtk-3.so.0 + 0x1fb23d)
    #25 0x00007f6dda301a65 _gdk_event_emit (libgdk-3.so.0 + 0x3ea65)
    #26 0x00007f6dda3589d2 gdk_event_source_dispatch (libgdk-3.so.0 + 0x959d2)
    #27 0x00007f6dd9c559db g_main_context_dispatch (libglib-2.0.so.0 + 0x589db)
    #28 0x00007f6dd9c55c88 g_main_context_iterate.constprop.0 (libglib-2.0.so.0 + 0x58c88)
    #29 0x00007f6dd9c55d3f g_main_context_iteration (libglib-2.0.so.0 + 0x58d3f)
    #30 0x00007f6dd9e8010d g_application_run (libgio-2.0.so.0 + 0xe510d)
    #31 0x00000000004503a6 main (.caja-wrapped + 0x503a6)
    #32 0x00007f6dd95bc24e __libc_start_call_main (libc.so.6 + 0x2924e)
    #33 0x00007f6dd95bc309 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x29309)
    #34 0x0000000000450435 _start (.caja-wrapped + 0x50435)
    
    Stack trace of thread 2488:
    #0  0x00007f6dd96956c9 __poll (libc.so.6 + 0x1026c9)
    #1  0x00007f6dd9c55c26 g_main_context_iterate.constprop.0 (libglib-2.0.so.0 + 0x58c26)
    #2  0x00007f6dd9c55d3f g_main_context_iteration (libglib-2.0.so.0 + 0x58d3f)
    #3  0x00007f6dd9c55d91 glib_worker_main (libglib-2.0.so.0 + 0x58d91)
    #4  0x00007f6dd9c808cd g_thread_proxy (libglib-2.0.so.0 + 0x838cd)
    #5  0x00007f6dd961be86 start_thread (libc.so.6 + 0x88e86)
    #6  0x00007f6dd96a2c60 __clone3 (libc.so.6 + 0x10fc60)
    
    Stack trace of thread 2491:
    #0  0x00007f6dd96956c9 __poll (libc.so.6 + 0x1026c9)
    #1  0x00007f6dd9c55c26 g_main_context_iterate.constprop.0 (libglib-2.0.so.0 + 0x58c26)
    #2  0x00007f6dd9c55d3f g_main_context_iteration (libglib-2.0.so.0 + 0x58d3f)
    #3  0x00007f6dd4adb46d dconf_gdbus_worker_thread (libdconfsettings.so + 0xb46d)
    #4  0x00007f6dd9c808cd g_thread_proxy (libglib-2.0.so.0 + 0x838cd)
    #5  0x00007f6dd961be86 start_thread (libc.so.6 + 0x88e86)
    #6  0x00007f6dd96a2c60 __clone3 (libc.so.6 + 0x10fc60)
    
    Stack trace of thread 2489:
    #0  0x00007f6dd96956c9 __poll (libc.so.6 + 0x1026c9)
    #1  0x00007f6dd9c55c26 g_main_context_iterate.constprop.0 (libglib-2.0.so.0 + 0x58c26)
    #2  0x00007f6dd9c55f73 g_main_loop_run (libglib-2.0.so.0 + 0x58f73)
    #3  0x00007f6dd9ebb216 gdbus_shared_thread_func (libgio-2.0.so.0 + 0x120216)
    #4  0x00007f6dd9c808cd g_thread_proxy (libglib-2.0.so.0 + 0x838cd)
    #5  0x00007f6dd961be86 start_thread (libc.so.6 + 0x88e86)
    #6  0x00007f6dd96a2c60 __clone3 (libc.so.6 + 0x10fc60)
    
    Stack trace of thread 2687:
    #0  0x00007f6dd969ad3d syscall (libc.so.6 + 0x107d3d)
    #1  0x00007f6dd9caa362 g_cond_wait_until (libglib-2.0.so.0 + 0xad362)
    #2  0x00007f6dd9c23a91 g_async_queue_pop_intern_unlocked (libglib-2.0.so.0 + 0x26a91)
    #3  0x00007f6dd9c240b2 g_async_queue_timeout_pop (libglib-2.0.so.0 + 0x270b2)
    #4  0x00007f6dd9c81259 g_thread_pool_thread_proxy (libglib-2.0.so.0 + 0x84259)
    #5  0x00007f6dd9c808cd g_thread_proxy (libglib-2.0.so.0 + 0x838cd)
    #6  0x00007f6dd961be86 start_thread (libc.so.6 + 0x88e86)
    #7  0x00007f6dd96a2c60 __clone3 (libc.so.6 + 0x10fc60)
    ELF object binary architecture: AMD x86-64
```

</details>

It looks like the wrong substitution is the cause, I revisited some of them:

| schema | a.k.a | package | ref |
|---|---|---|---|
| org.mate.caja-open-terminal | [COT_SCHEMA](https://github.com/mate-desktop/caja-extensions/blob/7f02c10ce3cb67c212386d286701998a18295976/open-terminal/caja-open-terminal.c#L49) | caja-extensions | [org.mate.caja-open-terminal.gschema.xml.in](https://github.com/mate-desktop/caja-extensions/blob/7f02c10ce3cb67c212386d286701998a18295976/open-terminal/org.mate.caja-open-terminal.gschema.xml.in#L2) |
| org.mate.caja.preferences | [CAJA_SCHEMA](https://github.com/mate-desktop/caja-extensions/blob/7f02c10ce3cb67c212386d286701998a18295976/open-terminal/caja-open-terminal.c#L51) | caja | [org.mate.caja.gschema.xml](https://github.com/mate-desktop/caja/blob/14dd4822ddbcafecd3bfb283920b6a60507134bd/libcaja-private/org.mate.caja.gschema.xml#L71) |
| org.mate.applications-terminal | [TERM_SCHEMA](https://github.com/mate-desktop/caja-extensions/blob/7f02c10ce3cb67c212386d286701998a18295976/open-terminal/caja-open-terminal.c#L53) | mate-desktop | [org.mate.applications-terminal.gschema.xml](https://github.com/mate-desktop/mate-desktop/blob/96e97b3bd0593c6c160d571c54ea2ebf6ee1c011/schemas/org.mate.applications-terminal.gschema.xml#L2) |
| org.mate.Caja.Sendto | N/A | caja-extensions | [org.mate.Caja.Sendto.gschema.xml.in](https://github.com/mate-desktop/caja-extensions/blob/7f02c10ce3cb67c212386d286701998a18295976/sendto/org.mate.Caja.Sendto.gschema.xml.in#LL3C8-L3C8) |
| org.mate.background | [WP_SCHEMA](https://github.com/mate-desktop/caja-extensions/blob/7f02c10ce3cb67c212386d286701998a18295976/wallpaper/caja-wallpaper-extension.c#L39) | mate-desktop |  [org.mate.background.gschema.xml.in](https://github.com/mate-desktop/mate-desktop/blob/96e97b3bd0593c6c160d571c54ea2ebf6ee1c011/schemas/org.mate.background.gschema.xml.in#L15) |

Also per [manual](https://nixos.org/manual/nixpkgs/unstable/#fun-substituteAll) it looks like for `substituteAll` "environment variables that start with an uppercase letter or an underscore are filtered out" so actually the previous substitution in substituteAll does not work at all. But those `@GSETTINGS_PATH@` are substituted because they are handled by `substituteInPlace`.


(See commit msg for more info).

###### Things done

I tested that this fixes the crash I mentioned above but I didn't test everything.

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
