### PR TITLE
nixos/firefox: add more options

### DIFF
--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -33,8 +33,6 @@ in
         "firefox-bin"
         "firefox-devedition-bin"
         "firefox-esr"
-        "firefox-esr-wayland"
-        "firefox-wayland"
       ];
     };
 

--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -15,15 +15,15 @@ let
     given control of your browser, unless of course they also control your
     NixOS configuration.
   '';
-
-in {
+in
+{
   options.programs.firefox = {
     enable = mkEnableOption (mdDoc "the Firefox web browser");
 
     package = mkOption {
-      description = mdDoc "Firefox package to use.";
       type = types.package;
       default = pkgs.firefox;
+      description = mdDoc "Firefox package to use.";
       defaultText = literalExpression "pkgs.firefox";
       relatedPackages = [
         "firefox"
@@ -37,6 +37,8 @@ in {
     };
 
     policies = mkOption {
+      type = policyFormat.type;
+      default = { };
       description = mdDoc ''
         Group policies to install.
 
@@ -48,21 +50,19 @@ in {
 
         ${organisationInfo}
       '';
-      type = policyFormat.type;
-      default = {};
     };
 
     preferences = mkOption {
+      type = with types; attrsOf (oneOf [ bool int string ]);
+      default = { };
       description = mdDoc ''
-        Preferences to set from `about://config`.
+        Preferences to set from `about:config`.
 
         Some of these might be able to be configured more ergonomically
         using policies.
 
         ${organisationInfo}
       '';
-      type = with types; attrsOf (oneOf [ bool int string ]);
-      default = {};
     };
   };
 
@@ -78,14 +78,11 @@ in {
       };
 
     # Preferences are converted into a policy
-    programs.firefox.policies =
-      mkIf (cfg.preferences != {})
-      {
-        Preferences = (mapAttrs (name: value: {
-          Value = value;
-          Status = "locked";
-        }) cfg.preferences);
-      };
+    programs.firefox.policies = mkIf (cfg.preferences != { }) {
+      Preferences = (mapAttrs
+        (name: value: { Value = value; Status = cfg.preferencesStatus; })
+        cfg.preferences);
+    };
   };
 
   meta.maintainers = with maintainers; [ danth ];

--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -69,12 +69,13 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    environment.etc."firefox/policies/policies.json".source =
-      let policiesJSON =
-        policyFormat.generate
-        "firefox-policies.json"
-        { inherit (cfg) policies; };
-      in mkIf (cfg.policies != {}) "${policiesJSON}";
+    environment.etc =
+      let
+        policiesJSON = policyFormat.generate "firefox-policies.json" { inherit (cfg) policies; };
+      in
+      mkIf (cfg.policies != { }) {
+        "firefox/policies/policies.json".source = "${policiesJSON}";
+      };
 
     # Preferences are converted into a policy
     programs.firefox.policies =


### PR DESCRIPTION
###### Description of changes
1. add preferencesStatus for preferences
2. add autoConfig since many config are not available in preferences
3. add nativeMessagingHosts options
4. fix ```error: The option `environment.etc."firefox/policies/policies.json".source' is used but not defined.```

`enableGnomeExtensions` and `enablePlasmaBrowserIntegration` are not added since they are covered by other modules. `wmc-mpris` is not added since it's deprecated. `chrome-token-signing` is not added because it should be migrated to web-eid first.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
