### PR TITLE
nextcloud-notify-push: init at 0.5.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1166,6 +1166,7 @@
   ./services/web-apps/moodle.nix
   ./services/web-apps/netbox.nix
   ./services/web-apps/nextcloud.nix
+  ./services/web-apps/nextcloud-notify_push.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/nifi.nix
   ./services/web-apps/node-red.nix

--- a/nixos/modules/services/web-apps/nextcloud-notify_push.nix
+++ b/nixos/modules/services/web-apps/nextcloud-notify_push.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, options, lib, pkgs, ... }:
 
 let
   cfg = config.services.nextcloud.notify_push;
@@ -6,23 +6,43 @@ in
 {
   options.services.nextcloud.notify_push = {
     enable = lib.mkEnableOption (lib.mdDoc "Notify push");
+
     package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.nextcloud-notify_push;
       defaultText = lib.literalMD "pkgs.nextcloud-notify_push";
       description = lib.mdDoc "Which package to use for notify_push";
     };
+
     socketPath = lib.mkOption {
       type = lib.types.str;
       default = "/run/nextcloud-notify_push/sock";
       description = lib.mdDoc "Socket path to use for notify_push";
     };
+
     logLevel = lib.mkOption {
       type = lib.types.enum [ "error" "warn" "info" "debug" "trace" ];
       default = "error";
       description = lib.mdDoc "Log level";
     };
-  };
+  } // (
+    lib.listToAttrs (
+      map (
+        opt: lib.nameValuePair opt (options.services.nextcloud.config.${opt} // {
+          default = config.services.nextcloud.config.${opt};
+          defaultText = lib.mdDoc "config.services.nextcloud.config.${opt}";
+        })
+      ) [
+        "dbtype"
+        "dbname"
+        "dbuser"
+        "dbpassFile"
+        "dbhost"
+        "dbport"
+        "dbtableprefix"
+      ]
+    )
+  );
 
   config = lib.mkIf cfg.enable {
     systemd.services.nextcloud-notify_push = let
@@ -35,13 +55,32 @@ in
       environment = {
         NEXTCLOUD_URL = nextcloudUrl;
         SOCKET_PATH = cfg.socketPath;
+        DATABASE_PREFIX = cfg.dbtableprefix;
         LOG = cfg.logLevel;
       };
       postStart = ''
         ${config.services.nextcloud.occ}/bin/nextcloud-occ notify_push:setup ${nextcloudUrl}/push
       '';
+      script = let
+        dbType = if cfg.dbtype == "pgsql" then "postgresql" else cfg.dbtype;
+        dbUser = lib.optionalString (cfg.dbuser != null) cfg.dbuser;
+        dbPass = lib.optionalString (cfg.dbpassFile != null) ":$DATABASE_PASSWORD";
+        isSocket = lib.hasPrefix "/" (toString cfg.dbhost);
+        dbHost = lib.optionalString (cfg.dbhost != null) (if
+          isSocket then
+            if dbType == "postgresql" then "?host=${cfg.dbhost}" else
+            if dbType == "mysql" then "?socket=${cfg.dbhost}" else throw "unsupported dbtype"
+          else
+            "@${cfg.dbhost}");
+        dbName = lib.optionalString (cfg.dbname != null) "/${cfg.dbname}";
+        dbUrl = "${dbType}://${dbUser}${dbPass}${lib.optionalString (!isSocket) dbHost}${dbName}${lib.optionalString isSocket dbHost}";
+      in lib.optionalString (dbPass != "") ''
+        export DATABASE_PASSWORD="$(<"${cfg.dbpassFile}")"
+      '' + ''
+        export DATABASE_URL="${dbUrl}"
+        ${cfg.package}/bin/notify_push --glob-config '${config.services.nextcloud.datadir}/config/config.php'
+      '';
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/notify_push --glob-config ${config.services.nextcloud.datadir}/config/config.php";
         User = "nextcloud";
         Group = "nextcloud";
         RuntimeDirectory = [ "nextcloud-notify_push" ];

--- a/nixos/modules/services/web-apps/nextcloud-notify_push.nix
+++ b/nixos/modules/services/web-apps/nextcloud-notify_push.nix
@@ -26,21 +26,19 @@ in
       description = lib.mdDoc "Log level";
     };
   } // (
