### PR TITLE
nordzy-cursor-theme: 0.1.0 -> 0.6.0

### DIFF
--- a/pkgs/data/icons/nordzy-cursor-theme/default.nix
+++ b/pkgs/data/icons/nordzy-cursor-theme/default.nix
@@ -5,24 +5,23 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "nordzy-cursor-theme";
-  version = "0.1.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "alvatip";
     repo = "Nordzy-cursors";
     rev = "v${version}";
-    sha256 = "XabfKFyeII7Xl+ozzpPnc4xFH4B7GzCTLq4M1QPSZPw=";
+    sha256 = "sha256-q9PEEyxejRQ8UCwbqsfOCL7M70pLCOLyCx8gEFmZkWA=";
   };
 
   installPhase = ''
     mkdir -p $out/share/icons
-
-    cp -r nordzy-dark/ $out/share/icons/Nordzy-cursors
+    cp -r Nordzy-cursors/ $out/share/icons/Nordzy-cursors
     mv $out/share/icons/Nordzy-cursors/index.theme $out/share/icons/Nordzy-cursors/cursor.theme
-    mv $out/share/icons/Nordzy-cursors/Nordzy-cursors $out/share/icons/Nordzy-cursors/cursors
-    cp -r nordzy-white/ $out/share/icons/Nordzy-white-cursors
+    cp -r Nordzy-cursors-white/ $out/share/icons/Nordzy-white-cursors
     mv $out/share/icons/Nordzy-white-cursors/index.theme $out/share/icons/Nordzy-white-cursors/cursor.theme
-    mv $out/share/icons/Nordzy-white-cursors/Nordzy-white-cursors $out/share/icons/Nordzy-white-cursors/cursors
+    cp -r Nordzy-cursors-lefthand/ $out/share/icons/Nordzy-cursors-lefthand
+    mv $out/share/icons/Nordzy-cursors-lefthand/index.theme $out/share/icons/Nordzy-cursors-lefthand/cursor.theme
   '';
 
   meta = with lib; {


### PR DESCRIPTION
No breaking changes afaik. New version includes updates to the icons as well as a set of left-handed icons.

Note the original version of this package renames the `index.theme` files as `cursor.theme`. This PR respects that but I don't see why it's needed, seems to work fine without.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
