### PR TITLE
gcc-aarch64-embedded: init at 11.3.rel1

### DIFF
--- a/pkgs/development/compilers/gcc-aarch64-embedded/11/default.nix
+++ b/pkgs/development/compilers/gcc-aarch64-embedded/11/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchurl
+, ncurses5
+, python38
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gcc-aarch64-embedded";
+  version = "11.3.rel1";
+
+  platform = {
+    aarch64-linux = "aarch64";
+    x86_64-darwin = "darwin-x86_64";
+    x86_64-linux  = "x86_64";
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/${version}/binrel/arm-gnu-toolchain-${version}-${platform}-aarch64-none-elf.tar.xz";
+    hash = {
+      aarch64-linux = "sha256-xe09gSOhr9Z99Zt95SC5GgruzXW3CLp1fHBvy0gj6Fo=";
+      x86_64-darwin = "sha256-y47lDfHVQTXcDleheH7ajAkPpVYaqiD8vMBUjfuNzrI=";
+      x86_64-linux  = "sha256-+55WKpDeGzopYblSGTwcZSCHKqFILApeCreZcOxudpA=";
+    }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf "$f" > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 ]} "$f" || true
+    done
+  '';
+
+  meta = with lib; {
+    description = "Pre-built GNU toolchain from aarch64 Cortex-A & Cortex-R processors";
+    homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = with maintainers; [ newam ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15212,6 +15212,9 @@ with pkgs;
 
   gcl_2_6_13_pre = callPackage ../development/compilers/gcl/2.6.13-pre.nix { };
 
+  gcc-aarch64-embedded-11 = callPackage ../development/compilers/gcc-aarch64-embedded/11 { };
+  gcc-aarch64-embedded = gcc-aarch64-embedded-11;
+
   gcc-arm-embedded-6 = callPackage ../development/compilers/gcc-arm-embedded/6 { };
   gcc-arm-embedded-7 = callPackage ../development/compilers/gcc-arm-embedded/7 { };
   gcc-arm-embedded-8 = callPackage ../development/compilers/gcc-arm-embedded/8 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `gcc-aarch64-embedded`, see <https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain>.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