-    lib.listToAttrs (
-      map (
-        opt: lib.nameValuePair opt (options.services.nextcloud.config.${opt} // {
-          default = config.services.nextcloud.config.${opt};
-          defaultText = lib.mdDoc "config.services.nextcloud.config.${opt}";
-        })
-      ) [
-        "dbtype"
-        "dbname"
-        "dbuser"
-        "dbpassFile"
-        "dbhost"
-        "dbport"
-        "dbtableprefix"
-      ]
+    lib.genAttrs [
+      "dbtype"
+      "dbname"
+      "dbuser"
+      "dbpassFile"
+      "dbhost"
+      "dbport"
+      "dbtableprefix"
+    ] (
+      opt: options.services.nextcloud.config.${opt} // {
+        default = config.services.nextcloud.config.${opt};
+        defaultText = "config.services.nextcloud.config.${opt}";
+      }
     )
   );
 

--- a/nixos/modules/services/web-apps/nextcloud-notify_push.nix
+++ b/nixos/modules/services/web-apps/nextcloud-notify_push.nix
@@ -84,6 +84,8 @@ in
         User = "nextcloud";
         Group = "nextcloud";
         RuntimeDirectory = [ "nextcloud-notify_push" ];
+        Restart = "on-failure";
+        RestartSec = "5s";
       };
     };
 

--- a/nixos/modules/services/web-apps/nextcloud-notify_push.nix
+++ b/nixos/modules/services/web-apps/nextcloud-notify_push.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.nextcloud.notify_push;
+in
+{
+  options.services.nextcloud.notify_push = {
+    enable = lib.mkEnableOption (lib.mdDoc "Notify push");
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.nextcloud-notify_push;
+      defaultText = lib.literalMD "pkgs.nextcloud-notify_push";
+      description = lib.mdDoc "Which package to use for notify_push";
+    };
+    socketPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/run/nextcloud-notify_push/sock";
+      description = lib.mdDoc "Socket path to use for notify_push";
+    };
+    logLevel = lib.mkOption {
+      type = lib.types.enum [ "error" "warn" "info" "debug" "trace" ];
+      default = "error";
+      description = lib.mdDoc "Log level";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.nextcloud-notify_push = let
+      nextcloudUrl = "http${lib.optionalString config.services.nextcloud.https "s"}://${config.services.nextcloud.hostName}";
+    in {
+      description = "Push daemon for Nextcloud clients";
+      documentation = [ "https://github.com/nextcloud/notify_push" ];
+      after = [ "phpfpm-nextcloud.service" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        NEXTCLOUD_URL = nextcloudUrl;
+        SOCKET_PATH = cfg.socketPath;
+        LOG = cfg.logLevel;
+      };
+      postStart = ''
+        ${config.services.nextcloud.occ}/bin/nextcloud-occ notify_push:setup ${nextcloudUrl}/push
+      '';
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/notify_push --glob-config ${config.services.nextcloud.datadir}/config/config.php";
+        User = "nextcloud";
+        Group = "nextcloud";
+        RuntimeDirectory = [ "nextcloud-notify_push" ];
+      };
+    };
+
+    services.nginx.virtualHosts.${config.services.nextcloud.hostName}.locations."^~ /push/" = {
+      proxyPass = "http://unix:${cfg.socketPath}";
+      proxyWebsockets = true;
+      recommendedProxySettings = true;
+    };
+  };
+}

