### PR TITLE
nixos/security/wrappers: fix for #98863

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -5,8 +5,8 @@ let
 
   parentWrapperDir = dirOf wrapperDir;
 
-  securityWrapper = pkgs.callPackage ./wrapper.nix {
-    inherit parentWrapperDir;
+  securityWrapper = sourceProg : pkgs.callPackage ./wrapper.nix {
+    inherit parentWrapperDir sourceProg;
   };
 
   fileModeType =
@@ -91,8 +91,7 @@ let
     , ...
     }:
     ''
-      cp ${securityWrapper}/bin/security-wrapper "$wrapperDir/${program}"
-      echo -n "${source}" > "$wrapperDir/${program}.real"
+      cp ${securityWrapper source}/bin/security-wrapper "$wrapperDir/${program}"
 
       # Prevent races
       chmod 0000 "$wrapperDir/${program}"
@@ -119,8 +118,7 @@ let
     , ...
     }:
     ''
-      cp ${securityWrapper}/bin/security-wrapper "$wrapperDir/${program}"
-      echo -n "${source}" > "$wrapperDir/${program}.real"
+      cp ${securityWrapper source}/bin/security-wrapper "$wrapperDir/${program}"
 
       # Prevent races
       chmod 0000 "$wrapperDir/${program}"

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -6,7 +6,7 @@ let
   parentWrapperDir = dirOf wrapperDir;
 
   securityWrapper = sourceProg : pkgs.callPackage ./wrapper.nix {
-    inherit parentWrapperDir sourceProg;
+    inherit sourceProg;
   };
 
   fileModeType =

--- a/nixos/modules/security/wrappers/wrapper.c
+++ b/nixos/modules/security/wrappers/wrapper.c
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
     // Read the capabilities set on the wrapper and raise them in to
     // the ambient set so the program we're wrapping receives the
     // capabilities too!
