### PR TITLE
fix splicing in overrideAttrs

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -88,32 +88,13 @@ rec {
       overrideArgs = copyArgs (newArgs: makeOverridable f (overrideWith newArgs));
       # Change the result of the function call by applying g to it
       overrideResult = g: makeOverridable (copyArgs (args: g (f args))) origArgs;
-
-      args =
-        (_: previousAttrs: {
-          passthru = (previousAttrs.passthru or { }) // {
-            override = overrideArgs;
-            overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
-            # error: stack overflow (possible infinite recursion)
-            #overrideAttrs = fdrv:
-            #  overrideResult (x: x.overrideAttrs fdrv);
-          };
-        });
-
     in
-      if builtins.isAttrs result && result ? overrideAttrs then
-        (result.overrideAttrs args) #// {
-          # is this even necessary?
-          # nix-diff shows no difference in cross/non
-          # nix-diff $(nix eval --raw "nixpkgs/$(git merge-base upstream/master HEAD)#nix.drvPath") $(nix eval --raw ".#nix.drvPath")
-          # nix-diff $(nix eval --raw "nixpkgs/$(git merge-base upstream/master HEAD)#pkgsCross.aarch64-multiplatform.nix.drvPath") $(nix eval --raw ".#pkgsCross.aarch64-multiplatform.nix.drvPath")
-          #overrideAttrs = fdrv:
-          #  overrideResult (x: x.overrideAttrs fdrv);
-        #}
-      else if builtins.isAttrs result then
+      if builtins.isAttrs result then
         result // {
           override = overrideArgs;
           overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
+          ${if result ? overrideAttrs then "overrideAttrs" else null} = fdrv:
+            overrideResult (x: x.overrideAttrs fdrv);
         }
       else if lib.isFunction result then
         # Transform the result into a functor while propagating its arguments

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -49,6 +49,8 @@ with pkgs;
 
   cross = callPackage ./cross {};
 
+  splicing = callPackage ./splicing {};
+
   php = recurseIntoAttrs (callPackages ./php {});
 
   pkg-config = recurseIntoAttrs (callPackage ../top-level/pkg-config/tests.nix { });

--- a/pkgs/test/splicing/default.nix
+++ b/pkgs/test/splicing/default.nix
@@ -1,0 +1,40 @@
+{ pkgs, stdenvNoCC, lib, }:
+let
+  pkgsCross = pkgs.pkgsCross.aarch64-multiplatform.__splicedPackages;
+  tests =
+    let
+      pythonInNativeBuildInputs = lib.elemAt pkgsCross.python3Packages.xpybutil.nativeBuildInputs 0;
+      overridenAttr = pkgsCross.hello.overrideAttrs (_: { something = "hello"; });
+    in
+    [
+      ({
+        name = "pythonInNativeBuildInputsShouldBeNative";
+        expr = pythonInNativeBuildInputs.stdenv.hostPlatform.system == "x86_64-linux";
+        expected = true;
+      })
+      ({
+        name = "overridenAttrShouldHaveSplicedAndSomething";
+        expr = if overridenAttr ? __spliced then overridenAttr.something == overridenAttr.__spliced.buildHost.something else false;
+        expected = true;
+      })
+      ({
+        name = "splicedShouldBeOverriden";
+        expr = pkgsCross.nix.aws-sdk-cpp.cmakeFlags == pkgsCross.nix.aws-sdk-cpp.__spliced.hostTarget.cmakeFlags;
+        expected = true;
+      })
+      ({
+        name = "notCrossOverriden";
+        expr = (pkgs.hello.overrideAttrs (_: _: { passthru = { o = "works"; }; })) ? o;
+        expected = true;
+      })
+    ];
+in
+{
+  test-splicing = stdenvNoCC.mkDerivation {
+    name = "test-splicing";
+    passthru = { inherit tests; };
+    buildCommand = ''
+      touch $out
+    '' + lib.concatMapStringsSep "\n" (t: "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo '${t.name} success') || (echo '${t.name} fail' && exit 1)") tests;
+  };
+}


### PR DESCRIPTION
see commit messages

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
