### PR TITLE
nixos: Fix fsck with systemd 251.6 and later

### DIFF
--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -300,7 +300,11 @@ in
     boot.supportedFilesystems = map (fs: fs.fsType) fileSystems;
 
     # Add the mount helpers to the system path so that `mount' can find them.
-    system.fsPackages = [ pkgs.dosfstools ];
+    system.fsPackages = [
+      pkgs.dosfstools
+      # This is needed for the main fsck utility wrapping the fs-specific ones.
+      pkgs.util-linux
+    ];
 
     environment.systemPackages = with pkgs; [ fuse3 fuse ] ++ config.system.fsPackages;
 


### PR DESCRIPTION
Version 251.6 of systemd introduced a [small change](https://github.com/systemd/systemd-stable/commit/73db7d99323c236625656f906eb4e429613d324b) that now checks whether the `fsck` command is available in *addition* to the filesystem specific `fsck.$fsname` executable.

When bumping systemd to version 251.7 [on our side](https://github.com/NixOS/nixpkgs/commit/844a08cc06b5c0703ba37f2318ef5b7d90665d04), we introduced that change. This subsequently caused our `fsck` test to fail and it looks like this was an oversight during the [pull request](https://github.com/NixOS/nixpkgs/pull/199618) introducing the bump.

Since the `fsck` wrapper binary is in `util-linux`, I decided to address this by adding `util-linux` to `fsPackages` because `util-linux` is already part of the closure of any NixOS system so the impact should be pretty low.