### PR TITLE
ocamlPackages.extlib: 1.7.8 -> 1.7.9

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -994,6 +994,12 @@ signald -d /var/lib/signald/db \
       </listitem>
       <listitem>
         <para>
+          <literal>ocamlPackages.ocaml_extlib</literal> has been renamed
+          to <literal>ocamlPackages.extlib</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>pkgs.fetchNextcloudApp</literal> has been rewritten
           to circumvent impurities in e.g. tarballs from GitHub and to
           make it easier to apply patches. This means that your hashes

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -307,6 +307,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - `stylua` no longer accepts `lua52Support` and `luauSupport` overrides, use `features` instead, which defaults to `[ "lua54" "luau" ]`.
 
+- `ocamlPackages.ocaml_extlib` has been renamed to `ocamlPackages.extlib`.
+
 - `pkgs.fetchNextcloudApp` has been rewritten to circumvent impurities in e.g. tarballs from GitHub and to make it easier to
   apply patches. This means that your hashes are out-of-date and the (previously required) attributes `name` and `version`
   are no longer accepted.

--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage, fetchFromGitHub
-, ocaml_extlib, ocamlfuse, gapi-ocaml, ocaml_sqlite3
+, extlib, ocamlfuse, gapi-ocaml, ocaml_sqlite3
 , tiny_httpd
 , ounit
 }:
@@ -18,7 +18,7 @@ buildDunePackage rec {
   doCheck = true;
   checkInputs = [ ounit ];
 
-  buildInputs = [ ocaml_extlib ocamlfuse gapi-ocaml ocaml_sqlite3 tiny_httpd ];
+  buildInputs = [ extlib ocamlfuse gapi-ocaml ocaml_sqlite3 tiny_httpd ];
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/applications/science/logic/beluga/default.nix
+++ b/pkgs/applications/science/logic/beluga/default.nix
@@ -14,7 +14,7 @@ ocamlPackages.buildDunePackage rec {
   useDune2 = true;
 
   buildInputs = with ocamlPackages; [
-    gen sedlex ocaml_extlib dune-build-info linenoise
+    gen sedlex extlib dune-build-info linenoise
   ];
 
   postPatch = ''

--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -13,7 +13,7 @@ let
       sha
       dune_2
       luv
-      ocaml_extlib
+      extlib
     ] else if lib.versionAtLeast version "4.0"
     then with ocaml-ng.ocamlPackages_4_10; [
       ocaml
@@ -25,7 +25,7 @@ let
       sha
       dune_2
       luv
-      ocaml_extlib-1-7-7
+      extlib-1-7-7
     ] else with ocaml-ng.ocamlPackages_4_05; [
       ocaml
       camlp4

--- a/pkgs/development/ocaml-modules/cudf/default.nix
+++ b/pkgs/development/ocaml-modules/cudf/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, stdenv, ocaml, ocamlbuild, findlib, ocaml_extlib, glib, perl, pkg-config, stdlib-shims, ounit }:
+{ lib, fetchurl, stdenv, ocaml, ocamlbuild, findlib, extlib, glib, perl, pkg-config, stdlib-shims, ounit }:
 
 stdenv.mkDerivation {
   pname = "ocaml${ocaml.version}-cudf";
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     stdlib-shims
   ];
   propagatedBuildInputs = [
-    ocaml_extlib
+    extlib
   ];
 
   checkTarget = [

--- a/pkgs/development/ocaml-modules/dose3/default.nix
+++ b/pkgs/development/ocaml-modules/dose3/default.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage, fetchFromGitLab
 , camlzip, ocamlgraph, parmap, re, stdlib-shims
-, base64, bz2, ocaml_extlib, cudf
+, base64, bz2, extlib, cudf
 , dpkg, git, ocaml, ounit, python39, python39Packages
 }:
 
@@ -27,7 +27,7 @@ buildDunePackage rec {
     bz2
     camlzip
     cudf
-    ocaml_extlib
+    extlib
     ocamlgraph
     re
     stdlib-shims

--- a/pkgs/development/ocaml-modules/extlib/1.7.7.nix
+++ b/pkgs/development/ocaml-modules/extlib/1.7.7.nix
@@ -1,14 +1,33 @@
 # Older version of extlib for Haxe 4.0 and 4.1.
 # May be replaceable by the next extlib + extlib-base64 release.
-{ lib, fetchurl, ocaml, ocaml_extlib }:
+{ stdenv, lib, fetchurl, ocaml, findlib, cppo
+# De facto, option minimal seems to be the default. See the README.
+, minimal ? true
+}:
 
-ocaml_extlib.overrideAttrs (x: rec {
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-extlib";
   version = "1.7.7";
+
   src = fetchurl {
-    url = "https://github.com/ygrek/ocaml-extlib/releases/download/${version}/extlib-${version}.tar.gz";
+    url = "https://ygrek.org/p/release/ocaml-extlib/extlib-${version}.tar.gz";
     sha256 = "1sxmzc1mx3kg62j8kbk0dxkx8mkf1rn70h542cjzrziflznap0s1";
   };
-  meta = x.meta // {
+
+  nativeBuildInputs = [ ocaml findlib cppo ];
+
+  strictDeps = true;
+
+  createFindlibDestdir = true;
+
+  makeFlags = lib.optional minimal "minimal=1";
+
+  meta = {
+    homepage = "https://github.com/ygrek/ocaml-extlib";
+    description = "Enhancements to the OCaml Standard Library modules";
+    license = lib.licenses.lgpl21Only;
+    inherit (ocaml.meta) platforms;
+    maintainers = [ lib.maintainers.sternenseemann ];
     broken = lib.versionAtLeast ocaml.version "4.12";
   };
-})
+}

--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -1,30 +1,24 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, cppo
-# De facto, option minimal seems to be the default. See the README.
-, minimal ? true
-}:
+{ buildDunePackage, lib, fetchurl, cppo }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-extlib";
-  version = "1.7.8";
+buildDunePackage rec {
+  pname = "extlib";
+  version = "1.7.9";
+
+  minimalOCamlVersion = "4.02";
 
   src = fetchurl {
-    url = "https://ygrek.org/p/release/ocaml-extlib/extlib-${version}.tar.gz";
-    sha256 = "0npq4hq3zym8nmlyji7l5cqk6drx2rkcx73d60rxqh5g8dla8p4k";
+    url = "https://ygrek.org/p/release/ocaml-${pname}/${pname}-${version}.tar.gz";
+    sha512 = "2386ac69f037ea520835c0624d39ae9fbffe43a20b18e247de032232ed6f419d667b53d2314c6f56dc71d368bf0b6201a56c2f3f2a5bdfd933766c5a6cb98768";
   };
 
-  nativeBuildInputs = [ ocaml findlib cppo ];
+  nativeBuildInputs = [ cppo ];
 
-  strictDeps = true;
-
-  createFindlibDestdir = true;
-
-  makeFlags = lib.optional minimal "minimal=1";
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/ygrek/ocaml-extlib";
     description = "Enhancements to the OCaml Standard Library modules";
     license = lib.licenses.lgpl21Only;
-    inherit (ocaml.meta) platforms;
     maintainers = [ lib.maintainers.sternenseemann ];
   };
 }

