### PR TITLE
build-support/writeTextFile: set as executable before `checkPhase`

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -137,9 +137,8 @@ rec {
           echo -n "$text" > "$target"
         fi
 
-        eval "$checkPhase"
-
         (test -n "$executable" && chmod +x "$target") || true
+        eval "$checkPhase"
       '';
 
   /*


### PR DESCRIPTION
###### Description of changes

Apologies if the current ordering is actually intentional; I couldn't find anything explicitly discussing this.

The motivation is to be able to execute the shell script produced by `writeShellApplication` and friends within `checkPhase` without needing to (redundantly) `chmod +x` the binary.

A quick test case:
```nix
let
  np = import ./. {};
in
  np.writeTextFile {
    name = "example";
    text = "exit 0";
    executable = true;
    destination = "/bin/example";

    # Prior to this change, this would fail as `$out/bin/example` isn't
    # marked executable until after `checkPhase`.
    checkPhase = ''
      $out/bin/example
    '';
  }
```

This brings `writeTextFile` in line with `concatTextFile` which already
behaves like this: https://github.com/NixOS/nixpkgs/commit/67320a16689b84361777f3a03c8dcc5b72a339dc#diff-cee9bb7e2319268439691163bc3cd95b6059fc41b9c2a074ef002848bdb59839L362-L365

Looking at the commit where `checkPhase` was added to `writeTextFile` the ordering _seems_ unintentional: https://github.com/NixOS/nixpkgs/commit/f49c2fbf7a0594717a16432295983512091fba26

The only semi-plausible rationale for the current ordering I can come up with is cross-compiling; i.e. we want to discourage unconditionally executing the binary directly during `checkPhase` since it may contain native code or may have something like `runtimeShell` in its shebang.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
