### PR TITLE
systemd: 251.8 -> 252.1

### DIFF
--- a/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -13,17 +13,17 @@ unit.  (However, this ignores the fsck unit, so it's not perfect...)
  1 file changed, 4 deletions(-)
 
 diff --git a/rules.d/99-systemd.rules.in b/rules.d/99-systemd.rules.in
-index 25b8a590a6..d18999ea87 100644
+index 3dbba1f850..40d367d1c8 100644
 --- a/rules.d/99-systemd.rules.in
 +++ b/rules.d/99-systemd.rules.in
-@@ -17,10 +17,6 @@ SUBSYSTEM=="ubi", TAG+="systemd"
- SUBSYSTEM=="block", TAG+="systemd"
+@@ -20,10 +20,6 @@ SUBSYSTEM=="block", TAG+="systemd"
+ SUBSYSTEM=="block", ENV{DM_SUSPENDED}=="1", IMPORT{db}="SYSTEMD_READY", GOTO="systemd_end"
  SUBSYSTEM=="block", ACTION=="add", ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", ENV{SYSTEMD_READY}="0"
  
 -# Ignore encrypted devices with no identified superblock on it, since
 -# we are probably still calling mke2fs or mkswap on it.
 -SUBSYSTEM=="block", ENV{DM_UUID}=="CRYPT-*", ENV{ID_PART_TABLE_TYPE}=="", ENV{ID_FS_USAGE}=="", ENV{SYSTEMD_READY}="0"
 -
- # add symlink to GPT root disk
- SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="gpt-auto-root"
- SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="gpt-auto-root-luks"
+ # Explicitly set SYSTEMD_READY=1 for DM devices that don't have it set yet, so that we always have something to import above
+ SUBSYSTEM=="block", ENV{DM_UUID}=="?*", ENV{SYSTEMD_READY}=="", ENV{SYSTEMD_READY}="1"
+ 

--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -25,10 +25,10 @@ index f683f05981..5a04c2c2a6 100644
                          "/etc"))
                  return true;
 diff --git a/src/shutdown/umount.c b/src/shutdown/umount.c
-index 820aa8e286..653e43053d 100644
+index e650b82170..5d0d41aa28 100644
 --- a/src/shutdown/umount.c
 +++ b/src/shutdown/umount.c
