### PR TITLE
python3Packages.versioningit: 2.0.1 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/versioningit/default.nix
+++ b/pkgs/development/python-modules/versioningit/default.nix
@@ -17,8 +17,9 @@
 buildPythonPackage rec {
   pname = "versioningit";
   version = "2.1.0";
-  disabled = pythonOlder "3.8";
   format = "pyproject";
+
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
@@ -35,9 +36,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     packaging
     setuptools
-    tomli
   ] ++ lib.optionals (pythonOlder "3.10") [
     importlib-metadata
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/versioningit/default.nix
+++ b/pkgs/development/python-modules/versioningit/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "versioningit";
-  version = "2.0.1";
+  version = "2.1.0";
   disabled = pythonOlder "3.8";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-gJfiYNm99nZYW9gTO/e1//rDeox2KWJVtC2Gy1EqsuM=";
+    hash = "sha256-c/KWXjDS6/1/+ra/JjaPIjdXBiLdKknH+8GZXenGdtY=";
   };
 
   postPatch = ''


### PR DESCRIPTION


###### Description of changes
https://github.com/jwodder/versioningit/blob/master/CHANGELOG.md#v210-2022-10-25

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
