### PR TITLE
python310Packages.repeated-test: init at 2.3.1

### DIFF
--- a/pkgs/development/python-modules/clize/default.nix
+++ b/pkgs/development/python-modules/clize/default.nix
@@ -8,9 +8,9 @@
 , pytestCheckHook
 , pythonOlder
 , python-dateutil
-, setuptools
+, repeated-test
+, setuptools-scm
 , sigtools
-, unittest2
 }:
 
 buildPythonPackage rec {
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    setuptools
+    setuptools-scm
   ];
 
   propagatedBuildInputs = [
@@ -42,14 +42,11 @@ buildPythonPackage rec {
     ];
   };
 
-  # repeated_test no longer exists in nixpkgs
-  # also see: https://github.com/epsy/clize/issues/74
-  doCheck = false;
   checkInputs = [
     pytestCheckHook
     python-dateutil
     pygments
-    unittest2
+    repeated-test
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/od/default.nix
+++ b/pkgs/development/python-modules/od/default.nix
@@ -1,19 +1,24 @@
-{ lib, buildPythonPackage, fetchPypi, unittest2 }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, repeated-test
+}:
 
 buildPythonPackage rec {
   pname = "od";
   version = "2.0.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-uGkj2Z8mLg51IV+FOqwZl1hT7zVyjmD1CcY/VbH4tKk=";
   };
 
-  # repeated_test no longer exists in nixpkgs
-  # also see: https://github.com/epsy/od/issues/1
-  doCheck = false;
   checkInputs = [
-    unittest2
+    repeated-test
   ];
 
   meta = with lib; {
@@ -21,5 +26,4 @@ buildPythonPackage rec {
     homepage = "https://github.com/epsy/od";
     license = licenses.mit;
   };
-
 }

--- a/pkgs/development/python-modules/od/default.nix
+++ b/pkgs/development/python-modules/od/default.nix
@@ -14,16 +14,21 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-uGkj2Z8mLg51IV+FOqwZl1hT7zVyjmD1CcY/VbH4tKk=";
+    hash = "sha256-uGkj2Z8mLg51IV+FOqwZl1hT7zVyjmD1CcY/VbH4tKk=";
   };
 
   checkInputs = [
     repeated-test
   ];
 
+  pythonImportsCheck = [
+    "od"
+  ];
+
   meta = with lib; {
     description = "Shorthand syntax for building OrderedDicts";
     homepage = "https://github.com/epsy/od";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/repeated-test/default.nix
+++ b/pkgs/development/python-modules/repeated-test/default.nix
@@ -32,9 +32,14 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pythonImportsCheck = [
+    "repeated_test"
+  ];
+
   meta = with lib; {
-    description = "A quick unittest-compatible framework for repeating a test function over many fixtures";
+    description = "Unittest-compatible framework for repeating a test function over many fixtures";
     homepage = "https://github.com/epsy/repeated_test";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/repeated-test/default.nix
+++ b/pkgs/development/python-modules/repeated-test/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+, six
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "repeated-test";
+  version = "2.3.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    pname = "repeated_test";
+    inherit version;
+    hash = "sha256-TbVyQA7EjCSwo6qfDksbE8IU1ElkSCABEUBWy5j1KJc=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "A quick unittest-compatible framework for repeating a test function over many fixtures";
+    homepage = "https://github.com/epsy/repeated_test";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/sigtools/default.nix
+++ b/pkgs/development/python-modules/sigtools/default.nix
@@ -1,13 +1,13 @@
 { lib
+, attrs
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
-, sphinx
 , mock
+, pythonOlder
 , repeated-test
-, unittestCheckHook
-, attrs
 , setuptools-scm
+, sphinx
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-S44TWpzU0uoA2mcMCTNy105nK6OruH9MmNjnPepURFw=";
+    hash = "sha256-S44TWpzU0uoA2mcMCTNy105nK6OruH9MmNjnPepURFw=";
   };
 
   nativeBuildInputs = [
@@ -37,10 +37,14 @@ buildPythonPackage rec {
     unittestCheckHook
   ];
 
-  meta = with lib; {
-    description = "Utilities for working with 3.3's inspect.Signature objects.";
-    homepage = "https://pypi.python.org/pypi/sigtools";
-    license = licenses.mit;
-  };
+  pythonImportsCheck = [
+    "sigtools"
+  ];
 
+  meta = with lib; {
+    description = "Utilities for working with inspect.Signature objects";
+    homepage = "https://sigtools.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
 }

--- a/pkgs/development/python-modules/sigtools/default.nix
+++ b/pkgs/development/python-modules/sigtools/default.nix
@@ -1,13 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , sphinx
 , mock
-, coverage
-, unittest2
+, repeated-test
+, unittestCheckHook
 , attrs
-, funcsigs
-, six
 , setuptools-scm
 }:
 
@@ -15,6 +14,8 @@ buildPythonPackage rec {
   pname = "sigtools";
   version = "4.0.1";
   format = "pyproject";
+
+  disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;
@@ -29,12 +30,12 @@ buildPythonPackage rec {
     attrs
   ];
 
-  patchPhase = ''sed -i s/test_suite="'"sigtools.tests"'"/test_suite="'"unittest2.collector"'"/ setup.py'';
-
-  # repeated_test no longer exists in nixpkgs
-  # Also see: https://github.com/epsy/sigtools/issues/26
-  doCheck = false;
-  checkInputs = [ sphinx mock coverage unittest2 ];
+  checkInputs = [
+    mock
+    repeated-test
+    sphinx
+    unittestCheckHook
+  ];
 
   meta = with lib; {
     description = "Utilities for working with 3.3's inspect.Signature objects.";

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -179,7 +179,7 @@ mapAliases ({
   qasm2image = throw "qasm2image is no longer maintained (since November 2018), and is not compatible with the latest pythonPackages.qiskit versions."; # added 2020-12-09
   qiskit-aqua = throw "qiskit-aqua has been removed due to deprecation, with its functionality moved to different qiskit packages";
   rdflib-jsonld = throw "rdflib-jsonld is not compatible with rdflib 6"; # added 2021-11-05
-  repeated_test = throw "repeated_test is no longer maintained"; # added 2022-01-11
+  repeated_test = repeated-test; # added 2022-11-15
   requests_oauthlib = requests-oauthlib; # added 2022-02-12
   requests_toolbelt = requests-toolbelt; # added 2017-09-26
   roboschool = throw "roboschool is deprecated in favor of PyBullet and has been removed"; # added 2022-01-15

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9646,6 +9646,8 @@ self: super: with self; {
 
   reparser = callPackage ../development/python-modules/reparser { };
 
+  repeated-test = callPackage ../development/python-modules/repeated-test { };
+
   repocheck = callPackage ../development/python-modules/repocheck { };
 
   reportengine = callPackage ../development/python-modules/reportengine { };


### PR DESCRIPTION
###### Description of changes

This package was removed earlier this year for being unmaintained and depending on the deprecated `unittest2` package in https://github.com/NixOS/nixpkgs/pull/154656, but it has been active and released again recently. We can bring it back, clean up some of its dependencies, and reenable tests in the packages that used it.

Related to https://github.com/NixOS/nixpkgs/pull/154264 and https://github.com/NixOS/nixpkgs/pull/154650.

Reenables tests for the following packages, which had issues tying back to this that were resolved:

- [x] clize: https://github.com/epsy/clize/issues/74
- [x] od: https://github.com/epsy/od/issues/1
- [x] sigtools: https://github.com/epsy/sigtools/issues/26 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
