### PR TITLE
openshot-qt: fix Python 3.10 incompatibility

### DIFF
--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , mkDerivationWith
 , fetchFromGitHub
+, fetchpatch
 , doxygen
 , gtk3
 , libopenshot
@@ -46,6 +47,22 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     # tries to create caching directories during install
     export HOME=$(mktemp -d)
   '';
+
+  # Following Arch PKGBUILD for Python 3.10 compatibility
+  # https://github.com/OpenShot/openshot-qt/issues/4608
+  # https://github.com/archlinux/svntogit-community/commits/packages/openshot/trunk
+  patches = [
+    (fetchpatch {
+      name = "video-widget.patch";
+      url = "https://github.com/OpenShot/openshot-qt/commit/9748a13268d66a5949aebc970637b5903756d018.patch";
+      hash = "sha256-QwLtcooDJeYWDp80a1dUFo2so/zEWqqsq5IgkXWX324=";
+    })
+    (fetchpatch {
+      name = "python-3.10-int.patch";
+      url = "https://github.com/OpenShot/openshot-qt/commit/fff785eb1e3e0c30ed6ca57e2d1933aaa807ae22.patch";
+      hash = "sha256-ee/s7rhF71ot5oPkGK+j59mL1B3e72xoH27KFoDL8s8=";
+    })
+  ];
 
   postFixup = ''
     wrapProgram $out/bin/openshot-qt \


### PR DESCRIPTION
###### Description of changes

Current Openshot release is over a year old and is not compatible with Python 3.10 so crashes on startup: https://github.com/OpenShot/openshot-qt/issues/4608.

Pulled in the same unreleased PR patches that Arch did and it starts now. Haven't had the chance to test a project or anything yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).