### PR TITLE
python310Packages.pytest-asyncio: get reverse dependencies ready for update

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -64,6 +64,7 @@ let
           sha256 = "sha256-bKrPLbD9zG7DwIYBst1cb+zkDsM8B02wh3D80iortpw=";
         };
         propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ self.daphne ];
+        pytestFlagsArray = [ "--asyncio-mode=auto" ];
       });
 
       daphne = super.daphne.overridePythonAttrs (oldAttrs: rec {

--- a/pkgs/development/python-modules/aioftp/default.nix
+++ b/pkgs/development/python-modules/aioftp/default.nix
@@ -33,10 +33,6 @@ buildPythonPackage rec {
     trustme
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   disabledTests = lib.optionals stdenv.isDarwin [
     # uses 127.0.0.2, which macos doesn't like
     "test_pasv_connection_pasv_forced_response_address"

--- a/pkgs/development/python-modules/aiogithubapi/default.nix
+++ b/pkgs/development/python-modules/aiogithubapi/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/aioswitcher/default.nix
+++ b/pkgs/development/python-modules/aioswitcher/default.nix
@@ -44,10 +44,6 @@ buildPythonPackage rec {
     time-machine
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   disabledTests = [
     # AssertionError: Expected <14:00> to be equal to <17:00>, but was not.
     "test_schedule_parser_with_a_weekly_recurring_enabled_schedule_data"

--- a/pkgs/development/python-modules/aiosyncthing/default.nix
+++ b/pkgs/development/python-modules/aiosyncthing/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/amqtt/default.nix
+++ b/pkgs/development/python-modules/amqtt/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/channels/default.nix
+++ b/pkgs/development/python-modules/channels/default.nix
@@ -41,10 +41,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ] ++ passthru.optional-dependencies.daphne;
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   pythonImportsCheck = [
     "channels"
   ];

--- a/pkgs/development/python-modules/discovery30303/default.nix
+++ b/pkgs/development/python-modules/discovery30303/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/dynalite-devices/default.nix
+++ b/pkgs/development/python-modules/dynalite-devices/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   pythonImportsCheck = [ "dynalite_devices_lib" ];

--- a/pkgs/development/python-modules/gql/default.nix
+++ b/pkgs/development/python-modules/gql/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
   '';
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/homematicip/default.nix
+++ b/pkgs/development/python-modules/homematicip/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/hypercorn/default.nix
+++ b/pkgs/development/python-modules/hypercorn/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchFromGitLab
+, fetchFromGitHub
 , pythonOlder
 , typing-extensions
 , wsproto
@@ -10,24 +10,26 @@
 , mock
 , poetry-core
 , pytest-asyncio
-, pytest-cov
-, pytest-sugar
 , pytest-trio
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "Hypercorn";
-  version = "0.13.2";
+  version = "0.14.3";
   disabled = pythonOlder "3.7";
   format = "pyproject";
 
-  src = fetchFromGitLab {
+  src = fetchFromGitHub {
     owner = "pgjones";
     repo = pname;
     rev = version;
-    sha256 = "sha256-fIjw5A6SvFUv8cU7xunVlPYphv+glypY4pzvHNifYLQ=";
+    hash = "sha256-ECREs8UwqTWUweUrwnUwpVotCII2v4Bz7ZCk3DSAd8I=";
   };
+
+  postPatch = ''
+    sed -i "/^addopts/d" pyproject.toml
+  '';
 
   nativeBuildInputs = [
     poetry-core
@@ -38,20 +40,14 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytest-asyncio
-    pytest-cov
-    pytest-sugar
     pytest-trio
     pytestCheckHook
   ] ++ lib.optionals (pythonOlder "3.8") [ mock ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   pythonImportsCheck = [ "hypercorn" ];
 
   meta = with lib; {
-    homepage = "https://pgjones.gitlab.io/hypercorn/";
+    homepage = "https://github.com/pgjones/hypercorn";
     description = "The ASGI web server inspired by Gunicorn";
     license = licenses.mit;
     maintainers = with maintainers; [ dgliwka ];

--- a/pkgs/development/python-modules/jsonrpc-websocket/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-websocket/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
     "tests.py"
   ];
 

--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -79,7 +79,6 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
     "--benchmark-disable"
   ];
 

--- a/pkgs/development/python-modules/pylitterbot/default.nix
+++ b/pkgs/development/python-modules/pylitterbot/default.nix
@@ -49,10 +49,6 @@ buildPythonPackage rec {
       --replace 'deepdiff = "^5.8.1"' 'deepdiff = ">=5.8.1"'
   '';
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   pythonImportsCheck = [
     "pylitterbot"
   ];

--- a/pkgs/development/python-modules/pylutron-caseta/default.nix
+++ b/pkgs/development/python-modules/pylutron-caseta/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pyotgw/default.nix
+++ b/pkgs/development/python-modules/pyotgw/default.nix
@@ -30,10 +30,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   pythonImportsCheck = [
     "pyotgw"
   ];

--- a/pkgs/development/python-modules/pypck/default.nix
+++ b/pkgs/development/python-modules/pypck/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   disabledTests = lib.optionals stdenv.isDarwin [

--- a/pkgs/development/python-modules/pyspcwebgw/default.nix
+++ b/pkgs/development/python-modules/pyspcwebgw/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   pythonImportsCheck = [ "pyspcwebgw" ];

--- a/pkgs/development/python-modules/pytautulli/default.nix
+++ b/pkgs/development/python-modules/pytautulli/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/python-kasa/default.nix
+++ b/pkgs/development/python-modules/python-kasa/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/python-smarttub/default.nix
+++ b/pkgs/development/python-modules/python-smarttub/default.nix
@@ -38,10 +38,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   postPatch = ''
     substituteInPlace setup.py \
       --replace "pyjwt~=2.1.0" "pyjwt>=2.1.0"

--- a/pkgs/development/python-modules/pytraccar/default.nix
+++ b/pkgs/development/python-modules/pytraccar/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/pywizlight/default.nix
+++ b/pkgs/development/python-modules/pywizlight/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/renault-api/default.nix
+++ b/pkgs/development/python-modules/renault-api/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/respx/default.nix
+++ b/pkgs/development/python-modules/respx/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "respx";
-  version = "0.19.2";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "lundberg";
     repo = pname;
     rev = version;
-    sha256 = "sha256-uNmSBJOQF4baq8AWzfwj0kinO19jr6Mp9Yblys/WmZs=";
+    sha256 = "sha256-xb5jb+l6wA1v/r2yGUB6IuUVXIaTc+3O/w5xn/+A74o=";
   };
 
   propagatedBuildInputs = [
@@ -35,10 +35,6 @@ buildPythonPackage rec {
     trio
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   postPatch = ''
     sed -i "/--cov/d" setup.cfg
   '';
@@ -52,6 +48,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python library for mocking HTTPX";
     homepage = "https://lundberg.github.io/respx/";
+    changelog = "https://github.com/lundberg/respx/blob/${src.rev}/CHANGELOG.md";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/structlog/default.nix
+++ b/pkgs/development/python-modules/structlog/default.nix
@@ -39,10 +39,6 @@ buildPythonPackage rec {
     simplejson
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   meta = with lib; {
     description = "Painless structural logging";
     homepage = "https://github.com/hynek/structlog";

--- a/pkgs/development/python-modules/subarulink/default.nix
+++ b/pkgs/development/python-modules/subarulink/default.nix
@@ -36,10 +36,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   postPatch = ''
     substituteInPlace setup.cfg \
       --replace "--cov=subarulink" ""

--- a/pkgs/development/python-modules/unifi-discovery/default.nix
+++ b/pkgs/development/python-modules/unifi-discovery/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/xbox-webapi/default.nix
+++ b/pkgs/development/python-modules/xbox-webapi/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
-    "--asyncio-mode=legacy"
+    "--asyncio-mode=auto"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/zigpy-znp/default.nix
+++ b/pkgs/development/python-modules/zigpy-znp/default.nix
@@ -49,10 +49,6 @@ buildPythonPackage rec {
     asynctest
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=legacy"
-  ];
-
   pythonImportsCheck = [
     "zigpy_znp"
   ];


### PR DESCRIPTION
###### Description of changes
prepare for the next pytest-asyncio bump: https://github.com/NixOS/nixpkgs/pull/200807
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
