### PR TITLE
asterisk: 16.26.1 -> 16.29.0, 18.12.1 -> 18.15.0, 19.4.1 -> 19.7.0, init 20.0.0

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  # remove when upgrading to pjsip >1.12.1
+  # remove when upgrading to pjsip >2.12.1
   pjsip_patches = [
     (fetchpatch {
       name = "0150-CVE-2022-31031.patch";

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -3,12 +3,30 @@
   util-linux, dmidecode, libuuid, newt,
   lua, speex, libopus, opusfile, libogg,
   srtp, wget, curl, iksemel, pkg-config,
-  autoconf, libtool, automake,
+  autoconf, libtool, automake, fetchpatch,
   python39, writeScript,
   withOpus ? true,
 }:
 
 let
+  # remove when upgrading to pjsip >1.12.1
+  pjsip_patches = [
+    (fetchpatch {
+      name = "0150-CVE-2022-31031.patch";
+      url = "https://github.com/pjsip/pjproject/commit/450baca94f475345542c6953832650c390889202.patch";
+      sha256 = "sha256-30kHrmB51UIw4x/J6/CD+vPKf/gBYDCcFoUpwEWkDMY=";
+    })
+    (fetchpatch {
+      name = "0151-CVE-2022-39244.patch";
+      url = "https://github.com/pjsip/pjproject/commit/c4d34984ec92b3d5252a7d5cddd85a1d3a8001ae.patch";
+      sha256 = "sha256-hTUMh6bYAizn6GF+sRV1vjKVxSf9pnI+eQdPOqsdJI4=";
+    })
+    (fetchpatch {
+      name = "0152-CVE-2022-39269.patch";
+      url = "https://github.com/pjsip/pjproject/commit/d2acb9af4e27b5ba75d658690406cec9c274c5cc.patch";
+      sha256 = "sha256-bKE/MrRAqN1FqD2ubhxIOOf5MgvZluHHeVXPjbR12iQ=";
+    })
+  ];
   common = {version, sha256, externals}: stdenv.mkDerivation {
     inherit version;
     pname = "asterisk";
@@ -58,6 +76,9 @@ let
         cp ${asterisk-opus}/codecs/* ./codecs
         cp ${asterisk-opus}/formats/* ./formats
       ''}
+      ${lib.concatMapStringsSep "\n" (patch: ''
+        cp ${patch} ./third-party/pjproject/patches/${patch.name}
+      '') pjsip_patches}
       ./bootstrap.sh
     '';
 
@@ -69,6 +90,7 @@ let
     ];
 
     preBuild = ''
+      cat third-party/pjproject/source/pjlib-util/src/pjlib-util/scanner.c
       make menuselect.makeopts
       ${lib.optionalString (externals ? "addons/mp3") ''
         substituteInPlace menuselect.makeopts --replace 'format_mp3 ' ""
@@ -91,11 +113,6 @@ let
       license = licenses.gpl2Only;
       maintainers = with maintainers; [ auntie DerTim1 yorickvp ];
     };
-  };
-
-  pjproject_2_12 = fetchurl {
-    url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.12/pjproject-2.12.tar.bz2";
-    hash = "sha256-T3q4r/4WCAZCNGnULxMnNKH9wEK7gkseV/sV8IPasHQ=";
   };
 
   pjproject_2_12_1 = fetchurl {
@@ -121,7 +138,6 @@ let
   versions = lib.mapAttrs (_: {version, sha256}: common {
     inherit version sha256;
     externals = {
-      "externals_cache/pjproject-2.12.tar.bz2" = pjproject_2_12;
       "externals_cache/pjproject-2.12.1.tar.bz2" = pjproject_2_12_1;
       "addons/mp3" = mp3-202;
     };

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -98,6 +98,11 @@ let
     hash = "sha256-T3q4r/4WCAZCNGnULxMnNKH9wEK7gkseV/sV8IPasHQ=";
   };
 
+  pjproject_2_12_1 = fetchurl {
+    url = "https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.12.1/pjproject-2.12.1.tar.bz2";
+    hash = "sha256-DiNH1hB5ZheYzyUjFyk1EtlsMJlgjf+QRVKjEk+hNjc=";
+  };
+
   mp3-202 = fetchsvn {
     url = "http://svn.digium.com/svn/thirdparty/mp3/trunk";
     rev = "202";
@@ -117,6 +122,7 @@ let
     inherit version sha256;
     externals = {
       "externals_cache/pjproject-2.12.tar.bz2" = pjproject_2_12;
+      "externals_cache/pjproject-2.12.1.tar.bz2" = pjproject_2_12_1;
       "addons/mp3" = mp3-202;
     };
   }) (lib.importJSON ./versions.json);
@@ -136,6 +142,7 @@ in {
   # 16.x    LTS        2018-10-09  2022-10-09  2023-10-09
   # 18.x    LTS        2020-10-20  2024-10-20  2025-10-20
   # 19.x    Standard   2021-11-02  2022-11-02  2023-11-02
+  # 20.x    LTS        2022-11-02  2026-10-19  2027-10-19
   asterisk-lts = versions.asterisk_18;
   asterisk-stable = versions.asterisk_19;
   asterisk = versions.asterisk_19.overrideAttrs (o: {

--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -1,14 +1,18 @@
 {
   "asterisk_16": {
-    "sha256": "201c92e591fc1db2c71b264907beef594d62d660168d42b5e83f9dc593b1bce0",
-    "version": "16.26.1"
+    "sha256": "406a91290e18d25a6fc23ae6b9c56b1fb2bd70216e336c74cf9c26b908c89c3d",
+    "version": "16.29.0"
   },
   "asterisk_18": {
-    "sha256": "acbb58e5c3cd2b9c7c4506fa80b717c3c3c550ce9722ff0177b4f11f98725563",
-    "version": "18.12.1"
+    "sha256": "a963dafeba0e7e1051a1ac56964999c111dbcdb25a47010bc1f772bf8edbed75",
+    "version": "18.15.0"
   },
   "asterisk_19": {
-    "sha256": "6b0b985163f20fcc8f8878069b8a9ee725eef4cfbdb1c1031fe3840fb32d7abe",
-    "version": "19.4.1"
+    "sha256": "832a967c5a040b0768c0e8df1646762f7304019fcf7f2e065a8b4828fa4092b7",
+    "version": "19.7.0"
+  },
+  "asterisk_20": {
+    "sha256": "949022c20dc6da65b456e1b1b5b42a7901bb41fc9ce20920891739e7220d72eb",
+    "version": "20.0.0"
   }
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23489,7 +23489,7 @@ with pkgs;
 
   inherit (callPackages ../servers/asterisk { })
     asterisk asterisk-stable asterisk-lts
-    asterisk_16 asterisk_18 asterisk_19;
+    asterisk_16 asterisk_18 asterisk_19 asterisk_20;
 
   asterisk-module-sccp = callPackage ../servers/asterisk/sccp { };
 


### PR DESCRIPTION

###### Description of changes

Ran update script. Not changing lts,stable,default versions for 22.11 but they should change for 23.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
