### PR TITLE
qt5.qtwayland: backport wayland bugfix for menus

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwayland-menus-broken-fix.patch
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland-menus-broken-fix.patch
@@ -1,0 +1,63 @@
+Backport of https://codereview.qt-project.org/c/qt/qtwayland/+/418303
+
+diff --git a/src/client/qwaylandintegration.cpp b/src/client/qwaylandintegration.cpp
+index fbf00c6..25b7c0b 100644
+--- a/src/client/qwaylandintegration.cpp
++++ b/src/client/qwaylandintegration.cpp
+@@ -117,6 +117,9 @@ QWaylandIntegration::QWaylandIntegration()
+         mFailed = true;
+         return;
+     }
++
++    QWaylandWindow::fixedToplevelPositions =
++            !qEnvironmentVariableIsSet("QT_WAYLAND_DISABLE_FIXED_POSITIONS");
+ #if QT_CONFIG(clipboard)
+     mClipboard.reset(new QWaylandClipboard(mDisplay.data()));
+ #endif
+diff --git a/src/client/qwaylandwindow.cpp b/src/client/qwaylandwindow.cpp
+index 71d0e94..66abff7 100644
+--- a/src/client/qwaylandwindow.cpp
++++ b/src/client/qwaylandwindow.cpp
+@@ -363,8 +363,13 @@ void QWaylandWindow::setGeometry_helper(const QRect &rect)
+     }
+ }
+ 
+-void QWaylandWindow::setGeometry(const QRect &rect)
++void QWaylandWindow::setGeometry(const QRect &r)
+ {
++    auto rect = r;
++    if (fixedToplevelPositions && !QPlatformWindow::parent() && window()->type() != Qt::Popup
++        && window()->type() != Qt::ToolTip) {
++        rect.moveTo(screen()->geometry().topLeft());
++    }
+     setGeometry_helper(rect);
+ 
+     if (window()->isVisible() && rect.isValid()) {
+@@ -1046,6 +1051,13 @@ void QWaylandWindow::handleScreensChanged()
+ 
+     QWindowSystemInterface::handleWindowScreenChanged(window(), newScreen->QPlatformScreen::screen());
+     mLastReportedScreen = newScreen;
++    if (fixedToplevelPositions && !QPlatformWindow::parent() && window()->type() != Qt::Popup
++        && window()->type() != Qt::ToolTip
++        && geometry().topLeft() != newScreen->geometry().topLeft()) {
++        auto geometry = this->geometry();
++        geometry.moveTo(newScreen->geometry().topLeft());
++        setGeometry(geometry);
++    }
+ 
+     int scale = newScreen->isPlaceholder() ? 1 : static_cast<QWaylandScreen *>(newScreen)->scale();
+     if (scale != mScale) {
+diff --git a/src/client/qwaylandwindow_p.h b/src/client/qwaylandwindow_p.h
+index ea3d199..487a91a 100644
+--- a/src/client/qwaylandwindow_p.h
++++ b/src/client/qwaylandwindow_p.h
+@@ -98,6 +98,9 @@ public:
+     QWaylandWindow(QWindow *window, QWaylandDisplay *display);
+     ~QWaylandWindow() override;
+ 
++    // Keep Toplevels position on the top left corner of their screen
++    static inline bool fixedToplevelPositions = true;
++
+     virtual WindowType windowType() const = 0;
+     virtual void ensureSize();
+     WId winId() const override;

--- a/pkgs/development/libraries/qt-5/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwayland.nix
@@ -11,6 +11,7 @@ qtModule {
     # wrapped executables from `wrapQtAppsHook` (see comment in patch for further
     # context).  Beware: shared among different Qt5 versions.
     ./qtwayland-app_id.patch
+
     # Backport of https://codereview.qt-project.org/c/qt/qtwayland/+/388338
     # Pulled from Fedora as they modified it to not apply to KDE as Plasma 5.x
     # doesn't behave properly with the patch applied. See the discussion at
@@ -19,5 +20,9 @@ qtModule {
       url = "https://src.fedoraproject.org/rpms/qt5-qtwayland/raw/46376bb00d4c3dd3db2e82ad7ca5301ce16ea4ab/f/0080-Client-set-constraint-adjustments-for-popups-in-xdg.patch";
       sha256 = "sha256-XP+noYCk8fUdA0ItCqMjV7lSXDlNdB7Az9q7NRpupHc=";
     })
+
+    # https://codereview.qt-project.org/c/qt/qtwayland/+/418303
+    # Fixes QT menus being broken for QT5 apps on Wayland.
+    ./qtwayland-menus-broken-fix.patch
   ];
 }


### PR DESCRIPTION
###### Description of changes
This patch backports a bugfix[1] from QT6 to fix QT applications not showing select options (or showing them somewhere completely else) when using HiDPI screens.

Confirmed on my 27" WQHD screen that the issue is now gone with `wpa_gui` and `vorta`.

[1] https://codereview.qt-project.org/c/qt/qtwayland/+/418303

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBsodass ich ggf. UTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
