### PR TITLE
babeltrace: fix cross-compilation

### DIFF
--- a/pkgs/development/tools/misc/babeltrace/default.nix
+++ b/pkgs/development/tools/misc/babeltrace/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, glib, libuuid, popt, elfutils }:
+{ lib, stdenv, fetchurl, autoreconfHook, pkg-config, glib, libuuid, popt, elfutils }:
 
 stdenv.mkDerivation rec {
   pname = "babeltrace";
@@ -9,8 +9,17 @@ stdenv.mkDerivation rec {
     sha256 = "1hkg3phnamxfrhwzmiiirbhdgckzfkqwhajl0lmr1wfps7j47wcz";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  # The pre-generated ./configure script uses an old autoconf version which
+  # breaks cross-compilation (replaces references to malloc with rpl_malloc).
+  # Re-generate with nixpkgs's autoconf. This requires glib to be present in
+  # nativeBuildInputs for its m4 macros to be present.
+  nativeBuildInputs = [ autoreconfHook glib pkg-config ];
   buildInputs = [ glib libuuid popt elfutils ];
+
+  # --enable-debug-info (default) requires the configure script to run host
+  # executables to determine the elfutils library version, which cannot be done
+  # while cross compiling.
+  configureFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-debug-info";
 
   meta = with lib; {
     description = "Command-line tool and library to read and convert LTTng tracefiles";


### PR DESCRIPTION
###### Description of changes

Note: `glib` cross-compilation is at present broken on `master`. I've done my testing with e9c35f11 cherry-picked.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
