### PR TITLE
or-tools: add darwin support

### DIFF
--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -39,6 +39,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/google/or-tools/commit/a26602f24781e7bfcc39612568aa9f4010bb9736.patch";
       hash = "sha256-gM0rW0xRXMYaCwltPK0ih5mdo3HtX6mKltJDHe4gbLc=";
     })
+    # Backport fix in cmake test configuration where pip installs newer version from PyPi over local build,
+    #  breaking checkPhase: https://github.com/google/or-tools/issues/3260
+    (fetchpatch {
+      url = "https://github.com/google/or-tools/commit/edd1544375bd55f79168db315151a48faa548fa0.patch";
+      hash = "sha256-S//1YM3IoRCp3Ghg8zMF0XXgIpVmaw4gH8cVb9eUbqM=";
+    })
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     "-DFETCH_PYTHON_DEPS=OFF"
     "-DUSE_GLPK=ON"
     "-DUSE_SCIP=OFF"
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [ "-DCMAKE_MACOSX_RPATH=OFF" ];
   nativeBuildInputs = [
     cmake
     ensureNewerSourcesForZipFilesHook
@@ -104,6 +104,6 @@ stdenv.mkDerivation rec {
       Google's software suite for combinatorial optimization.
     '';
     maintainers = with maintainers; [ andersk ];
-    platforms = with platforms; linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

Add support for `or-tools` on Mac. Build was borked because of `@rpath` issues in the generated dynlib and binaries used for testing (`checkPhase` a la `ctest`). This works on my machine so sharing the changes with all.

Some related discussion:
- [cmake MACOSX_RPATH](https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_RPATH.html)
- #30150
- [LLVM mailing list on RPATH](https://lists.llvm.org/pipermail/llvm-dev/2017-October/118049.html)

This also seems to me the lesser of two evils. `fixdarwindylibnames` exists but presents two problems, making it insufficient.
1. the script runs after the `checkPhase`, so I need to run it as the `postBuildHook` as `ctest` uses linked objects and fails to pass.
2. the script only patches `dylib` files. This project creates a large amount of executables that do not get patched and are used by `ctest`. Again failing the `checkPhase`. 

Open to thoughts, I'm using it now and it functions well enough. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
