### PR TITLE
Revert "oneDNN: 2.3.2 -> 2.5.2"

### DIFF
--- a/pkgs/development/libraries/oneDNN/default.nix
+++ b/pkgs/development/libraries/oneDNN/default.nix
@@ -5,7 +5,7 @@
 # https://github.com/oneapi-src/oneDNN#oneapi-deep-neural-network-library-onednn
 stdenv.mkDerivation rec {
   pname = "oneDNN";
-  version = "2.5.2";
+  version = "2.7.1";
 
   src = fetchFromGitHub {
     owner = "oneapi-src";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#200665

I made a mistake and didn't realize the sha256 was unchanged.