### PR TITLE
jfrog-cli: init at 2.29.2

### DIFF
--- a/pkgs/development/tools/misc/jfrog-cli/default.nix
+++ b/pkgs/development/tools/misc/jfrog-cli/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "jfrog-cli";
+  version = "2.29.2";
+
+  src = fetchFromGitHub {
+    owner = "jfrog";
+    repo = "jfrog-cli";
+    rev = "v${version}";
+    hash = "sha256-E7bajdWBBlqSV76on3M9DLtm0R1WE1mRVKDSo/y+6E0=";
+  };
+
+  CGO_ENABLED = 0;
+
+  vendorHash = "sha256-QLqAbIyudQzav5vmUpLRlDuFJF+DqDZzm+f6KGThjlk=";
+
+  ldflags = [ "-s" "-w" "-extldflags '-static'" ];
+
+  postBuild = ''
+    mv $GOPATH/bin/{jfrog-cli,jf}
+  '';
+
+  # Most of them seem to require network access.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A client that provides a simple interface that automates access to the JFrog products";
+    homepage = "https://github.com/jfrog/jfrog-cli";
+    license = licenses.asl20;
+    maintainers = with maintainers; [terlar];
+    mainProgram = "jf";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8168,6 +8168,8 @@ with pkgs;
 
   jfmt = callPackage ../development/tools/jfmt { };
 
+  jfrog-cli = callPackage ../development/tools/misc/jfrog-cli { };
+
   jfsutils = callPackage ../tools/filesystems/jfsutils { };
 
   jhead = callPackage ../tools/graphics/jhead { };


### PR DESCRIPTION
###### Description of changes

Adding jfrog-cli (picking up where #110339 left off). Since then the version has changed to 2.x and the cli has been renamed to `jf`, see:
- https://jfrog.com/getcli/
- https://github.com/jfrog/jfrog-cli/blob/v2/build/build.sh

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
