### PR TITLE
lokinet: 0.9.9 -> 0.9.10

### DIFF
--- a/pkgs/applications/networking/p2p/lokinet/default.nix
+++ b/pkgs/applications/networking/p2p/lokinet/default.nix
@@ -7,6 +7,7 @@
 , libuv
 , nlohmann_json
 , pkg-config
+, spdlog
 , sqlite
 , systemd
 , unbound
@@ -15,14 +16,14 @@
 
 stdenv.mkDerivation rec {
   pname = "lokinet";
-  version = "0.9.9";
+  version = "0.9.10";
 
   src = fetchFromGitHub {
     owner = "oxen-io";
     repo = "lokinet";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-AaGsRg9S9Cng9emI/mN09QSOIRbE+x3916clWAwLnRs=";
+    sha256 = "sha256-dLkIFp1yz5MgUDxYQHN4zv2mexEb4GfkxlTOZyECsew=";
   };
 
   nativeBuildInputs = [
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
     libuv
     libsodium
     nlohmann_json
+    spdlog
     sqlite
     systemd
     unbound
@@ -46,14 +48,6 @@ stdenv.mkDerivation rec {
     "-DWITH_BOOTSTRAP=OFF" # we provide bootstrap files manually
     "-DWITH_SETCAP=OFF"
   ];
-
-  # copy bootstrap files
-  # see https://github.com/oxen-io/lokinet/issues/1765#issuecomment-938208774
-  postInstall = ''
-    mkdir -p $out/share/testnet
-    cp $src/contrib/bootstrap/mainnet.signed $out/share/bootstrap.signed
-    cp $src/contrib/bootstrap/testnet.signed $out/share/testnet/bootstrap.signed
-  '';
 
   meta = with lib; {
     description = "Anonymous, decentralized and IP based overlay network for the internet";


### PR DESCRIPTION
###### Description of changes
Updated to 0.9.10.

Lokinet now automatically symlinks the bootstrap file in `/var/lib/lokinet` so we don't need to do it anymore.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
