### PR TITLE
python3Packages.latexify-py: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/latexify-py/default.nix
+++ b/pkgs/development/python-modules/latexify-py/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hatchling
+, dill
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "latexify-py";
+  version = "0.2.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "latexify_py";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-b0/cKMfIONVd6A5AYRyLx/qsFVpUjeAsadQyu/mPYxo=";
+  };
+
+  nativeBuildInputs = [ hatchling ];
+
+  propagatedBuildInputs = [ dill ];
+
+  preCheck = ''
+    cd src
+  '';
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "latexify" ];
+
+  meta = with lib; {
+    description = "Generates LaTeX math description from Python functions";
+    homepage = "https://github.com/google/latexify_py";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5055,6 +5055,8 @@ self: super: with self; {
 
   latexcodec = callPackage ../development/python-modules/latexcodec { };
 
+  latexify-py = callPackage ../development/python-modules/latexify-py { };
+
   launchpadlib = callPackage ../development/python-modules/launchpadlib { };
 
   laundrify-aio = callPackage ../development/python-modules/laundrify-aio { };


### PR DESCRIPTION
###### Description of changes

- new package

![FhkFrL_UYAILNkx](https://user-images.githubusercontent.com/42201/201987247-a7dc8b61-b382-45a5-b559-ad673cf0ae1a.jpeg)



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
