### PR TITLE
libmodbus: 3.1.7 → 3.1.8, enable on darwin

### DIFF
--- a/pkgs/development/libraries/libmodbus/default.nix
+++ b/pkgs/development/libraries/libmodbus/default.nix
@@ -1,13 +1,17 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "libmodbus";
-  version = "3.1.7";
+  version = "3.1.8";
 
-  src = fetchurl {
-    url = "http://libmodbus.org/releases/libmodbus-${version}.tar.gz";
-    sha256 = "sha256-ff6VhDHQVwsnHhpbMpt2pljonGFM8RnrWq23Jch/j70=";
+  src = fetchFromGitHub {
+    owner = "stephane";
+    repo = "libmodbus";
+    rev = "v${version}";
+    hash = "sha256-rIsMTSyctPZmIh6hFeL3MxyNzey0+iOc2lbBKTkE7To=";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags = [
     # when cross-compiling we assume that the host system will return a valid
@@ -23,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Library to send/receive data according to the Modbus protocol";
     homepage = "https://libmodbus.org/";
     license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/stephane/libmodbus/releases/tag/v3.1.8)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
