### PR TITLE
python3Packages.httpcore: 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -14,6 +14,12 @@
 , pythonOlder
 , sniffio
 , socksio
+
+# for passthru.tests
+, falcon
+, httpx
+, pytest-httpx
+, respx
 }:
 
 buildPythonPackage rec {
@@ -48,13 +54,18 @@ buildPythonPackage rec {
     sniffio
   ];
 
-  passthru.optional-dependencies = {
-    http2 = [
-      h2
-    ];
-    socks = [
-      socksio
-    ];
+  passthru = {
+    optional-dependencies = {
+      http2 = [
+        h2
+      ];
+      socks = [
+        socksio
+      ];
+    };
+    tests = {
+      inherit falcon httpx pytest-httpx respx;
+    };
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , certifi
 , fetchFromGitHub
+, fetchpatch
 , h11
 , h2
 , pproxy
@@ -17,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "httpcore";
-  version = "0.15.0";
+  version = "0.16.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -26,13 +27,19 @@ buildPythonPackage rec {
     owner = "encode";
     repo = pname;
     rev = version;
-    hash = "sha256-FF3Yzac9nkVcA5bHVOz2ymvOelSfJ0K6oU8UWpBDcmo=";
+    hash = "sha256-mnd2VRtuDU0hCpzrMOWXHEj3NkF0GL8jRLhbrT+jXzg=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "h11>=0.11,<0.13" "h11>=0.11,<0.14"
-  '';
+  patches = [
+    # upstream have moved to pytest-httpbin 2.x. we have not.
+    (fetchpatch {
+      name = "restore-httpbin-error-suppression.patch";
+      url = "https://github.com/encode/httpcore/commit/168c8a71b299ba1e4b5a4a556dbcf3c30d953f53.patch";
+      includes = [ "setup.cfg" ];
+      revert = true;
+      hash = "sha256-Re33tZAgKl+KSTFhbZoRz1jJVgb/6OxLjral8dBaOJE=";
+    })
+  ];
 
   propagatedBuildInputs = [
     anyio


### PR DESCRIPTION
###### Description of changes

Looks like `httpx` might not quite be ready for this: https://github.com/encode/httpx/discussions/2438

Hence draft. Once that's cleared up we can proceed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
