### PR TITLE
d-seams: fix failing build

### DIFF
--- a/pkgs/applications/science/chemistry/d-seams/default.nix
+++ b/pkgs/applications/science/chemistry/d-seams/default.nix
@@ -1,4 +1,4 @@
-{ clangStdenv, fetchFromGitHub, catch2, rang, fmt, libyamlcpp, cmake
+{ clangStdenv, fetchFromGitHub, fetchpatch, catch2, rang, fmt, libyamlcpp, cmake
 , eigen, lua, luaPackages, liblapack, blas, lib, boost, gsl }:
 
 clangStdenv.mkDerivation rec {
@@ -12,6 +12,13 @@ clangStdenv.mkDerivation rec {
     sha256 = "03zhhl9vhi3rhc3qz1g3zb89jksgpdlrk15fcr8xcz8pkj6r5b1i";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "use_newer_cxxopts_which_builds_with_clang11.patch";
+      url = "https://github.com/d-SEAMS/seams-core/commit/f6156057e43d0aa1a0df9de67d8859da9c30302d.patch";
+      hash = "sha256-PLbT1lqdw+69lIHH96MPcGRjfIeZyb88vc875QLYyqw=";
+    })
+  ];
   nativeBuildInputs = [ cmake lua luaPackages.luafilesystem ];
   buildInputs = [ fmt rang libyamlcpp eigen catch2 boost gsl liblapack blas ];
 


### PR DESCRIPTION
`cxxopts` failing to build with clang11:

```
/build/source/src/include/external/cxxopts.hpp:488:42: error: no member named 'numeric_limits' in namespace 'std'
            if (u > static_cast<U>(-std::numeric_limits<T>::min()))
```

Use the [patch](https://github.com/d-SEAMS/seams-core/commit/f6156057e43d0aa1a0df9de67d8859da9c30302d) from upstream, which updates cxxopts 2.2.0 -> 3.0.0

ZHF: https://github.com/NixOS/nixpkgs/issues/199919

###### Description of changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
