### PR TITLE
tensorflow-bin: Support macos arm64

### DIFF
--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -51,7 +51,7 @@ in buildPythonPackage {
 
   src = let
     pyVerNoDot = lib.strings.stringAsChars (x: if x == "." then "" else x) python.pythonVersion;
-    platform = if stdenv.isDarwin then "mac" else "linux";
+    platform = if stdenv.isDarwin && stdenv.isAarch64 then "macarm" else if stdenv.isDarwin then "mac" else "linux";
     unit = if cudaSupport then "gpu" else "cpu";
     key = "${platform}_py_${pyVerNoDot}_${unit}";
   in fetchurl packages.${key};
@@ -112,7 +112,9 @@ in buildPythonPackage {
         -e "/Requires-Dist: tensorflow-io-gcs-filesystem/d"
     )
     wheel pack ./unpacked/tensorflow*
-    mv *.whl $orig_name # avoid changes to the _os_arch.whl suffix
+    if [[ ! -e $orig_name ]]; then
+        mv *.whl $orig_name # avoid changes to the _os_arch.whl suffix
+    fi
 
     popd
   '';
@@ -197,6 +199,6 @@ in buildPythonPackage {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.asl20;
     maintainers = with maintainers; [ jyp abbradar cdepillabout ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }

--- a/pkgs/development/python-modules/tensorflow/binary-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/binary-hashes.nix
@@ -48,4 +48,16 @@ mac_py_310_cpu = {
   url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.1-cp310-cp310-macosx_10_14_x86_64.whl";
   sha256 = "0baq0djx8vhn8d75wyf82m6iqgfxwcrgg4xcvlr20m4x9bmysxrc";
 };
+macarm_py_310_cpu = {
+  url = "https://files.pythonhosted.org/packages/e4/84/45714d6497ced8de8c3f6105d071147f8f20de18114685de40c5cb9d6069/tensorflow_macos-2.9.1-cp310-cp310-macosx_11_0_arm64.whl";
+  sha256 = "1xy87cw4dbb41q8246fllspjb1j071gn67xxl8912nm672zdgdyg";
+};
+macarm_py_39_cpu = {
+  url = "https://files.pythonhosted.org/packages/3a/ae/b8eda20c9dfe04b99997cd4595599449592b6c0a4c0dc55114800768f093/tensorflow_macos-2.9.1-cp39-cp39-macosx_11_0_arm64.whl";
+  sha256 = "1nb1aszbmbawp0rvvvar48ndyjw8lg68c3p24qgj741qpzj28fmj";
+};
+macarm_py_38_cpu = {
+  url = "https://files.pythonhosted.org/packages/5e/87/1c81905cbae192764595b7d1d09da15bee9aeb8c0bf37197724160ab98be/tensorflow_macos-2.9.1-cp38-cp38-macosx_11_0_arm64.whl";
+  sha256 = "16l4vgi4dl7bpp51x31ixkc1hvx48wbzvldr7xr1lcad6wsngbb9";
+};
 }


### PR DESCRIPTION
###### Description of changes

While upstream Tensorflow does not provide binary releases of tensorflow for ARM64 macOS, Apple does, through the tensorflow-macos pypi package. This MR adds support to tensorflow-bin through this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
