### PR TITLE
atlas: init at 0.9.0

### DIFF
--- a/pkgs/development/tools/database/atlas/default.nix
+++ b/pkgs/development/tools/database/atlas/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+}:
+
+buildGoModule rec {
+  pname = "atlas";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "ariga";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-4IDVsy4CseIiORaC8O72mcHp4w1YHUZfe0xoaxHRQTs=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-7+AVDNzydyFO+RmQfybpG6RSU+4qrf/1IEYOSWRBl7Y=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X ariga.io/atlas/cmd/atlas/internal/cmdapi.version=v${version}"
+  ];
+
+  # subPackages = [ "cmd/atlas"] does not work
+  modRoot = "cmd/atlas";
+
+  nativeCheckInputs = [ git ];
+
+  meta = with lib; {
+    description = "An open source tool that helps developers manage their database schemas by applying modern DevOps principles";
+    homepage = "https://atlasgo.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23485,6 +23485,8 @@ with pkgs;
 
   asterisk-module-sccp = callPackage ../servers/asterisk/sccp { };
 
+  atlas = callPackage ../development/tools/database/atlas { };
+
   sabnzbd = callPackage ../servers/sabnzbd { };
 
   baserow = callPackage ../servers/baserow { };


### PR DESCRIPTION
###### Description of changes

Resolves #197774.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
