### PR TITLE
sonic-pi: add updateScript and add ruby to nativeBuildInputs

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -216,6 +216,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://sonic-pi.net/";
     description = "Free live coding synth for everyone originally designed to support computing and music lessons within schools";

--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
     copyDesktopItems
     cmake
     pkg-config
+    ruby
     erlang
     elixir
     beamPackages.hex
@@ -94,7 +95,6 @@ stdenv.mkDerivation rec {
 
   checkInputs = [
     parallel
-    ruby
     supercollider-with-sc3-plugins
     jack2
   ];

--- a/pkgs/applications/audio/sonic-pi/update.sh
+++ b/pkgs/applications/audio/sonic-pi/update.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix jq common-updater-scripts
+
+set -euo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel || (printf 'Could not find root of nixpkgs repo\nAre we running from within the nixpkgs git repo?\n' >&2; exit 1))"
+
+stripwhitespace() {
+    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+nixeval() {
+    nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1" | jq -r .
+}
+
+vendorhash() {
+    (nix --extra-experimental-features nix-command build --impure --argstr nixpkgs "$nixpkgs" --argstr attr "$1" --expr '{ nixpkgs, attr }: let pkgs = import nixpkgs {}; in with pkgs.lib; (getAttrFromPath (splitString "." attr) pkgs).overrideAttrs (attrs: { outputHash = fakeHash; })' --no-link 2>&1 >/dev/null | tail -n3 | grep -F got: | cut -d: -f2- | stripwhitespace) 2>/dev/null || true
+}
+
+findpath() {
+    path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+
+    if [ -n "$outpath" ]; then
+        path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"
+    fi
+
+    echo "$path"
+}
+
+attr="${UPDATE_NIX_ATTR_PATH:-sonic-pi}"
+version="$(cd "$nixpkgs" && list-git-tags --pname="$(nixeval "$attr".pname)" --attr-path="$attr" | grep '^v' | sed -e 's|^v||' | sort -V | tail -n1)"
+
+pkgpath="$(findpath "$attr")"
+
+updated="$(cd "$nixpkgs" && update-source-version "$attr" "$version" --file="$pkgpath" --print-changes | jq -r length)"
+
+if [ "$updated" -eq 0 ]; then
+    echo 'update.sh: Package version not updated, nothing to do.'
+    exit 0
+fi
+
+curhash="$(nixeval "$attr.mixFodDeps.outputHash")"
+newhash="$(vendorhash "$attr.mixFodDeps")"
+
+if [ -n "$newhash" ] && [ "$curhash" != "$newhash" ]; then
+    sed -i -e "s|\"$curhash\"|\"$newhash\"|" "$pkgpath"
+else
+    echo 'update.sh: New vendorHash same as old vendorHash, nothing to do.'
+fi


### PR DESCRIPTION
###### Description of changes

Misc updates to Sonic Pi package:
* Add an `updateScript` to automate upgrades
* Add `ruby` to `nativeBuildInputs` per https://github.com/NixOS/nixpkgs/pull/180732#discussion_r1026045116

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).