### PR TITLE
libcxx: link correct libcxxabi version

### DIFF
--- a/pkgs/development/compilers/llvm/10/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/10/libcxx/default.nix
@@ -51,6 +51,20 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
+  preInstall = lib.optionalString (stdenv.isDarwin) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/10/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/10/libcxx/default.nix
@@ -55,11 +55,11 @@ stdenv.mkDerivation {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/10/libcxxabi/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/11/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxx/default.nix
@@ -67,6 +67,20 @@ stdenv.mkDerivation {
       stdenv.hostPlatform != stdenv.buildPlatform
     ) "-DCMAKE_SYSTEM_VERSION=20.1.0";
 
+  preInstall = lib.optionalString (stdenv.isDarwin) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/11/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxx/default.nix
@@ -71,11 +71,11 @@ stdenv.mkDerivation {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
@@ -46,6 +46,8 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxxabi/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/12/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxx/default.nix
@@ -46,11 +46,11 @@ stdenv.mkDerivation {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/12/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxx/default.nix
@@ -42,6 +42,20 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
+  preInstall = lib.optionalString (stdenv.isDarwin) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxxabi/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -50,11 +50,11 @@ stdenv.mkDerivation rec {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -46,6 +46,20 @@ stdenv.mkDerivation rec {
   buildFlags = lib.optional headersOnly "generate-cxx-headers";
   installTargets = lib.optional headersOnly "install-cxx-headers";
 
+  preInstall = lib.optionalString (stdenv.isDarwin && !headersOnly) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   # At this point, cxxabi headers would be installed in the dev output, which
   # prevents moveToOutput from doing its job later in the build process.
   postInstall = lib.optionalString (!headersOnly) ''

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/14/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxx/default.nix
@@ -62,6 +62,20 @@ stdenv.mkDerivation rec {
   buildFlags = lib.optional headersOnly "generate-cxx-headers";
   installTargets = lib.optional headersOnly "install-cxx-headers";
 
+  preInstall = lib.optionalString (stdenv.isDarwin && !headersOnly) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/14/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxx/default.nix
@@ -66,11 +66,11 @@ stdenv.mkDerivation rec {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation rec {
   installPhase = if stdenv.isDarwin
     then ''
       for file in lib/*.dylib; do
+        if [ -L "$file" ]; then continue; fi
+
         # Fix up the install name. Preserve the basename, just replace the path.
         installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
         if [ -L "$file" ]; then continue; fi
 
         # Fix up the install name. Preserve the basename, just replace the path.
-        installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+        installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
         # this should be done in CMake, but having trouble figuring out
         # the magic combination of necessary CMake variables
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
         # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
         # libcxxabi to sometimes link against a different version of itself.
         # Here we simply make that second reference point to ourselves.
-        for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
           ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
         done
       done

--- a/pkgs/development/compilers/llvm/5/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/5/libcxx/default.nix
@@ -45,11 +45,11 @@ stdenv.mkDerivation {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/5/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/5/libcxx/default.nix
@@ -41,6 +41,20 @@ stdenv.mkDerivation {
     "-DLIBCXX_CXX_ABI=libcxxabi"
   ] ++ lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
 
+  preInstall = lib.optionalString (stdenv.isDarwin) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/5/libcxxabi/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/6/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/6/libcxx/default.nix
@@ -51,11 +51,11 @@ stdenv.mkDerivation {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/6/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/6/libcxx/default.nix
@@ -47,6 +47,20 @@ stdenv.mkDerivation {
     "-DLIBCXX_CXX_ABI=libcxxabi"
   ] ++ lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
 
+  preInstall = lib.optionalString (stdenv.isDarwin) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/6/libcxxabi/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/7/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/7/libcxx/default.nix
@@ -52,6 +52,20 @@ stdenv.mkDerivation {
     ++ lib.optional (stdenv.hostPlatform.useLLVM or false) "-DLIBCXX_USE_COMPILER_RT=ON"
     ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF" ;
 
+  preInstall = lib.optionalString (stdenv.isDarwin) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/7/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/7/libcxx/default.nix
@@ -56,11 +56,11 @@ stdenv.mkDerivation {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
@@ -46,6 +46,8 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/7/libcxxabi/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/8/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/8/libcxx/default.nix
@@ -55,6 +55,20 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
+  preInstall = lib.optionalString (stdenv.isDarwin) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/8/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/8/libcxx/default.nix
@@ -59,11 +59,11 @@ stdenv.mkDerivation {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/8/libcxxabi/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/9/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/9/libcxx/default.nix
@@ -51,6 +51,20 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
+  preInstall = lib.optionalString (stdenv.isDarwin) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/9/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/9/libcxx/default.nix
@@ -55,11 +55,11 @@ stdenv.mkDerivation {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/9/libcxxabi/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 

--- a/pkgs/development/compilers/llvm/git/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxx/default.nix
@@ -76,6 +76,20 @@ stdenv.mkDerivation rec {
   buildFlags = lib.optional headersOnly "generate-cxx-headers";
   installTargets = lib.optional headersOnly "install-cxx-headers";
 
+  preInstall = lib.optionalString (stdenv.isDarwin && !headersOnly) ''
+    for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
+      baseName=$(basename $(otool -D $file | tail -n 1))
+      installName="$out/lib/$baseName"
+      abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
+
+      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+        ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
+      done
+    done
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/git/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxx/default.nix
@@ -80,11 +80,11 @@ stdenv.mkDerivation rec {
     for file in lib/*.dylib; do
       if [ -L "$file" ]; then continue; fi
 
-      baseName=$(basename $(otool -D $file | tail -n 1))
+      baseName=$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))
       installName="$out/lib/$baseName"
       abiName=$(echo "$baseName" | sed -e 's/libc++/libc++abi/')
 
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other ${libcxxabi}/lib/$abiName $file
       done
     done

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
       if [ -L "$file" ]; then continue; fi
 
       # Fix up the install name. Preserve the basename, just replace the path.
-      installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
+      installName="$out/lib/$(basename $(${stdenv.cc.targetPrefix}otool -D $file | tail -n 1))"
 
       # this should be done in CMake, but having trouble figuring out
       # the magic combination of necessary CMake variables
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
       # cc-wrapper passes '-lc++abi' to all c++ link steps, but that causes
       # libcxxabi to sometimes link against a different version of itself.
       # Here we simply make that second reference point to ourselves.
-      for other in $(otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
+      for other in $(${stdenv.cc.targetPrefix}otool -L $file | awk '$1 ~ "/libc\\+\\+abi" { print $1 }'); do
         ${stdenv.cc.targetPrefix}install_name_tool -change $other $installName $file
       done
     done

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -70,6 +70,8 @@ stdenv.mkDerivation rec {
 
   preInstall = lib.optionalString stdenv.isDarwin ''
     for file in lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+
       # Fix up the install name. Preserve the basename, just replace the path.
       installName="$out/lib/$(basename $(otool -D $file | tail -n 1))"
 


### PR DESCRIPTION
###### Description of changes

This is a follow-up to @stephank's PR here: https://github.com/NixOS/nixpkgs/pull/196909
Firstly, skip the dylib fixups introduced in that PR for symlinks. This is the same behaviour as the standard `fixDarwinDylibNames` hook.

The main change is to do the same fixup on libc++.dylib as done on libc++abi.dylib
Current behaviour emits a `/nix/store/$hash-libc++-$version/lib/libc++.dylib` which loads libc++abi from the build stdenv, which on Darwin is `/nix/store/$hash-libcxx-11.1.0/lib/libc++abi.dylib` – not necessarily the correct version.

Combined with the symlink breakage, using `llvmPackages_14.libcxxStdenv` in my flake causes dyld to partially load 2 copies of libc++abi. It only seems to load the BSS segment twice, so *most* things work, apart from a very subtle bug inside `std::current_exception()`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
