### PR TITLE
gnat11: Fix by building with older gnatboot

### DIFF
--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -1,14 +1,29 @@
 { stdenv, lib, autoPatchelfHook, fetchzip, xz, ncurses5, readline, gmp, mpfr
 , expat, libipt, zlib, dejagnu, sourceHighlight, python3, elfutils, guile, glibc
+, majorVersion
 }:
+
+let
+  versionMap = {
+    "11" = {
+      version = "11.2.0-4";
+      hash = "sha256-8fMBJp6igH+Md5jE4LMubDmC4GLt4A+bZG/Xcz2LAJQ=";
+    };
+    "12" = {
+      version = "12.1.0-2";
+      hash = "sha256-EPDPOOjWJnJsUM7GGxj20/PXumjfLoMIEFX1EDtvWVY=";
+    };
+  };
+
+in with versionMap.${majorVersion};
 
 stdenv.mkDerivation rec {
   pname = "gnatboot";
-  version = "12.1.0-2";
+  inherit version;
 
   src = fetchzip {
     url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-${version}/gnat-x86_64-linux-${version}.tar.gz";
-    hash = "sha256-EPDPOOjWJnJsUM7GGxj20/PXumjfLoMIEFX1EDtvWVY=";
+    inherit hash;
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14169,7 +14169,7 @@ with pkgs;
     gnatboot =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
-      then buildPackages.gnatboot
+      then buildPackages.gnatboot11
       else buildPackages.gnat11;
   });
 
@@ -14185,11 +14185,13 @@ with pkgs;
     gnatboot =
       if stdenv.hostPlatform == stdenv.targetPlatform
          && stdenv.buildPlatform == stdenv.hostPlatform
-      then buildPackages.gnatboot
+      then buildPackages.gnatboot12
       else buildPackages.gnat12;
   });
 
-  gnatboot = wrapCC (callPackage ../development/compilers/gnatboot { });
+  gnatboot = gnatboot12;
+  gnatboot11 = wrapCC (callPackage ../development/compilers/gnatboot { majorVersion = "11"; });
+  gnatboot12 = wrapCC (callPackage ../development/compilers/gnatboot { majorVersion = "12"; });
 
   gnu-smalltalk = callPackage ../development/compilers/gnu-smalltalk { };
 


### PR DESCRIPTION
GCC's installation instructions strongly recommend using an older version of GNAT to build GNAT, as "[[m]ore recent versions of GNAT than the version built are not guaranteed to work and will often fail during the build with compilation errors.][1]"

The recent upgrade of gnatboot to a 12.1 release in commit bc640dc unfortunately [resulted in such a failure for gnat11][2], resulting in the same errors as [GCC bug 103357][3], which was marked WONTFIX for the reason above.

This patch therefore reverts gnat11 to being built with an earlier 11.x gnatboot version, while keeping the updated 12.1 gnatboot to build gnat12 (which is fine because the latter is currently version 12.2). Fixing gnat11 is also a step towards re-enabling the coreboot-toolchain-* packages to be built with Ada support.

To facilitate such explicit version dependencies while retaining the meaning of the existing gnatboot package, and in the fashion of the existing gcc packages, this patch also creates the packages gnatboot11 and gnatboot12 with gnatboot made an alias of gnatboot12.

[1]: https://gcc.gnu.org/install/prerequisites.html
[2]: https://github.com/NixOS/nixpkgs/pull/182414#issuecomment-1204432909
[3]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103357

###### Description of changes

- Add version-specific gnatboot packages (gnatboot11 and gnatboot12)
- Make gnatboot an alias for gnatboot12 (but keep its effective definition unchanged)
- Make gnat11 build with gnatboot11
- Make gnat12 build with gnatboot12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) (but [see below](<#note1>))
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<a name="note1" />Additionally, while not every resulting binary from the updated gnatboot11 and gnat11 have been tested manually, the use of nixpkgs-review resulted in gnatboot11 successfully building gnat11, and then that gnat11 being successfully building all of the coreboot-toolchain-* packages, so at least important parts of the gnatboot11 and gnat11 binaries have had their basic functionality well-exercised.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
