### PR TITLE
lib/strings.nix: add meson-related utilities

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -101,6 +101,7 @@ let
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
       getName getVersion
+      mesonOption mesonBool mesonEnable
       nameFromURL enableFeature enableFeatureAs withFeature
       withFeatureAs fixedWidthString fixedWidthNumber isStorePath
       toInt toIntBase10 readPathsFromFile fileContents;

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -661,6 +661,61 @@ rec {
       name = head (splitString sep filename);
     in assert name != filename; name;
 
+  /* Create a -D<feature>=<value> string that can be passed to typical Meson
+     invocations.
+
+    Type: mesonOption :: string -> string -> string
+
+     @param feature The feature to be set
+     @param value The desired value
+
+     Example:
+       mesonOption "engine" "opengl"
+       => "-Dengine=opengl"
+  */
+  mesonOption = feature: value:
+    assert (lib.isString feature);
+    assert (lib.isString value);
+    "-D${feature}=${value}";
+
+  /* Create a -D<condition>={true,false} string that can be passed to typical
+     Meson invocations.
+
+    Type: mesonBool :: string -> bool -> string
+
+     @param condition The condition to be made true or false
+     @param flag The controlling flag of the condition
+
+     Example:
+       mesonBool "hardened" true
+       => "-Dhardened=true"
+       mesonBool "static" false
+       => "-Dstatic=false"
+  */
+  mesonBool = condition: flag:
+    assert (lib.isString condition);
+    assert (lib.isBool flag);
+    mesonOption condition (lib.boolToString flag);
+
+  /* Create a -D<feature>={enabled,disabled} string that can be passed to
+     typical Meson invocations.
+
+    Type: mesonEnable :: string -> bool -> string
+
+     @param feature The feature to be enabled or disabled
+     @param flag The controlling flag
+
+     Example:
+       mesonEnable "docs" true
+       => "-Ddocs=enabled"
+       mesonEnable "savage" false
+       => "-Dsavage=disabled"
+  */
+  mesonEnable = feature: flag:
+    assert (lib.isString feature);
+    assert (lib.isBool flag);
+    mesonOption feature (if flag then "enabled" else "disabled");
+
   /* Create an --{enable,disable}-<feat> string that can be passed to
      standard GNU Autoconf scripts.
 

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -100,20 +100,20 @@ in stdenv.mkDerivation rec {
   NIX_LDFLAGS = lib.optionalString x11Support "-lX11 -lXext ";
 
   mesonFlags = let
-    mesonFeatureFlag = feature: flag: "-D${feature}=${if flag then "enabled" else "disabled"}";
+    inherit (lib) mesonOption mesonBool mesonEnable;
   in [
-    "-Ddefault_library=shared"
-    "-Dlibmpv=true"
-    (mesonFeatureFlag "libarchive" archiveSupport)
-    (mesonFeatureFlag "manpage-build" true)
-    (mesonFeatureFlag "cdda" cddaSupport)
-    (mesonFeatureFlag "dvbin" dvbinSupport)
-    (mesonFeatureFlag "dvdnav" dvdnavSupport)
-    (mesonFeatureFlag "openal" openalSupport)
-    (mesonFeatureFlag "sdl2" sdl2Support)
+    (mesonOption "default_library" "shared")
+    (mesonBool "libmpv" true)
+    (mesonEnable "libarchive" archiveSupport)
+    (mesonEnable "manpage-build" true)
+    (mesonEnable "cdda" cddaSupport)
+    (mesonEnable "dvbin" dvbinSupport)
+    (mesonEnable "dvdnav" dvdnavSupport)
+    (mesonEnable "openal" openalSupport)
+    (mesonEnable "sdl2" sdl2Support)
     # Disable whilst Swift isn't supported
-    (mesonFeatureFlag "swift-build" swiftSupport)
-    (mesonFeatureFlag "macos-cocoa-cb" swiftSupport)
+    (mesonEnable "swift-build" swiftSupport)
+    (mesonEnable "macos-cocoa-cb" swiftSupport)
   ];
 
   mesonAutoFeatures = "auto";
@@ -125,10 +125,10 @@ in stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-  ] ++ lib.optionals stdenv.isDarwin [
-    xcbuild.xcrun
-  ] ++ lib.optionals swiftSupport [ swift ]
-    ++ lib.optionals waylandSupport [ wayland-scanner ];
+  ]
+  ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun ]
+  ++ lib.optionals swiftSupport [ swift ]
+  ++ lib.optionals waylandSupport [ wayland-scanner ];
 
   buildInputs = [
     ffmpeg

--- a/pkgs/development/tools/build-managers/muon/default.nix
+++ b/pkgs/development/tools/build-managers/muon/default.nix
@@ -81,14 +81,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   buildPhase = let
-    muonFeatureFlag = feature: flag:
-      "-D${feature}=${if flag then "enabled" else "disabled"}";
-    muonConditionFlag = condition: flag:
-      "-D${condition}=${lib.boolToString flag}";
+    muonBool = lib.mesonBool;
+    muonEnable = lib.mesonEnable;
+
     cmdlineForMuon = lib.concatStringsSep " " [
-      (muonConditionFlag "static" stdenv.targetPlatform.isStatic)
-      (muonFeatureFlag "docs" buildDocs)
-      (muonFeatureFlag "samurai" embedSamurai)
+      (muonBool "static" stdenv.targetPlatform.isStatic)
+      (muonEnable "docs" buildDocs)
+      (muonEnable "samurai" embedSamurai)
     ];
     cmdlineForSamu = "-j$NIX_BUILD_CORES";
   in ''

--- a/pkgs/tools/wayland/slurp/default.nix
+++ b/pkgs/tools/wayland/slurp/default.nix
@@ -1,29 +1,29 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, cairo
+, libxkbcommon
 , meson
 , ninja
 , pkg-config
-, cairo
-, libxkbcommon
+, scdoc
 , wayland
 , wayland-protocols
 , wayland-scanner
-, buildDocs ? true, scdoc
+, buildDocs ? true
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "slurp";
-  version = "1.3.2";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = "slurp";
-    rev = "v${version}";
-    sha256 = "sha256-5ZB34rqLyZmfjT/clxNRDmF0qgITFZ5xt/gIEXQzvQE=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-jUuY2wuN00libHDaJEmrvQAb1o989Ly3nLyKHV0jz8Q=";
   };
 
-  strictDeps = true;
   nativeBuildInputs = [
     meson
     ninja
@@ -38,13 +38,16 @@ stdenv.mkDerivation rec {
     wayland-protocols
   ];
 
-  mesonFlags = lib.optional buildDocs "-Dman-pages=enabled";
+  strictDeps = true;
+
+  mesonFlags = [ (lib.mesonEnable "man-pages" buildDocs) ];
 
   meta = with lib; {
-    description = "Select a region in a Wayland compositor";
     homepage = "https://github.com/emersion/slurp";
+    description = "Select a region in a Wayland compositor";
+    changelog = "https://github.com/emersion/slurp/releases/tag/v${finalAttrs.version}";
     license = licenses.mit;
     maintainers = with maintainers; [ buffet ];
-    platforms = platforms.linux;
+    inherit (wayland.meta) platforms;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
