### PR TITLE
sbclPackages: mark some failing packages as broken

### DIFF
--- a/pkgs/development/lisp-modules-new/import/database/sqlite.lisp
+++ b/pkgs/development/lisp-modules-new/import/database/sqlite.lisp
@@ -90,8 +90,6 @@ in {")
    "hu.dwim.zlib"
    ;; Missing libgvc.so native library
    "hu.dwim.graphviz"
-   ;; Missing zmq.h C header
-   "pzmq"
    ))
 
 (defmethod database->nix-expression ((database sqlite-database) outfile)

--- a/pkgs/development/lisp-modules-new/import/database/sqlite.lisp
+++ b/pkgs/development/lisp-modules-new/import/database/sqlite.lisp
@@ -90,6 +90,9 @@ in {")
    "hu.dwim.zlib"
    ;; Missing libgvc.so native library
    "hu.dwim.graphviz"
+   ;; These require libRmath.so, but I don't know where to get it from
+   "cl-random"
+   "cl-random-tests"
    ))
 
 (defmethod database->nix-expression ((database sqlite-database) outfile)

--- a/pkgs/development/lisp-modules-new/import/database/sqlite.lisp
+++ b/pkgs/development/lisp-modules-new/import/database/sqlite.lisp
@@ -80,6 +80,7 @@ in {")
    "hu.dwim.quasi-quote"
    ;; Tries to write in $HOME
    "ubiquitous"
+   "math"
    ;; Upstream bad packaging, multiple systems in clml.blas.asd
    "clml.blas.hompack"
    ;; Fails on SBCL due to heap exhaustion

--- a/pkgs/development/lisp-modules-new/import/database/sqlite.lisp
+++ b/pkgs/development/lisp-modules-new/import/database/sqlite.lisp
@@ -71,6 +71,29 @@ getAttr = builtins.getAttr;
 
 in {")
 
+;; Random compilation errors
+(defparameter +broken-packages+
+  (list
+   ;; no dispatch function defined for #\t
+   "hu.dwim.logger"
+   "hu.dwim.serializer"
+   "hu.dwim.quasi-quote"
+   ;; Tries to write in $HOME
+   "ubiquitous"
+   ;; Upstream bad packaging, multiple systems in clml.blas.asd
+   "clml.blas.hompack"
+   ;; Fails on SBCL due to heap exhaustion
+   "magicl"
+   ;; Probably missing dependency in QL data
+   "mcclim-bezier"
+   ;; Missing dependency on c2ffi cffi extension
+   "hu.dwim.zlib"
+   ;; Missing libgvc.so native library
+   "hu.dwim.graphviz"
+   ;; Missing zmq.h C header
+   "pzmq"
+   ))
+
 (defmethod database->nix-expression ((database sqlite-database) outfile)
   (sqlite:with-open-database (db (database-url database))
     (with-open-file (f outfile
@@ -131,6 +154,7 @@ in {")
                                        (remove "asdf"
                                                (str:split-omit-nulls #\, deps)
                                                :test #'string=))))
-                ,@(when (find #\/ name)
+                ,@(when (or (find #\/ name)
+                            (find name +broken-packages+ :test #'string=))
                     '(("meta" (:attrs ("broken" (:symbol "true"))))))))))))
       (format f "~%}~%"))))

--- a/pkgs/development/lisp-modules-new/imported.nix
+++ b/pkgs/development/lisp-modules-new/imported.nix
@@ -57419,9 +57419,6 @@ in {
     });
     systems = [ "pzmq" ];
     lispLibs = [ (getAttr "cffi" pkgs) (getAttr "cffi-grovel" pkgs) ];
-    meta = {
-      broken = true;
-    };
   };
   pzmq-compat = {
     pname = "pzmq-compat";

--- a/pkgs/development/lisp-modules-new/imported.nix
+++ b/pkgs/development/lisp-modules-new/imported.nix
@@ -20457,6 +20457,9 @@ in {
     });
     systems = [ "cl-random" ];
     lispLibs = [ (getAttr "alexandria" pkgs) (getAttr "anaphora" pkgs) (getAttr "array-operations" pkgs) (getAttr "cl-num-utils" pkgs) (getAttr "cl-rmath" pkgs) (getAttr "cl-slice" pkgs) (getAttr "gsll" pkgs) (getAttr "let-plus" pkgs) (getAttr "lla" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   cl-random-forest = {
     pname = "cl-random-forest";
@@ -20496,6 +20499,9 @@ in {
     });
     systems = [ "cl-random-tests" ];
     lispLibs = [ (getAttr "cl-random" pkgs) (getAttr "clunit" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   cl-rdfxml = {
     pname = "cl-rdfxml";

--- a/pkgs/development/lisp-modules-new/imported.nix
+++ b/pkgs/development/lisp-modules-new/imported.nix
@@ -25092,6 +25092,9 @@ in {
     });
     systems = [ "clml.blas.hompack" ];
     lispLibs = [ (getAttr "f2cl-lib" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   clml_dot_blas_dot_real = {
     pname = "clml.blas.real";
@@ -36543,10 +36546,6 @@ in {
     });
     systems = [ "gsll" ];
     lispLibs = [ (getAttr "alexandria" pkgs) (getAttr "foreign-array" pkgs) (getAttr "cffi-grovel" pkgs) (getAttr "cffi-libffi" pkgs) (getAttr "lisp-unit" pkgs) (getAttr "metabang-bind" pkgs) (getAttr "trivial-features" pkgs) (getAttr "trivial-garbage" pkgs) ];
-    meta = {
-      # needs "nativeLibs=nixpkgs.gsl" for libgslcblas.so and a way to set CFLAGS="-I gsl/include" or something similar
-      broken = true;
-    };
   };
   gt = {
     pname = "gt";
@@ -37991,6 +37990,9 @@ in {
     });
     systems = [ "hu.dwim.graphviz" ];
     lispLibs = [ (getAttr "cffi" pkgs) (getAttr "hu_dot_dwim_dot_asdf" pkgs) (getAttr "metabang-bind" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   hu_dot_dwim_dot_graphviz_dot_documentation = {
     pname = "hu.dwim.graphviz.documentation";
@@ -38030,6 +38032,9 @@ in {
     });
     systems = [ "hu.dwim.logger" ];
     lispLibs = [ (getAttr "bordeaux-threads" pkgs) (getAttr "hu_dot_dwim_dot_asdf" pkgs) (getAttr "hu_dot_dwim_dot_def" pkgs) (getAttr "hu_dot_dwim_dot_def_plus_hu_dot_dwim_dot_common" pkgs) (getAttr "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" pkgs) (getAttr "hu_dot_dwim_dot_util" pkgs) (getAttr "local-time" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   hu_dot_dwim_dot_logger_plus_iolib = {
     pname = "hu.dwim.logger+iolib";
@@ -38381,6 +38386,9 @@ in {
     });
     systems = [ "hu.dwim.quasi-quote" ];
     lispLibs = [ (getAttr "babel" pkgs) (getAttr "babel-streams" pkgs) (getAttr "hu_dot_dwim_dot_asdf" pkgs) (getAttr "hu_dot_dwim_dot_common" pkgs) (getAttr "hu_dot_dwim_dot_defclass-star_plus_hu_dot_dwim_dot_def" pkgs) (getAttr "hu_dot_dwim_dot_syntax-sugar" pkgs) (getAttr "hu_dot_dwim_dot_util" pkgs) (getAttr "hu_dot_dwim_dot_walker" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   hu_dot_dwim_dot_quasi-quote_dot_css = {
     pname = "hu.dwim.quasi-quote.css";
@@ -38718,6 +38726,9 @@ in {
     });
     systems = [ "hu.dwim.serializer" ];
     lispLibs = [ (getAttr "babel" pkgs) (getAttr "hu_dot_dwim_dot_asdf" pkgs) (getAttr "hu_dot_dwim_dot_common" pkgs) (getAttr "hu_dot_dwim_dot_def" pkgs) (getAttr "hu_dot_dwim_dot_syntax-sugar" pkgs) (getAttr "hu_dot_dwim_dot_util" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   hu_dot_dwim_dot_serializer_dot_documentation = {
     pname = "hu.dwim.serializer.documentation";
@@ -39379,6 +39390,9 @@ in {
     });
     systems = [ "hu.dwim.zlib" ];
     lispLibs = [ (getAttr "alexandria" pkgs) (getAttr "cffi" pkgs) (getAttr "cffi-libffi" pkgs) (getAttr "hu_dot_dwim_dot_asdf" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   hu_dot_dwim_dot_zlib_slash_fancy = {
     pname = "hu.dwim.zlib_fancy";
@@ -47717,6 +47731,9 @@ in {
     });
     systems = [ "mcclim-bezier" ];
     lispLibs = [ (getAttr "flexichain" pkgs) (getAttr "clim" pkgs) (getAttr "clim-pdf" pkgs) (getAttr "clim-postscript" pkgs) (getAttr "mcclim-clx" pkgs) (getAttr "mcclim-null" pkgs) (getAttr "mcclim-render" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   mcclim-bezier_slash_clx = {
     pname = "mcclim-bezier_clx";
@@ -57402,6 +57419,9 @@ in {
     });
     systems = [ "pzmq" ];
     lispLibs = [ (getAttr "cffi" pkgs) (getAttr "cffi-grovel" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   pzmq-compat = {
     pname = "pzmq-compat";
@@ -68823,6 +68843,9 @@ in {
     });
     systems = [ "ubiquitous" ];
     lispLibs = [  ];
+    meta = {
+      broken = true;
+    };
   };
   ubiquitous-concurrent = {
     pname = "ubiquitous-concurrent";

--- a/pkgs/development/lisp-modules-new/imported.nix
+++ b/pkgs/development/lisp-modules-new/imported.nix
@@ -47325,6 +47325,9 @@ in {
     });
     systems = [ "math" ];
     lispLibs = [ (getAttr "cl-utilities" pkgs) (getAttr "font-discovery" pkgs) (getAttr "gsll" pkgs) (getAttr "vgplot" pkgs) ];
+    meta = {
+      broken = true;
+    };
   };
   math_slash_appr = {
     pname = "math_appr";

--- a/pkgs/development/lisp-modules-new/patches/cl-freetype2-fix-grovel-includes.patch
+++ b/pkgs/development/lisp-modules-new/patches/cl-freetype2-fix-grovel-includes.patch
@@ -1,0 +1,16 @@
+--- a/src/ffi/grovel/grovel-freetype.h
++++ b/src/ffi/grovel/grovel-freetype.h
+@@ -2,7 +2,7 @@
+ #include <ft2build.h>
+ #include FT_FREETYPE_H
+ 
+-#include <ftsystem.h>
+-#include <fttypes.h>
+-#include <ftlist.h>
+-#include <ftimage.h>
++#include <freetype/ftsystem.h>
++#include <freetype/fttypes.h>
++#include <freetype/ftlist.h>
++#include <freetype/ftimage.h>
+
+Diff finished.  Mon Nov 14 22:41:57 2022

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -42,6 +42,9 @@ let
     cl-gtk2-pango = pkg: {
       nativeLibs = [ pango ];
     };
+    cl-rsvg2 = pkg: {
+      nativeLibs = [ librsvg ];
+    };
     cl-cffi-gtk-gdk = pkg: {
       nativeLibs = [ gtk3 ];
     };

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -22,6 +22,11 @@ let
     cl-cairo2 = pkg: {
       nativeLibs = [ cairo ];
     };
+    cl-freetype2 = pkg: {
+      nativeLibs = [ freetype ];
+      nativeBuildInputs = [ freetype ];
+      patches = [ ./patches/cl-freetype2-fix-grovel-includes.patch ];
+    };
     cl-cffi-gtk-gdk = pkg: {
       nativeLibs = [ gtk3 ];
     };

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -148,6 +148,10 @@ let
     cl-readline = pkg: {
       nativeLibs = [ pkgs.readline ];
     };
+    pzmq = pkg: {
+      nativeBuildInputs = [ pkgs.zeromq ];
+      nativeLibs = [ pkgs.zeromq ];
+    };
   };
 
   qlpkgs =

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -19,6 +19,9 @@ let
     cl-cffi-gtk-cairo = pkg: {
       nativeLibs = [ cairo ];
     };
+    cl-cairo2 = pkg: {
+      nativeLibs = [ cairo ];
+    };
     cl-cffi-gtk-gdk = pkg: {
       nativeLibs = [ gtk3 ];
     };

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -130,6 +130,24 @@ let
       nativeLibs = [ libfixposix ];
       systems = [ "iolib" "iolib/os" "iolib/pathnames" ];
     };
+    cl-ana_dot_hdf-cffi = pkg: {
+      nativeBuildInputs = [ pkgs.hdf5 ];
+      nativeLibs = [ pkgs.hdf5 ];
+      NIX_LDFLAGS = [ "-lhdf5" ];
+    };
+    gsll = pkg: {
+      nativeBuildInputs = [ pkgs.gsl ];
+      nativeLibs = [ pkgs.gsl ];
+    };
+    cl-libyaml = pkg: {
+      nativeLibs = [ pkgs.libyaml ];
+    };
+    cl-libxml2 = pkg: {
+      nativeLibs = [ pkgs.libxml2 ];
+    };
+    cl-readline = pkg: {
+      nativeLibs = [ pkgs.readline ];
+    };
   };
 
   qlpkgs =

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -30,6 +30,9 @@ let
       nativeBuildInputs = [ freetype ];
       patches = [ ./patches/cl-freetype2-fix-grovel-includes.patch ];
     };
+    cl-pango = pkg: {
+      nativeLibs = [ pango ];
+    };
     cl-cffi-gtk-gdk = pkg: {
       nativeLibs = [ gtk3 ];
     };

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -178,6 +178,18 @@ let
       nativeBuildInputs = [ pkgs.zeromq ];
       nativeLibs = [ pkgs.zeromq ];
     };
+    pzmq-compat = pkg: {
+      nativeBuildInputs = [ pkgs.zeromq ];
+      nativeLibs = [ pkgs.zeromq ];
+    };
+    pzmq-examples = pkg: {
+      nativeBuildInputs = [ pkgs.zeromq ];
+      nativeLibs = [ pkgs.zeromq ];
+    };
+    pzmq-test = pkg: {
+      nativeBuildInputs = [ pkgs.zeromq ];
+      nativeLibs = [ pkgs.zeromq ];
+    };
   };
 
   qlpkgs =

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -22,6 +22,9 @@ let
     cl-cairo2 = pkg: {
       nativeLibs = [ cairo ];
     };
+    cl-cairo2-xlib = pkg: {
+      nativeLibs = [ gtk2-x11 ];
+    };
     cl-freetype2 = pkg: {
       nativeLibs = [ freetype ];
       nativeBuildInputs = [ freetype ];

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -33,6 +33,15 @@ let
     cl-pango = pkg: {
       nativeLibs = [ pango ];
     };
+    cl-gtk2-gdk = pkg: {
+      nativeLibs = [ gtk2-x11 ];
+    };
+    cl-gtk2-glib = pkg: {
+      nativeLibs = [ glib ];
+    };
+    cl-gtk2-pango = pkg: {
+      nativeLibs = [ pango ];
+    };
     cl-cffi-gtk-gdk = pkg: {
       nativeLibs = [ gtk3 ];
     };

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -130,7 +130,7 @@ let
       nativeLibs = [ libfixposix ];
       systems = [ "iolib" "iolib/os" "iolib/pathnames" ];
     };
-    cl-ana_dot_hdf-cffi = pkg: {
+    "cl-ana.hdf-cffi" = pkg: {
       nativeBuildInputs = [ pkgs.hdf5 ];
       nativeLibs = [ pkgs.hdf5 ];
       NIX_LDFLAGS = [ "-lhdf5" ];


### PR DESCRIPTION
fixes #201094 

Added a list of broken packages and re-run `ql-import.lisp`.

Also see https://github.com/NixOS/nixpkgs/pull/200573 https://github.com/NixOS/nixpkgs/pull/195393