### PR TITLE
mlt: Add rubberband support

### DIFF
--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper
 , SDL, ffmpeg_4, frei0r, libjack2, libdv, libsamplerate, libexif
 , libvorbis, libxml2, movit, pkg-config, sox, fftw, opencv4, SDL2
-, gtk2, gitUpdater, libebur128
+, gtk2, gitUpdater, libebur128, rubberband
 , jack2, ladspa-sdk, swig, which, ncurses
 , enablePython ? false, python3
 }:
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     SDL ffmpeg_4 frei0r libjack2 libdv libsamplerate libvorbis libxml2.dev
     movit sox libexif gtk2 fftw libebur128 opencv4 SDL2 jack2
-    ladspa-sdk
+    ladspa-sdk rubberband
   ] ++ lib.optional enablePython ncurses;
 
   nativeBuildInputs = [ pkg-config makeWrapper which ]

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -20,6 +20,7 @@
 , ladspa-sdk
 , gitUpdater
 , ladspaPlugins
+, rubberband
 , mkDerivation
 , which
 }:
@@ -53,6 +54,7 @@ mkDerivation rec {
     opencv3
     ladspa-sdk
     ladspaPlugins
+    rubberband
   ];
 
   nativeBuildInputs = [ cmake which pkg-config ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Adds rubberband support to mlt. Fixes #201654 .

CC @goibhniu @peti 