### PR TITLE
nvtop: fix build

### DIFF
--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -6,6 +6,8 @@
 , cudatoolkit
 , libdrm
 , ncurses
+, nvtop
+, testers
 , addOpenGLRunpath
 , amd ? true
 , nvidia ? true
@@ -53,6 +55,14 @@ stdenv.mkDerivation rec {
   postFixup = (lib.optionalString amd amd-postFixup) + (lib.optionalString nvidia nvidia-postFixup);
 
   doCheck = true;
+
+  passthru = {
+    tests.version = testers.testVersion {
+      inherit version;
+      package = nvtop;
+      command = "nvtop --version";
+    };
+  };
 
   meta = with lib; {
     description = "A (h)top like task monitor for AMD, Intel and NVIDIA GPUs";

--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -8,16 +8,16 @@
 , ncurses
 , nvtop
 , testers
+, udev
 , addOpenGLRunpath
 , amd ? true
 , nvidia ? true
-, udev
 }:
 
 let
   pname-suffix = if amd && nvidia then "" else if amd then "-amd" else "-nvidia";
   nvidia-postFixup = "addOpenGLRunpath $out/bin/nvtop";
-  libPath = lib.makeLibraryPath [ libdrm ncurses ];
+  libPath = lib.makeLibraryPath [ libdrm ncurses udev ];
   amd-postFixup = ''
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = with lib; [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DBUILD_TESTING=ON"
+    "-DUSE_LIBUDEV_OVER_LIBSYSTEMD=ON"
   ] ++ optional nvidia "-DNVML_INCLUDE_DIRS=${cudatoolkit}/include"
   ++ optional nvidia "-DNVML_LIBRARIES=${cudatoolkit}/targets/x86_64-linux/lib/stubs/libnvidia-ml.so"
   ++ optional (!amd) "-DAMDGPU_SUPPORT=OFF"


### PR DESCRIPTION
###### Description of changes

See https://github.com/NixOS/nixpkgs/issues/201340

* Added passthru.tests.version to test final binary
* Fix build by using udev over systemd as recommended with the AppImage build

Sorry again for breaking the nvtop package! 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
