### PR TITLE
sof-firmware: 2.2 -> 2.2.2

### DIFF
--- a/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
@@ -5,23 +5,26 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "sof-firmware";
-  version = "2.2";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "thesofproject";
     repo = "sof-bin";
     rev = "v${version}";
-    sha256 = "sha256-/gjGTDOXJ0vz/MH2hlistS3X3Euqf8T6TLnD1A2SBYo=";
+    sha256 = "sha256-ztewE/8Mc0bbKbxmbJ2sBn3TysuM9hoaSgqrboy77oI=";
   };
 
   dontFixup = true; # binaries must not be stripped or patchelfed
 
+  # There is no proper structure in the upstream repo.
+  # This needs to be adapted by hand for every new release.
   installPhase = ''
     runHook preInstall
-    cd "v${lib.versions.majorMinor version}.x"
-    mkdir -p $out/lib/firmware/intel/
-    cp -a sof-v${version} $out/lib/firmware/intel/sof
-    cp -a sof-tplg-v${version} $out/lib/firmware/intel/sof-tplg
+    cd "v2.2.x"
+    mkdir -p $out/lib/firmware/intel/sof{,-tplg}
+    cp -a sof-v2.2/* $out/lib/firmware/intel/sof
+    cp -a sof-v2.2.2/* $out/lib/firmware/intel/sof
+    cp -a sof-tplg-v2.2.1/* $out/lib/firmware/intel/sof-tplg
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New upstream release: https://github.com/thesofproject/sof-bin/releases/tag/v2.2.2
Adds support for Intel Raptor Lake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
