### PR TITLE
 haskellPackages.mkDerivation: add support for --enable-relocatable 

### DIFF
--- a/pkgs/development/compilers/ghc/9.2.4.nix
+++ b/pkgs/development/compilers/ghc/9.2.4.nix
@@ -194,6 +194,15 @@ stdenv.mkDerivation (rec {
       extraPrefix = "utils/haddock/";
       stripLen = 1;
     })
+    # Don't generate code that doesn't compile when --relocatable is passed to
+    # Setup.hs
+    # Can be removed if the Cabal library included with ghc backports the linked fix
+    (fetchpatch {
+      url = "https://github.com/haskell/cabal/commit/6c796218c92f93c95e94d5ec2d077f6956f68e98.patch";
+      stripLen = 1;
+      extraPrefix = "libraries/Cabal/";
+      sha256 = "sha256-yRQ6YmMiwBwiYseC5BsrEtDgFbWvst+maGgDtdD0vAY=";
+    })
   ];
 
   postPatch = "patchShebangs .";

--- a/pkgs/test/haskell/default.nix
+++ b/pkgs/test/haskell/default.nix
@@ -4,6 +4,7 @@ lib.recurseIntoAttrs {
   shellFor = callPackage ./shellFor { };
   cabalSdist = callPackage ./cabalSdist { };
   documentationTarball = callPackage ./documentationTarball { };
+  pathsModule = lib.recurseIntoAttrs (callPackage ./pathsModule { });
   setBuildTarget = callPackage ./setBuildTarget { };
   writers = callPackage ./writers { };
 }

--- a/pkgs/test/haskell/pathsModule/default.nix
+++ b/pkgs/test/haskell/pathsModule/default.nix
@@ -1,0 +1,46 @@
+{ haskell, lib, runCommand }:
+
+let
+  ghcSets = lib.filterAttrs
+    (name: set:
+      !(lib.hasPrefix "ghc92" name) && # TODO: https://github.com/NixOS/nixpkgs/pull/200063
+      !(lib.hasPrefix "ghc94" name) && # TODO
+      !(lib.hasPrefix "ghcHEAD" name) && # TODO
+      set ? ghc && set.ghc ? bootPkgs && !set.ghc.isGhcjs or false
+    )
+    haskell.packages;
+
+  mkPkg = pkgSet: enableRelocatable:
+    haskell.lib.compose.justStaticExecutables (
+      pkgSet.callPackage (
+        { mkDerivation, ghc }:
+        mkDerivation {
+          pname = "pathsModule${lib.optionalString enableRelocatable "-reloc"}-ghc-${ghc.version}";
+          version = "0.0.0.0";
+          src = ./test-pkg;
+          inherit enableRelocatable;
+          license = lib.licenses.mit;
+          doHaddock = false;
+        }
+      ) { }
+    );
+
+  mkTest = pkgSet: relocatable:
+    let
+      testPkg = mkPkg pkgSet relocatable;
+      binPath = "${testPkg}/bin";
+    in
+      runCommand "test-bindir-output-${testPkg.name}" { } (''
+        "${binPath}/pathsModule" | grep "${binPath}"
+      '' + lib.optionalString relocatable ''
+        cp -r ${binPath}/.. reloc
+        ./reloc/bin/pathsModule | grep "$(realpath ./reloc/bin)"
+      '' + ''
+        touch $out
+      '');
+in
+
+lib.mapAttrs (_: set: lib.recurseIntoAttrs {
+  relocatable = mkTest set true;
+  traditional = mkTest set false;
+}) ghcSets

--- a/pkgs/test/haskell/pathsModule/test-pkg/Main.hs
+++ b/pkgs/test/haskell/pathsModule/test-pkg/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Paths_pathsModule
+
+main :: IO ()
+main = getBinDir >>= putStrLn

--- a/pkgs/test/haskell/pathsModule/test-pkg/pathsModule.cabal
+++ b/pkgs/test/haskell/pathsModule/test-pkg/pathsModule.cabal
@@ -1,0 +1,13 @@
+cabal-version:      1.22
+name:               pathsModule
+version:            0.0.0.0
+license:            MIT
+author:             sternenseemann
+build-type:         Simple
+
+executable pathsModule
+    main-is:          Main.hs
+    other-modules:    Paths_pathsModule
+    build-depends:    base
+    hs-source-dirs:   .
+    default-language: Haskell2010


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
