### PR TITLE
clickhouse: divided into lts package and stable

### DIFF
--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -6,71 +6,86 @@
 , nixosTests
 }:
 
-stdenv.mkDerivation rec {
-  pname = "clickhouse";
-  version = "22.8.5.29";
+let
+  common = {version-type, version, hash}: stdenv.mkDerivation {
+    pname = "clickhouse-${version-type}";
+    inherit version;
 
-  broken = stdenv.buildPlatform.is32bit; # not supposed to work on 32-bit https://github.com/ClickHouse/ClickHouse/pull/23959#issuecomment-835343685
+    broken = stdenv.buildPlatform.is32bit; # not supposed to work on 32-bit https://github.com/ClickHouse/ClickHouse/pull/23959#issuecomment-835343685
 
-  src = fetchFromGitHub {
-    owner  = "ClickHouse";
-    repo   = "ClickHouse";
-    rev    = "v${version}-lts";
-    fetchSubmodules = true;
-    sha256 = "sha256-JRdZb5YgaumTnjJEYIXh9o3NSv67DAdl9gizVKvGTJI=";
+    src = fetchFromGitHub {
+      owner  = "ClickHouse";
+      repo   = "ClickHouse";
+      rev    = "v${version}-${version-type}";
+      fetchSubmodules = true;
+      inherit hash;
+    };
+
+    nativeBuildInputs = [ cmake libtool llvm-bintools ninja ];
+    buildInputs = [
+      boost brotli capnproto cctz clang-unwrapped double-conversion
+      icu jemalloc libxml2 lld llvm lz4 libmysqlclient openssl perl
+      poco protobuf python3 rapidjson re2 rdkafka readline sparsehash unixODBC
+      xxHash zstd
+    ] ++ lib.optional stdenv.hostPlatform.isx86 libcpuid;
+
+    postPatch = ''
+      patchShebangs src/
+      patchShebangs cmake/ld.lld.in
+
+      substituteInPlace src/Storages/System/StorageSystemLicenses.sh \
+        --replace 'git rev-parse --show-toplevel' '$src'
+      substituteInPlace utils/check-style/check-duplicate-includes.sh \
+        --replace 'git rev-parse --show-toplevel' '$src'
+      substituteInPlace utils/check-style/check-ungrouped-includes.sh \
+        --replace 'git rev-parse --show-toplevel' '$src'
+      substituteInPlace utils/list-licenses/list-licenses.sh \
+        --replace 'git rev-parse --show-toplevel' '$src'
+      substituteInPlace utils/check-style/check-style \
+        --replace 'git rev-parse --show-toplevel' '$src'
+    '';
+
+    cmakeFlags = [
+      "-DENABLE_TESTS=OFF"
+      "-DENABLE_CCACHE=0"
+      "-DENABLE_EMBEDDED_COMPILER=ON"
+      "-USE_INTERNAL_LLVM_LIBRARY=OFF"
+    ];
+
+    postInstall = ''
+      rm -rf $out/share/clickhouse-test
+
+      sed -i -e '\!<log>/var/log/clickhouse-server/clickhouse-server\.log</log>!d' \
+        $out/etc/clickhouse-server/config.xml
+      substituteInPlace $out/etc/clickhouse-server/config.xml \
+        --replace "<errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>" "<console>1</console>"
+    '';
+
+    hardeningDisable = [ "format" ];
+
+    # Builds in 7+h with 2 cores, and ~20m with a big-parallel builder.
+    requiredSystemFeatures = [ "big-parallel" ];
+
+    passthru.tests.clickhouse = nixosTests.clickhouse;
+
+    meta = with lib; {
+      homepage = "https://clickhouse.com";
+      description = "Column-oriented database management system";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ orivej ];
+      platforms = platforms.linux;
+    };
   };
-
-  nativeBuildInputs = [ cmake libtool llvm-bintools ninja ];
-  buildInputs = [
-    boost brotli capnproto cctz clang-unwrapped double-conversion
-    icu jemalloc libxml2 lld llvm lz4 libmysqlclient openssl perl
-    poco protobuf python3 rapidjson re2 rdkafka readline sparsehash unixODBC
-    xxHash zstd
-  ] ++ lib.optional stdenv.hostPlatform.isx86 libcpuid;
-
-  postPatch = ''
-    patchShebangs src/
-
-    substituteInPlace src/Storages/System/StorageSystemLicenses.sh \
-      --replace 'git rev-parse --show-toplevel' '$src'
-    substituteInPlace utils/check-style/check-duplicate-includes.sh \
-      --replace 'git rev-parse --show-toplevel' '$src'
-    substituteInPlace utils/check-style/check-ungrouped-includes.sh \
-      --replace 'git rev-parse --show-toplevel' '$src'
-    substituteInPlace utils/list-licenses/list-licenses.sh \
-      --replace 'git rev-parse --show-toplevel' '$src'
-    substituteInPlace utils/check-style/check-style \
-      --replace 'git rev-parse --show-toplevel' '$src'
-  '';
-
-  cmakeFlags = [
-    "-DENABLE_TESTS=OFF"
-    "-DENABLE_CCACHE=0"
-    "-DENABLE_EMBEDDED_COMPILER=ON"
-    "-USE_INTERNAL_LLVM_LIBRARY=OFF"
-  ];
-
-  postInstall = ''
-    rm -rf $out/share/clickhouse-test
-
-    sed -i -e '\!<log>/var/log/clickhouse-server/clickhouse-server\.log</log>!d' \
-      $out/etc/clickhouse-server/config.xml
-    substituteInPlace $out/etc/clickhouse-server/config.xml \
-      --replace "<errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>" "<console>1</console>"
-  '';
-
-  hardeningDisable = [ "format" ];
-
-  # Builds in 7+h with 2 cores, and ~20m with a big-parallel builder.
-  requiredSystemFeatures = [ "big-parallel" ];
-
-  passthru.tests.clickhouse = nixosTests.clickhouse;
-
-  meta = with lib; {
-    homepage = "https://clickhouse.com";
-    description = "Column-oriented database management system";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ orivej ];
-    platforms = platforms.linux;
+in
+{
+  clickhouse = common {
+    version-type = "stable";
+    version = "22.10.2.11";
+    hash = "sha256-jUS5EMrr5NPQld4I8d10AlIhQFaNLi6Q+VczDAd7P2U=";
+  };
+  clickhouse-lts = common {
+    version-type = "lts";
+    version = "22.8.8.3";
+    hash = "sha256-vX4Yll0zd/6yXO5NImJzuY91zPTcljSHh4+pz05phqQ=";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23520,12 +23520,12 @@ with pkgs;
 
   clamsmtp = callPackage ../servers/mail/clamsmtp { };
 
-  clickhouse = callPackage ../servers/clickhouse {
-    # upstream requires llvm12 as of v22.3.2.2
+  inherit (callPackage ../servers/clickhouse {
+    # upstream requires llvm13 as of v22.8.5.29
     inherit (llvmPackages_13) clang-unwrapped lld llvm;
     llvm-bintools = llvmPackages_13.bintools;
     stdenv = llvmPackages_13.stdenv;
-  };
+  }) clickhouse clickhouse-lts;
 
   clickhouse-cli = with python3Packages; toPythonApplication clickhouse-cli;
 


### PR DESCRIPTION
###### Description of changes

Hi. Currently there is only available "lts" package and it is not possible to install "stable". 
So i divided it into lts package and stable :) 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
