### PR TITLE
krb5Full: turn into alias

### DIFF
--- a/nixos/modules/config/krb5/default.nix
+++ b/nixos/modules/config/krb5/default.nix
@@ -82,8 +82,8 @@ in {
 
       kerberos = mkOption {
         type = types.package;
-        default = pkgs.krb5Full;
-        defaultText = literalExpression "pkgs.krb5Full";
+        default = pkgs.krb5;
+        defaultText = literalExpression "pkgs.krb5";
         example = literalExpression "pkgs.heimdal";
         description = lib.mdDoc ''
           The Kerberos implementation that will be present in

--- a/nixos/modules/services/system/kerberos/mit.nix
+++ b/nixos/modules/services/system/kerberos/mit.nix
@@ -33,7 +33,7 @@ let
 in
 
 {
-  config = mkIf (cfg.enable && kerberos == pkgs.krb5Full) {
+  config = mkIf (cfg.enable && kerberos == pkgs.krb5) {
     systemd.services.kadmind = {
       description = "Kerberos Administration Daemon";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/tests/kerberos/mit.nix
+++ b/nixos/tests/kerberos/mit.nix
@@ -9,7 +9,7 @@ import ../make-test-python.nix ({pkgs, ...}: {
     };
     krb5 = {
       enable = true;
-      kerberos = pkgs.krb5Full;
+      kerberos = pkgs.krb5;
       libdefaults = {
         default_realm = "FOO.BAR";
       };

--- a/nixos/tests/krb5/example-config.nix
+++ b/nixos/tests/krb5/example-config.nix
@@ -11,7 +11,7 @@ import ../make-test-python.nix ({ pkgs, ...} : {
     { pkgs, ... }: {
       krb5 = {
         enable = true;
-        kerberos = pkgs.krb5Full;
+        kerberos = pkgs.krb5;
         libdefaults = {
           default_realm = "ATHENA.MIT.EDU";
         };

--- a/pkgs/development/python-modules/cccolutils/default.nix
+++ b/pkgs/development/python-modules/cccolutils/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , git
 , gitpython
-, krb5Full
+, krb5
 , mock
 , pytestCheckHook
 , pythonOlder
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [
-    krb5Full
+    krb5
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/gssapi/default.nix
+++ b/pkgs/development/python-modules/gssapi/default.nix
@@ -6,7 +6,7 @@
 , six
 , decorator
 , nose
-, krb5Full
+, krb5
 , GSS
 , parameterized
 , shouldbe
@@ -30,12 +30,12 @@ buildPythonPackage rec {
   # It's used to locate headers
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'get_output(f"{kc} gssapi --prefix")' '"${lib.getDev krb5Full}"'
+      --replace 'get_output(f"{kc} gssapi --prefix")' '"${lib.getDev krb5}"'
   '';
 
   nativeBuildInputs = [
     cython
-    krb5Full
+    krb5
   ];
 
   propagatedBuildInputs =  [

--- a/pkgs/development/python-modules/k5test/default.nix
+++ b/pkgs/development/python-modules/k5test/default.nix
@@ -3,7 +3,7 @@
 , buildPythonPackage
 , fetchPypi
 , substituteAll
-, krb5Full
+, krb5
 , findutils
 , which
 , pythonOlder
@@ -23,9 +23,9 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit findutils krb5Full;
+      inherit findutils krb5;
       # krb5-config is in dev output
-      krb5FullDev = krb5Full.dev;
+      krb5Dev = krb5.dev;
       which = "${which}/bin/which";
     })
   ];

--- a/pkgs/development/python-modules/k5test/fix-paths.patch
+++ b/pkgs/development/python-modules/k5test/fix-paths.patch
@@ -7,13 +7,13 @@ index e289fac..e2f486a 100644
      # if there was no LD_LIBRARY_PATH, or the above failed
      if _PLUGIN_DIR is None:
 -        lib_dir = os.path.join(get_output('krb5-config --prefix'), 'lib64')
-+        lib_dir = os.path.join(get_output('@krb5FullDev@/bin/krb5-config --prefix'), 'lib64')
++        lib_dir = os.path.join(get_output('@krb5Dev@/bin/krb5-config --prefix'), 'lib64')
          _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_installed(lib_dir))
  
      # /usr/lib64 seems only to be distinct on Fedora/RHEL/Centos family
      if _PLUGIN_DIR is None:
 -        lib_dir = os.path.join(get_output('krb5-config --prefix'), 'lib')
-+        lib_dir = os.path.join(get_output('@krb5FullDev@/bin/krb5-config --prefix'), 'lib')
++        lib_dir = os.path.join(get_output('@krb5Dev@/bin/krb5-config --prefix'), 'lib')
          _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_installed(lib_dir))
  
      if _PLUGIN_DIR is not None:
@@ -53,7 +53,7 @@ index 161e5ad..9f50049 100644
          if provider_cls == K5Realm:
              krb5_config = _discover_path('krb5-config',
 -                                         '/usr/bin/krb5-config', kwargs)
-+                                         '@krb5Full@/bin/krb5-config', kwargs)
++                                         '@krb5@/bin/krb5-config', kwargs)
  
              try:
                  krb5_version = subprocess.check_output(
@@ -62,7 +62,7 @@ index 161e5ad..9f50049 100644
                  if 'heimdal' in krb5_version.lower() or (
                          sys.platform == 'darwin' and
 -                        krb5_config == '/usr/bin/krb5-config'):
-+                        krb5_config == '@krb5Full@/bin/krb5-config'):
++                        krb5_config == '@krb5@/bin/krb5-config'):
                      provider_cls = HeimdalRealm
                  else:
                      provider_cls = MITRealm
@@ -78,14 +78,14 @@ index 161e5ad..9f50049 100644
 -            ('kprop', 'kprop', '/usr/sbin/kprop'),
 -            ('_kinit', 'kinit', '/usr/bin/kinit'),
 -            ('_klist', 'klist', '/usr/bin/klist'),
-+            ('kdb5_util', 'kdb5_util', '@krb5Full@/bin/kdb5_util'),
-+            ('krb5kdc', 'krb5kdc', '@krb5Full@/bin/kdb5kdc'),
-+            ('kadmin', 'kadmin', '@krb5Full@/bin/admin'),
-+            ('kadmin_local', 'kadmin.local', '@krb5Full@/bin/kadmin.local'),
-+            ('kadmind', 'kadmind', '@krb5Full@/bin/kadmind'),
-+            ('kprop', 'kprop', '@krb5Full@/bin/kprop'),
-+            ('_kinit', 'kinit', '@krb5Full@/bin/kinit'),
-+            ('_klist', 'klist', '@krb5Full@/bin/klist'),
++            ('kdb5_util', 'kdb5_util', '@krb5@/bin/kdb5_util'),
++            ('krb5kdc', 'krb5kdc', '@krb5@/bin/kdb5kdc'),
++            ('kadmin', 'kadmin', '@krb5@/bin/admin'),
++            ('kadmin_local', 'kadmin.local', '@krb5@/bin/kadmin.local'),
++            ('kadmind', 'kadmind', '@krb5@/bin/kadmind'),
++            ('kprop', 'kprop', '@krb5@/bin/kprop'),
++            ('_kinit', 'kinit', '@krb5@/bin/kinit'),
++            ('_klist', 'klist', '@krb5@/bin/klist'),
          ]
  
      @property
@@ -95,15 +95,15 @@ index 161e5ad..9f50049 100644
              ('krb5kdc', 'kdc', os.path.join(base, 'kdc')),
 -            ('kadmin', 'kadmin', '/usr/bin/kadmin'),
 -            ('kadmin_local', 'kadmin', '/usr/bin/kadmin'),
-+            ('kadmin', 'kadmin', '@krb5Full@/bin/kadmin'),
-+            ('kadmin_local', 'kadmin', '@krb5Full@/bin/kadmin'),
++            ('kadmin', 'kadmin', '@krb5@/bin/kadmin'),
++            ('kadmin_local', 'kadmin', '@krb5@/bin/kadmin'),
              ('kadmind', 'kadmind', os.path.join(base, 'kadmind')),
 -            ('_kinit', 'kinit', '/usr/bin/kinit'),
 -            ('_klist', 'klist', '/usr/bin/klist'),
 -            ('_ktutil', 'ktutil', '/usr/bin/ktutil'),
-+            ('_kinit', 'kinit', '@krb5Full@/bin/kinit'),
-+            ('_klist', 'klist', '@krb5Full@/bin/klist'),
-+            ('_ktutil', 'ktutil', '@krb5Full@/bin/ktutil'),
++            ('_kinit', 'kinit', '@krb5@/bin/kinit'),
++            ('_klist', 'klist', '@krb5@/bin/klist'),
++            ('_ktutil', 'ktutil', '@krb5@/bin/ktutil'),
          ]
  
      @property
@@ -116,7 +116,7 @@ index 3c64b9e..59da1ab 100644
      global _KRB_VERSION
      if _KRB_VERSION is None:
 -        _KRB_VERSION = _utils.get_output("krb5-config --version")
-+        _KRB_VERSION = _utils.get_output("@krb5FullDev@/bin/krb5-config --version")
++        _KRB_VERSION = _utils.get_output("@krb5Dev@/bin/krb5-config --version")
          _KRB_VERSION = _KRB_VERSION.split(' ')[-1].split('.')
  
      def make_ext_test(func):

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -729,6 +729,7 @@ mapAliases ({
   kodiPlainWayland = kodi-wayland;
   kodiPlugins = kodiPackages; # Added 2021-03-09;
   kramdown-rfc2629 = rubyPackages.kramdown-rfc2629; # Added 2021-03-23
+  krb5Full = krb5;
   krename-qt5 = throw "'krename-qt5' has been renamed to/replaced by 'krename'"; # Converted to throw 2022-02-22
   krita-beta = krita; # moved from top-level 2021-12-23
   kube-aws = throw "kube-aws is deprecated and archived by upstream"; # Added 2022-04-05

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19996,7 +19996,6 @@ with pkgs;
   krb5 = callPackage ../development/libraries/kerberos/krb5.nix {
     inherit (buildPackages.darwin) bootstrap_cmds;
   };
-  krb5Full = krb5;
   libkrb5 = krb5.override { type = "lib"; };
 
   kronosnet = callPackage ../development/libraries/kronosnet { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1207,15 +1207,15 @@ let
       url = "mirror://cpan/authors/id/S/SJ/SJQUINNEY/Authen-Krb5-Admin-0.17.tar.gz";
       hash = "sha256-XdScrNmD79YajD8aVlcbtzeF6xVZCLXXvsl+7XjfDFQ=";
     };
-    propagatedBuildInputs = [ pkgs.krb5Full.dev AuthenKrb5 ];
+    propagatedBuildInputs = [ pkgs.krb5.dev AuthenKrb5 ];
     # The following ENV variables are required by Makefile.PL to find
-    # programs in krb5Full.dev. It is not enough to just specify the
-    # path to krb5-config as this tool returns the prefix of krb5Full,
+    # programs in krb5.dev. It is not enough to just specify the
+    # path to krb5-config as this tool returns the prefix of krb5,
     # which implies a working value for KRB5_LIBDIR, but not the others.
     perlPreHook = ''
-      export KRB5_CONFTOOL=${pkgs.krb5Full.dev}/bin/krb5-config
-      export KRB5_BINDIR=${pkgs.krb5Full.dev}/bin
-      export KRB5_INCDIR=${pkgs.krb5Full.dev}/include
+      export KRB5_CONFTOOL=${pkgs.krb5.dev}/bin/krb5-config
+      export KRB5_BINDIR=${pkgs.krb5.dev}/bin
+      export KRB5_INCDIR=${pkgs.krb5.dev}/include
     '';
     # Tests require working Kerberos infrastructure so replace with a
     # simple attempt to exercise the module.
@@ -10529,8 +10529,8 @@ let
       url = "mirror://cpan/authors/id/A/AG/AGROLMS/GSSAPI-0.28.tar.gz";
       hash = "sha256-fY8se2F2L7TsctLsKBKQ8vh/nH0pgnPaRSVDKmXncNY=";
     };
-    propagatedBuildInputs = [ pkgs.krb5Full.dev ];
-    makeMakerFlags = [ "--gssapiimpl" "${pkgs.krb5Full.dev}" ];
+    propagatedBuildInputs = [ pkgs.krb5.dev ];
+    makeMakerFlags = [ "--gssapiimpl" "${pkgs.krb5.dev}" ];
     meta = {
       description = "Perl extension providing access to the GSSAPIv2 library";
       license = with lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4046,7 +4046,7 @@ self: super: with self; {
   gspread = callPackage ../development/python-modules/gspread { };
 
   gssapi = callPackage ../development/python-modules/gssapi {
-    inherit (pkgs) krb5Full;
+    inherit (pkgs) krb5;
     inherit (pkgs.darwin.apple_sdk.frameworks) GSS;
   };
 
@@ -4940,7 +4940,7 @@ self: super: with self; {
   jxmlease = callPackage ../development/python-modules/jxmlease { };
 
   k5test = callPackage ../development/python-modules/k5test {
-    inherit (pkgs) krb5Full findutils which;
+    inherit (pkgs) krb5 findutils which;
   };
 
   kaa-base = callPackage ../development/python-modules/kaa-base { };


### PR DESCRIPTION
###### Description of changes
make this an actual alias, instead of having two attributes for the same package

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).