### PR TITLE
gnomeExtensions.tophat: patch missing dependency

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -10,6 +10,7 @@
 , nvme-cli
 , procps
 , pulseaudio
+, libgtop
 , python3
 , smartmontools
 , substituteAll
@@ -99,6 +100,15 @@ super: lib.trivial.pipe super [
     ];
 
     meta.maintainers = with lib.maintainers; [ rhoriguchi ];
+  }))
+
+  (patchExtension "tophat@fflewddur.github.io" (old: {
+    patches = [
+      (substituteAll {
+        src = ./extensionOverridesPatches/tophat_at_fflewddur.github.io.patch;
+        gtop_path = "${libgtop}/lib/girepository-1.0";
+      })
+    ];
   }))
 
   (patchExtension "unite@hardpixel.eu" (old: {

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/tophat_at_fflewddur.github.io.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/tophat_at_fflewddur.github.io.patch
@@ -1,0 +1,13 @@
+diff --git a/extension.js b/extension.js
+index 60396f8..b044872 100644
+--- a/extension.js
++++ b/extension.js
+@@ -20,6 +20,8 @@
+ 
+ /* exported init, enable, disable */
+ 
++imports.gi.GIRepository.Repository.prepend_search_path('@gtop_path@');
++
+ let depFailures = [];
+ let missingLibs = [];
+ 


### PR DESCRIPTION
###### Description of changes

Should fix #194524. Did not test, please test @not-my-segfault.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

**cc** @piegamesde @jtojnar