### PR TITLE
qtwebkit: Mark known vulnerable

### DIFF
--- a/pkgs/applications/kde/kdevelop/kdevelop.nix
+++ b/pkgs/applications/kde/kdevelop/kdevelop.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, cmake, gettext, pkg-config, extra-cmake-modules
-, qtquickcontrols, qtwebkit, qttools, kde-cli-tools, qtbase
+, qtquickcontrols, qttools, kde-cli-tools, qtbase
 , kconfig, kdeclarative, kdoctools, kiconthemes, ki18n, kitemmodels, kitemviews
 , kjobwidgets, kcmutils, kio, knewstuff, knotifyconfig, kparts, ktexteditor
 , threadweaver, kxmlgui, kwindowsystem, grantlee, kcrash, karchive, kguiaddons
@@ -24,7 +24,7 @@ mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    qtquickcontrols qtwebkit boost libkomparediff2
+    qtquickcontrols boost libkomparediff2
     kconfig kdeclarative kdoctools kiconthemes ki18n kitemmodels kitemviews
     kjobwidgets kcmutils kio knewstuff knotifyconfig kparts ktexteditor
     threadweaver kxmlgui kwindowsystem grantlee plasma-framework krunner

--- a/pkgs/applications/kde/rocs.nix
+++ b/pkgs/applications/kde/rocs.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, boost,
-  qtbase, qtscript, qtquickcontrols, qtwebkit, qtxmlpatterns, grantlee,
+  qtbase, qtscript, qtquickcontrols, qtxmlpatterns, grantlee,
   kdoctools, karchive, kxmlgui, kcrash, kdeclarative, ktexteditor, kguiaddons
 }:
 
@@ -19,7 +19,7 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     boost
-    qtbase qtscript qtquickcontrols qtwebkit qtxmlpatterns grantlee
+    qtbase qtscript qtquickcontrols qtxmlpatterns grantlee
     kxmlgui kcrash kdeclarative karchive ktexteditor kguiaddons
   ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -69,5 +69,8 @@ qtModule {
 
   meta = {
     maintainers = with lib.maintainers; [ abbradar periklis ];
+    knownVulnerabilities = [
+      "QtWebkit upstream is unmaintained and receives no security updates, see https://blogs.gnome.org/mcatanzaro/2022/11/04/stop-using-qtwebkit/"
+    ];
   };
 }


### PR DESCRIPTION
The browser engine is based off an old Webkit version, receives no security backports, does no releases.

The WebKitGTK people have counted over 500 CVEs they fixed since 2016.

Adding known vulnerable to make people aware they're using a browser engine that is not up to todays standards and could very likely be easily compromised.

https://blogs.gnome.org/mcatanzaro/2017/02/08/an-update-on-webkit-security-updates/
https://github.com/qutebrowser/qutebrowser/issues/4039#issue-338246939
https://blogs.gnome.org/mcatanzaro/2022/11/04/stop-using-qtwebkit/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
