### PR TITLE
Asphyxia core: init at 1.40d

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -429,6 +429,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://asphyxia-core.github.io/">Asphyxia
+          CORE</link>, an e-amuse emulator for Konami rhythm games.
+          Available as
+          <link linkend="opt-services.asphyxia-core.enable">services.asphyxia-core</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://www.ausweisapp.bund.de/">AusweisApp2</link>,
           the authentication software for the German ID card. Available
           as

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -142,6 +142,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Grafana Tempo](https://www.grafana.com/oss/tempo/), a distributed tracing store. Available as [services.tempo](#opt-services.tempo.enable).
 
+- [Asphyxia CORE](https://asphyxia-core.github.io/), an e-amuse emulator for Konami rhythm games. Available as [services.asphyxia-core](#opt-services.asphyxia-core.enable).
+
 - [AusweisApp2](https://www.ausweisapp.bund.de/), the authentication software for the German ID card. Available as [programs.ausweisapp](#opt-programs.ausweisapp.enable).
 
 - [Patroni](https://github.com/zalando/patroni), a template for PostgreSQL HA with ZooKeeper, etcd or Consul.

--- a/nixos/modules/services/games/asphyxia-core.nix
+++ b/nixos/modules/services/games/asphyxia-core.nix
@@ -1,0 +1,143 @@
+{ config, lib, options, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.asphyxia-core;
+  configAsIni = generators.toINIWithGlobalSection {} {
+    globalSection = {
+      port = cfg.port;
+      bind = cfg.bind;
+      ping_ip = cfg.pingIp;
+      matching_port = cfg.matchingPort;
+      allow_register = cfg.allowRegister;
+      maintenance_mode = cfg.maintenanceMode;
+      enable_paseli = cfg.enablePaseli;
+    };
+    sections = {};
+  };
+
+  configIniFile = pkgs.writeText "config.ini" configAsIni;
+
+  configDir = pkgs.runCommand "createConfigDir" {} ''
+    mkdir -p $out
+    ln -s ${configIniFile} $out/config.ini
+    ln -s ${corePlugins} $out/plugins
+  '';
+
+  corePlugins = pkgs.fetchgit {
+    url = "https://github.com/asphyxia-core/plugins";
+    rev = "81630a86a299fd278b86b04dd94ece0b36525b2f";
+    sha256 = "sha256-HNtVzlnGbOqXWVbyRqV4sJWOGk9srARPx7vAjmAh4QY=";
+  };
+in
+{
+  options = {
+    services.asphyxia-core = {
+      enable = mkEnableOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          If enabled, starts an Asphyxia-core server.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 8083;
+        description = lib.mdDoc ''
+          Specifies the port to listen on.
+        '';
+      };
+
+      matchingPort = mkOption {
+        type = types.port;
+        default = 5700;
+        description = lib.mdDoc ''
+          Specifies the matching port to listen on for multiplayer sessions.
+        '';
+      };
+
+      bind = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = lib.mdDoc ''
+          Sets the hostname or IP address to bind to.
+        '';
+      };
+
+      pingIp = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = lib.mdDoc ''
+          An ICMP pingable target to make your games think they are online.
+        '';
+      };
+
+      allowRegister = mkOption {
+        type = types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Whether to allow user registration.
+        '';
+      };
+
+      enablePaseli = mkOption {
+        type = types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Whether to enable Paseli.
+        '';
+      };
+
+      maintenanceMode = mkEnableOption "the maintenance mode";
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Whether to automatically open ports in the firewall.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.asphyxia-core;
+        description = lib.mdDoc ''
+          Asphyxia package to use.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.asphyxia = {
+      description = "Asphyxia Server Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Restart = "always";
+        DynamicUser = true;
+        StateDirectory="asphyxia-core";
+        WorkingDirectory="${dirOf configIniFile}";
+        ExecStart="exec -a ${configDir}/asphyxia-core ${cfg.package}/bin/asphyxia-core -d /var/lib/asphyxia-core";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port cfg.matchingPort ];
+    };
+  };
+}

--- a/pkgs/games/asphyxia-core/default.nix
+++ b/pkgs/games/asphyxia-core/default.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "asphyxia-core";
+  version = "1.40";
+
+  src = fetchurl {
+    url = "https://github.com/asphyxia-core/asphyxia-core.github.io/releases/download/v${version}/asphyxia-core-linux-x64.zip";
+    sha256 = "sha256-YFAXHzxoLuKfflwqYvpifefRE2/KbShuQ0v+0LG7OCg=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  sourceRoot = ".";
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv asphyxia-core $out/bin/asphyxia-core
+  '';
+
+  preFixup = ''
+    orig_size=$(stat --printf=%s $out/bin/asphyxia-core)
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/asphyxia-core
+    patchelf --set-rpath ${lib.makeLibraryPath [stdenv.cc.cc]} $out/bin/asphyxia-core
+    chmod +x $out/bin/asphyxia-core
+    new_size=$(stat --printf=%s $out/bin/asphyxia-core)
+    ###### zeit-pkg fixing starts here.
+    # we're replacing plaintext js code that looks like
+    # PAYLOAD_POSITION = '1234                  ' | 0
+    # [...]
+    # PRELUDE_POSITION = '1234                  ' | 0
+    # ^-----20-chars-----^^------22-chars------^
+    # ^-- grep points here
+    #
+    # var_* are as described above
+    # shift_by seems to be safe so long as all patchelf adjustments occur
+    # before any locations pointed to by hardcoded offsets
+
+    var_skip=20
+    var_select=22
+    shift_by=$(expr $new_size - $orig_size)
+
+    function fix_offset {
+      # $1 = name of variable to adjust
+      location=$(grep -obUam1 "$1" $out/bin/asphyxia-core | cut -d: -f1)
+      location=$(expr $location + $var_skip)
+      value=$(dd if=$out/bin/asphyxia-core iflag=count_bytes,skip_bytes skip=$location \
+                 bs=1 count=$var_select status=none)
+      value=$(expr $shift_by + $value)
+      echo -n $value | dd of=$out/bin/asphyxia-core bs=1 seek=$location conv=notrunc
+    }
+    fix_offset PAYLOAD_POSITION
+    fix_offset PRELUDE_POSITION
+  '';
+
+  # this binary is very sensitive to parts of it being moved around / changed in length,
+  # so avoid stripping it.
+  dontStrip = true;
+
+
+  meta = with lib; {
+    description = ''An "e-amuse emulator", for running Konami rhythm games without connecting to the internet.'';
+    homepage = "https://asphyxia-core.github.io/";
+    license = licenses.unfreeRedistributable;
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
Adding Asphyxia-core - a server for Konami rhythm games. https://asphyxia-core.github.io/
Asphyxia is closed-source, so this packages a binary. The license is set to `unfreeRedistributable`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
