### PR TITLE
yosys: 0.22 -> 0.23

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -8,7 +8,6 @@
 , libffi
 , makeWrapper
 , pkg-config
-, protobuf
 , python3
 , readline
 , symlinkJoin
@@ -72,13 +71,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname   = "yosys";
-  version = "0.22";
+  version = "0.23";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
     rev   = "${pname}-${version}";
-    hash  = "sha256-us4GiulqkzcwD2iuNXB5eTd3iqgUdvj9Nd2p/9TJerQ=";
+    hash  = "sha256-mOakdXhSij8k4Eo7RwpKjd59IkNjw31NNFDJtL6Adgo=";
   };
 
   enableParallelBuilding = true;
@@ -87,14 +86,13 @@ in stdenv.mkDerivation rec {
     tcl
     readline
     libffi
-    protobuf
     zlib
     (python3.withPackages (pp: with pp; [
       click
     ]))
   ];
 
-  makeFlags = [ "ENABLE_PROTOBUF=1" "PREFIX=${placeholder "out"}"];
+  makeFlags = [ "PREFIX=${placeholder "out"}"];
 
   patches = [
     ./plugin-search-dirs.patch
@@ -115,9 +113,6 @@ in stdenv.mkDerivation rec {
     chmod -R u+w .
     make config-${if stdenv.cc.isClang or false then "clang" else "gcc"}
     echo 'ABCEXTERNAL = ${abc-verifier}/bin/abc' >> Makefile.conf
-
-    # we have to do this ourselves for some reason...
-    (cd misc && ${protobuf}/bin/protoc --cpp_out ../backends/protobuf/ ./yosys.proto)
 
     if ! grep -q "ABCREV = ${shortAbcRev}" Makefile; then
       echo "ERROR: yosys isn't compatible with the provided abc (${shortAbcRev}), failing."


### PR DESCRIPTION
###### Description of changes
https://github.com/YosysHQ/yosys/releases/tag/yosys-0.23
The protobuf backend was removed in https://github.com/YosysHQ/yosys/pull/3508.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).