### PR TITLE
checkov: Fix build

### DIFF
--- a/pkgs/development/tools/analysis/checkov/default.nix
+++ b/pkgs/development/tools/analysis/checkov/default.nix
@@ -141,6 +141,10 @@ buildPythonApplication rec {
     "checkov"
   ];
 
+  postInstall = ''
+    chmod +x $out/bin/checkov
+  '';
+
   meta = with lib; {
     description = "Static code analysis tool for infrastructure-as-code";
     homepage = "https://github.com/bridgecrewio/checkov";

--- a/pkgs/development/tools/analysis/checkov/default.nix
+++ b/pkgs/development/tools/analysis/checkov/default.nix
@@ -42,6 +42,10 @@ buildPythonApplication rec {
     hash = "sha256-dXpgm9S++jtBhuzX9db8Pm5LF6Qb4isXx5uyOGdWGUc=";
   };
 
+  patches = [
+    ./flake8-compat-5.x.patch
+  ];
+
   nativeBuildInputs = with py.pkgs; [
     pythonRelaxDepsHook
     setuptools-scm

--- a/pkgs/development/tools/analysis/checkov/flake8-compat-5.x.patch
+++ b/pkgs/development/tools/analysis/checkov/flake8-compat-5.x.patch
@@ -1,0 +1,25 @@
+diff --git a/flake8_plugins/flake8_class_attributes_plugin/tests/conftest.py b/flake8_plugins/flake8_class_attributes_plugin/tests/conftest.py
+index 1ad762aed..c91078dcf 100644
+--- a/flake8_plugins/flake8_class_attributes_plugin/tests/conftest.py
++++ b/flake8_plugins/flake8_class_attributes_plugin/tests/conftest.py
+@@ -1,6 +1,7 @@
+ import ast
+ import os
+ 
++import flake8
+ from flake8.options.manager import OptionManager
+ 
+ from flake8_plugins.flake8_class_attributes_plugin.flake8_class_attributes.checker import ClassAttributesChecker
+@@ -17,7 +18,11 @@ def run_validator_for_test_file(filename, max_annotations_complexity=None,
+         raw_content = file_handler.read()
+     tree = ast.parse(raw_content)
+ 
+-    options = OptionManager('flake8_class_attributes_order', '0.1.3')
++    options = OptionManager(
++        version=flake8.__version__,
++        plugin_versions='flake8_class_attributes_order: 0.1.3',
++        parents=[],
++        )
+     options.use_class_attributes_order_strict_mode = strict_mode
+     options.class_attributes_order = attributes_order
+     ClassAttributesChecker.parse_options(options)


### PR DESCRIPTION
###### Description of changes

checkov build has been broken since
https://hydra.nixos.org/build/187798638 due to a minor incompatibility with flake8 5.x; this remedies it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
