### PR TITLE
plotjuggler: init at 3.6.0

### DIFF
--- a/pkgs/applications/science/robotics/plotjuggler/default.nix
+++ b/pkgs/applications/science/robotics/plotjuggler/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, cmake
+, extra-cmake-modules
+, fetchFromGitHub
+, mkDerivation
+, mosquitto
+, protobuf
+, qtbase
+, qtsvg
+, qtwebsockets
+, qtx11extras
+, zeromq
+, zstd
+}:
+
+mkDerivation rec {
+  pname = "PlotJuggler";
+  version = "3.6.0";
+
+  src = fetchFromGitHub {
+    owner = "facontidavide";
+    repo = "PlotJuggler";
+    rev = version;
+    sha256 = "sha256-b/0ttdTF5BFTSP6DGMUg0bziwJQ2SRK3fsTeKoxkzjc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    mosquitto
+    protobuf
+    qtbase
+    qtsvg
+    qtwebsockets
+    qtx11extras
+    zeromq
+    zstd
+  ];
+
+  # Remove executable bit from libraries so they don't get wrapped in wrap-qt-apps-hook
+  preFixup = ''
+    chmod -x $out/bin/*.dylib $out/bin/*.so
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.plotjuggler.io/";
+    description = "Fast, intuitive and extensible time series visualization tool.";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ bouk ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10623,6 +10623,8 @@ with pkgs;
 
   pastebinit = callPackage ../tools/misc/pastebinit { };
 
+  plotjuggler = libsForQt5.callPackage ../applications/science/robotics/plotjuggler { };
+
   pmacct = callPackage ../tools/networking/pmacct { };
 
   pmix = callPackage ../development/libraries/pmix { };


### PR DESCRIPTION
###### Description of changes

Add [plotjuggler](https://www.plotjuggler.io/) package. I had to remove the executable bit from the plugins, because the qt5 wrapper also applies to libraries. This should [probably be fixed in the wrapper](https://github.com/bouk/nixpkgs/commit/c1de20610149c07659fb5396f86a1aa4bb05654a)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
