### PR TITLE
ipmitool: 1.8.18 -> 1.8.19

### DIFF
--- a/pkgs/tools/system/ipmitool/default.nix
+++ b/pkgs/tools/system/ipmitool/default.nix
@@ -1,58 +1,28 @@
-{ stdenv, lib, fetchurl, openssl, fetchpatch, static ? stdenv.hostPlatform.isStatic }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, openssl, readline }:
 
 stdenv.mkDerivation rec {
   pname = "ipmitool";
-  version = "1.8.18";
+  version = "1.8.19";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "0kfh8ny35rvwxwah4yv91a05qwpx74b5slq2lhrh71wz572va93m";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "IPMITOOL_${lib.replaceStrings ["."] ["_"] version}";
+    hash = "sha256-VVYvuldRIHhaIUibed9cLX8Avfy760fdBLNO8MoUKCk=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/i/ipmitool/1.8.18-6/debian/patches/0120-openssl1.1.patch";
-      sha256 = "1xvsjxb782lzy72bnqqnsk3r5h4zl3na95s4pqn2qg7cic2mnbfk";
-    })
-    # Fix build on non-linux systems
-    (fetchpatch {
-      url = "https://github.com/ipmitool/ipmitool/commit/5db314f694f75c575cd7c9ffe9ee57aaf3a88866.patch";
-      sha256 = "01niwrgajhrdhl441gzmw6v1r1yc3i8kn98db4b6smfn5fwdp1pa";
-    })
-    (fetchpatch {
-      name = "CVE-2020-5208.patch";
-      url = "https://github.com/ipmitool/ipmitool/commit/e824c23316ae50beb7f7488f2055ac65e8b341f2.patch";
-      sha256 = "sha256-X7MnoX2fzByRpRY4p33xetT+V2aehlQ/qU+aeaqtTUY=";
-    })
-    # Pull upstream patch to support upstream gcc-10:
-    #   https://github.com/ipmitool/ipmitool/pull/180
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/ipmitool/ipmitool/commit/51c7e0822f531469cf860dfa5d010c87b284b747.patch";
-      sha256 = "sha256-5UszUdVw3s2S5RCm5Exq4mqDqiYcN62in1O5+TZu9YA=";
-    })
-  ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ openssl readline ];
 
-  buildInputs = [ openssl ];
-
-  configureFlags = [
-    "--infodir=${placeholder "out"}/share/info"
-    "--mandir=${placeholder "out"}/share/man"
-  ] ++ lib.optionals static [
-    "LDFLAGS=-static"
-    "--enable-static"
-    "--disable-shared"
-  ] ++ lib.optionals (!static) [
-    "--enable-shared"
-  ];
-
-  makeFlags = lib.optional static "AM_LDFLAGS=-all-static";
-  dontDisableStatic = static;
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace 'AC_MSG_WARN([** Neither wget nor curl could be found.])' 'AM_CONDITIONAL([DOWNLOAD], [false])'
+  '';
 
   meta = with lib; {
     description = "Command-line interface to IPMI-enabled devices";
     license = licenses.bsd3;
-    homepage = "https://sourceforge.net/projects/ipmitool/";
+    homepage = "https://github.com/ipmitool/ipmitool";
     platforms = platforms.unix;
     maintainers = with maintainers; [ fpletz ];
   };


### PR DESCRIPTION
###### Description of changes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
