### PR TITLE
{cargo-auditable,rust-audit-info}: update

### DIFF
--- a/pkgs/development/tools/rust/cargo-auditable/default.nix
+++ b/pkgs/development/tools/rust/cargo-auditable/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-auditable";
-  version = "0.5.3";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "rust-secure-code";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-bRx+a6vzjiS2dglVkTyUm8OASM2Qq05S7LuVkHaIYMU=";
+    sha256 = "sha256-udn/Z+raf/fkJ5M/FSH9Au+J9ASu0rz6ZJSl8P+jLT4=";
   };
 
-  cargoSha256 = "sha256-QZi45U+MV8h4AMcN3QLIfAn/gHzoBWuOsC7gDSBY2jI=";
+  cargoSha256 = "sha256-k3wWdlLYGZZ44IHatXWq8TK2xCia3YES2jX286QkNH0=";
 
   meta = with lib; {
     description = "A tool to make production Rust binaries auditable";

--- a/pkgs/development/tools/rust/rust-audit-info/default.nix
+++ b/pkgs/development/tools/rust/rust-audit-info/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-audit-info";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-oxlbtFDQj6nyBXzNczG6ZhSOHvVQjK1FimWm/pSZHtY=";
+    sha256 = "sha256-g7ElNehBAVSRRlqsxkNm20C0KOMkf310bXNs3EN+/NQ=";
   };
 
-  cargoSha256 = "sha256-Y+5OUfsmUhDP9Fn8s9nso0W25eTFodDIVEVusn6HRmk=";
+  cargoSha256 = "sha256-bKrdgz6dyv/PF5JXMq7uvsh7SsK/qEd2W7tm6+YYlxg=";
 
   meta = with lib; {
     description = "A command-line tool to extract the dependency trees embedded in binaries by cargo-auditable";


### PR DESCRIPTION
###### Description of changes

https://github.com/rust-secure-code/cargo-auditable/compare/v0.5.3...v0.5.4

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
