### PR TITLE
tetrio-plus-desktop: init at 0.23.13

### DIFF
--- a/pkgs/games/tetrio-desktop/plus.nix
+++ b/pkgs/games/tetrio-desktop/plus.nix
@@ -1,0 +1,29 @@
+{ fetchzip
+, tetrio-desktop
+, lib
+}:
+
+let
+  version = "0.23.13";
+  patchedAsar = fetchzip {
+    url = "https://gitlab.com/UniQMG/tetrio-plus/uploads/a9647feffc484304ee49c4d3fd4ce718/tetrio-plus_0.23.13_app.asar.zip";
+    sha256 = "sha256-NSOVZjm4hDXH3f0gFG8ijLmdUTyMRFYGhxpwysoYIVg=";
+  };
+in tetrio-desktop.overrideAttrs (old: {
+  pname = "tetrio-plus-desktop";
+  version = old.version + "+${version}";
+
+  installPhase = old.installPhase + ''
+    cp ${patchedAsar}/app.asar $out/opt/TETR.IO/resources
+  '';
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/UniQMG/tetrio-plus";
+    downloadPage = "https://gitlab.com/UniQMG/tetrio-plus/-/releases";
+    description = "TETR.IO PLUS desktop client";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ Enzime ];
+    mainProgram = "tetrio-desktop";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34485,6 +34485,8 @@ with pkgs;
 
   tetrio-desktop = callPackage ../games/tetrio-desktop { };
 
+  tetrio-plus-desktop = callPackage ../games/tetrio-desktop/plus.nix { };
+
   tr-patcher = callPackage ../games/tr-patcher { };
 
   tes3cmd = callPackage ../games/tes3cmd { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).