### PR TITLE
github-copilot-intellij-agent: init at 1.2.8.2631

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5318,6 +5318,12 @@
       fingerprint = "F7D3 7890 228A 9074 40E1  FD48 46B9 228E 814A 2AAC";
     }];
   };
+  hacker1024 = {
+    name = "hacker1024";
+    email = "hacker1024@users.sourceforge.net";
+    github = "hacker1024";
+    githubId = 20849728;
+  };
   hagl = {
     email = "harald@glie.be";
     github = "hagl";

--- a/pkgs/development/tools/github-copilot-intellij-agent/default.nix
+++ b/pkgs/development/tools/github-copilot-intellij-agent/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, lib, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  pname = "github-copilot-intellij-agent";
+  version = "1.2.8.2631";
+
+  src = fetchurl {
+    name = "${pname}-${version}-plugin.zip";
+    url = "https://plugins.jetbrains.com/plugin/download?updateId=341846";
+    hash = "sha256-0nnSMdx9Vb2WyNHreOJMP15K1+AII/kCEAOiFK5Mhik=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    unzip -p $src github-copilot-intellij/copilot-agent/bin/copilot-agent-${
+      if stdenv.isDarwin then (if stdenv.isAarch64 then "macos-arm64" else "macos") else "linux"
+    } | install -m755 /dev/stdin $out/bin/copilot-agent
+
+    runHook postInstall
+  '';
+
+  # https://discourse.nixos.org/t/unrelatable-error-when-working-with-patchelf/12043
+  # https://github.com/NixOS/nixpkgs/blob/db0d8e10fc1dec84f1ccb111851a82645aa6a7d3/pkgs/development/web/now-cli/default.nix
+  preFixup = let
+    binaryLocation = "$out/bin/copilot-agent";
+    libPath = lib.makeLibraryPath [ stdenv.cc.cc ];
+  in ''
+    orig_size=$(stat --printf=%s ${binaryLocation})
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ${binaryLocation}
+    patchelf --set-rpath ${libPath} ${binaryLocation}
+    chmod +x ${binaryLocation}
+
+    new_size=$(stat --printf=%s ${binaryLocation})
+
+    var_skip=20
+    var_select=22
+    shift_by=$(expr $new_size - $orig_size)
+
+    function fix_offset {
+      location=$(grep -obUam1 "$1" ${binaryLocation} | cut -d: -f1)
+      location=$(expr $location + $var_skip)
+      value=$(dd if=${binaryLocation} iflag=count_bytes,skip_bytes skip=$location \
+                 bs=1 count=$var_select status=none)
+      value=$(expr $shift_by + $value)
+      echo -n $value | dd of=${binaryLocation} bs=1 seek=$location conv=notrunc
+    }
+
+    fix_offset PAYLOAD_POSITION
+    fix_offset PRELUDE_POSITION
+  '';
+
+  dontStrip = true;
+
+  meta = rec {
+    description = "The GitHub copilot IntelliJ plugin's native component";
+    longDescription = ''
+      The GitHub copilot IntelliJ plugin's native component.
+      bin/copilot-agent must be symlinked into the plugin directory, replacing the existing binary.
+
+      For example:
+
+      ```shell
+      ln -fs /run/current-system/sw/bin/copilot-agent ~/.local/share/JetBrains/IntelliJIdea2022.2/github-copilot-intellij/copilot-agent/bin/copilot-agent-linux
+      ```
+    '';
+    homepage = "https://plugins.jetbrains.com/plugin/17718-github-copilot";
+    downloadPage = homepage;
+    changelog = homepage;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ hacker1024 ];
+    mainProgram = "copilot-agent";
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2665,6 +2665,8 @@ with pkgs;
 
   github-commenter = callPackage ../development/tools/github-commenter { };
 
+  github-copilot-intellij-agent = callPackage ../development/tools/github-copilot-intellij-agent { };
+
   github-desktop = callPackage ../applications/version-management/github-desktop {
     curl = curl.override { openssl = openssl_1_1; };
   };


### PR DESCRIPTION
###### Description of changes

This patches and packages the GitHub Copilot IntelliJ plugin's native component to use Nix libraries.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
