### PR TITLE
Cinnamon 5.6

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -13,7 +13,9 @@
     <itemizedlist spacing="compact">
       <listitem>
         <para>
-          Create the first release note entry in this section!
+          Cinnamon has been updated to 5.6, see
+          <link xlink:href="https://github.com/NixOS/nixpkgs/pull/201328#issue-1449910204">the
+          pull request</link> for what is changed.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -8,7 +8,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- Cinnamon has been updated to 5.6, see [the pull request](https://github.com/NixOS/nixpkgs/pull/201328#issue-1449910204) for what is changed.
 
 ## New Services {#sec-release-23.05-new-services}
 

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -171,11 +171,10 @@ in
         # theme
         sound-theme-freedesktop
         nixos-artwork.wallpapers.simple-dark-gray
-        mint-artwork
+        mint-artwork # cursors
         mint-themes
         mint-x-icons
         mint-y-icons
-        vanilla-dmz
       ] config.environment.cinnamon.excludePackages);
 
       xdg.mime.enable = true;

--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "timeshift";
-  version = "22.06.5";
+  version = "22.11.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "timeshift";
     rev = version;
-    sha256 = "IHX/F3tnl3ckX20mnPHmuK/W4pRTFHzBUfaJg2sMpqc=";
+    sha256 = "JYYiqJzLszaCJSl7fDb9Oz8tdIYAnqEbJoRg4zw3wbg=";
   };
 
   patches = [

--- a/pkgs/applications/editors/xed-editor/default.nix
+++ b/pkgs/applications/editors/xed-editor/default.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xed-editor";
-  version = "3.2.7";
+  version = "3.2.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xed";
     rev = version;
-    sha256 = "sha256-aO5ilmlkSAxlkWYdSLmrcm7pC8GbITpCitd4TXp5tfY=";
+    sha256 = "sha256-ax769qjV0oZ6tnEE5FsXNbHETI6KNgvh0WviBsPs9j8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/video/hypnotix/default.nix
+++ b/pkgs/applications/video/hypnotix/default.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
       src = ./libmpv-path.patch;
       libmpv = "${lib.getLib mpv}/lib/libmpv${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
+
+    # Fix launching with mpv 0.35.0 (ubuntu 22.04 doesn't have libmpv.so.2)
+    # https://github.com/linuxmint/hypnotix/issues/254
+    ./fix-deprecated-mpv-detach-destroy.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/video/hypnotix/default.nix
+++ b/pkgs/applications/video/hypnotix/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hypnotix";
-  version = "2.9";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "hypnotix";
     rev = version;
-    hash = "sha256-jjCyO6lyhqH4xeNp5uy/KqNr5Mvv+45pJGHFOXNi0rk=";
+    hash = "sha256-ZSHChUkd1yXVGNUotzyZ9eB7s3apwvRmEJcO5J0vsZQ=";
   };
 
   patches = [

--- a/pkgs/applications/video/hypnotix/fix-deprecated-mpv-detach-destroy.patch
+++ b/pkgs/applications/video/hypnotix/fix-deprecated-mpv-detach-destroy.patch
@@ -1,0 +1,22 @@
+diff --git a/usr/lib/hypnotix/mpv.py b/usr/lib/hypnotix/mpv.py
+index f42a3be..db94bf6 100644
+--- a/usr/lib/hypnotix/mpv.py
++++ b/usr/lib/hypnotix/mpv.py
+@@ -528,7 +528,7 @@ _mpv_create = backend.mpv_create
+ _handle_func('mpv_create_client',           [c_char_p],                                 MpvHandle, notnull_errcheck)
+ _handle_func('mpv_client_name',             [],                                         c_char_p, errcheck=None)
+ _handle_func('mpv_initialize',              [],                                         c_int, ec_errcheck)
+-_handle_func('mpv_detach_destroy',          [],                                         None, errcheck=None)
++_handle_func('mpv_destroy',                 [],                                         None, errcheck=None)
+ _handle_func('mpv_terminate_destroy',       [],                                         None, errcheck=None)
+ _handle_func('mpv_load_config_file',        [c_char_p],                                 c_int, ec_errcheck)
+ _handle_func('mpv_get_time_us',             [],                                         c_ulonglong, errcheck=None)
+@@ -881,7 +881,7 @@ class MPV(object):
+                         self._message_handlers[target](*args)
+ 
+                 if eid == MpvEventID.SHUTDOWN:
+-                    _mpv_detach_destroy(self._event_handle)
++                    _mpv_destroy(self._event_handle)
+                     return
+ 
+             except Exception as e:

--- a/pkgs/desktops/cinnamon/cinnamon-common/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-common/default.nix
@@ -54,13 +54,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-common";
-  version = "5.4.12";
+  version = "5.6.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cinnamon";
     rev = version;
-    hash = "sha256-uyQZXri3V3dKnowB97QlPWboZz1neblyvCuSacsPROg=";
+    hash = "sha256-JvdbapOJq2w0tObnGd8t+SLruWN0sblKhSf2dlHR9Go=";
   };
 
   patches = [
@@ -136,7 +136,9 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  # use locales from cinnamon-translations (not using --localedir because datadir is used)
+  # Use locales from cinnamon-translations.
+  # FIXME: Upstream does not respect localedir option from Meson currently.
+  # https://github.com/linuxmint/cinnamon/pull/11244#issuecomment-1305855783
   postInstall = ''
     ln -s ${cinnamon-translations}/share/locale $out/share/locale
   '';
@@ -149,26 +151,16 @@ stdenv.mkDerivation rec {
 
     sed "s|/usr/share/sounds|/run/current-system/sw/share/sounds|g" -i ./files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
 
-    sed "s|/usr/bin/upload-system-info|${xapp}/bin/upload-system-info|g" -i ./files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
     sed "s|\"upload-system-info\"|\"${xapp}/bin/upload-system-info\"|g" -i ./files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
-
-    sed "s|/usr/bin/cinnamon-control-center|${cinnamon-control-center}/bin/cinnamon-control-center|g" -i ./files/usr/bin/cinnamon-settings
 
     sed "s|/usr/bin/cinnamon-screensaver-command|/run/current-system/sw/bin/cinnamon-screensaver-command|g" \
       -i ./files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js -i ./files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
 
-    # this one really IS optional
-    sed "s|/usr/bin/gnome-control-center|/run/current-system/sw/bin/gnome-control-center|g" -i ./files/usr/bin/cinnamon-settings
-
     sed "s|\"/usr/lib\"|\"${cinnamon-control-center}/lib\"|g" -i ./files/usr/share/cinnamon/cinnamon-settings/bin/capi.py
-
-    # another bunch of optional stuff
-    sed "s|/usr/bin|/run/current-system/sw/bin|g" -i ./files/usr/bin/cinnamon-launcher
 
     sed 's|"lspci"|"${pciutils}/bin/lspci"|g' -i ./files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
 
     sed "s| cinnamon-session| ${cinnamon-session}/bin/cinnamon-session|g" -i ./files/usr/bin/cinnamon-session-cinnamon  -i ./files/usr/bin/cinnamon-session-cinnamon2d
-    sed "s|/usr/bin|$out/bin|g" -i ./files/usr/share/xsessions/cinnamon.desktop ./files/usr/share/xsessions/cinnamon2d.desktop ./files/usr/share/applications/cinnamon2d.desktop
 
     sed "s|msgfmt|${gettext}/bin/msgfmt|g" -i ./files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
 

--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -9,7 +9,6 @@
 , libnotify
 , libxml2
 , gnome-online-accounts
-, cinnamon-settings-daemon
 , colord
 , polkit
 , libxkbfile
@@ -36,13 +35,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-control-center";
-  version = "5.4.7";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-38n1QCygkBq+wOLwui1oF6MtDWxAFWxp5U1omSVtbro=";
+    hash = "sha256-WK35uDckIYU4HwuYtLj+CFVJD8O78LTQcnOvjp/et2s=";
   };
 
   buildInputs = [
@@ -56,7 +55,6 @@ stdenv.mkDerivation rec {
     libgnomekbd
     libxklavier
     colord
-    cinnamon-settings-daemon
     libgudev
     libwacom
     gnome-online-accounts
@@ -75,10 +73,6 @@ stdenv.mkDerivation rec {
     ./panels/datetime/tz.h:34:#  define TZ_DATA_FILE "/usr/share/lib/zoneinfo/tab/zone_sun.tab" */
 
   postPatch = ''
-    find . -type f -exec sed -i \
-      -e s,/usr/share/locale,/run/current-system/sw/share/locale,g \
-      {} +
-
     sed 's|TZ_DIR "/usr/share/zoneinfo/"|TZ_DIR "${tzdata}/share/zoneinfo/"|g' -i ./panels/datetime/test-timezone.c
     sed 's|TZ_DATA_FILE "/usr/share/zoneinfo/zone.tab"|TZ_DATA_FILE "${tzdata}/share/zoneinfo/zone.tab"|g' -i ./panels/datetime/tz.h
     sed 's|"/usr/share/i18n/locales/"|"${glibc}/share/i18n/locales/"|g' -i panels/datetime/test-endianess.c

--- a/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-control-center/default.nix
@@ -80,26 +80,10 @@ stdenv.mkDerivation rec {
     patchShebangs meson_install_schemas.py
   '';
 
-  # it needs to have access to that file, otherwise we can't run tests after build
-
-  preBuild = ''
-    mkdir -p $out/share/cinnamon-control-center/
-    ln -s $PWD/panels/datetime $out/share/cinnamon-control-center/
-  '';
-
   mesonFlags = [
-    # TODO: https://github.com/NixOS/nixpkgs/issues/36468
-    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
     # use locales from cinnamon-translations
     "--localedir=${cinnamon-translations}/share/locale"
   ];
-
-  preInstall = ''
-    rm -r $out
-  '';
-
-  # the only test is wacom-calibrator and it seems to need an xserver and prob more services aswell
-  doCheck = false;
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/desktops/cinnamon/cinnamon-desktop/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-desktop/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-desktop";
-  version = "5.4.2";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-U05JiW6PaRAEEQ/uq3wmZSQGohMz4M86Ji9pBl2Azg8=";
+    hash = "sha256-ajtKvy9CMr+Vsmdn49ZWYtbniZV1dqWJGTou3QY4oPc=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/cinnamon/cinnamon-menus/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-menus/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-menus";
-  version = "5.4.0";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-Q4bgaX8nGSWHKHR3+hFTlHtNhSmZW8ZEHi8DaXKQ+fM=";
+    hash = "sha256-6IOlXQhAy6YrSqybfGFUyn3Q2COvzwpj67y/k/YLNhU=";
   };
 
   buildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-screensaver";
-  version = "5.4.4";
+  version = "5.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-D+SpAO4i4KGFWJI94LalTMB3j1YPvV63cKb34FDDprk=";
+    hash = "sha256-dnfUvRlmsdUXfjAxPv+i/uJ8kr0LQ/i7ClUMtjjIWMo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-session/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-session/default.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-session";
-  version = "5.4.0";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-m16nf3eC15ZT8eDvRTylBfxsnShkU1Sm8J9qcRGeGQo=";
+    hash = "sha256-lyASp0jFwaPLPQ3Jnow6eTpUBybwhSEmQUK/20fsh7I=";
   };
 
   patches = [

--- a/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
@@ -32,13 +32,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-settings-daemon";
-  version = "5.4.5";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-qjI1z1MuaI5JFqjHap/+aYDQ0YuP9VNnnY6vy/AaKqs=";
+    hash = "sha256-VUGOBvMInruX1JVk9ECP8++FUrBQwDJhkZT/1pPg2wU=";
   };
 
   patches = [

--- a/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-translations";
-  version = "5.4.2";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-vt60qarNfTX9R5kGOeUBCskKK2zLdEE+ACT0EGvUeao=";
+    hash = "sha256-ztHHqX0OuwSFGlxCoJhZXnUsMM0WrkwiQINgDVlb0XA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cjs/default.nix
+++ b/pkgs/desktops/cinnamon/cjs/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cjs";
-  version = "5.4.1";
+  version = "5.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "cjs";
     rev = version;
-    hash = "sha256-8LIVM9+Wt9V7iKUwqTBUTf8LiQ16NE3CYtCJknjl56o=";
+    hash = "sha256-f9esbQi5WWSMAGlEs9HJFToOvmOrbP2lDW1gGh/48gw=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/cinnamon/mint-artwork/default.nix
+++ b/pkgs/desktops/cinnamon/mint-artwork/default.nix
@@ -7,11 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-artwork";
-  version = "1.6.0";
+  version = "1.6.8";
 
   src = fetchurl {
-    url = "http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz";
-    hash = "sha256-un5T56zzN2vRVp42RHczDEKwrweSeygASkFJU5LXCDo=";
+    urls = [
+      "http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz"
+      "https://web.archive.org/web/20221129013553/http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz"
+    ];
+    hash = "sha256-HPnb5Mb6tvzREZbW9SyDNQ6ST6RPmOUVdA9MW8oyRAM=";
   };
 
   nativeBuildInputs = [
@@ -25,9 +28,7 @@ stdenv.mkDerivation rec {
     find . -type f -exec sed -i \
       -e s,/usr/share/backgrounds/linuxmint/default_background.jpg,${nixos-artwork.wallpapers.simple-dark-gray}/share/artwork/gnome/nix-wallpaper-simple-dark-gray.png,g \
       -e s,/usr/share,$out/share,g \
-      -e s,DMZ-White,Vanilla-DMZ,g \
-      -e s,DMZ-Black,Vanilla-DMZ-AA,g \
-      -e s,linuxmint-logo-5,cinnamon-symbolic,g \
+      -e s,linuxmint-logo-ring-symbolic,cinnamon-symbolic,g \
       {} +
 
     # fixup broken symlink

--- a/pkgs/desktops/cinnamon/mint-themes/default.nix
+++ b/pkgs/desktops/cinnamon/mint-themes/default.nix
@@ -1,20 +1,19 @@
 { fetchFromGitHub
 , lib
-, stdenv
+, stdenvNoCC
 , python3
 , sassc
 , sass
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "mint-themes";
   version = "2.0.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
-    # they don't exactly do tags, it's just a named commit
-    rev = "3a202e401abca98623cd1dbc412221682081244c";
+    rev = version;
     hash = "sha256-OgyLNc6gwMn7dG5/T67Toiqsij1rJYV6k6Un2cgr2oQ=";
   };
 

--- a/pkgs/desktops/cinnamon/mint-themes/default.nix
+++ b/pkgs/desktops/cinnamon/mint-themes/default.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-themes";
-  version = "2.0.5";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-OgyLNc6gwMn7dG5/T67Toiqsij1rJYV6k6Un2cgr2oQ=";
+    hash = "sha256-3DwD1JVzl7446Fn+XMxwh2WA72ks4esnrLpyYBF9xWc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-x-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-x-icons/default.nix
@@ -1,6 +1,6 @@
 { fetchFromGitHub
 , lib
-, stdenv
+, stdenvNoCC
 , gnome
 , gnome-icon-theme
 , hicolor-icon-theme
@@ -9,15 +9,14 @@
 , ubuntu-themes
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "mint-x-icons";
   version = "1.6.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
-    # they don't exactly do tags, it's just a named commit
-    rev = "4ab3c314db1b3751d87d5769629b28ac0ca3c671";
+    rev = version;
     hash = "sha256-cPRae3EjzVtAL1Ei2LB4UNUU/m87mFT94xY/NnNR6JM=";
   };
 

--- a/pkgs/desktops/cinnamon/mint-y-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-y-icons/default.nix
@@ -1,21 +1,20 @@
 { fetchFromGitHub
 , lib
-, stdenv
+, stdenvNoCC
 , gnome
 , gnome-icon-theme
 , hicolor-icon-theme
 , gtk3
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "mint-y-icons";
   version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
-    # they don't exactly do tags, it's just a named commit
-    rev = "57d16eb85f2af40be17e2232d279bb65b689f5b7";
+    rev = version;
     hash = "sha256-voFYz0MiuqyNSngi4QZUJKDIjggQWOAV5B30zMP8iTk=";
   };
 

--- a/pkgs/desktops/cinnamon/mint-y-icons/default.nix
+++ b/pkgs/desktops/cinnamon/mint-y-icons/default.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.6.1";
+  version = "1.6.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-voFYz0MiuqyNSngi4QZUJKDIjggQWOAV5B30zMP8iTk=";
+    hash = "sha256-XnQcVlN4xtZQDjijNV09m2m0ODYfFbrQaNd8ZQVToIw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/cinnamon/muffin/default.nix
+++ b/pkgs/desktops/cinnamon/muffin/default.nix
@@ -35,7 +35,7 @@
 
 stdenv.mkDerivation rec {
   pname = "muffin";
-  version = "5.4.7";
+  version = "5.6.0";
 
   outputs = [ "out" "dev" "man" ];
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-Zx6au1FXLgK8PRmkh8jaGJ3Zh0YYFj2zmbxhgXAFgDg=";
+    hash = "sha256-vUkxR3HfzubaOoXxo6xHDLLy+zVBYE9i5s+yp1rbJaw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation rec {
   pname = "nemo";
-  version = "5.4.3";
+  version = "5.6.0";
 
   # TODO: add plugins support (see https://github.com/NixOS/nixpkgs/issues/78327)
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-f3rO0lpOcwpSpIpKrslf6/6nqFbbGTwnKbHpWO+Uf+Q=";
+    sha256 = "sha256-+JrfFqKZhzYOyp7z2x22bw2f8Gip7Qh8d30tC7LWHEU=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/cinnamon/pix/default.nix
+++ b/pkgs/desktops/cinnamon/pix/default.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pix";
-  version = "2.8.7";
+  version = "2.8.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-aID0jxOMFegkcAflTY0VevZyN1HFivkTFi3has8MOY0=";
+    sha256 = "sha256-dvxbnf6tvBAwYM0EKpd/mPfW2PXeV1H2khYl8LIJqa0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/xapp/default.nix
+++ b/pkgs/desktops/cinnamon/xapp/default.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xapp";
-  version = "2.2.15";
+  version = "2.4.1";
 
   outputs = [ "out" "dev" ];
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-X/exXQY/v+TU8HnnquleP21tCYR9h7t43AIw4tTKVOY=";
+    hash = "sha256-c86n3aYSS3Klm2HtN8dIN5UvL6Jxz9y1fMF1QAefCIg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/xreader/default.nix
+++ b/pkgs/desktops/cinnamon/xreader/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xreader";
-  version = "3.4.5";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-lRtBxqD45/3Wjp0Sq8A0L3Zmg33Pq6iIsA8jeywnDBc=";
+    sha256 = "sha256-CXhktA0BvJ0mczhH6kTOMzLeDG9rThy3g3VOcOWlBDw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/xviewer/default.nix
+++ b/pkgs/desktops/cinnamon/xviewer/default.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xviewer";
-  version = "3.2.10";
+  version = "3.2.11";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    sha256 = "sha256-c3K9yjeaAlyXqgxzHgnLXgqwaB5Fdw+mS9jricy8QA8=";
+    sha256 = "sha256-EyrK4mnAHt/Lypuz7XX7+GFGfkfC5VDIit2WYZawI04=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/xapp/default.nix
+++ b/pkgs/development/python-modules/xapp/default.nix
@@ -1,6 +1,9 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
+, python
+, meson
+, ninja
 , psutil
 , pygobject3
 , gtk3
@@ -11,14 +14,21 @@
 
 buildPythonPackage rec {
   pname = "xapp";
-  version = "2.2.2";
+  version = "2.4.0";
+
+  format = "other";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "python-xapp";
     rev = version;
-    hash = "sha256-ntjJ/O6HiRZMsqsuQY4HLM4fBE0aWpn/L4n5YCRlhhg=";
+    hash = "sha256-qEK71cGNGmaThxlFVsfnLUTD83RTr8GP+501c4UbHCk=";
   };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
 
   propagatedBuildInputs = [
     psutil
@@ -31,6 +41,13 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace "xapp/os.py" --replace "/usr/bin/pkexec" "${polkit}/bin/pkexec"
+  '';
+
+  postInstall = ''
+    # This is typically set by pipInstallHook/eggInstallHook,
+    # so we have to do so manually when using meson.
+    # https://github.com/NixOS/nixpkgs/issues/175227
+    export PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
 
   doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12053,6 +12053,7 @@ self: super: with self; {
   };
 
   xapp = callPackage ../development/python-modules/xapp {
+    inherit (pkgs.buildPackages) meson;
     inherit (pkgs) gtk3 gobject-introspection polkit;
     inherit (pkgs.cinnamon) xapp;
   };


### PR DESCRIPTION
**Update:**
Please also read https://www.linuxmint.com/rel_vera_cinnamon_whatsnew.php

---

This PR updates Cinnamon to 5.6, which is part of Linux Mint 21.1.

#### Lots of cosmetic changes!

Cosmetic changes are "design changes" (e.g. what theme, color, etc to use). Those changes are made by Linux Mint and we don't do random modifications, report to upstream if you don't like the changes. For items marked with *, you are only affected if you didn't set the related keys explicitly before and you can go back to old settings by using `gsettings`.

The following change set are generated from mint-artwork 1.6.5, cinnamon-common 5.6.2, nemo 5.6.0, mint-y-icons 1.6.3, things can still change in follow-up updates.

- The default cursor theme is now a mint-modified Bibata-Modern-Classic (see [this issue](https://github.com/ful1e5/Bibata_Cursor/issues?q=Linux+Mint%2C+sponsoring+and+pull+requests)), provided by mint-artwork. See change log from [mint-artwork](http://packages.linuxmint.com/pool/main/m/mint-artwork/) (download the `*.tar.xz` file and go to `debian/` folder) for more info. Note that we are removing `vanilla-dmz` from the module.
- \* The default GTK theme and icon theme is now Mint-Y-Aqua, it is changed by mint-artwork.
- \* Home/trash/network desktop icons are no longer presented on desktop, this is announced in [Sep news](https://blog.linuxmint.com/?p=4408), still changed by mint-artwork.
- Nemo no longer highlight selected icons, this is announced in [Oct news](https://blog.linuxmint.com/?p=4424), changed by https://github.com/linuxmint/nemo/commit/fdd47db7a7399ae12e21912fa33bd81cd1ba0eac.
- \* There is a new cornerbar applet that replaces show-desktop, changed by https://github.com/linuxmint/cinnamon/commit/cd47f9aef5c383a108c5f77098d3c602b2e0bc86.
- The places icon set has been switched to a Papirus based one, now you might see yellow folder icons everywhere, changed by https://github.com/linuxmint/mint-y-icons/commit/7f804620de2955d7d91e60ddfa1bdfb1fcd967b0.
- The Mint-Y-Yellow theme is gone, changed by https://github.com/linuxmint/mint-y-icons/commit/41fcdb33cd845861e14ab595d0c27259b50459b9.

If some of your settings are "changed" / "broken" after this update, reconfigure them in the cinnamon-settings app.