### PR TITLE
steamos-devkit: init at 0.20221101

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9629,6 +9629,12 @@
     githubId = 43796009;
     name = "Max Wilson";
   };
+  myaats = {
+    email = "mats@mats.sh";
+    github = "Myaats";
+    githubId = 6295090;
+    name = "Mats";
+  };
   myrl = {
     email = "myrl.0xf@gmail.com";
     github = "Myrl";

--- a/pkgs/development/python-modules/signalslot/default.nix
+++ b/pkgs/development/python-modules/signalslot/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, contexter
+, eventlet
+, mock
+, pytestCheckHook
+, six
+, weakrefmethod
+}:
+
+buildPythonPackage rec {
+  pname = "signalslot";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Z26RPNau+4719e82jMhb2LyIR6EvsANI8r3+eKuw494=";
+  };
+
+  propagatedBuildInputs = [
+    contexter
+    six
+    weakrefmethod
+  ];
+
+  checkInputs = [
+    eventlet
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "signalslot" ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--pep8 --cov" "" \
+      --replace "--cov-report html" ""
+  '';
+
+  meta = with lib; {
+    description = "Simple Signal/Slot implementation";
+    homepage = "https://github.com/numergy/signalslot";
+    license = licenses.mit;
+    maintainers = with maintainers; [ myaats ];
+  };
+}

--- a/pkgs/development/python-modules/weakrefmethod/default.nix
+++ b/pkgs/development/python-modules/weakrefmethod/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi, unittest2 }:
+
+buildPythonPackage rec {
+  pname = "weakrefmethod";
+  version = "1.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-N7wfu1V1rPghctTre2/EQS131aHXDf8sH4pFdDAc2mY=";
+  };
+
+  checkInputs = [
+    unittest2
+  ];
+
+  pythonImportsCheck = [ "weakrefmethod" ];
+
+  meta = with lib; {
+    description = "A WeakMethod class for storing bound methods using weak references";
+    homepage = "https://github.com/twang817/weakrefmethod";
+    license = licenses.psfl;
+    maintainers = with maintainers; [ myaats ];
+  };
+}

