### PR TITLE
synth: apply patch to fix on rust 1.65

### DIFF
--- a/pkgs/tools/misc/synth/default.nix
+++ b/pkgs/tools/misc/synth/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch
 , stdenv
 , AppKit
 , Security
@@ -18,6 +19,15 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-COy8szsYKEzjtRBH8063ug5BkMv3qpc3i2RNb+n4I04=";
+
+  patches = [
+    # https://github.com/shuttle-hq/synth/pull/391
+    (fetchpatch {
+      name = "fix-for-rust-1.65.patch";
+      url = "https://github.com/shuttle-hq/synth/commit/c69b9b5c72441a51d09fc977de16b09a60eeecd3.patch";
+      hash = "sha256-uRCf+rEYTRgYPyrAbcXNEwpB92tzN8oYgv+/TyJaoHo=";
+    })
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
     AppKit


### PR DESCRIPTION
###### Description of changes

This addresses https://github.com/shuttle-hq/synth/issues/337 by pulling in https://github.com/shuttle-hq/synth/pull/391 to fix the build on Rust 1.65 now that https://github.com/NixOS/nixpkgs/pull/199664 is merged.

This must be go on staging right now because Rust 1.65 is on staging, and this patch does _not_ build using Rust 1.64.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
