### PR TITLE
babl,gegl: update

### DIFF
--- a/pkgs/development/libraries/babl/default.nix
+++ b/pkgs/development/libraries/babl/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "babl";
-  version = "0.1.96";
+  version = "0.1.98";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://download.gimp.org/pub/babl/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-M2c/5Fmpg/QRJFpJ+B/X8ZZq8eqOypsJWpQMVCuFRfY=";
+    sha256 = "87Ii+E5GJzXeY/qcNlGULyt4/TFMc6IuBf98c6/SOvE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gegl/default.nix
+++ b/pkgs/development/libraries/gegl/default.nix
@@ -10,6 +10,7 @@
 , glib
 , babl
 , libpng
+, llvmPackages
 , cairo
 , libjpeg
 , librsvg
@@ -36,14 +37,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gegl";
-  version = "0.4.38";
+  version = "0.4.40";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
   src = fetchurl {
     url = "https://download.gimp.org/pub/gegl/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-5KM8hDClBC+6hDm1lTSOcYcPDZX7+IX/VT+QIMG+11A=";
+    sha256 = "zd6A0VpJ2rmmFO+Y+ATIzm5M/hM5o8JAw08/tFQ2uF0=";
   };
 
   nativeBuildInputs = [
@@ -77,7 +78,11 @@ stdenv.mkDerivation rec {
     luajit
     openexr
     suitesparse
-  ] ++ lib.optional stdenv.isDarwin OpenCL;
+  ] ++ lib.optionals stdenv.isDarwin [
+    OpenCL
+  ] ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
 
   # for gegl-4.0.pc
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Updates of GIMP dependencies:
https://www.gimp.org/news/2022/11/18/gimp-2-99-14-released/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran GIMP on NixOS
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
