### PR TITLE
blobfuse2: init at 2.0.0-preview.4

### DIFF
--- a/pkgs/tools/filesystems/blobfuse2/default.nix
+++ b/pkgs/tools/filesystems/blobfuse2/default.nix
@@ -1,0 +1,68 @@
+{ fetchFromGitHub, buildGoModule, fuse3, lib }:
+
+let
+  version = "2.0.0-preview.4";
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "azure-storage-fuse";
+    rev = "blobfuse2-${version}";
+    sha256 = "sha256-4uKD3SK1AW/GA+rud2xV7gTPH6QLuN9FutZTsdEdvuA=";
+  };
+in
+buildGoModule rec {
+  pname = "blobfuse2";
+  inherit version src;
+
+  vendorSha256 = "sha256-ZGo+6ydpTFIUUX9V3sMbywGtmqo8CwVpwEsaK+PByTk=";
+
+  buildInputs = [ fuse3 ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    # We do not set trimpath for tests, in case they reference test assets
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+
+    for pkg in $(getGoDirs test); do
+      # should not be ran
+      if [ $pkg == "." ]; then continue; fi
+      # requires network
+      if [ $pkg == "./cmd" ]; then continue; fi
+      # fails with "Unable to open config file"
+      if [ $pkg == "./component/azstorage" ]; then continue; fi
+      # fails with an error
+      if [ $pkg == "./test/accoutcleanup" ]; then continue; fi
+      # we don't need benchmark
+      if [ $pkg == "./test/benchmark_test" ]; then continue; fi
+      # can't run e2e tests
+      if [ $pkg == "./test/e2e_tests" ]; then continue; fi
+      # fails with an error
+      if [ $pkg == "./test/mount_test" ]; then continue; fi
+      if [ $pkg == "./test/sdk_test" ]; then continue; fi
+      # we don't need stress test
+      if [ $pkg == "./test/stress_test" ]; then continue; fi
+      # fails with an error
+      if [ $pkg == "./tools/health-monitor/monitor/cpu_mem_profiler" ]; then continue; fi
+
+      echo "Testing $pkg"
+      buildGoDir test "$pkg"
+    done
+
+    runHook postCheck
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  postInstall = ''
+    cp $out/bin/azure-storage-fuse $out/bin/blobfuse2
+  '';
+
+  meta = with lib; {
+    description = "Mount an Azure Blob storage as filesystem through FUSE (version 2)";
+    license = licenses.mit;
+    maintainers = with maintainers; [ GuillaumeDesforges ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3180,6 +3180,8 @@ with pkgs;
 
   blobfuse = callPackage ../tools/filesystems/blobfuse { };
 
+  blobfuse2 = callPackage ../tools/filesystems/blobfuse2 { };
+
   blockdiag = with python3Packages; toPythonApplication blockdiag;
 
   bluez-alsa = callPackage ../tools/bluetooth/bluez-alsa { };


### PR DESCRIPTION
###### Description of changes

Azure has released preview for a new blobfuse tool (blobfuse2).

This PR introduces blobfuse2 at the top level, since it is still a preview.
Still, adding blobfuse2 is motivated because it is used by Azure users.

See Azure documentation: https://learn.microsoft.com/en-us/azure/storage/blobs/blobfuse2-what-is

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The binary `bin/blobfuse2` was tested manually as well with my own storage account.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
