### PR TITLE
Audiobookshelf package and module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -32,6 +32,13 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/advplyr/audiobookshelf/">audiobookshelf</link>,
+          a self-hosted audiobook and podcast server. Available as
+          <link linkend="opt-services.audiobookshelf.enable">services.audiobookshelf</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/akinomyoga/ble.sh">blesh</link>,
           a line editor written in pure bash. Available as
           <link linkend="opt-programs.bash.blesh.enable">programs.bash.blesh</link>.

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -16,6 +16,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Akkoma](https://akkoma.social), an ActivityPub microblogging server. Available as [services.akkoma](options.html#opt-services.akkoma.enable).
 
+- [audiobookshelf](https://github.com/advplyr/audiobookshelf/), a self-hosted audiobook and podcast server. Available as [services.audiobookshelf](#opt-services.audiobookshelf.enable).
+
 - [blesh](https://github.com/akinomyoga/ble.sh), a line editor written in pure bash. Available as [programs.bash.blesh](#opt-programs.bash.blesh.enable).
 
 - [webhook](https://github.com/adnanh/webhook), a lightweight webhook server. Available as [services.webhook](#opt-services.webhook.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1112,6 +1112,7 @@
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/baget.nix
+  ./services/web-apps/audiobookshelf.nix
   ./services/web-apps/bookstack.nix
   ./services/web-apps/calibre-web.nix
   ./services/web-apps/changedetection-io.nix

--- a/nixos/modules/services/web-apps/audiobookshelf.nix
+++ b/nixos/modules/services/web-apps/audiobookshelf.nix
@@ -1,0 +1,102 @@
+{ pkgs
+, lib
+, config
+, ...
+}:
+
+with lib; let
+  cfg = config.services.audiobookshelf;
+in
+
+{
+  options.services.audiobookshelf = {
+    enable = mkEnableOption (lib.mdDoc  "Audiobookshelf, self-hosted audiobook and podcast server");
+
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      description = lib.mdDoc ''
+        The port that Audiobookshelf will listen on.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "audiobookshelf";
+      description = lib.mdDoc ''
+        User account under which Audiobookshelf runs.
+      '';
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "audiobookshelf";
+      description = lib.mdDoc ''
+        Group under which Audiobookshelf runs.
+      '';
+    };
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Whether to open the firewall for the port in {option}`services.audiobookshelf.port`.
+      '';
+    };
+    configDir = mkOption {
+      type = types.str;
+      default = "/etc/audiobookshelf";
+      description = lib.mdDoc ''
+        Configuration directory Audiobookshelf will use.
+      '';
+    };
+
+    metadataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/audiobookshelf";
+      description = lib.mdDoc ''
+        Metadata directory Audiobookshelf will use.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+
+    users.groups = mkIf (cfg.group == "audiobookshelf") {
+      audiobookshelf = { };
+    };
+
+    users.users = mkIf (cfg.user == "audiobookshelf") {
+      audiobookshelf = {
+        group = cfg.group;
+        description = "Audiobookshelf Daemon user";
+        isSystemUser = true;
+      };
+    };
+
+    systemd.services.audiobookshelf = {
+      environment = {
+        PORT = builtins.toString cfg.port;
+        CONFIG_PATH = cfg.configDir;
+        METADATA_PATH = cfg.metadataDir;
+      };
+      description = "Audiobookshelf is a self-hosted audiobook and podcast server";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Type = "simple";
+        Restart = "on-failure";
+        StateDirectory = mkIf (cfg.metadataDir == "/var/lib/audiobookshelf") "audiobookshelf";
+        ConfigurationDirectory = mkIf (cfg.configDir == "/etc/audiobookshelf") "audiobookshelf";
+        ExecStart = "${pkgs.audiobookshelf}/bin/audiobookshelf";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ dit7ya ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -84,6 +84,7 @@ in {
   atd = handleTest ./atd.nix {};
   atop = handleTest ./atop.nix {};
   atuin = handleTest ./atuin.nix {};
+  audiobookshelf = handleTest ./audiobookshelf.nix {};
   auth-mysql = handleTest ./auth-mysql.nix {};
   avahi = handleTest ./avahi.nix {};
   avahi-with-resolved = handleTest ./avahi.nix { networkd = true; };

--- a/nixos/tests/audiobookshelf.nix
+++ b/nixos/tests/audiobookshelf.nix
@@ -1,0 +1,23 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+with lib;
+
+{
+  name = "audiobookshelf";
+  meta.maintainers = with maintainers; [ dit7ya ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.audiobookshelf = {
+        enable = true;
+        port = 1234;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("audiobookshelf.service")
+    machine.wait_for_open_port(1234)
+    machine.succeed("curl --fail http://localhost:1234/")
+  '';
+})

--- a/pkgs/servers/web-apps/audiobookshelf/default.nix
+++ b/pkgs/servers/web-apps/audiobookshelf/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, fetchFromGitHub
+, buildNpmPackage
+, stdenv
+, nodejs
+, ffmpeg
+}:
+
+let
+
+  pname = "audiobookshelf";
+  version = "2.2.11";
+
+  src = fetchFromGitHub {
+    owner = "advplyr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-ZDFOrDyzkGLDODfQJWO7nljrMFbq2pyDkCEN443A8m0=";
+  };
+
+  client = buildNpmPackage rec {
+    inherit src version;
+    pname = "audiobookshelf-client";
+
+    sourceRoot = "source/client";
+
+    NODE_OPTIONS = "--openssl-legacy-provider";
+    npmDepsHash = "sha256-IUTV0sWyMscN4CqaEprAARI/R1eYyQ0G6BrzNuzGojw=";
+
+    npmBuildScript = "generate";
+    installPhase = ''
+      mkdir -p $out/share
+      mv dist $out/share/audiobookshelf-client
+    '';
+  };
+in
+buildNpmPackage {
+  inherit src version pname;
+
+  npmDepsHash = "sha256-42qG/OLoPmKrRL44POoLtk5kzVQX2ZXmEfSOaUHL4lw=";
+
+  npmInstallFlags = "--only-production";
+
+  buildPhase = ''
+    mkdir -p "$out/bin" "$out/lib/audiobookshelf/client/dist"
+    cp prod.js "$out/lib/audiobookshelf"
+    cp package* "$out/lib/audiobookshelf"
+    cp -r server "$out/lib/audiobookshelf"
+    cp -r node_modules "$out/lib/audiobookshelf"
+    cp -r ${client}/share/audiobookshelf-client/*  "$out/lib/audiobookshelf/client/dist"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    makeWrapper ${nodejs}/bin/node "$out/bin/audiobookshelf" --add-flags "$out/lib/audiobookshelf/prod.js" \
+      --prefix PATH : ${ lib.makeBinPath [ffmpeg]} \
+      --prefix SOURCE : "nixos"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Self-hosted audiobook and podcast server";
+    homepage = "https://github.com/advplyr/audiobookshelf";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/servers/web-apps/audiobookshelf/default.nix
+++ b/pkgs/servers/web-apps/audiobookshelf/default.nix
@@ -4,6 +4,7 @@
 , stdenv
 , nodejs
 , ffmpeg
+, nixosTests
 }:
 
 let
@@ -59,6 +60,10 @@ buildNpmPackage {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    audiobookshelf = nixosTests.audiobookshelf;
+  };
 
   meta = with lib; {
     description = "Self-hosted audiobook and podcast server";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3433,6 +3433,8 @@ with pkgs;
 
   atftp = callPackage ../tools/networking/atftp { };
 
+  audiobookshelf = callPackage ../servers/web-apps/audiobookshelf { };
+
   authoscope = callPackage ../tools/security/authoscope {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

https://github.com/advplyr/audiobookshelf/

Self-hosted audiobook and podcast server

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
