### PR TITLE
briar-desktop: 0.2.1-beta -> 0.3.1-beta

### DIFF
--- a/pkgs/applications/networking/instant-messengers/briar-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/briar-desktop/default.nix
@@ -1,7 +1,8 @@
 { lib
 , stdenv
-, fetchzip
+, fetchurl
 , openjdk
+, libnotify
 , makeWrapper
 , tor
 , p7zip
@@ -18,13 +19,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "briar-desktop";
-  version = "0.2.1-beta";
+  version = "0.3.1-beta";
 
-  src = fetchzip {
-    url = "https://code.briarproject.org/briar/briar-desktop/-/jobs/18424/artifacts/download?file_type=archive";
-    sha256 = "sha256-ivMbgo0+iZE4/Iffq9HUBErGIQMVLrRZUQ6R3V3X8II=";
-    extension = "zip";
+  src = fetchurl {
+    url = "https://desktop.briarproject.org/jars/linux/0.3.1-beta/briar-desktop-linux-0.3.1-beta.jar";
+    sha256 = "841dc198101e6e8aa6b5ab6bd6b80e9c6b2593cb88bc3b2592f947baf963389d";
   };
+
+  dontUnpack = true;
 
   nativeBuildInputs = [
     makeWrapper
@@ -33,9 +35,12 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/{bin,lib}
-    cp ${src}/briar-desktop.jar $out/lib/
+    cp ${src} $out/lib/briar-desktop.jar
     makeWrapper ${openjdk}/bin/java $out/bin/briar-desktop \
-      --add-flags "-jar $out/lib/briar-desktop.jar"
+      --add-flags "-jar $out/lib/briar-desktop.jar" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
+        libnotify
+      ]}"
   '';
 
   fixupPhase = ''


### PR DESCRIPTION
###### Description of changes

briar-desktop 0.2.1-beta has expired and will no longer run.

briar-desktop 0.3.1-beta also adds functionality such as notifications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
