### PR TITLE
ocamlPackages.mtime: 1.2.0 → 1.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/metrics/unix.nix
+++ b/pkgs/development/ocaml-modules/metrics/unix.nix
@@ -6,6 +6,11 @@ buildDunePackage rec {
 
   inherit (metrics) version src;
 
+  # Fixes https://github.com/mirage/metrics/issues/57
+  postPatch = ''
+    substituteInPlace src/unix/dune --replace "mtime mtime.clock" "mtime"
+  '';
+
   propagatedBuildInputs = [ gnuplot lwt metrics mtime uuidm ];
 
   checkInputs = [ metrics-lwt ];

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -1,37 +1,25 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, js_of_ocaml
-, jsooSupport ? lib.versionAtLeast ocaml.version "4.03"
-}:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
 
 with lib;
 
-let param =
-  if versionAtLeast ocaml.version "4.03"
-  then {
-    version = "1.2.0";
-    sha256 = "0zm1jvqkz3ghznfsm3bbv9q2zinp9grggdf7k9phjazjvny68xb8";
-  } else {
-    version = "0.8.4";
-    sha256 = "1adm8sc3lkjly99hyi5gqnxas748k7h62ljgn8x423nkn8gyp8dh";
-  };
-in
+throwIfNot (versionAtLeast ocaml.version "4.08")
+  "mtime is not available for OCaml ${ocaml.version}"
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-mtime";
-  inherit (param) version;
+  version = "1.4.0";
 
   src = fetchurl {
-    url = "https://erratique.ch/software/mtime/releases/mtime-${param.version}.tbz";
-    inherit (param) sha256;
+    url = "https://erratique.ch/software/mtime/releases/mtime-${version}.tbz";
+    sha256 = "sha256-VQyYEk8+57Yq8SUuYossaQUHZKqemHDJtf4LK8qjxvc=";
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
-  buildInputs = [ topkg ] ++ optional jsooSupport js_of_ocaml;
+  buildInputs = [ topkg ];
 
   strictDeps = true;
 
-  buildPhase = "${topkg.buildPhase} --with-js_of_ocaml ${boolToString jsooSupport}";
-
-  inherit (topkg) installPhase;
+  inherit (topkg) buildPhase installPhase;
 
   meta = {
     description = "Monotonic wall-clock time for OCaml";


### PR DESCRIPTION
###### Description of changes

https://github.com/dbuenzli/mtime/blob/v1.4.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
