### PR TITLE
odin2: unstable-2022-02-23 -> 2.3.4

### DIFF
--- a/pkgs/applications/audio/odin2/default.nix
+++ b/pkgs/applications/audio/odin2/default.nix
@@ -18,14 +18,14 @@
 
 stdenv.mkDerivation rec {
   pname = "odin2";
-  version = "unstable-2022-02-23";
+  version = "2.3.4";
 
   src = fetchFromGitHub {
-    owner = "baconpaul";
+    owner = "TheWaveWarden";
     repo = "odin2";
-    rev = "ed02d06cfb5db8a118d291c00bd2e4cd6e262cde";
+    rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-VkZ+mqCmqWQafdN0nQxJdPxbiaZ37/0jOhLvVbnGLvQ=";
+    sha256 = "sha256-N96Nb7G6hqfh8DyMtHbttl/fRZUkS8f2KfPSqeMAhHY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/odin2/default.nix
+++ b/pkgs/applications/audio/odin2/default.nix
@@ -62,10 +62,12 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib/vst3
+    mkdir -p $out/bin $out/lib/vst3 $out/lib/lv2 $out/lib/clap
     cd Odin2_artefacts/Release
+    cp Standalone/Odin2 $out/bin
     cp -r VST3/Odin2.vst3 $out/lib/vst3
-    cp -r Standalone/Odin2 $out/bin
+    cp -r LV2/Odin2.lv2 $out/lib/lv2
+    cp -r CLAP/Odin2.clap $out/lib/clap
 '';
 
 


### PR DESCRIPTION
###### Description of changes

Switch to the latest version. (It was released on 2022-08-08 and includes all commits from unstable-2022-02-23.)
Install LV2 and CLAP plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

/cc @magnetophon