### PR TITLE
edk2-uefi-shell: fix build when sandboxing is disabled on x86_64-darwin

### DIFF
--- a/pkgs/tools/misc/edk2-uefi-shell/default.nix
+++ b/pkgs/tools/misc/edk2-uefi-shell/default.nix
@@ -16,6 +16,10 @@ edk2.mkDerivation "ShellPkg/ShellPkg.dsc" (finalAttrs: {
 
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isClang [ "-fno-pic" "-Qunused-arguments" ];
 
+  # Set explicitly to use Python 3 from nixpkgs. Otherwise, the build system will detect and try to
+  # use `/usr/bin/python3` on Darwin when sandboxing is disabled.
+  PYTHON_COMMAND = "${lib.getBin python3}/bin/python3";
+
   # We only have a .efi file in $out which shouldn't be patched or stripped
   dontPatchELF = true;
   dontStrip = true;


### PR DESCRIPTION
###### Description of changes

The build still fails on Hydra because sandboxing is disabled. This is due to the build system’s trying to use the system-provided Python 3, which requires Xcode. Specify the path to the nixpkg Python 3, so that doesn’t happen.

ZHF: #199919

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
