### PR TITLE
webkitgtk: Bind NixOS directories to sandbox last

### DIFF
--- a/pkgs/development/libraries/webkitgtk/fix-bubblewrap-paths.patch
+++ b/pkgs/development/libraries/webkitgtk/fix-bubblewrap-paths.patch
@@ -1,16 +1,17 @@
-diff -ru old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
---- old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp	2019-09-09 04:47:07.000000000 -0400
-+++ webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp	2019-09-20 21:14:10.537921173 -0400
-@@ -724,6 +724,12 @@
-         "--ro-bind-try", "/usr/local/lib64", "/usr/local/lib64",
+diff --git a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+index 0a201fe176..fa3690c12a 100644
+--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
++++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+@@ -819,6 +819,12 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
+         sandboxArgs.append("--unshare-ipc");
+     }
  
-         "--ro-bind-try", PKGLIBEXECDIR, PKGLIBEXECDIR,
++    // Nix Directories
++    sandboxArgs.appendVector(Vector<CString>({ "--ro-bind", "@storeDir@", "@storeDir@" }));
++    sandboxArgs.appendVector(Vector<CString>({ "--ro-bind-try", "/run/current-system", "/run/current-system" }));
++    sandboxArgs.appendVector(Vector<CString>({ "--ro-bind-try", "@driverLink@/lib", "@driverLink@/lib" }));
++    sandboxArgs.appendVector(Vector<CString>({ "--ro-bind-try", "@driverLink@/share", "@driverLink@/share" }));
 +
-+        // Nix Directories
-+        "--ro-bind", "@storeDir@", "@storeDir@",
-+        "--ro-bind", "/run/current-system", "/run/current-system",
-+        "--ro-bind-try", "@driverLink@/lib", "@driverLink@/lib",
-+        "--ro-bind-try", "@driverLink@/share", "@driverLink@/share",
-     };
-     // We would have to parse ld config files for more info.
-     bindPathVar(sandboxArgs, "LD_LIBRARY_PATH");
+ #if ENABLE(DEVELOPER_MODE)
+     const char* execDirectory = g_getenv("WEBKIT_EXEC_PATH");
+     if (execDirectory) {


### PR DESCRIPTION
###### Description of changes

Since https://github.com/WebKit/WebKit/commit/31ac354cbeecf866f9a38f7b2f8f59f7975d3f6a, bubblewrap gets called the following way on NixOS system, when it has `share/fonts` in `environment.pathsToLink`:

    $ bwrap --ro-bind /nix/store /nix/store --ro-bind /run/current-system /run/current-system --ro-bind-try /run/current-system/sw/share/fonts /run/current-system/sw/share/fonts -- $(realpath $(which true))
    bwrap: Can't mkdir parents for /run/current-system/sw/share/fonts: No such file or directory

It fails because `/run/current-system/sw` is a symlink so bubblewrap is not be able to add another mountpoint inside.

Ideally, we would remove the `/run/current-system/sw` bind mount and mount only specific subdirectories we need, like the fonts. Unfortunately, it is not clear what else is needed. For example, [in the past](https://github.com/NixOS/nixpkgs/commit/756e60344fd83427148d8acf416c63573404a2e9), Pipewire’s Jack module was loaded from `/run/current-system/sw/lib`.

So, for now, let’s keep the and mount and move the binding of NixOS directories to the end. Adding bindings starting at leaves and moving to root should be fine.

While at it, let’s also make the binding of `/run/current-system` conditional, since it will not be available outside of NixOS.

Fixes: https://github.com/NixOS/nixpkgs/issues/197085

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Untested.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
