### PR TITLE
python310Packages.pylint: 2.14.5 -> 2.15.5

### DIFF
--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -1,12 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonAtLeast
 , pythonOlder
 , isPyPy
 , lazy-object-proxy
 , setuptools
-, setuptools-scm
 , typing-extensions
 , typed-ast
 , pylint
@@ -16,26 +14,24 @@
 
 buildPythonPackage rec {
   pname = "astroid";
-  version = "2.11.7"; # Check whether the version is compatible with pylint
+  version = "2.12.12"; # Check whether the version is compatible with pylint
+  format = "pyproject";
 
-  disabled = pythonOlder "3.6.2";
+  disabled = pythonOlder "3.7.2";
 
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-HpniGxKf+daMh/sxP9T9UriYRrUFWqk7kDa8r+EqtVI=";
+    hash = "sha256-FN/bBAxx9p1iAB3WXIZyyKv/zse7xtXzslclADMbouA=";
   };
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   nativeBuildInputs = [
-    setuptools-scm
+    setuptools
   ];
 
   propagatedBuildInputs = [
     lazy-object-proxy
-    setuptools
     wrapt
   ] ++ lib.optionals (pythonOlder "3.10") [
     typing-extensions
@@ -45,11 +41,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # AssertionError: Lists differ: ['ABC[16 chars]yBase', 'Final', 'Generic', 'MyProtocol', 'Protocol', 'object'] != ['ABC[16 chars]yBase', 'Final', 'Generic', 'MyProtocol', 'object']
-    "test_mro_typing_extensions"
+    typing-extensions
   ];
 
   passthru.tests = {

--- a/pkgs/development/python-modules/deal-solver/default.nix
+++ b/pkgs/development/python-modules/deal-solver/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     z3
     astroid
-  ];
+  ] ++ z3.requiredPythonModules;
 
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -2,6 +2,7 @@
 , lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , pythonOlder
 , installShellFiles
 , astroid
@@ -9,6 +10,8 @@
 , isort
 , mccabe
 , platformdirs
+, requests
+, setuptools
 , tomli
 , tomlkit
 , typing-extensions
@@ -20,8 +23,8 @@
 
 buildPythonPackage rec {
   pname = "pylint";
-  version = "2.14.5";
-  format = "setuptools";
+  version = "2.15.5";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7.2";
 
@@ -29,11 +32,25 @@ buildPythonPackage rec {
     owner = "PyCQA";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-JTFGplqIA6WavwzKOkrm1rHBKNRrplBPvAdEkb/fTlI=";
+    hash = "sha256-dchzwMaUhHB1TqcaMZO9tCZ4KA5I1T+tdkGOxikm5AY=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-dummy-plugin-tests.patch";
+      url = "https://github.com/PyCQA/pylint/commit/e75089bae209d1b9ca72903c0d65530b02f67fdf.patch";
+      hash = "sha256-4ErlCMLTI5xIu1dCvcJsvo03dwcgLLbFFQ5M7DFdL3o=";
+    })
+    (fetchpatch {
+      name = "fix-pythonpath-tests.patch";
+      url = "https://github.com/PyCQA/pylint/commit/6725f761f2ac7a853e315790b496a2eb4d926694.patch";
+      hash = "sha256-Xaeub7uUaC07BBuusA6+neGiXFWWfVNBkGXmYJe7ot4=";
+    })
+  ];
 
   nativeBuildInputs = [
     installShellFiles
+    setuptools
   ];
 
   propagatedBuildInputs = [
@@ -61,6 +78,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytest-xdist
     pytestCheckHook
+    requests
     typing-extensions
   ];
 


### PR DESCRIPTION
###### Description of changes

https://github.com/PyCQA/pylint/releases/tag/v2.15.5
https://github.com/PyCQA/pylint/releases/tag/v2.15.4
https://github.com/PyCQA/pylint/releases/tag/v2.15.3
https://github.com/PyCQA/pylint/releases/tag/v2.15.2
https://github.com/PyCQA/pylint/releases/tag/v2.15.1
https://github.com/PyCQA/pylint/releases/tag/v2.15.0

and

https://github.com/PyCQA/astroid/releases/tag/v2.12.12
https://github.com/PyCQA/astroid/releases/tag/v2.12.11
https://github.com/PyCQA/astroid/releases/tag/v2.12.10
https://github.com/PyCQA/astroid/releases/tag/v2.12.9
https://github.com/PyCQA/astroid/releases/tag/v2.12.8
https://github.com/PyCQA/astroid/releases/tag/v2.12.7
https://github.com/PyCQA/astroid/releases/tag/v2.12.6
https://github.com/PyCQA/astroid/releases/tag/v2.12.5
https://github.com/PyCQA/astroid/releases/tag/v2.12.4
https://github.com/PyCQA/astroid/releases/tag/v2.12.3
https://github.com/PyCQA/astroid/releases/tag/v2.12.2
https://github.com/PyCQA/astroid/releases/tag/v2.12.1
https://github.com/PyCQA/astroid/releases/tag/v2.12.0

Additional notes regarding the Z3/deal-solver change:

Had a conversation on Matrix that the `propagatedInputs` on the Z3 derivation are not automatically carried along even after wrapping `z3.python` within `toPythonModule`. For now, I've updated the derivations to pass them through and use them explicitly, but if this is ever changed to work automatically, this can be cleaned up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
