### PR TITLE
zlint: init at 3.4.0

### DIFF
--- a/pkgs/tools/security/zlint/default.nix
+++ b/pkgs/tools/security/zlint/default.nix
@@ -1,0 +1,30 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "zlint";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "zmap";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-l39GdfEKUAw5DQNjx6ZBgfGtengRlUUasm0G07kAA2A=";
+  };
+
+  modRoot = "v3";
+  vendorHash = "sha256-OiHEyMHuSiWDB/1YRvAhErb1h/rFfXXVcagcP386doc=";
+  preBuild = ''
+    # not in the go.mod
+    rm -rf cmd/genTestCerts
+  '';
+
+  # Tests rely on git and we don't have the .git dir because modRoot is in a subdir
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/zmap/zlint/";
+    license = licenses.asl20;
+    description = "X.509 Certificate Linter focused on Web PKI standards and requirements.";
+    maintainers = with maintainers; [ baloo ];
+  };
+}

--- a/pkgs/tools/security/zlint/default.nix
+++ b/pkgs/tools/security/zlint/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, git
 , testers
 , zlint
 }:
@@ -14,8 +13,7 @@ buildGoModule rec {
     owner = "zmap";
     repo = "zlint";
     rev = "v${version}";
-    leaveDotGit = true;
-    hash = "sha256-1T8WAWsivSEB2xVEM+GpWJuD3DGXPa9uNpuN6/ABsns=";
+    hash = "sha256-l39GdfEKUAw5DQNjx6ZBgfGtengRlUUasm0G07kAA2A=";
   };
 
   modRoot = "v3";
@@ -38,12 +36,8 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  checkInputs = [ git ];
-
-  preCheck = ''
-    # Test all targets.
-    unset subPackages
-  '';
+  # Checks rely on .git directory, leaveDotGit makes the source derivation flaky.
+  doCheck = false;
 
   passthru.tests.version = testers.testVersion {
     package = zlint;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13279,6 +13279,8 @@ with pkgs;
 
   zkar = callPackage ../tools/security/zkar { };
 
+  zlint = callPackage ../tools/security/zlint { };
+
   zmap = callPackage ../tools/security/zmap { };
 
   zpool-iostat-viz = callPackage ../tools/filesystems/zpool-iostat-viz { };


### PR DESCRIPTION
###### Description of changes

This adds `zlint` which is a linter for certificates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
