### PR TITLE
tree-sitter-grammars: update

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-julia",
-  "rev": "bedd19f3c3d745c3da8451a35c7bfc5f48d07ee6",
-  "date": "2022-11-05T17:27:50-05:00",
-  "path": "/nix/store/ldklarlvv3jlxsfi7gnqmim7csnxp2qf-tree-sitter-julia",
-  "sha256": "0cnp0rff6igjfz9i8ckffj9r1fr2nzdw82hag6dml331z7nbjjkf",
+  "rev": "628713553c42f30595a3b0085bb587e9359b986a",
+  "date": "2022-11-15T18:14:44-05:00",
+  "path": "/nix/store/4d712q8sjvbh845cd2b0xbvlng1iasaj-tree-sitter-julia",
+  "sha256": "12xlv4gbqdw0mr1zgnzs74pxpdkq4vfvs77gnr49zsrycjflf7xw",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-r.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-r.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/r-lib/tree-sitter-r",
-  "rev": "0f4f66e5050037b759ea040dafd596bcdda1de94",
-  "date": "2022-10-12T16:08:16-07:00",
-  "path": "/nix/store/yffaihslg48mx67cy4gw8n8m3wrc9a7h-tree-sitter-r",
-  "sha256": "1qw2ngr9db3nv9bc74y2rlsvbk9np5djj1pxhb3ks5dkk7airf76",
+  "rev": "80efda55672d1293aa738f956c7ae384ecdc31b4",
+  "date": "2022-11-10T09:19:03-08:00",
+  "path": "/nix/store/x7rjhqp9qxh9xwq2l38jz5wbkbzz0vfl-tree-sitter-r",
+  "sha256": "1n7yxi2wf9xj8snw0b85a5w40vhf7x1pwirnwfk78ilr6hhz4ix9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rego.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rego.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/FallenAngel97/tree-sitter-rego",
-  "rev": "6d70da3a998fd0081efc5d1019c71e74cc1568e9",
-  "date": "2022-08-17T15:53:32+03:00",
-  "path": "/nix/store/r23jy7qfsl6snbp0z7p5lk9x0q9ssgzs-tree-sitter-rego",
-  "sha256": "1phjhrngv818mcwvbrfpi0hrzc05cjckds5ddmndc8h7wi0db9cb",
+  "rev": "b2667c975f07b33be3ceb83bea5cfbad88095866",
+  "date": "2022-11-18T14:07:12+02:00",
+  "path": "/nix/store/ky8xv5v5i273n0zqin0mnsx810382wfn-tree-sitter-rego",
+  "sha256": "18qw5ahx6qcfq9gs6gcakl178gnnryksv6gyamyd6vypz20kwz6b",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/derekstride/tree-sitter-sql",
-  "rev": "70c50264ae022193adb364ffa7a767d765ed9857",
-  "date": "2022-11-02T09:36:19-04:00",
-  "path": "/nix/store/f1pg3pf4fyfmls30l1ma1nlwq61fxxqs-tree-sitter-sql",
-  "sha256": "16s58bvll2r80zga63fjzjbkfxm3zdr3vljjk69cvjwnpy668yfh",
+  "rev": "4f1b91246b43190e34957d9de9a0f3625879ba33",
+  "date": "2022-11-18T10:16:02-05:00",
+  "path": "/nix/store/l84kfw631akx7v4k6c0s4hdvaanjh8a1-tree-sitter-sql",
+  "sha256": "03wbxfkwk5i31knf1hgqkb56r66vk18k5n4919hhnhy9vvrm0mw3",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
