### PR TITLE
remove dead `make-symlinks` builder

### DIFF
--- a/pkgs/build-support/make-symlinks/builder.sh
+++ b/pkgs/build-support/make-symlinks/builder.sh
@@ -1,9 +1,0 @@
-source $stdenv/setup
-
-mkdir $out
-for file in $files
-do
-  subdir=`dirname $file`
-  mkdir -p $out/$subdir
-  ln -s $dir/$file $out/$file
-done

--- a/pkgs/build-support/make-symlinks/default.nix
+++ b/pkgs/build-support/make-symlinks/default.nix
@@ -1,7 +1,0 @@
-{name ? "", stdenv, dir, files}:
-
-stdenv.mkDerivation {
-  inherit dir files;
-  name = if name == "" then dir.name else name;
-  builder = ./builder.sh;
-}


### PR DESCRIPTION
Introduced in 5808ac7148850a79d9ff59e37368bdd13f187adf, never used again after b06335a835ac8b7bc40c77e0089e8e8556bac3cc.

Doesn't seem very useful now with `symlinkJoin`, `buildEnv` etc.