### PR TITLE
php80.packages.php-parallel-lint: Fix build

### DIFF
--- a/pkgs/development/php-packages/php-parallel-lint/default.nix
+++ b/pkgs/development/php-packages/php-parallel-lint/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchFromGitHub, makeWrapper, lib, php }:
+{ mkDerivation, fetchFromGitHub, makeWrapper, lib, php, php81 }:
 let
   pname = "php-parallel-lint";
   version = "1.3.2";
@@ -10,13 +10,17 @@ mkDerivation {
     owner = "php-parallel-lint";
     repo = "PHP-Parallel-Lint";
     rev = "v${version}";
-    sha256 = "sha256-pTHH19HwqyOj5pSmH7l0JlntNVtMdu4K9Cl+qyrrg9U=";
+    # `.gitattibutes` exclude `box.json` from the archive produced git.
+    forceFetchGit = true;
+    sha256 = "SPP1ynxJad2m5wknGt8z94fW7Ucx8nqLvwZVmlylOgM=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     php.packages.composer
-    php.packages.box
+    # box is only available for PHP ≥ 8.1 but the purpose of this tool is to validate
+    # that project does not use features not available on older PHP versions.
+    php81.packages.box
   ];
 
   buildPhase = ''
@@ -36,7 +40,6 @@ mkDerivation {
   '';
 
   meta = with lib; {
-    broken = lib.versionOlder php.version "8.1"; # Broken on PHP older than 8.1.
     description = "Tool to check syntax of PHP files faster than serial check with fancier output";
     license = licenses.bsd2;
     homepage = "https://github.com/php-parallel-lint/PHP-Parallel-Lint";


### PR DESCRIPTION
###### Description of changes

One of the main use cases of this program is ensuring that a project
targeting older PHP version does not use syntax that is not available there.

https://github.com/NixOS/nixpkgs/commit/2db0ddb968357051237915256b7a1fc841492762

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
