### PR TITLE
notmuch-mailmover: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1071,6 +1071,12 @@
     githubId = 56009;
     name = "Arcadio Rubio García";
   };
+  archer-65 = {
+    email = "mario.liguori.056@gmail.com";
+    github = "archer-65";
+    githubId = 76066109;
+    name = "Mario Liguori";
+  };
   archseer = {
     email = "blaz@mxxn.io";
     github = "archseer";

--- a/pkgs/applications/networking/mailreaders/notmuch/notmuch-mailmover.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/notmuch-mailmover.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
     description = "Application to assign notmuch tagged mails to IMAP folders";
     homepage = "https://github.com/michaeladler/notmuch-mailmover/";
     license = licenses.asl20;
-    maintainers = with maintainers; [archer-65];
+    maintainers = with maintainers; [michaeladler archer-65];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch/notmuch-mailmover.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/notmuch-mailmover.nix
@@ -1,4 +1,5 @@
 {
+  notmuch,
   lib,
   stdenv,
   fetchFromGitHub,
@@ -12,10 +13,12 @@ rustPlatform.buildRustPackage rec {
     owner = "michaeladler";
     repo = pname;
     rev = "v${version}";
-    sha256 = lib.fakeSha256;
+    sha256 = "sha256-b2Q1JcXIp56Niv5kdPgQSM91e8hPPdyhWIG4f7kQn78=";
   };
 
-  cargoSha256 = lib.fakeSha256;
+  buildInputs = [notmuch];
+
+  cargoSha256 = "sha256-AW0mCdQN3WJhSErJ/MqnNIsRX+C6Pb/zHCQh7v/70MU=";
 
   meta = with lib; {
     description = "Application to assign notmuch tagged mails to IMAP folders";

--- a/pkgs/applications/networking/mailreaders/notmuch/notmuch-mailmover.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/notmuch-mailmover.nix
@@ -1,9 +1,8 @@
-{
-  notmuch,
-  lib,
-  stdenv,
-  fetchFromGitHub,
-  rustPlatform,
+{ notmuch
+, lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
 }:
 rustPlatform.buildRustPackage rec {
   pname = "notmuch-mailmover";
@@ -16,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-b2Q1JcXIp56Niv5kdPgQSM91e8hPPdyhWIG4f7kQn78=";
   };
 
-  buildInputs = [notmuch];
+  buildInputs = [ notmuch ];
 
   cargoSha256 = "sha256-AW0mCdQN3WJhSErJ/MqnNIsRX+C6Pb/zHCQh7v/70MU=";
 
@@ -24,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     description = "Application to assign notmuch tagged mails to IMAP folders";
     homepage = "https://github.com/michaeladler/notmuch-mailmover/";
     license = licenses.asl20;
-    maintainers = with maintainers; [michaeladler archer-65];
+    maintainers = with maintainers; [ michaeladler archer-65 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch/notmuch-mailmover.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/notmuch-mailmover.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "notmuch-mailmover";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "michaeladler";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = lib.fakeSha256;
+  };
+
+  cargoSha256 = lib.fakeSha256;
+
+  meta = with lib; {
+    description = "Application to assign notmuch tagged mails to IMAP folders";
+    homepage = "https://github.com/michaeladler/notmuch-mailmover/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [archer-65];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30965,6 +30965,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  notmuch-mailmover = callPackage ../applications/networking/mailreaders/notmuch/notmuch-mailmover.nix { };
+
   notejot = callPackage ../applications/misc/notejot { };
 
   notmuch-mutt = callPackage ../applications/networking/mailreaders/notmuch/mutt.nix { };


### PR DESCRIPTION
###### Description of changes

This changes add `notmuch-mailmover`, a tool to move `notmuch` tagged mails into IMAP folders. This package is based on `afew`'s MailMover one, but easier (and more flexible) to configure.
[Homepage](https://github.com/michaeladler/notmuch-mailmover/)
@michaeladler 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
