### PR TITLE
fishPlugins.tide: init at 5.5.1

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -33,4 +33,5 @@ lib.makeScope newScope (self: with self; {
 
   sponge = callPackage ./sponge.nix { };
 
+  tide = callPackage ./tide.nix { };
 })

--- a/pkgs/shells/fish/plugins/tide.nix
+++ b/pkgs/shells/fish/plugins/tide.nix
@@ -1,0 +1,28 @@
+{ lib, buildFishPlugin, fetchFromGitHub }:
+
+# Due to a quirk in tide breaking wrapFish, we need to add additional commands in the config.fish
+# Refer to the following comment to get you setup: https://github.com/NixOS/nixpkgs/pull/201646#issuecomment-1320893716
+buildFishPlugin rec {
+  pname = "tide";
+  version = "5.5.1";
+
+  src = fetchFromGitHub {
+    owner = "IlanCosman";
+    repo = "tide";
+    rev = "v${version}";
+    sha256 = "sha256-vi4sYoI366FkIonXDlf/eE2Pyjq7E/kOKBrQS+LtE+M=";
+  };
+
+  #buildFishplugin will only move the .fish files, but tide has a tide configure function
+  postInstall = ''
+    cp -R functions/tide $out/share/fish/vendor_functions.d/
+  '';
+
+  meta = with lib; {
+    description = "The ultimate Fish prompt.";
+    homepage = "https://github.com/IlanCosman/tide";
+    license = licenses.mit;
+    maintainers = [ maintainers.jocelynthode ];
+  };
+}
+


### PR DESCRIPTION
###### Description of changes

This fish plugin provides a nice native fish prompt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
