### PR TITLE
lint-staged: init at 13.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9322,6 +9322,15 @@
     githubId = 249317;
     name = "montag451";
   };
+  montchr = {
+    name = "Chris Montgomery";
+    email = "chris@cdom.io";
+    github = "montchr";
+    githubId = 1757914;
+    keys = [{
+      fingerprint = "6460 4147 C434 F65E C306  A21F 135E EDD0 F719 34F3";
+    }];
+  };
   moosingin3space = {
     email = "moosingin3space@gmail.com";
     github = "moosingin3space";

--- a/pkgs/development/tools/misc/lint-staged/default.nix
+++ b/pkgs/development/tools/misc/lint-staged/default.nix
@@ -1,0 +1,26 @@
+{ lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage rec {
+  pname = "lint-staged";
+  version = "13.0.3";
+
+  src = fetchFromGitHub {
+    owner = "okonet";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-gQrgDX0+fpLz4Izrw29ChwBUXXXrUyZqV7BWtz9Ru8k=";
+  };
+
+  npmDepsHash = "sha256-n8UAupSb8fA+1oemKAVZEGs024ToRTNUTWKz1V88I/o=";
+
+  dontNpmBuild = true;
+
+  meta = with lib; {
+    description = "Run linters on git staged files";
+    homepage = "https://github.com/okonet/lint-staged";
+    license = licenses.mit;
+    maintainers = with maintainers; [ montchr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -506,6 +506,8 @@ with pkgs;
 
   html5validator = python3Packages.callPackage ../applications/misc/html5validator { };
 
+  lint-staged = callPackage ../development/tools/misc/lint-staged { };
+
   buildcatrust = with python3.pkgs; toPythonApplication buildcatrust;
 
   probe-rs-cli = callPackage ../development/tools/rust/probe-rs-cli {


### PR DESCRIPTION
###### Description of changes

- Add the `lint-staged` package @ v13.0.3
- Add myself to the list of maintainers

`lint-staged` provides a graceful workflow for linting partially-staged or fully-staged files in a git repo, usually in a `pre-commit` hook. It can even manage formatting-related side effects to partially-staged files. Oftentimes I see these tasks handled in a very fragile and bespoke way across many projects, but this tool is the only approach I've worked with that hasn't been prone to frustrating bugs while I commit individual hunks of files. At the moment, `lint-staged` is the only reason I prefer keeping a `package.json` around in my non-JS repos. I think it would be great if it were available as a Nix installable since perhaps it could then find greater usage outside of the JS ecosystem.

It appears as though this is the first package to use `buildNpmPackage`! I initially attempted to add `lint-staged` to the list in `node-packages.json`, however I was unable to update the generated file due to an npm package that failed to fetch.

Re: functionality: I've removed `lint-staged` from my personal configs' `package.json` and swapped it out with the package from this branch. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
