### PR TITLE
pocket-casts: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/applications/audio/pocket-casts/default.nix
+++ b/pkgs/applications/audio/pocket-casts/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pocket-casts";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchurl {
     url = "https://github.com/felicianotech/pocket-casts-desktop-app/releases/download/v${version}/${pname}_${version}_amd64.deb";
-    sha256 = "sha256-frBtIxwRO/6k6j0itqN10t+9AyNadqXm8vC1YP960ts=";
+    sha256 = "sha256-nHdF9RDOkM9HwwmK/axiIPM4nmKrWp/FHNC/EI1vTTc=";
   };
 
   nativeBuildInputs = [
@@ -18,31 +18,32 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ alsa-lib gtk3 libXScrnSaver libXtst mesa nss ];
 
-  dontBuild = true;
-  dontConfigure = true;
-
-  unpackPhase = ''
-    dpkg-deb -x ${src} ./
+  unpackCmd = ''
+    # If unpacking using -x option, there is a permission error
+    dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner;
   '';
 
   installPhase = ''
     runHook preInstall
 
-    mv usr $out
-    mv opt $out
-    mv "$out/opt/Pocket Casts" $out/opt/pocket-casts
-    mv $out/share/icons/hicolor/0x0 $out/share/icons/hicolor/256x256
+    mkdir -p $out
+    mv bin $out
+    mv lib $out
+    mv share $out
+
+    cp $out/lib/pocket-casts/resources/app/icon.png $out/share/pixmaps/pocket-casts.png
 
     runHook postInstall
   '';
 
   postFixup = ''
     substituteInPlace $out/share/applications/pocket-casts.desktop \
-      --replace '"/opt/Pocket Casts/pocket-casts"' $out/bin/pocket-casts \
-      --replace '/usr/share/icons/hicolor/0x0/apps/pocket-casts.png' "pocket-casts"
+      --replace Name=pocket-casts "Name=Pocket Casts" \
+      --replace GenericName=pocket-casts "GenericName=Podcasts App" \
+      --replace Exec=pocket-casts Exec=$out/bin/pocket-casts
     makeWrapper ${electron}/bin/electron \
       $out/bin/pocket-casts \
-      --add-flags $out/opt/pocket-casts/resources/app.asar
+      --add-flags $out/lib/pocket-casts/resources/app/main.js
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4762,9 +4762,7 @@ with pkgs;
 
   pn = callPackage ../tools/text/pn { };
 
-  pocket-casts = callPackage ../applications/audio/pocket-casts {
-    electron = electron_14;
-  };
+  pocket-casts = callPackage ../applications/audio/pocket-casts { };
 
   pouf = callPackage ../tools/misc/pouf { };
 


### PR DESCRIPTION
###### Description of changes

Closes #175999 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
