### PR TITLE
ocamlPackages.reactivedata: 0.2.2 → 0.3

### DIFF
--- a/pkgs/development/ocaml-modules/reactivedata/default.nix
+++ b/pkgs/development/ocaml-modules/reactivedata/default.nix
@@ -1,34 +1,26 @@
-{ lib, stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, react, opaline }:
+{ lib, fetchFromGitHub, buildDunePackage, react }:
 
-if lib.versionOlder ocaml.version "4.04"
-then throw "reactiveData is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-reactiveData";
-  version = "0.2.2";
+buildDunePackage rec {
+  pname = "reactiveData";
+  version = "0.3";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "reactiveData";
     rev = version;
-    sha256 = "sha256-YLkacIbjxZQ/ThgSxjTqviBYih6eW2GX5H7iybQDv1A=";
+    sha256 = "sha256-imUphE1vMe3bYqHhgTuGT+B7uLn75acX6fAwBLh1tz4=";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild opaline ];
   propagatedBuildInputs = [ react ];
 
   strictDeps = true;
-
-  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
-
-  installPhase = "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
 
   meta = with lib; {
     description = "An OCaml module for functional reactive programming (FRP) based on React";
     homepage = "https://github.com/ocsigen/reactiveData";
     license = licenses.lgpl21;
-    platforms = ocaml.meta.platforms or [ ];
     maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
@@ -6,7 +6,8 @@
 buildDunePackage {
   pname = "js_of_ocaml-tyxml";
 
-  inherit (js_of_ocaml-compiler) version src useDune2;
+  inherit (js_of_ocaml-compiler) version src;
+  duneVersion = "3";
 
   buildInputs = [ js_of_ocaml-ppx ];
 


### PR DESCRIPTION
###### Description of changes

Support for future OCaml: https://github.com/ocsigen/reactiveData/blob/0.3/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
