### PR TITLE
podman packages: refactor wrappers

### DIFF
--- a/pkgs/applications/virtualization/cri-o/wrapper.nix
+++ b/pkgs/applications/virtualization/cri-o/wrapper.nix
@@ -3,7 +3,6 @@
 , makeWrapper
 , lib
 , extraPackages ? []
-, cri-o
 , runc # Default container runtime
 , crun # Container runtime (default with cgroups v2 for podman/buildah)
 , conmon # Container runtime monitor
@@ -12,8 +11,6 @@
 }:
 
 let
-  cri-o = cri-o-unwrapped;
-
   binPath = lib.makeBinPath ([
     runc
     crun
@@ -22,13 +19,13 @@ let
     iptables
   ] ++ extraPackages);
 
-in runCommand cri-o.name {
-  name = "${cri-o.pname}-wrapper-${cri-o.version}";
-  inherit (cri-o) pname version passthru;
+in runCommand cri-o-unwrapped.name {
+  name = "${cri-o-unwrapped.pname}-wrapper-${cri-o-unwrapped.version}";
+  inherit (cri-o-unwrapped) pname version passthru;
 
   preferLocalBuild = true;
 
-  meta = builtins.removeAttrs cri-o.meta [ "outputsToInstall" ];
+  meta = builtins.removeAttrs cri-o-unwrapped.meta [ "outputsToInstall" ];
 
   outputs = [
     "out"
@@ -40,7 +37,7 @@ in runCommand cri-o.name {
   ];
 
 } ''
-  ln -s ${cri-o.man} $man
+  ln -s ${cri-o-unwrapped.man} $man
 
   mkdir -p $out/bin
   ln -s ${cri-o-unwrapped}/share $out/share

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -5,7 +5,6 @@
 , lib
 , stdenv
 , extraPackages ? []
-, podman # Docker compat
 , runc # Default container runtime
 , crun # Container runtime (default with cgroups v2 for podman/buildah)
 , conmon # Container runtime monitor
@@ -23,8 +22,6 @@
 # adding aardvark-dns/netavark to `helpersBin` requires changes to the modules and tests
 
 let
-  podman = podman-unwrapped;
-
   binPath = lib.makeBinPath ([
   ] ++ lib.optionals stdenv.isLinux [
     runc
@@ -38,24 +35,24 @@ let
   ] ++ extraPackages);
 
   helpersBin = symlinkJoin {
-    name = "${podman.pname}-helper-binary-wrapper-${podman.version}";
+    name = "${podman-unwrapped.pname}-helper-binary-wrapper-${podman-unwrapped.version}";
 
     # this only works for some binaries, others may need to be be added to `binPath` or in the modules
     paths = [
       gvproxy
     ] ++ lib.optionals stdenv.isLinux [
       catatonit # added here for the pause image and also set in `containersConf` for `init_path`
-      podman.rootlessport
+      podman-unwrapped.rootlessport
     ];
   };
 
-in runCommand podman.name {
-  name = "${podman.pname}-wrapper-${podman.version}";
-  inherit (podman) pname version passthru;
+in runCommand podman-unwrapped.name {
+  name = "${podman-unwrapped.pname}-wrapper-${podman-unwrapped.version}";
+  inherit (podman-unwrapped) pname version passthru;
 
   preferLocalBuild = true;
 
-  meta = builtins.removeAttrs podman.meta [ "outputsToInstall" ];
+  meta = builtins.removeAttrs podman-unwrapped.meta [ "outputsToInstall" ];
 
   outputs = [
     "out"
@@ -67,7 +64,7 @@ in runCommand podman.name {
   ];
 
 } ''
-  ln -s ${podman.man} $man
+  ln -s ${podman-unwrapped.man} $man
 
   mkdir -p $out/bin
   ln -s ${podman-unwrapped}/etc $out/etc

--- a/pkgs/development/tools/buildah/wrapper.nix
+++ b/pkgs/development/tools/buildah/wrapper.nix
@@ -4,7 +4,6 @@
 , lib
 , stdenv
 , extraPackages ? []
-, buildah
 , runc # Default container runtime
 , crun # Container runtime (default with cgroups v2 for podman/buildah)
 , conmon # Container runtime monitor
@@ -15,10 +14,6 @@
 }:
 
 let
-  buildah = buildah-unwrapped;
-
-  preferLocalBuild = true;
-
   binPath = lib.makeBinPath ([
   ] ++ lib.optionals stdenv.isLinux [
     runc
@@ -30,11 +25,13 @@ let
     iptables
   ] ++ extraPackages);
 
-in runCommand buildah.name {
-  name = "${buildah.pname}-wrapper-${buildah.version}";
-  inherit (buildah) pname version;
+in runCommand buildah-unwrapped.name {
+  name = "${buildah-unwrapped.pname}-wrapper-${buildah-unwrapped.version}";
+  inherit (buildah-unwrapped) pname version;
 
-  meta = builtins.removeAttrs buildah.meta [ "outputsToInstall" ];
+  preferLocalBuild = true;
+
+  meta = builtins.removeAttrs buildah-unwrapped.meta [ "outputsToInstall" ];
 
   outputs = [
     "out"
@@ -46,7 +43,7 @@ in runCommand buildah.name {
   ];
 
 } ''
-  ln -s ${buildah.man} $man
+  ln -s ${buildah-unwrapped.man} $man
 
   mkdir -p $out/bin
   ln -s ${buildah-unwrapped}/share $out/share


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
