### PR TITLE
swayhide: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8236,7 +8236,7 @@
     email = "valentinobocchetti59@gmail.com";
     github = "luftmensch-luftmensch";
     githubId = 65391343;
-  }
+  };
   luispedro = {
     email = "luis@luispedro.org";
     github = "luispedro";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8231,6 +8231,12 @@
       fingerprint = "66D1 3048 2B5F 2069 81A6  6B83 6F98 7CCF 224D 20B9";
     }];
   };
+  luftmensch-luftmensch = {
+    name = "Valentino Bocchetti";
+    email = "valentinobocchetti59@gmail.com";
+    github = "luftmensch-luftmensch";
+    githubId = 65391343;
+  }
   luispedro = {
     email = "luis@luispedro.org";
     github = "luispedro";

--- a/pkgs/applications/window-managers/sway/swayhide.nix
+++ b/pkgs/applications/window-managers/sway/swayhide.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "swayhide";
+  version = "v0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "NomisIV";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-ICDz3oDuXl/DAO4njoLJuv7hRXt76nGPPQlBVcc+hZo=";
+  };
+
+  cargoSha256 = "sha256-N3fuBnz8kKO5ncwbVx7ED4ufmXoTY6zNiW+8UcJigCA=";
+
+  meta = with lib; {
+    description = "A window swallower for swaywm";
+    homepage    = "https://github.com/NomisIV/swayhide/";
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ luftmensch-luftmensch ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/applications/window-managers/sway/swayhide.nix
+++ b/pkgs/applications/window-managers/sway/swayhide.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "NomisIV";
     repo = pname;
-    rev = "v${version}";
+    rev = "${version}";
     sha256 = "sha256-ICDz3oDuXl/DAO4njoLJuv7hRXt76nGPPQlBVcc+hZo=";
   };
 

--- a/pkgs/applications/window-managers/sway/swayhide.nix
+++ b/pkgs/applications/window-managers/sway/swayhide.nix
@@ -7,12 +7,12 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "swayhide";
-  version = "v0.2.1";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "NomisIV";
     repo = pname;
-    rev = "${version}";
+    rev = "v${version}";
     sha256 = "sha256-ICDz3oDuXl/DAO4njoLJuv7hRXt76nGPPQlBVcc+hZo=";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29401,6 +29401,7 @@ with pkgs;
   sway = callPackage ../applications/window-managers/sway/wrapper.nix { };
   swaybg = callPackage ../applications/window-managers/sway/bg.nix { };
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
+  swayhide = callPackage ../applications/window-managers/sway/swayhide.nix { };
   swaylock = callPackage ../applications/window-managers/sway/lock.nix { };
   swayws = callPackage ../applications/window-managers/sway/ws.nix { };
   swaywsr = callPackage ../applications/window-managers/sway/wsr.nix { };


### PR DESCRIPTION
###### Description of changes

This change add **swayhide**, a  window swallower for swaywm

[Homepage](https://github.com/NomisIV/swayhide)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
