### PR TITLE
rustic-rs: init at 0.3.2

### DIFF
--- a/pkgs/tools/backup/rustic-rs/default.nix
+++ b/pkgs/tools/backup/rustic-rs/default.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, rustPlatform, stdenv, darwin, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rustic-rs";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "rustic-rs";
+    repo = "rustic";
+    rev = "v${version}";
+    hash = "sha256-MGFtJUfPK6IH3w8xe/RZaXS+QDIVS3jFSnf4VYiSLM4=";
+  };
+
+  cargoHash = "sha256-siJrqL7HjUQvcyXpUN5rQWNeQNBc+693N1xTSvlOixI=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ darwin.Security ];
+
+  postInstall = ''
+    for shell in {ba,fi,z}sh; do
+      $out/bin/rustic completions $shell > rustic.$shell
+    done
+
+    installShellCompletion rustic.{ba,fi,z}sh
+  '';
+
+  meta = {
+    homepage = "https://github.com/rustic-rs/rustic";
+    changelog = "https://github.com/rustic-rs/rustic/blob/${src.rev}/changelog/${version}.txt";
+    description = "fast, encrypted, deduplicated backups powered by pure Rust";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    license = [ lib.licenses.mit lib.licenses.asl20 ];
+    maintainers = [ lib.maintainers.nobbz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24433,6 +24433,8 @@ with pkgs;
 
   roon-server = callPackage ../servers/roon-server { };
 
+  rustic-rs = callPackage ../tools/backup/rustic-rs { };
+
   supervise = callPackage ../tools/system/supervise { };
 
   spamassassin = callPackage ../servers/mail/spamassassin { };


### PR DESCRIPTION
###### Description of changes

fast, encrypted, deduplicated backups powered by pure Rust

https://github.com/rustic-rs/rustic (Currently no dedicated homepage)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
