### PR TITLE
r2modman: init at 3.1.39

### DIFF
--- a/pkgs/tools/games/r2modman/default.nix
+++ b/pkgs/tools/games/r2modman/default.nix
@@ -1,0 +1,55 @@
+{ lib, stdenv, fetchurl, dpkg, makeWrapper, steam-run }:
+
+stdenv.mkDerivation rec {
+  pname = "r2modman";
+  version = "3.1.39";
+
+  src = fetchurl {
+    url = "https://github.com/ebkr/r2modmanPlus/releases/download/v${version}/r2modman_${version}_amd64.deb ";
+    sha256 = "sha256-Wy3C7acAD5g//DVua+8v3jGF3qHXnu/3vR2e0wcHCKk=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  unpackCmd = "dpkg -x $curSrc src";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -r opt/ usr/share/ $out
+
+    mkdir $out/bin
+    ln -s $out/opt/r2modman/r2modman $out/bin/
+
+    substituteInPlace $out/share/applications/r2modman.desktop \
+      --replace /opt/ $out/opt/
+
+    runHook postInstall
+  '';
+
+  # Wrap program with steam-run, as it needs steam's dependencies
+  # to interact with steam and run games.
+  postFixup = ''
+    mv $out/opt/r2modman/r2modman $out/opt/r2modman/.r2modman-unwrapped
+    makeWrapper ${steam-run}/bin/steam-run $out/opt/r2modman/r2modman \
+      --add-flags $out/opt/r2modman/.r2modman-unwrapped \
+      --add-flags --no-sandbox \
+      --prefix LD_LIBRARY_PATH : $out/opt/r2modman \
+      --argv0 r2modman
+  '';
+
+  meta = with lib; {
+    description = "A simple and easy to use mod manager for several games using Thunderstore";
+    homepage = "https://github.com/ebkr/r2modmanPlus";
+    downloadPage = "https://github.com/ebkr/r2modmanPlus/releases";
+    changelog = "https://github.com/ebkr/r2modmanPlus/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ huantian ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1407,6 +1407,8 @@ with pkgs;
 
   quich = callPackage ../tools/misc/quich { } ;
 
+  r2modman = callPackage ../tools/games/r2modman { };
+
   redfang = callPackage ../tools/networking/redfang { };
 
   scarab = callPackage ../tools/games/scarab { };


### PR DESCRIPTION
###### Description of changes

> A simple and easy to use mod manager for several games using Thunderstore

I attempted to build this from source, but had no luck with `mkYarnPackage`. Perhaps someone more knowledgeable could try to?

Only able to test Dyson Sphere Program, downloading mods and launching the game works. I'm using `steam-run` since the program needs to be able to access and run the steam executable to launch the games, which means it needs all the libraries required by steam.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
