### PR TITLE
cubeb: Add Darwin support

### DIFF
--- a/pkgs/development/libraries/audio/cubeb/default.nix
+++ b/pkgs/development/libraries/audio/cubeb/default.nix
@@ -1,8 +1,9 @@
 { lib, stdenv, fetchFromGitHub
 , cmake
 , pkg-config
+, alsa-lib
 , jack2
-, pulseaudio
+, libpulseaudio
 , sndio
 , speexdsp
 , lazyLoad ? true
@@ -25,8 +26,9 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
+    alsa-lib
     jack2
-    pulseaudio
+    libpulseaudio
     sndio
     speexdsp
   ];
@@ -43,7 +45,7 @@ stdenv.mkDerivation {
 
   passthru = {
     # For downstream users when lazyLoad is true
-    backendLibs = [ jack2 pulseaudio sndio speexdsp ];
+    backendLibs = [ alsa-lib jack2 libpulseaudio sndio ];
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/audio/cubeb/default.nix
+++ b/pkgs/development/libraries/audio/cubeb/default.nix
@@ -6,10 +6,23 @@
 , libpulseaudio
 , sndio
 , speexdsp
-, lazyLoad ? true
+, AudioUnit
+, CoreAudio
+, CoreServices
+, lazyLoad ? !stdenv.isDarwin
 }:
 
-stdenv.mkDerivation {
+assert lib.assertMsg (stdenv.isDarwin -> !lazyLoad) "cubeb: lazyLoad is inert on Darwin";
+
+let
+  backendLibs = [
+    alsa-lib
+    jack2
+    libpulseaudio
+    sndio
+  ];
+
+in stdenv.mkDerivation {
   pname = "cubeb";
   version = "unstable-2022-10-18";
 
@@ -25,13 +38,10 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
-  buildInputs = [
-    alsa-lib
-    jack2
-    libpulseaudio
-    sndio
-    speexdsp
-  ];
+  buildInputs = [ speexdsp ] ++ (
+    if stdenv.isDarwin then [ AudioUnit CoreAudio CoreServices ]
+    else backendLibs
+  );
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
@@ -45,14 +55,14 @@ stdenv.mkDerivation {
 
   passthru = {
     # For downstream users when lazyLoad is true
-    backendLibs = [ alsa-lib jack2 libpulseaudio sndio ];
+    backendLibs = lib.optionals lazyLoad backendLibs;
   };
 
   meta = with lib; {
     description = "Cross platform audio library";
     homepage = "https://github.com/mozilla/cubeb";
     license = licenses.isc;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ zhaofengli ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18309,7 +18309,9 @@ with pkgs;
   # justStaticExecutables is needed due to https://github.com/NixOS/nix/issues/2990
   cachix = haskell.lib.compose.justStaticExecutables haskellPackages.cachix;
 
-  cubeb = callPackage ../development/libraries/audio/cubeb { };
+  cubeb = callPackage ../development/libraries/audio/cubeb {
+    inherit (darwin.apple_sdk.frameworks) AudioUnit CoreAudio CoreServices;
+  };
 
   hercules-ci-agent = callPackage ../development/tools/continuous-integration/hercules-ci-agent { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Makes `cubeb` work on macOS. Also cherry-picking a fix from @SuperSamus in #200241.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (Rosetta 2)
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