-@@ -518,6 +518,8 @@ static int delete_md(MountPoint *m) {
+@@ -522,6 +522,8 @@ static int delete_md(MountPoint *m) {
  
  static bool nonunmountable_path(const char *path) {
          return path_equal(path, "/")

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -10,10 +10,10 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 4ce80bba70..bb149192bd 100644
+index 01a67b5553..86dd2cea84 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -5651,6 +5651,7 @@ static int run(int argc, char *argv[]) {
+@@ -5636,6 +5636,7 @@ static int run(int argc, char *argv[]) {
                                  goto finish;
                          }
                  } else {
@@ -21,7 +21,7 @@ index 4ce80bba70..bb149192bd 100644
                          _cleanup_free_ char *p = NULL;
  
                          if (arg_pivot_root_new)
-@@ -5665,6 +5666,7 @@ static int run(int argc, char *argv[]) {
+@@ -5650,6 +5651,7 @@ static int run(int argc, char *argv[]) {
                                                      "Directory %s doesn't look like it has an OS tree (/usr/ directory is missing). Refusing.", arg_directory);
                                  goto finish;
                          }

--- a/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Look for fsck in the right place
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/fsck/fsck.c b/src/fsck/fsck.c
-index 745d01ff50..dd4eef45c3 100644
+index 595434ab57..374a4e6c76 100644
 --- a/src/fsck/fsck.c
 +++ b/src/fsck/fsck.c
-@@ -368,7 +368,7 @@ static int run(int argc, char *argv[]) {
+@@ -373,7 +373,7 @@ static int run(int argc, char *argv[]) {
                  } else
                          dash_c[0] = 0;
  

--- a/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
@@ -14,7 +14,7 @@ Also, remove /usr and /lib as these don't exist on NixOS.
  2 files changed, 6 insertions(+), 19 deletions(-)
 
 diff --git a/src/basic/path-lookup.c b/src/basic/path-lookup.c
-index 1f4331a8bf..4b9a8ae26e 100644
+index 36f386254b..a968d28dfc 100644
 --- a/src/basic/path-lookup.c
 +++ b/src/basic/path-lookup.c
 @@ -92,11 +92,7 @@ int xdg_user_data_dir(char **ret, const char *suffix) {

--- a/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -13,10 +13,10 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 296b759959..71ef7f27b4 100644
+index a59afafb58..d9e7d77913 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -1428,7 +1428,8 @@ static unsigned manager_dispatch_stop_when_bound_queue(Manager *m) {
+@@ -1432,7 +1432,8 @@ static unsigned manager_dispatch_stop_when_bound_queue(Manager *m) {
                  if (!unit_is_bound_by_inactive(u, &culprit))
                          continue;
  

--- a/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -11,10 +11,10 @@ Subject: [PATCH] hostnamed, localed, timedated: disable methods that change
  3 files changed, 25 insertions(+)
 
 diff --git a/src/hostname/hostnamed.c b/src/hostname/hostnamed.c
-index 5f09e6d0eb..46bef3b59d 100644
+index 486b093062..580e933f14 100644
 --- a/src/hostname/hostnamed.c
 +++ b/src/hostname/hostnamed.c
-@@ -910,6 +910,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
+@@ -906,6 +906,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
          if (r < 0)
                  return r;
  
@@ -24,7 +24,7 @@ index 5f09e6d0eb..46bef3b59d 100644
          name = empty_to_null(name);
  
          context_read_etc_hostname(c);
-@@ -973,6 +976,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
+@@ -969,6 +972,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
          if (r < 0)
                  return r;
  
@@ -35,10 +35,10 @@ index 5f09e6d0eb..46bef3b59d 100644
  
          context_read_machine_info(c);
 diff --git a/src/locale/localed.c b/src/locale/localed.c
-index 89bf9c6fba..af2f37a4ca 100644
+index 7aa47f18c2..0a8ef68931 100644
 --- a/src/locale/localed.c
 +++ b/src/locale/localed.c
-@@ -359,6 +359,9 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
+@@ -309,6 +309,9 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
          if (r < 0)
                  return r;
  
@@ -48,7 +48,7 @@ index 89bf9c6fba..af2f37a4ca 100644
          use_localegen = locale_gen_check_available();
  
          /* If single locale without variable name is provided, then we assume it is LANG=. */
-@@ -484,6 +487,9 @@ static int method_set_vc_keyboard(sd_bus_message *m, void *userdata, sd_bus_erro
+@@ -423,6 +426,9 @@ static int method_set_vc_keyboard(sd_bus_message *m, void *userdata, sd_bus_erro
          if (r < 0)
                  return r;
  
@@ -58,7 +58,7 @@ index 89bf9c6fba..af2f37a4ca 100644
          keymap = empty_to_null(keymap);
          keymap_toggle = empty_to_null(keymap_toggle);
  
-@@ -664,6 +670,9 @@ static int method_set_x11_keyboard(sd_bus_message *m, void *userdata, sd_bus_err
+@@ -602,6 +608,9 @@ static int method_set_x11_keyboard(sd_bus_message *m, void *userdata, sd_bus_err
          if (r < 0)
                  return r;
  
@@ -69,10 +69,10 @@ index 89bf9c6fba..af2f37a4ca 100644
          model = empty_to_null(model);
          variant = empty_to_null(variant);
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index 9ca5d37b75..e41d8d73df 100644
+index 373574cc06..6dbf73eb42 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
-@@ -669,6 +669,10 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
+@@ -665,6 +665,10 @@ static int method_set_timezone(sd_bus_message *m, void *userdata, sd_bus_error *
          if (r < 0)
                  return r;
  
@@ -83,7 +83,7 @@ index 9ca5d37b75..e41d8d73df 100644
          if (!timezone_is_valid(z, LOG_DEBUG))
                  return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Invalid or not installed time zone '%s'", z);
  
-@@ -748,6 +752,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error
+@@ -743,6 +747,9 @@ static int method_set_local_rtc(sd_bus_message *m, void *userdata, sd_bus_error
          if (r < 0)
                  return r;
  
@@ -93,7 +93,7 @@ index 9ca5d37b75..e41d8d73df 100644
          if (lrtc == c->local_rtc && !fix_system)
                  return sd_bus_reply_method_return(m, NULL);
  
-@@ -930,6 +937,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
+@@ -923,6 +930,9 @@ static int method_set_ntp(sd_bus_message *m, void *userdata, sd_bus_error *error
          if (r < 0)
                  return r;
  

--- a/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -35,10 +35,10 @@ index e486474c44..5f373d0723 100644
      <literal>Etc/UTC</literal>. The resulting link should lead to the
      corresponding binary
 diff --git a/src/basic/time-util.c b/src/basic/time-util.c
-index 0ad8de4b9a..b794c6c7d0 100644
+index 71b2f67350..465f1c0b15 100644
 --- a/src/basic/time-util.c
 +++ b/src/basic/time-util.c
-@@ -1281,7 +1281,7 @@ static int get_timezones_from_zone1970_tab(char ***ret) {
+@@ -1280,7 +1280,7 @@ static int get_timezones_from_zone1970_tab(char ***ret) {
  
          assert(ret);
  
@@ -47,7 +47,7 @@ index 0ad8de4b9a..b794c6c7d0 100644
          if (!f)
                  return -errno;
  
-@@ -1320,7 +1320,7 @@ static int get_timezones_from_tzdata_zi(char ***ret) {
+@@ -1319,7 +1319,7 @@ static int get_timezones_from_tzdata_zi(char ***ret) {
          _cleanup_strv_free_ char **zones = NULL;
          int r;
  
@@ -56,7 +56,7 @@ index 0ad8de4b9a..b794c6c7d0 100644
          if (!f)
                  return -errno;
  
-@@ -1433,7 +1433,7 @@ int verify_timezone(const char *name, int log_level) {
+@@ -1431,7 +1431,7 @@ int verify_timezone(const char *name, int log_level) {
          if (p - name >= PATH_MAX)
                  return -ENAMETOOLONG;
  
@@ -65,7 +65,7 @@ index 0ad8de4b9a..b794c6c7d0 100644
  
          fd = open(t, O_RDONLY|O_CLOEXEC);
          if (fd < 0)
-@@ -1491,7 +1491,7 @@ int get_timezone(char **ret) {
+@@ -1489,7 +1489,7 @@ int get_timezone(char **ret) {
          if (r < 0)
                  return r; /* returns EINVAL if not a symlink */
  
@@ -75,10 +75,10 @@ index 0ad8de4b9a..b794c6c7d0 100644
                  return -EINVAL;
  
 diff --git a/src/firstboot/firstboot.c b/src/firstboot/firstboot.c
-index 39160182ef..8dcc3307c8 100644
+index 065ee896cd..1b260416c8 100644
 --- a/src/firstboot/firstboot.c
 +++ b/src/firstboot/firstboot.c
-@@ -494,7 +494,7 @@ static int process_timezone(void) {
+@@ -510,7 +510,7 @@ static int process_timezone(void) {
          if (isempty(arg_timezone))
                  return 0;
  
@@ -86,12 +86,12 @@ index 39160182ef..8dcc3307c8 100644
 +        e = strjoina("zoneinfo/", arg_timezone);
  
          (void) mkdir_parents(etc_localtime, 0755);
-         if (symlink(e, etc_localtime) < 0)
+         r = symlink_atomic(e, etc_localtime);
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index bb149192bd..08751ed944 100644
+index 86dd2cea84..4e5f03669d 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -1901,8 +1901,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
+@@ -1905,8 +1905,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
  static const char *timezone_from_path(const char *path) {
          return PATH_STARTSWITH_SET(
                          path,
@@ -103,7 +103,7 @@ index bb149192bd..08751ed944 100644
  
  static bool etc_writable(void) {
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index e41d8d73df..ff1a384b3b 100644
+index 6dbf73eb42..a36dd459d2 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
 @@ -282,7 +282,7 @@ static int context_read_data(Context *c) {

--- a/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
+++ b/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
@@ -10,10 +10,10 @@ NixOS has an option to link the xkb data files to /etc/X11, but not to
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/locale/localectl.c b/src/locale/localectl.c
-index 661d54c27d..e98b578531 100644
+index c23f1fa3f6..ad2eba82ad 100644
 --- a/src/locale/localectl.c
 +++ b/src/locale/localectl.c
-@@ -277,7 +277,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
+@@ -299,7 +299,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
          } state = NONE, look_for;
          int r;
  

--- a/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
+++ b/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] build: don't create statedir and don't touch prefixdir
  1 file changed, 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 9c170acc0a..818b7a3eb5 100644
+index 76ad51d3fb..839dcef437 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -3928,9 +3928,6 @@ install_data('LICENSE.GPL2',
+@@ -4067,9 +4067,6 @@ install_data('LICENSE.GPL2',
  install_subdir('LICENSES',
                 install_dir : docdir)
  

--- a/pkgs/os-specific/linux/systemd/0012-add-rootprefix-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0012-add-rootprefix-to-lookup-dir-paths.patch
@@ -12,10 +12,10 @@ files that I might have missed.
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/src/basic/def.h b/src/basic/def.h
-index 0a1ae023a3..cc00ff6c68 100644
+index 2b4de29021..1bd61dc45f 100644
 --- a/src/basic/def.h
 +++ b/src/basic/def.h
-@@ -39,13 +39,15 @@
+@@ -44,13 +44,15 @@
          "/run/" n "\0"                          \
          "/usr/local/lib/" n "\0"                \
          "/usr/lib/" n "\0"                      \

--- a/pkgs/os-specific/linux/systemd/0013-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+++ b/pkgs/os-specific/linux/systemd/0013-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
@@ -6,19 +6,18 @@ Subject: [PATCH] systemd-shutdown: execute scripts in
 
 This is needed for NixOS to use such scripts as systemd directory is immutable.
 ---
- src/shutdown/shutdown.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/shutdown/shutdown.c | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/src/shutdown/shutdown.c b/src/shutdown/shutdown.c
-index 2c3cbec02c..1b876203c6 100644
+index dcee0f9006..24b03d6948 100644
 --- a/src/shutdown/shutdown.c
 +++ b/src/shutdown/shutdown.c
-@@ -335,7 +335,7 @@ int main(int argc, char *argv[]) {
+@@ -334,6 +334,7 @@ static void init_watchdog(void) {
+ int main(int argc, char *argv[]) {
+         static const char* const dirs[] = {
+                 SYSTEM_SHUTDOWN_PATH,
++                "/etc/systemd/system-shutdown",
+                 NULL
+         };
          _cleanup_free_ char *cgroup = NULL;
-         char *arguments[3];
-         int cmd, r, umount_log_level = LOG_INFO;
--        static const char* const dirs[] = {SYSTEM_SHUTDOWN_PATH, NULL};
-+        static const char* const dirs[] = {SYSTEM_SHUTDOWN_PATH, "/etc/systemd/system-shutdown", NULL};
- 
-         /* The log target defaults to console, but the original systemd process will pass its log target in through a
-          * command line argument, which will override this default. Also, ensure we'll never log to the journal or

--- a/pkgs/os-specific/linux/systemd/0014-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+++ b/pkgs/os-specific/linux/systemd/0014-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
@@ -9,10 +9,10 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+)
 
 diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
-index 65e391d02a..28af2f8bf5 100644
+index 3461d3e45f..d7d0ec2a7a 100644
 --- a/src/sleep/sleep.c
 +++ b/src/sleep/sleep.c
-@@ -180,6 +180,7 @@ static int execute(
+@@ -184,6 +184,7 @@ static int execute(
          };
          static const char* const dirs[] = {
                  SYSTEM_SLEEP_PATH,

--- a/pkgs/os-specific/linux/systemd/0015-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0015-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -10,7 +10,7 @@ systemd itself uses extensively.
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/basic/path-util.h b/src/basic/path-util.h
-index 553aa4fb58..46294f4bb1 100644
+index 22d3632e6e..1e8bbb242b 100644
 --- a/src/basic/path-util.h
 +++ b/src/basic/path-util.h
 @@ -24,11 +24,11 @@

--- a/pkgs/os-specific/linux/systemd/0017-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0017-inherit-systemd-environment-when-calling-generators.patch
@@ -16,10 +16,10 @@ executables that are being called from managers.
  1 file changed, 8 insertions(+)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 71ef7f27b4..33ded94a7c 100644
+index d9e7d77913..ba3ce14bf0 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -3704,9 +3704,17 @@ static int build_generator_environment(Manager *m, char ***ret) {
+@@ -3693,9 +3693,17 @@ static int build_generator_environment(Manager *m, char ***ret) {
           * adjust generated units to that. Let's pass down some bits of information that are easy for us to
           * determine (but a bit harder for generator scripts to determine), as environment variables. */
  

--- a/pkgs/os-specific/linux/systemd/0018-core-don-t-taint-on-unmerged-usr.patch
+++ b/pkgs/os-specific/linux/systemd/0018-core-don-t-taint-on-unmerged-usr.patch
@@ -17,10 +17,10 @@ See also: https://github.com/systemd/systemd/issues/24191
  1 file changed, 4 deletions(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 33ded94a7c..8847479799 100644
+index ba3ce14bf0..03bf66ff74 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -4488,10 +4488,6 @@ char* manager_taint_string(const Manager *m) {
+@@ -4493,10 +4493,6 @@ char* manager_taint_string(const Manager *m) {
          if (m->taint_usr)
                  stage[n++] = "split-usr";
  

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -122,13 +122,13 @@ assert withHomed -> withCryptsetup;
 let
   wantCurl = withRemote || withImportd;
   wantGcrypt = withResolved || withImportd;
-  version = "251.8";
+  version = "252.1";
 
   # Bump this variable on every (major) version change. See below (in the meson options list) for why.
   # command:
   #  $ curl -s https://api.github.com/repos/systemd/systemd/releases/latest | \
   #     jq '.created_at|strptime("%Y-%m-%dT%H:%M:%SZ")|mktime'
-  releaseTimestamp = "1653143108";
+  releaseTimestamp = "1667246393";
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -139,7 +139,7 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "sha256-kao0xJwwJc4zUyaK5yxyGip4E6ADak98iVv5E8Hw0zk=";
+    hash = "sha256-G43qbNF7znTITSM78sOL0qi8nqaA7qIhmiqP/rZKjXY=";
   };
 
   # On major changes, or when otherwise required, you *must* reformat the patches,


### PR DESCRIPTION
###### Description of changes

Systemd v252 changelog [here](https://github.com/systemd/systemd/releases/tag/v252).

###### Things done

Most of the patches rebased cleanly, with the exceptions of `0013` and `0001`. I could use another set of eyes on the `0001` patch, because the file it patches had one or two other lines of changes that could be relevant. I wasn't sure, but it looked fine to me.

I ran all the systemd related tests with this based on `nixos-unstable-small`, and the only failures were ones that are already failing on hydra (in particular, for systemd stage 1, a couple of installer tests and the hibernation test).

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
