### PR TITLE
linkFarm: make last entry win in case of list repeats

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -489,7 +489,8 @@ rec {
   let
     entries' =
       if (lib.isAttrs entries) then entries
-      else if (lib.isList entries) then lib.listToAttrs (map (x: lib.nameValuePair x.name x.path) entries)
+      # We do this foldl to have last-wins semantics in case of repeated entries
+      else if (lib.isList entries) then lib.foldl (a: b: a // { "${b.name}" = b.path; }) { } entries
       else throw "linkFarm entries must be either attrs or a list!";
 
     linkCommands = lib.mapAttrsToList (name: path: ''

--- a/pkgs/build-support/trivial-builders/test/link-farm.nix
+++ b/pkgs/build-support/trivial-builders/test/link-farm.nix
@@ -1,0 +1,45 @@
+{ linkFarm, hello, writeTextFile, runCommand }:
+let
+  foo = writeTextFile {
+    name = "foo";
+    text = "foo";
+  };
+
+  linkFarmFromList = linkFarm "linkFarmFromList" [
+    { name = "foo"; path = foo; }
+    { name = "hello"; path = hello; }
+  ];
+
+  linkFarmWithRepeats = linkFarm "linkFarmWithRepeats" [
+    { name = "foo"; path = foo; }
+    { name = "hello"; path = hello; }
+    { name = "foo"; path = hello; }
+  ];
+
+  linkFarmFromAttrs = linkFarm "linkFarmFromAttrs" {
+    inherit foo hello;
+  };
+in
+runCommand "test-linkFarm" { } ''
+  function assertPathEquals() {
+    local a b;
+    a="$(realpath "$1")"
+    b="$(realpath "$2")"
+    if [ "$a" != "$b" ]; then
+      echo "path mismatch!"
+      echo "a: $1 -> $a"
+      echo "b: $2 -> $b"
+      exit 1
+    fi
+  }
+
+  assertPathEquals "${linkFarmFromList}/foo" "${foo}"
+  assertPathEquals "${linkFarmFromList}/hello" "${hello}"
+
+  assertPathEquals "${linkFarmWithRepeats}/foo" "${hello}"
+  assertPathEquals "${linkFarmWithRepeats}/hello" "${hello}"
+
+  assertPathEquals "${linkFarmFromAttrs}/foo" "${foo}"
+  assertPathEquals "${linkFarmFromAttrs}/hello" "${hello}"
+  touch $out
+''

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -67,6 +67,7 @@ with pkgs;
     references = callPackage ../build-support/trivial-builders/test/references.nix {};
     overriding = callPackage ../build-support/trivial-builders/test-overriding.nix {};
     concat = callPackage ../build-support/trivial-builders/test/concat-test.nix {};
+    linkFarm = callPackage ../build-support/trivial-builders/test/link-farm.nix {};
   };
 
   writers = callPackage ../build-support/writers/test.nix {};


### PR DESCRIPTION
###### Description of changes

Small follow-up to #170048 which should fix the tests.

I think the semantics of last-wins in case of repeats in the list makes more
sense than the default of `listToAttrs`, which is first-wins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
