### PR TITLE
python310Packages.smpplib: use pytestCheckHook, remove tox requirement

### DIFF
--- a/pkgs/development/python-modules/smpplib/default.nix
+++ b/pkgs/development/python-modules/smpplib/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchPypi, lib, python, six, tox, mock, pytest }:
+{ buildPythonPackage, fetchPypi, lib, python, six, mock, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "smpplib";
@@ -10,11 +10,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six ];
-  checkInputs = [ tox mock pytest ];
-
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [ mock pytestCheckHook ];
 
   postInstall = ''
     rm -rf $out/${python.sitePackages}/tests

--- a/pkgs/development/python-modules/smpplib/default.nix
+++ b/pkgs/development/python-modules/smpplib/default.nix
@@ -1,4 +1,11 @@
-{ buildPythonPackage, fetchPypi, lib, python, six, mock, pytestCheckHook }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, six
+, mock
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "smpplib";
@@ -9,17 +16,27 @@ buildPythonPackage rec {
     sha256 = "c0b01947b47e404f42ccb59e906b6e4eb507963c971d59b44350db0f29c76166";
   };
 
-  propagatedBuildInputs = [ six ];
-  checkInputs = [ mock pytestCheckHook ];
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
 
   postInstall = ''
     rm -rf $out/${python.sitePackages}/tests
   '';
 
+  pythonImportsCheck = [
+    "smpplib"
+  ];
+
   meta = with lib; {
     description = "SMPP library for Python";
     homepage = "https://github.com/python-smpplib/python-smpplib";
     license = licenses.lgpl3Plus;
-    maintainers = [ maintainers.globin ];
+    maintainers = with maintainers; [ globin ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
