### PR TITLE
exploitdb: 2022-10-18 -> 2022-11-12

### DIFF
--- a/pkgs/tools/security/exploitdb/default.nix
+++ b/pkgs/tools/security/exploitdb/default.nix
@@ -1,18 +1,18 @@
 { lib
 , stdenv
-, fetchFromGitHub
+, fetchFromGitLab
 , makeWrapper
 }:
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2022-10-18";
+  version = "2022-11-12";
 
-  src = fetchFromGitHub {
-    owner = "offensive-security";
+  src = fetchFromGitLab {
+    owner = "exploit-database";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-qyRAwy4rGaV7fiU0gwvnf6yT4ZAAXYTtZubh+GtsJU8=";
+    hash = "sha256-0k9q+xwzIdmhVe5zL1qoE6QzzGV3gm6RL97c7zi3Rg8=";
   };
 
   nativeBuildInputs = [
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/offensive-security/exploitdb";
+    homepage = "https://gitlab.com/exploit-database/exploitdb";
     description = "Archive of public exploits and corresponding vulnerable software";
     license = with licenses; [ gpl2Plus gpl3Plus mit ];
     maintainers = with maintainers; [ applePrincess fab ];


### PR DESCRIPTION
###### Description of changes
update to 2022-11-12. Change repo to gitlab
commit tagged as 2022-11-12: https://gitlab.com/exploit-database/exploitdb/-/commit/c9e53fa57b5d05510ab09ee8c8a64d9b853de570
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
