### PR TITLE
python3.pkgs.ldap: disable failing test

### DIFF
--- a/pkgs/development/python-modules/python-ldap/default.nix
+++ b/pkgs/development/python-modules/python-ldap/default.nix
@@ -45,6 +45,10 @@ buildPythonPackage rec {
     export SCHEMA="${openldap}/etc/schema"
   '';
 
+  disabledTests = [
+    "test_tls_ext_noca" # fails with openssl 3
+  ];
+
   doCheck = !stdenv.isDarwin;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/python-ldap/default.nix
+++ b/pkgs/development/python-modules/python-ldap/default.nix
@@ -46,7 +46,8 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    "test_tls_ext_noca" # fails with openssl 3
+    # https://github.com/python-ldap/python-ldap/issues/501
+    "test_tls_ext_noca"
   ];
 
   doCheck = !stdenv.isDarwin;


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).