### PR TITLE
inetutils: fix cross

### DIFF
--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, ncurses, perl, help2man
 , apparmorRulesFromClosure
+, libxcrypt
 }:
 
 stdenv.mkDerivation rec {
@@ -18,8 +19,9 @@ stdenv.mkDerivation rec {
     ./inetutils-1_9-PATH_PROCNET_DEV.patch
   ];
 
+  strictDeps = true;
   nativeBuildInputs = [ help2man perl /* for `whois' */ ];
-  buildInputs = [ ncurses /* for `talk' */ ];
+  buildInputs = [ ncurses /* for `talk' */ libxcrypt ];
 
   # Don't use help2man if cross-compiling
   # https://lists.gnu.org/archive/html/bug-sed/2017-01/msg00001.html


### PR DESCRIPTION
###### Description of changes

I guess with #181764 this might've broken for cross. Perl propagates libxcrypt, but is only listed in nativeBuildInputs. List libxcrypt in buildInputs to ensure it's picked up properly.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
