### PR TITLE
hatch: 1.3.1 -> 1.6.3

### DIFF
--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -20,7 +20,7 @@
 
 let
   pname = "hatchling";
-  version = "1.9.0";
+  version = "1.11.1";
 in
 buildPythonPackage {
   inherit pname version;
@@ -28,7 +28,7 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-tXxzYvQ3uUJuS5QiiiHSrFgE+7KrywGt3iVEo1uzA80=";
+    hash = "sha256-n4Q2H3DPOnq5VDsMPsxkIR7SuopganHrakc8HJsI4dA=";
   };
 
   # listed in backend/src/hatchling/ouroboros.py
@@ -72,6 +72,7 @@ buildPythonPackage {
   meta = with lib; {
     description = "Modern, extensible Python build backend";
     homepage = "https://hatch.pypa.io/latest/";
+    changelog = "https://github.com/pypa/hatch/blob/hatchling-v${version}/docs/history.md#hatchling";
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ofek ];
   };

--- a/pkgs/development/tools/hatch/default.nix
+++ b/pkgs/development/tools/hatch/default.nix
@@ -7,22 +7,25 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "hatch";
-  version = "1.3.1";
+  version = "1.6.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "hatch";
     rev = "hatch-v${version}";
-    sha256 = "sha256-ftT86HX5CVbiHe5yzXT2gNl8Rx+f+fmiAJRnOuDpvYI=";
+    hash = "sha256-3nPh6F+TmLoogz9FgaZMub7hPJIzANCY4oWk9Mq22Pc=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
     click
     hatchling
     httpx
+    hyperlink
     keyring
+    packaging
     pexpect
+    platformdirs
     pyperclip
     rich
     shellingham
@@ -36,6 +39,7 @@ python3.pkgs.buildPythonApplication rec {
     git
     pytestCheckHook
     pytest-mock
+    pytest-xdist
   ];
 
   preCheck = ''
@@ -54,6 +58,7 @@ python3.pkgs.buildPythonApplication rec {
     "test_editable_exact"
     "test_editable_exact_extra_dependencies"
     "test_editable_exact_force_include"
+    "test_editable_exact_force_include_option"
     "test_editable_exact_force_include_build_data_precedence"
     "test_editable_pth"
     # AssertionError: assert len(extract_installed_requirements(output.splitlines())) > 0
@@ -63,6 +68,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = with lib; {
     description = "Modern, extensible Python project manager";
     homepage = "https://hatch.pypa.io/latest/";
+    changelog = "https://github.com/pypa/hatch/blob/${src.rev}/docs/history.md#hatch";
     license = licenses.mit;
     maintainers = with maintainers; [ onny ];
   };


### PR DESCRIPTION
ZHF: #199919

###### Description of changes
https://github.com/pypa/hatch/blob/hatch-v1.6.3/docs/history.md#hatch
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @NixOS/nixos-release-managers 