-    if (make_caps_ambient(self_path) != 0) {
+    if (make_caps_ambient("/proc/self/exe") != 0) {
         free(self_path);
         return 1;
     }

--- a/nixos/modules/security/wrappers/wrapper.c
+++ b/nixos/modules/security/wrappers/wrapper.c
@@ -15,17 +15,15 @@
 #include <stdint.h>
 #include <syscall.h>
 #include <byteswap.h>
+#include <elf.h>
 
-#ifndef SOURCE_PROG
-#error SOURCE_PROG should be defined via preprocessor commandline
-#endif
-
-#define ASSERT(expr) ((expr) ? (void) 0 : assert_failure(#expr))
 
 extern char **environ;
 
 // Wrapper debug variable name
 static char *wrapper_debug = "WRAPPER_DEBUG";
+
+#define LOG_PREFIX "nixos-setuid-wrapper: "
 
 #define CAP_SETPCAP 8
 
@@ -35,23 +33,25 @@ static char *wrapper_debug = "WRAPPER_DEBUG";
 #define LE32_TO_H(x) (x)
 #endif
 
-static noreturn void assert_failure(const char *assertion) {
-    fprintf(stderr, "Assertion `%s` in NixOS's wrapper.c failed.\n", assertion);
-    fflush(stderr);
-    abort();
-}
+#if ELF_HEADER_SIZE == 32
+typedef Elf32_Ehdr Ehdr;
+#elif ELF_HEADER_SIZE == 64
+typedef Elf64_Ehdr Ehdr;
+#else
+#error unsupported ELF_HEADER_SIZE
+#endif
 
 int get_last_cap(unsigned *last_cap) {
     FILE* file = fopen("/proc/sys/kernel/cap_last_cap", "r");
     if (file == NULL) {
         int saved_errno = errno;
-        fprintf(stderr, "failed to open /proc/sys/kernel/cap_last_cap: %s\n", strerror(errno));
+        perror(LOG_PREFIX "failed to open /proc/sys/kernel/cap_last_cap\n");
         return -saved_errno;
     }
     int res = fscanf(file, "%u", last_cap);
     if (res == EOF) {
         int saved_errno = errno;
-        fprintf(stderr, "could not read number from /proc/sys/kernel/cap_last_cap: %s\n", strerror(errno));
+        perror(LOG_PREFIX "could not read number from /proc/sys/kernel/cap_last_cap: %s\n");
         return -saved_errno;
     }
     fclose(file);
@@ -61,16 +61,17 @@ int get_last_cap(unsigned *last_cap) {
 // Given the path to this program, fetch its configured capability set
 // (as set by `setcap ... /path/to/file`) and raise those capabilities
 // into the Ambient set.
-static int make_caps_ambient(const char *self_path) {
+static int make_caps_ambient(int exe_fd) {
     struct vfs_ns_cap_data data = {};
-    int r = getxattr(self_path, "security.capability", &data, sizeof(data));
+
+    int r = fgetxattr(exe_fd, "security.capability", &data, sizeof(data));
 
     if (r < 0) {
         if (errno == ENODATA) {
             // no capabilities set
             return 0;
         }
-        fprintf(stderr, "cannot get capabilities for %s: %s", self_path, strerror(errno));
+        fprintf(stderr, LOG_PREFIX "cannot get capabilities for wrapper: %s", strerror(errno));
         return 1;
     }
 
@@ -85,7 +86,7 @@ static int make_caps_ambient(const char *self_path) {
             size = VFS_CAP_U32_3;
             break;
         default:
-            fprintf(stderr, "BUG! Unsupported capability version 0x%x on %s. Report to NixOS bugtracker\n", version, self_path);
+            fprintf(stderr, LOG_PREFIX "BUG! Unsupported capability version 0x%x on wrapper. Report to NixOS bugtracker\n", version);
             return 1;
     }
 
@@ -102,7 +103,7 @@ static int make_caps_ambient(const char *self_path) {
     }
 
     if (syscall(SYS_capset, &header, &user_data) < 0) {
-        fprintf(stderr, "failed to inherit capabilities: %s", strerror(errno));
+        fprintf(stderr, LOG_PREFIX "failed to inherit capabilities: %s", strerror(errno));
         return 1;
     }
     unsigned last_cap;
@@ -125,36 +126,120 @@ static int make_caps_ambient(const char *self_path) {
         // though???? I'm preferring a strict vs. loose policy here.
         if (cap == CAP_SETPCAP) {
             if(getenv(wrapper_debug)) {
-                fprintf(stderr, "cap_setpcap in set, skipping it\n");
+                fprintf(stderr, LOG_PREFIX "cap_setpcap in set, skipping it\n");
             }
             continue;
         }
         if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, (unsigned long) cap, 0, 0)) {
-            fprintf(stderr, "cannot raise the capability %d into the ambient set: %s\n", cap, strerror(errno));
+            fprintf(stderr, LOG_PREFIX "cannot raise the capability %d into the ambient set: %s\n", cap, strerror(errno));
             return 1;
         }
         if (getenv(wrapper_debug)) {
-            fprintf(stderr, "raised %d into the ambient capability set\n", cap);
+            fprintf(stderr, LOG_PREFIX "raised %d into the ambient capability set\n", cap);
         }
     }
 
     return 0;
 }
 
+ssize_t get_file_size(int exe_fd) {
+  struct stat s;
+
+  if (fstat(exe_fd, &s) == -1) {
+    fprintf(stderr, LOG_PREFIX "failed to stat file /proc/self/exe: %s\n", strerror(errno));
+    return -1;
+  }
+
+  return s.st_size;
+}
+
+int pread_all(int fd, void* buf, size_t size, off_t offset) {
+    for (;;) {
+        ssize_t nread = pread(fd, buf, size, offset);
+        if (nread > 0) {
+            if (nread != size) {
+              fprintf(stderr, LOG_PREFIX "short read on /proc/self/exe: expected: %zu, got: %zd\n", size, nread);
+              return -1;
+            }
+            return 0;
+        }
+        if (errno != EINTR) {
+            perror(LOG_PREFIX "failed to read /proc/self/exe");
+            return -1;
+        }
+    }
+}
+
+ssize_t get_elf_size(int exe_fd) {
+  Ehdr elf_header;
+  if (pread_all(exe_fd, &elf_header, sizeof(Ehdr), 0) == -1) {
+      return -1;
+  };
+
+  return elf_header.e_shoff + (elf_header.e_shnum * elf_header.e_shentsize);
+}
+
+// Reads the program name from the end of the ELF structure. We assume that the
+// program name was appended to the program using `echo -n`.
+char* get_progname(int exe_fd) {
+    ssize_t file_size = get_file_size(exe_fd);
+    if (file_size < 0) {
+        return NULL;
+    }
+
+    ssize_t elf_size = get_elf_size(exe_fd);
+    if (elf_size < 0) {
+        return NULL;
+    }
+
+    if (elf_size > file_size) {
+        fprintf(stderr, LOG_PREFIX "ELF size of /proc/self/exe is larger than file size!?\n");
+        return NULL;
+    }
+
+    if (elf_size == file_size) {
+        fprintf(stderr, LOG_PREFIX "no extra bytes found for target program name found in security wrapper, did you forget to concat it?\n");
+        return NULL;
+    }
+
+    char *prog_name = calloc(file_size - elf_size, 1);
+    if (!prog_name) {
+        perror(LOG_PREFIX "cannot allocate memory for prog_name");
+        return NULL;
+    }
+
+    if (pread_all(exe_fd, prog_name, file_size - elf_size, elf_size) == -1) {
+        free(prog_name);
+        return NULL;
+    };
+
+    return prog_name;
+}
+
 int main(int argc, char **argv) {
-    ASSERT(argc >= 1);
+    int exe_fd = open("/proc/self/exe", O_CLOEXEC);
+    if (exe_fd < 0) {
+        perror(LOG_PREFIX "cannot open /proc/self/exe");
+        return 1;
+    }
+
+    char *prog_name = get_progname(exe_fd);
+    if (!prog_name) {
+        return 1;
+    }
 
     // Read the capabilities set on the wrapper and raise them in to
     // the ambient set so the program we're wrapping receives the
     // capabilities too!
-    if (make_caps_ambient("/proc/self/exe") != 0) {
+    if (make_caps_ambient(exe_fd) != 0) {
+        free(prog_name);
         return 1;
     }
 
-    execve(SOURCE_PROG, argv, environ);
-    
-    fprintf(stderr, "%s: cannot run `%s': %s\n",
-        argv[0], SOURCE_PROG, strerror(errno));
+    execve(prog_name, argv, environ);
+
+    fprintf(stderr, LOG_PREFIX "cannot execute `%s': %s\n", prog_name, strerror(errno));
+    free(prog_name);
 
     return 1;
 }

--- a/nixos/modules/security/wrappers/wrapper.nix
+++ b/nixos/modules/security/wrappers/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, linuxHeaders, parentWrapperDir, debug ? false }:
+{ stdenv, linuxHeaders, parentWrapperDir, sourceProg, debug ? false }:
 # For testing:
 # $ nix-build -E 'with import <nixpkgs> {}; pkgs.callPackage ./wrapper.nix { parentWrapperDir = "/run/wrappers"; debug = true; }'
 stdenv.mkDerivation {
@@ -8,6 +8,7 @@ stdenv.mkDerivation {
   hardeningEnable = [ "pie" ];
   CFLAGS = [
     ''-DWRAPPER_DIR="${parentWrapperDir}"''
+    ''-DSOURCE_PROG="${sourceProg}"''
   ] ++ (if debug then [
     "-Werror" "-Og" "-g"
   ] else [

--- a/nixos/modules/security/wrappers/wrapper.nix
+++ b/nixos/modules/security/wrappers/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, linuxHeaders, parentWrapperDir, sourceProg, debug ? false }:
+{ stdenv, linuxHeaders, sourceProg, debug ? false }:
 # For testing:
 # $ nix-build -E 'with import <nixpkgs> {}; pkgs.callPackage ./wrapper.nix { parentWrapperDir = "/run/wrappers"; debug = true; }'
 stdenv.mkDerivation {
@@ -7,7 +7,6 @@ stdenv.mkDerivation {
   dontUnpack = true;
   hardeningEnable = [ "pie" ];
   CFLAGS = [
-    ''-DWRAPPER_DIR="${parentWrapperDir}"''
     ''-DSOURCE_PROG="${sourceProg}"''
   ] ++ (if debug then [
     "-Werror" "-Og" "-g"

--- a/nixos/modules/security/wrappers/wrapper.nix
+++ b/nixos/modules/security/wrappers/wrapper.nix
@@ -1,21 +1,30 @@
-{ stdenv, linuxHeaders, sourceProg, debug ? false }:
+{ stdenv, linuxHeaders, debug ? false }:
 # For testing:
 # $ nix-build -E 'with import <nixpkgs> {}; pkgs.callPackage ./wrapper.nix { parentWrapperDir = "/run/wrappers"; debug = true; }'
+
+let
+  elfHeaderSize = if stdenv.is64bit then
+                    "64"
+                  else if stdenv.is32bit then
+                    "32"
+                  else throw "unknown elf header size";
+in
 stdenv.mkDerivation {
-  name = "security-wrapper";
+  name = "nixos-security-wrapper";
   buildInputs = [ linuxHeaders ];
   dontUnpack = true;
   hardeningEnable = [ "pie" ];
   CFLAGS = [
-    ''-DSOURCE_PROG="${sourceProg}"''
+    ''-DELF_HEADER_SIZE=${elfHeaderSize}''
   ] ++ (if debug then [
     "-Werror" "-Og" "-g"
   ] else [
     "-Wall" "-O2"
   ]);
   dontStrip = debug;
+
   installPhase = ''
     mkdir -p $out/bin
-    $CC $CFLAGS ${./wrapper.c} -o $out/bin/security-wrapper
+    $CC $CFLAGS ${./wrapper.c} -o $out/bin/nixos-security-wrapper
   '';
 }

--- a/nixos/tests/wrappers.nix
+++ b/nixos/tests/wrappers.nix
@@ -70,6 +70,17 @@ in
       test_as_regular('/run/wrappers/bin/sgid_root_busybox id -g', '0')
       test_as_regular('/run/wrappers/bin/sgid_root_busybox id -rg', '${toString usersGid}')
 
+      # Test that in nonewprivs environment the wrappers simply exec their target.
+      test_as_regular('${pkgs.util-linux}/bin/setpriv --no-new-privs /run/wrappers/bin/suid_root_busybox id -u', '${toString userUid}')
+      test_as_regular('${pkgs.util-linux}/bin/setpriv --no-new-privs /run/wrappers/bin/suid_root_busybox id -ru', '${toString userUid}')
+      test_as_regular('${pkgs.util-linux}/bin/setpriv --no-new-privs /run/wrappers/bin/suid_root_busybox id -g', '${toString usersGid}')
+      test_as_regular('${pkgs.util-linux}/bin/setpriv --no-new-privs /run/wrappers/bin/suid_root_busybox id -rg', '${toString usersGid}')
+
+      test_as_regular('${pkgs.util-linux}/bin/setpriv --no-new-privs /run/wrappers/bin/sgid_root_busybox id -u', '${toString userUid}')
+      test_as_regular('${pkgs.util-linux}/bin/setpriv --no-new-privs /run/wrappers/bin/sgid_root_busybox id -ru', '${toString userUid}')
+      test_as_regular('${pkgs.util-linux}/bin/setpriv --no-new-privs /run/wrappers/bin/sgid_root_busybox id -g', '${toString usersGid}')
+      test_as_regular('${pkgs.util-linux}/bin/setpriv --no-new-privs /run/wrappers/bin/sgid_root_busybox id -rg', '${toString usersGid}')
+
       # We are only testing the permitted set, because it's easiest to look at with capsh.
       machine.fail(cmd_as_regular('${pkgs.libcap}/bin/capsh --has-p=CAP_CHOWN'))
       machine.fail(cmd_as_regular('${pkgs.libcap}/bin/capsh --has-p=CAP_SYS_ADMIN'))


### PR DESCRIPTION
This builds on top of this PR: https://github.com/NixOS/nixpkgs/pull/199599


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->