### PR TITLE
minidlna: 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/tools/networking/minidlna/default.nix
+++ b/pkgs/tools/networking/minidlna/default.nix
@@ -2,16 +2,15 @@
 
 let
   pname = "minidlna";
-  version = "1.3.1";
+  version = "1.3.2";
 in
 stdenv.mkDerivation {
   inherit pname version;
 
-  # tarball for 1.3.1 is missing
   src = fetchgit {
     url = "https://git.code.sf.net/p/${pname}/git";
     rev = "v${builtins.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-nbvz/QHSZBTZEqX/utOoOF5vorhrxGqIBA9qfpIZzyU=";
+    hash = "sha256-v+puglrbuLqHIAbrO7bhOA0npc/GYp0Bdi3DnD9qyII=";
   };
 
   preConfigure = ''


### PR DESCRIPTION
A few bug-fixes and upstream patches.

###### Description of changes

Contains a few bug-fixes and pull requests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
