### PR TITLE
python3Packages.pypandoc: 1.8.1 -> 1.10

### DIFF
--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -1,16 +1,16 @@
 { lib, substituteAll, buildPythonPackage, fetchFromGitHub
-, pandoc, texlive
+, pandoc, pandocfilters, texlive
 }:
 
 buildPythonPackage rec {
   pname = "pypandoc";
-  version = "1.8.1";
+  version = "1.10";
 
   src = fetchFromGitHub {
-    owner = "NicklasTegner";
+    owner = "JessicaTegner";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-1vQmONQFJrjptwVVjw25Wyt59loatjScsdnSax+q/f8=";
+    hash = "sha256:05m585l4sipjzpkrv4yj5s7w45yxhxlym55lkhnavsshlvisinkz";
   };
 
   patches = [
@@ -24,11 +24,12 @@ buildPythonPackage rec {
 
   checkInputs = [
     texlive.combined.scheme-small
+    pandocfilters
   ];
 
   meta = with lib; {
     description = "Thin wrapper for pandoc";
-    homepage = "https://github.com/NicklasTegner/pypandoc";
+    homepage = "https://github.com/JessicaTegner/pypandoc";
     license = licenses.mit;
     maintainers = with maintainers; [ sternenseemann bennofs ];
   };

--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -1,10 +1,18 @@
-{ lib, substituteAll, buildPythonPackage, fetchFromGitHub
-, pandoc, pandocfilters, texlive
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pandoc
+, pandocfilters
+, pythonOlder
+, substituteAll
+, texlive
 }:
 
 buildPythonPackage rec {
   pname = "pypandoc";
   version = "1.10";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "JessicaTegner";
@@ -25,6 +33,10 @@ buildPythonPackage rec {
   checkInputs = [
     texlive.combined.scheme-small
     pandocfilters
+  ];
+
+  pythonImportsCheck = [
+    "pypandoc"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
https://github.com/JessicaTegner/pypandoc/releases/tag/v1.9 https://github.com/JessicaTegner/pypandoc/releases/tag/v1.10

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested apostrophe HTML/PDF export.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
