### PR TITLE
usql: 0.12.13 -> 0.13.1

### DIFF
--- a/pkgs/applications/misc/usql/default.nix
+++ b/pkgs/applications/misc/usql/default.nix
@@ -1,32 +1,38 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , buildGoModule
 , unixODBC
 , icu
+, nix-update-script
+, testers
+, usql
 }:
 
 buildGoModule rec {
   pname = "usql";
-  version = "0.12.13";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "xo";
     repo = "usql";
     rev = "v${version}";
-    hash = "sha256-F/eOD7/w8HjJBeiXagaf4yBLZcZVuy93rfVFeSESlZo=";
+    hash = "sha256-bdejXGyvY+HAE4sOxhsZYZ5fCISEVxvfOlEjL/CgBLQ=";
   };
-
-  vendorHash = "sha256-7rMCqTfUs89AX0VP689BmKsuvLJWU5ANJVki+JMVf7g=";
 
   buildInputs = [ unixODBC icu ];
 
-  # Exclude broken impala driver
-  # The driver breaks too often and is not used.
+  vendorHash = "sha256-+4eRdr5MY9d0ordaDv8hZf4wGoZsp14MpOEp1vhr75w=";
+  proxyVendor = true;
+
+  # Exclude broken impala & hive driver
+  # These drivers break too often and are not used.
   #
   # See https://github.com/xo/usql/pull/347
   #
   excludedPackages = [
     "impala"
+    "hive"
   ];
 
   # These tags and flags are copied from build-release.sh
@@ -52,9 +58,21 @@ buildGoModule rec {
   # All the checks currently require docker instances to run the databases.
   doCheck = false;
 
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+    tests.version = testers.testVersion {
+      inherit version;
+      package = usql;
+      command = "usql --version";
+    };
+  };
+
   meta = with lib; {
     description = "Universal command-line interface for SQL databases";
     homepage = "https://github.com/xo/usql";
+    changelog = "https://github.com/xo/usql/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ georgyo anthonyroussel ];
     platforms = with platforms; linux ++ darwin;


### PR DESCRIPTION
###### Description of changes

* Upgrade from 0.12.13 to 0.13.1
  * https://github.com/xo/usql/releases/tag/v0.13.0
  * https://github.com/xo/usql/releases/tag/v0.13.1

* Add passthru.tests.version to test the final binary
* Add passthru.updateScript to update usql with ./maintainers/scripts/update.nix
* Add meta.changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