--- a/pkgs/development/ocaml-modules/lustre-v6/default.nix
+++ b/pkgs/development/ocaml-modules/lustre-v6/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchurl, ocaml_extlib, lutils, rdbg }:
+{ lib, buildDunePackage, fetchurl, extlib, lutils, rdbg }:
 
 buildDunePackage rec {
   pname = "lustre-v6";
@@ -14,7 +14,7 @@ buildDunePackage rec {
   };
 
   propagatedBuildInputs = [
-    ocaml_extlib
+    extlib
     lutils
     rdbg
   ];

--- a/pkgs/development/ocaml-modules/tcslib/default.nix
+++ b/pkgs/development/ocaml-modules/tcslib/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, ocamlPackages, buildOasisPackage, ounit, ocaml_extlib, num }:
+{ lib, fetchFromGitHub, ocamlPackages, buildOasisPackage, ounit, extlib, num }:
 
 buildOasisPackage rec {
   pname = "tcslib";
@@ -14,7 +14,7 @@ buildOasisPackage rec {
   };
 
   buildInputs = [ ounit ];
-  propagatedBuildInputs = [ ocaml_extlib num ];
+  propagatedBuildInputs = [ extlib num ];
 
   meta = {
     homepage = "https://github.com/tcsprojects/tcslib";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1260,9 +1260,9 @@ let
 
     ocaml-protoc = callPackage ../development/ocaml-modules/ocaml-protoc { };
 
-    ocaml_extlib = ocaml_extlib-1-7-8;
+    ocaml_extlib = ocaml_extlib-1-7-9;
 
-    ocaml_extlib-1-7-8 = callPackage ../development/ocaml-modules/extlib { };
+    ocaml_extlib-1-7-9 = callPackage ../development/ocaml-modules/extlib { };
 
     ocaml_extlib-1-7-7 = callPackage ../development/ocaml-modules/extlib/1.7.7.nix { };
 
@@ -1621,10 +1621,7 @@ let
 
     omake_rc1 = callPackage ../development/tools/ocaml/omake/0.9.8.6-rc1.nix { };
 
-    google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse {
-      # needs Base64 module
-      ocaml_extlib = ocaml_extlib.override { minimal = false; };
-    };
+    google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse { };
 
     hol_light = callPackage ../applications/science/logic/hol_light { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -411,6 +411,12 @@ let
 
     ethernet = callPackage ../development/ocaml-modules/ethernet { };
 
+    extlib = extlib-1-7-9;
+
+    extlib-1-7-9 = callPackage ../development/ocaml-modules/extlib { };
+
+    extlib-1-7-7 = callPackage ../development/ocaml-modules/extlib/1.7.7.nix { };
+
     ezjsonm = callPackage ../development/ocaml-modules/ezjsonm { };
 
     ezxmlm = callPackage ../development/ocaml-modules/ezxmlm { };
@@ -561,9 +567,7 @@ let
 
     iter = callPackage ../development/ocaml-modules/iter { };
 
-    javalib = callPackage ../development/ocaml-modules/javalib {
-      extlib = ocaml_extlib;
-    };
+    javalib = callPackage ../development/ocaml-modules/javalib { };
 
     dypgen = callPackage ../development/ocaml-modules/dypgen { };
 
@@ -1259,12 +1263,6 @@ let
     };
 
     ocaml-protoc = callPackage ../development/ocaml-modules/ocaml-protoc { };
-
-    ocaml_extlib = ocaml_extlib-1-7-9;
-
-    ocaml_extlib-1-7-9 = callPackage ../development/ocaml-modules/extlib { };
-
-    ocaml_extlib-1-7-7 = callPackage ../development/ocaml-modules/extlib/1.7.7.nix { };
 
     ocb-stubblr = callPackage ../development/ocaml-modules/ocb-stubblr { };
 


### PR DESCRIPTION
###### Description of changes

https://github.com/ygrek/ocaml-extlib/releases/tag/1.7.9

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
