### PR TITLE
duckdb: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/development/libraries/duckdb/version.patch
+++ b/pkgs/development/libraries/duckdb/version.patch
@@ -1,27 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 92c097228..5f51929f6 100644
+index 349af6acf7..7ffec0b4cb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -157,45 +157,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
+@@ -196,52 +196,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
    set(SUN TRUE)
  endif()
  
--execute_process(
--        COMMAND git log -1 --format=%h
--        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--        RESULT_VARIABLE GIT_RESULT
--        OUTPUT_VARIABLE GIT_COMMIT_HASH
--        OUTPUT_STRIP_TRAILING_WHITESPACE)
--execute_process(
--        COMMAND git describe --tags --abbrev=0
--        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--        OUTPUT_VARIABLE GIT_LAST_TAG
--        OUTPUT_STRIP_TRAILING_WHITESPACE)
--execute_process(
--        COMMAND git describe --tags --long
--        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--        OUTPUT_VARIABLE GIT_ITERATION
--        OUTPUT_STRIP_TRAILING_WHITESPACE)
+-find_package(Git)
+-if(Git_FOUND)
+-  if (NOT DEFINED GIT_COMMIT_HASH)
+-    execute_process(
+-            COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-            RESULT_VARIABLE GIT_RESULT
+-            OUTPUT_VARIABLE GIT_COMMIT_HASH
+-            OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  endif()
+-  execute_process(
+-          COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-          OUTPUT_VARIABLE GIT_LAST_TAG
+-          OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  execute_process(
+-          COMMAND ${GIT_EXECUTABLE} describe --tags --long
+-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-          OUTPUT_VARIABLE GIT_ITERATION
+-          OUTPUT_STRIP_TRAILING_WHITESPACE)
+-else()
+-  message("Git NOT FOUND")
+-endif()
 -
 -if(GIT_RESULT EQUAL "0")
 -  string(REGEX REPLACE "v([0-9]+).[0-9]+.[0-9]+" "\\1" DUCKDB_MAJOR_VERSION "${GIT_LAST_TAG}")
@@ -47,5 +54,5 @@ index 92c097228..5f51929f6 100644
 -endif()
 +set(DUCKDB_VERSION "@DUCKDB_VERSION@")
  
- option(AMALGAMATION_BUILD
-        "Build from the amalgamation files, rather than from the normal sources."
+ message(STATUS "git hash ${GIT_COMMIT_HASH}, version ${DUCKDB_VERSION}")
+ 

--- a/pkgs/development/python-modules/duckdb/default.nix
+++ b/pkgs/development/python-modules/duckdb/default.nix
@@ -13,13 +13,19 @@
 }:
 
 buildPythonPackage rec {
-  pname = "duckdb";
-  inherit (duckdb) version src patches;
+  inherit (duckdb) pname version src patches;
   format = "setuptools";
 
-  preConfigure = ''
+  # we can't use sourceRoot otherwise patches don't apply, because the patches
+  # apply to the C++ library
+  postPatch = ''
     cd tools/pythonpkg
-    substituteInPlace setup.py --replace "multiprocessing.cpu_count()" "$NIX_BUILD_CORES"
+
+    # 1. let nix control build cores
+    # 2. unconstrain setuptools_scm version
+    substituteInPlace setup.py \
+      --replace "multiprocessing.cpu_count()" "$NIX_BUILD_CORES" \
+      --replace "setuptools_scm<7.0.0" "setuptools_scm"
   '';
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump to 0.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
