### PR TITLE
python310Packages.pyxl3: remove unittest2

### DIFF
--- a/pkgs/development/python-modules/pyxl3/default.nix
+++ b/pkgs/development/python-modules/pyxl3/default.nix
@@ -1,8 +1,7 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, unittest2
-, python
+, fetchFromGitHub
+, pytestCheckHook
 , isPy27
 }:
 
@@ -11,20 +10,14 @@ buildPythonPackage rec {
   version = "1.4";
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "ad4cc56bf4b35def33783e6d4783882702111fe8f9a781c63228e2114067c065";
+  src = fetchFromGitHub {
+    owner = "gvanrossum";
+    repo = pname;
+    rev = "e6588c12caee49c43faf6aa260f04d7e971f6aa8";
+    hash = "sha256-8nKQgwLXPVgPxNRF4CryKJb7+llDsZHis5VctxqpIRo=";
   };
 
-  checkInputs = [ unittest2 ];
-
-  checkPhase = ''
-     ${python.interpreter} tests/test_basic.py
-  '';
-
-  # tests require weird codec installation
-  # which is not necessary for major use of package
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Python 3 port of pyxl for writing structured and reusable inline HTML";


### PR DESCRIPTION
In addition, we can enable its tests by fetching the source from GitHub instead of from PyPI.

Related to https://github.com/NixOS/nixpkgs/pull/154650 and https://github.com/NixOS/nixpkgs/pull/154264.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
