### PR TITLE
librewolf: drop upstreamed patch

### DIFF
--- a/pkgs/applications/networking/browsers/librewolf/librewolf.nix
+++ b/pkgs/applications/networking/browsers/librewolf/librewolf.nix
@@ -1,4 +1,4 @@
-{ callPackage, lib, stdenv, fetchpatch }:
+{ callPackage }:
 let
   src = callPackage ./src.nix { };
 in
@@ -6,13 +6,7 @@ rec {
 
   inherit (src) packageVersion firefox source;
 
-  extraPatches = lib.optionals stdenv.isAarch64 [
-    (fetchpatch { # https://bugzilla.mozilla.org/show_bug.cgi?id=1791275
-      name = "no-sysctl-aarch64.patch";
-      url = "https://hg.mozilla.org/mozilla-central/raw-rev/0efaf5a00aaceeed679885e4cd393bd9a5fcd0ff";
-      hash = "sha256-wS/KufeLFxCexQalGGNg8+vnQhzDiL79OLt8FtL/JJ8=";
-    })
-  ];
+  extraPatches = [ ];
 
   extraConfigureFlags = [
     "--with-app-name=librewolf"


### PR DESCRIPTION
This partially reverts commit 61598203a41345042d1ed0d68fbe3466be83c6be.
After update to 107 the patch is already in the src.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] no rebuild x86_64-linux
  - [ ] aarch64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