--- a/pkgs/servers/nextcloud/notify_push.nix
+++ b/pkgs/servers/nextcloud/notify_push.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitHub, fetchpatch, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "notify_push";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "nextcloud";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-LkC2mD3klMQRF3z5QuVPcRHzz33VJP+UcN6LxsQXq7Q=";
+  };
+
+  cargoHash = "sha256-GZikXM3AvhC2gtwE2wYbGV+aRV+QKothWQG17Vzi2Lc=";
+
+  passthru = {
+    test_client = rustPlatform.buildRustPackage {
+      pname = "${pname}-test_client";
+      inherit src version;
+
+      cargoPatches = [
+        # fix test client not being able to connect
+        (fetchpatch {
+          url = "https://github.com/nextcloud/notify_push/commit/03aa38d917bfcba4d07f72b6aedac6a5057cad81.patch";
+          hash = "sha256-dcN62tA05HH1RTvG0puonJjKMQn1EouA8iuz82vh2aU=";
+        })
+      ];
+
+      buildAndTestSubdir = "test_client";
+
+      cargoHash = "sha256-RALqjI6DlWmfgKvyaH4RiSyqWsIqUyY9f709hOi2ldc=";
+    };
+  };
+
+  meta = with lib; {
+    description = "Update notifications for nextcloud clients";
+    homepage = "https://github.com/nextcloud/notify_push";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ ajs124 ];
+  };
+}

--- a/pkgs/servers/nextcloud/packages/24.json
+++ b/pkgs/servers/nextcloud/packages/24.json
@@ -129,6 +129,16 @@
       "agpl"
     ]
   },
+  "notify_push": {
+    "sha256": "1raxkzdcd9mixg30ifv22lzf10j47n79n05yqbf6mjagrgj0rr7f",
+    "url": "https://github.com/nextcloud/notify_push/releases/download/v0.5.0/notify_push.tar.gz",
+    "version": "0.5.0",
+    "description": "Push update support for desktop app.\n\nOnce the app is installed, the push binary needs to be setup. You can either use the setup wizard with `occ notify_push:setup` or see the [README](http://github.com/nextcloud/notify_push) for detailed setup instructions",
+    "homepage": "",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "onlyoffice": {
     "sha256": "6117b7b8c5c7133975e4ebf482814cdcd3f94a1b3c76ea1b5eed47bdd1fbfcbb",
     "url": "https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v7.5.8/onlyoffice.tar.gz",

--- a/pkgs/servers/nextcloud/packages/25.json
+++ b/pkgs/servers/nextcloud/packages/25.json
@@ -109,6 +109,16 @@
       "agpl"
     ]
   },
+  "notify_push": {
+    "sha256": "1raxkzdcd9mixg30ifv22lzf10j47n79n05yqbf6mjagrgj0rr7f",
+    "url": "https://github.com/nextcloud/notify_push/releases/download/v0.5.0/notify_push.tar.gz",
+    "version": "0.5.0",
+    "description": "Push update support for desktop app.\n\nOnce the app is installed, the push binary needs to be setup. You can either use the setup wizard with `occ notify_push:setup` or see the [README](http://github.com/nextcloud/notify_push) for detailed setup instructions",
+    "homepage": "",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "onlyoffice": {
     "sha256": "0gy4n86q7b5qmy609ncibp94v1b3z9msc0129572qz2zyxfqxq3i",
     "url": "https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v7.6.8/onlyoffice.tar.gz",

--- a/pkgs/servers/nextcloud/packages/nextcloud-apps.json
+++ b/pkgs/servers/nextcloud/packages/nextcloud-apps.json
@@ -12,6 +12,7 @@
 , "mail"
 , "news"
 , "notes"
+, "notify_push"
 , "onlyoffice"
 , "polls"
 , "registration"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10128,6 +10128,8 @@ with pkgs;
 
   nextcloud-news-updater = callPackage ../servers/nextcloud/news-updater.nix { };
 
+  nextcloud-notify_push = callPackage ../servers/nextcloud/notify_push.nix { };
+
   ndstool = callPackage ../tools/archivers/ndstool { };
 
   nfs-ganesha = callPackage ../servers/nfs-ganesha { };


### PR DESCRIPTION
###### Description of changes
Probably only makes sense with a module

Do the maintainers have any preference of how to go about that?
Separate module? Put it into the nextcloud module? Stuff like that…

Edit: only took me >1.5y since https://github.com/NixOS/nixpkgs/pull/113958#pullrequestreview-597991184 to get this started.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).