### PR TITLE
dwarf-therapist: restrict platforms to x86

### DIFF
--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Tool to manage dwarves in a running game of Dwarf Fortress";
     maintainers = with maintainers; [ abbradar bendlas numinit jonringer ];
     license = licenses.mit;
-    platforms = platforms.unix;
+    platforms = platforms.x86;
     homepage = "https://github.com/Dwarf-Therapist/Dwarf-Therapist";
   };
 }

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
@@ -10,7 +10,7 @@ in
 
 stdenv.mkDerivation {
   pname = "dwarf-therapist";
-  version = dwarf-therapist.version;
+  inherit (dwarf-therapist) version meta;
 
   wrapper = substituteAll {
     src = ./dwarf-therapist.in;


### PR DESCRIPTION
Avoid trying to build for aarch64 on Hydra. Dwarf Fortress only runs on x86.

ZHF: #199919