### PR TITLE
python310Packages.rsa: update and fix tests

### DIFF
--- a/pkgs/development/python-modules/rsa/default.nix
+++ b/pkgs/development/python-modules/rsa/default.nix
@@ -1,36 +1,51 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, unittest2
+, fetchFromGitHub
+, poetry-core
 , pyasn1
-, mock
-, isPy3k
+, pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "rsa";
   version = "4.9";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-44RkpJxshdfxNRsBJmYUh6fgoUpQ8WdexQ6zTU8g7yE=";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "sybrenstuvel";
+    repo = "python-rsa";
+    rev = "version-${version}";
+    hash = "sha256-PwaRe+ICy0UoguXSMSh3PFl5R+YAhJwNdNN9isadlJY=";
   };
 
-  checkInputs = [ unittest2 mock ];
-  propagatedBuildInputs = [ pyasn1 ];
-
-  preConfigure = lib.optionalString (isPy3k && pythonOlder "3.7") ''
+  preConfigure = lib.optionalString (pythonOlder "3.7") ''
     substituteInPlace setup.py --replace "open('README.md')" "open('README.md',encoding='utf-8')"
   '';
 
-  # No tests in archive
-  doCheck = false;
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [ pyasn1 ];
+
+  preCheck = ''
+    sed -i '/addopts/d' tox.ini
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    "tests/test_mypy.py"
+  ];
 
   meta = with lib; {
     homepage = "https://stuvel.eu/rsa";
     license = licenses.asl20;
     description = "A pure-Python RSA implementation";
   };
-
 }


### PR DESCRIPTION
###### Description of changes

We can get rid of old Python 2 dependencies and enable the tests by fetching from GitHub.

Because this gets rid of unittest2, it's related to https://github.com/NixOS/nixpkgs/pull/154264 and https://github.com/NixOS/nixpkgs/pull/154650.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
