### PR TITLE
libhv: init at 1.3.0

### DIFF
--- a/pkgs/development/libraries/libhv/default.nix
+++ b/pkgs/development/libraries/libhv/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, cmake, curl, openssl, Security }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libhv";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ithewei";
+    repo = "libhv";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-LMk8B/1EofcQcIF3kGmtPdM2s+/gN9ctcsybwTpf4Po=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ curl openssl ] ++ lib.optional stdenv.isDarwin Security;
+
+  cmakeFlags = [
+    "-DENABLE_UDS=ON"
+    "-DWITH_MQTT=ON"
+    "-DWITH_CURL=ON"
+    "-DWITH_NGHTTP2=ON"
+    "-DWITH_OPENSSL=ON"
+    "-DWITH_KCP=ON"
+  ];
+
+  meta = with lib; {
+    description = "A c/c++ network library for developing TCP/UDP/SSL/HTTP/WebSocket/MQTT client/server";
+    homepage = "https://github.com/ithewei/libhv";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20400,6 +20400,10 @@ with pkgs;
 
   libhugetlbfs = callPackage ../development/libraries/libhugetlbfs { };
 
+  libhv = callPackage ../development/libraries/libhv {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   libhwy = callPackage ../development/libraries/libhwy { };
 
   libHX = callPackage ../development/libraries/libHX { };


### PR DESCRIPTION
###### Description of changes
[**libhv**](https://github.com/ithewei/libhv) - C/C++ network library for developing TCP/UDP/SSL/HTTP/WebSocket/MQTT client/server.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
