### PR TITLE
maliit-*: 2.0.0 -> 2.3.*

### DIFF
--- a/pkgs/applications/misc/maliit-framework/default.nix
+++ b/pkgs/applications/misc/maliit-framework/default.nix
@@ -24,23 +24,14 @@
 
 mkDerivation rec {
   pname = "maliit-framework";
-  version = "2.0.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "maliit";
     repo = "framework";
-    rev = version;
-    sha256 = "138jyvw130kmrldksbk4l38gvvahh3x51zi4vyplad0z5nxmbazb";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-q+hiupwlA0PfG+xtomCUp2zv6HQrGgmOd9CU193ucrY=";
   };
-
-  # in master post 2.2.1, see https://github.com/maliit/framework/issues/106
-  patches = [
-    (fetchpatch {
-      name = "fix-pkg-config.patch";
-      url = "https://github.com/maliit/framework/commit/1e20a4a5113f1c092295f5a5f04ab6e584f6fcff.patch";
-      sha256 = "0h7jfqnqvjka626wx2z2g150rch4air7q3zbq59gcb12g7x6gfyn";
-    })
-  ];
 
   buildInputs = [
     at-spi2-atk

--- a/pkgs/applications/misc/maliit-keyboard/default.nix
+++ b/pkgs/applications/misc/maliit-keyboard/default.nix
@@ -22,22 +22,14 @@
 
 mkDerivation rec {
   pname = "maliit-keyboard";
-  version = "2.0.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "maliit";
     repo = "keyboard";
     rev = version;
-    sha256 = "10dh0abxq90024dqq3fs8mjxww3igb4l09d19i2fq9f3flvh11hc";
+    sha256 = "sha256-XH3sKQuNMLgJi2aV+bnU2cflwkFIw4RYVfxzQiejCT0=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/maliit/keyboard/pull/34
-      url = "https://github.com/maliit/keyboard/commit/9848a73b737ad46b5790ebf713a559d340c91b82.patch";
-      sha256 = "0qrsga0npahjrgbl6mycvl6d6vjm0d17i5jadcn7y6khbhq2y6rg";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace data/schemas/org.maliit.keyboard.maliit.gschema.xml \


### PR DESCRIPTION
###### Description of changes

Package update for the keyboard used by Plasma Mobile.

Verified on `lenovo-krane` to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
