### PR TITLE
easyeffects: 6.3.0 -> 7.0.0

### DIFF
--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -3,9 +3,11 @@
 , desktop-file-utils
 , fetchFromGitHub
 , calf
+, fftw
 , fftwFloat
-, fmt_8
+, fmt_9
 , glib
+, gsl
 , gtk4
 , itstool
 , libadwaita
@@ -25,6 +27,7 @@
 , pkg-config
 , rnnoise
 , rubberband
+, speex
 , speexdsp
 , tbb
 , wrapGAppsHook4
@@ -34,13 +37,13 @@
 
 stdenv.mkDerivation rec {
   pname = "easyeffects";
-  version = "6.3.0";
+  version = "7.0.0";
 
   src = fetchFromGitHub {
     owner = "wwmm";
     repo = "easyeffects";
     rev = "v${version}";
-    sha256 = "sha256-OLxuE1jiALuKlC9U9esVlhaMBEaoZyNae8OO8upE4ZM=";
+    sha256 = "sha256-SjhJj5kClPd8DT1vzbSdqJ9AJw0XiX9Q8/R8SDnxGPQ=";
   };
 
   nativeBuildInputs = [
@@ -53,9 +56,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    fftw
     fftwFloat
-    fmt_8
+    fmt_9
     glib
+    gsl
     gtk4
     libadwaita
     libbs2b
@@ -69,6 +74,7 @@ stdenv.mkDerivation rec {
     pipewire
     rnnoise
     rubberband
+    speex
     speexdsp
     tbb
     zita-convolver


### PR DESCRIPTION
###### Description of changes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
