### PR TITLE
maestro: 1.11.3 -> 1.17.2

### DIFF
--- a/pkgs/development/mobile/maestro/default.nix
+++ b/pkgs/development/mobile/maestro/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "maestro";
-  version = "1.11.3";
+  version = "1.15.0";
 
   src = fetchurl {
-    url = "https://github.com/mobile-dev-inc/maestro/releases/download/cli-${version}/maestro-${version}.zip";
-    sha256 = "0hjsrwp6d1k68p0qhn7v9689ihy06ssnfpi8dj61jw6r64c234m4";
+    url = "https://github.com/mobile-dev-inc/maestro/releases/download/cli-${version}/maestro.zip";
+    sha256 = "1rv9481pffd27ksqdm6z809sa1c5cslxvq53bw04iqgwvhdjzm2m";
   };
 
   dontUnpack = true;
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir $out
     unzip $src -d $out
-    mv $out/maestro-$version/* $out
-    rm -rf $out/maestro-$version
+    mv $out/maestro/* $out
+    rm -rf $out/maestro
   '';
 
   postFixup = ''

--- a/pkgs/development/mobile/maestro/default.nix
+++ b/pkgs/development/mobile/maestro/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "maestro";
-  version = "1.15.0";
+  version = "1.17.2";
 
   src = fetchurl {
     url = "https://github.com/mobile-dev-inc/maestro/releases/download/cli-${version}/maestro.zip";
-    sha256 = "1rv9481pffd27ksqdm6z809sa1c5cslxvq53bw04iqgwvhdjzm2m";
+    sha256 = "1lf0226gl9912qrk4s57bsncv23886b8wk7wri6icg26xp1cxa3v";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
###### Description of changes

Update maestro to 1.17.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
