### PR TITLE
xpaste: init at 1.5

### DIFF
--- a/pkgs/tools/text/xpaste/default.nix
+++ b/pkgs/tools/text/xpaste/default.nix
@@ -21,13 +21,13 @@ python3Packages.buildPythonApplication rec {
   ];
 
   patches = [
-  (fetchpatch {
-    # https://github.com/ossobv/xpaste/pull/6
-    name = "fix-function-call-after-wayland-update.patch";
-    url = "https://github.com/ossobv/xpaste/commit/47412738dad4b5fc8bc287ead23c8440bfdc547d.patch";
-    hash = "sha256-t4LZG600AsFTtKjXCxioGcAP4YcHIdQ/fVMIYjsunuA=";
-  })
-];
+    (fetchpatch {
+      # https://github.com/ossobv/xpaste/pull/6
+      name = "fix-function-call-after-wayland-update.patch";
+      url = "https://github.com/ossobv/xpaste/commit/47412738dad4b5fc8bc287ead23c8440bfdc547d.patch";
+      hash = "sha256-t4LZG600AsFTtKjXCxioGcAP4YcHIdQ/fVMIYjsunuA=";
+    })
+  ];
 
   # no tests, no python module to import, no version output to check
   doCheck = false;

--- a/pkgs/tools/text/xpaste/default.nix
+++ b/pkgs/tools/text/xpaste/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "xpaste";
+  version = "1.5";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "ossobv";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Z9YxhVP+FUvWET91ob4SPSW+XX7/wzlgPr53vO517L4=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    xlib
+  ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Paste text into X windows that don't work with selections";
+    homepage = "https://github.com/ossobv/xpaste";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/tools/text/xpaste/default.nix
+++ b/pkgs/tools/text/xpaste/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , python3Packages
+, fetchpatch
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -19,7 +20,16 @@ python3Packages.buildPythonApplication rec {
     xlib
   ];
 
-  # no tests
+  patches = [
+  (fetchpatch {
+    # https://github.com/ossobv/xpaste/pull/6
+    name = "fix-function-call-after-wayland-update.patch";
+    url = "https://github.com/ossobv/xpaste/commit/47412738dad4b5fc8bc287ead23c8440bfdc547d.patch";
+    hash = "sha256-t4LZG600AsFTtKjXCxioGcAP4YcHIdQ/fVMIYjsunuA=";
+  })
+];
+
+  # no tests, no python module to import, no version output to check
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1476,6 +1476,8 @@ with pkgs;
 
   xcd = callPackage ../tools/misc/xcd { };
 
+  xpaste = callPackage ../tools/text/xpaste { };
+
   xrootd = callPackage ../tools/networking/xrootd { };
 
   xtrt = callPackage ../tools/archivers/xtrt { };


### PR DESCRIPTION
###### Description of changes

[Xpaste](https://github.com/ossobv/xpaste) allows pasting text by emulating keypresses. Useful for KVM windows.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