--- a/pkgs/development/tools/steamos-devkit/default.nix
+++ b/pkgs/development/tools/steamos-devkit/default.nix
@@ -1,0 +1,135 @@
+{ lib
+, fetchFromGitHub
+, fetchFromGitLab
+, writeScript
+, python3
+, copyDesktopItems
+, makeDesktopItem
+, pkg-config
+, SDL2
+}:
+let
+  # steamos-devkit requires a build of the unreleased pyimgui 2.0 branch, move to pythonPackages when 2.0 is released.
+  pyimgui = python3.pkgs.buildPythonPackage {
+    pname = "pyimgui";
+    version = "unstable-2022-03-06";
+
+    src = fetchFromGitHub {
+      owner = "pyimgui";
+      repo = "pyimgui";
+      rev = "1f095af5886f424ee12f26fa93b108b6420fafa4"; # dev/version-2.0 branch
+      fetchSubmodules = true;
+      sha256 = "sha256-k070ue132m8H1Zm8bo7J7spCS5dSTGOj689ci7vJ+aw=";
+    };
+
+    nativeBuildInputs = with python3.pkgs; [
+      cython
+      pkg-config
+      SDL2
+    ];
+
+    propagatedBuildInputs = with python3.pkgs; [
+      click
+      pyopengl
+      pysdl2
+    ];
+
+    # Requires OpenGL acceleration
+    doCheck = false;
+    pythonImportsCheck = [ "imgui" ];
+  };
+  steamos-devkit-script = ''
+    #!${python3.interpreter}
+    import os
+
+    # Change the cwd to avoid imgui using cwd which often is ~ to store the state, use the same location as the settings
+    path = os.path.expanduser(os.path.join("~", ".devkit-client-gui"))
+    os.makedirs(path, exist_ok=True)
+    os.chdir(path)
+
+    # Workaround to get pysdl to work on wayland, remove when https://gitlab.steamos.cloud/devkit/steamos-devkit/-/issues/1 is solved.
+    if os.environ.get("XDG_SESSION_TYPE") == "wayland":
+      os.environ["SDL_VIDEODRIVER"] = "wayland"
+
+    import devkit_client.gui2
+    devkit_client.gui2.main()
+  '';
+in
+python3.pkgs.buildPythonPackage rec {
+  pname = "steamos-devkit";
+  version = "0.20221101";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.steamos.cloud";
+    owner = "devkit";
+    repo = "steamos-devkit";
+    rev = "v${version}";
+    sha256 = "sha256-VKnfcMF3WxkvqxlhJF+5j4Hso/TZpSS4dMOmSrWagRU=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    appdirs
+    bcrypt
+    cffi
+    cryptography
+    idna
+    ifaddr
+    netifaces
+    numpy
+    paramiko
+    pycparser
+    pyimgui
+    pynacl
+    pysdl2
+    signalslot
+    six
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  postUnpack = ''
+    # Find the absolute source root to link correctly to the previous root
+    prevRoot=$(realpath $sourceRoot)
+
+    # Update the source root to the devkit_client package
+    sourceRoot="$sourceRoot/client"
+
+    # Link the setup script into the new source root
+    ln -s $prevRoot/setup/shiv-linux-setup.py $sourceRoot/setup.py
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+
+    # These are various assets like scripts that steamos-devkit will copy to the remote device
+    cp -R ./devkit-utils $out/${python3.sitePackages}/devkit-utils
+
+    # writeScript + symlink will be ignored by wrapPythonPrograms
+    # Copying it is undesirable too, just write it directly to a script instead
+    cat << EOF > $out/bin/steamos-devkit
+    ${steamos-devkit-script}
+    EOF
+    chmod +x $out/bin/steamos-devkit
+  '';
+
+  # There are no checks for steamos-devkit
+  doCheck = false;
+  pythonImportsCheck = [ "devkit_client" ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "SteamOS-Devkit";
+      exec = "steamos-devkit";
+      desktopName = "SteamOS Devkit Client";
+    })
+  ];
+
+  meta = with lib; {
+    description = "SteamOS Devkit Client";
+    homepage = "https://gitlab.steamos.cloud/devkit/steamos-devkit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ myaats ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25798,6 +25798,8 @@ with pkgs;
 
   statifier = callPackage ../os-specific/linux/statifier { };
 
+  steamos-devkit = callPackage ../development/tools/steamos-devkit { };
+
   swiftdefaultapps = callPackage ../os-specific/darwin/swiftdefaultapps { };
 
   sysdig = callPackage ../os-specific/linux/sysdig {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10225,6 +10225,8 @@ self: super: with self; {
 
   sievelib = callPackage ../development/python-modules/sievelib { };
 
+  signalslot = callPackage ../development/python-modules/signalslot { };
+
   signedjson = callPackage ../development/python-modules/signedjson { };
 
   sigrok = callPackage ../development/python-modules/sigrok { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11857,6 +11857,8 @@ self: super: with self; {
 
   wcwidth = callPackage ../development/python-modules/wcwidth { };
 
+  weakrefmethod = callPackage ../development/python-modules/weakrefmethod { };
+
   weasyprint = callPackage ../development/python-modules/weasyprint { };
 
   web3 = callPackage ../development/python-modules/web3 { };


### PR DESCRIPTION
###### Description of changes
Packaged the `steamos-devkit` client open-sourced by Valve for remotely developing on SteamOS devices (Currently only the Steam Deck). Providing features like pushing builds of applications, opening remote shells, browsing files, accessing the CEF console, showing device logs and remote debugging functionality.

###### Things done
Introduced two new python-packages, `signalslot` and `weakrefmethod`. Packaged `pyimgui` within the `steamos-devkit` package as it relies on the yet to be released `pyimgui` version-2.0 branch. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
