### PR TITLE
lollypop: 1.4.36 -> 1.4.35

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -25,7 +25,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "lollypop";
-  version = "1.4.36";
+  version = "1.4.35";
 
   format = "other";
   doCheck = false;
@@ -34,7 +34,7 @@ python3.pkgs.buildPythonApplication rec  {
     url = "https://gitlab.gnome.org/World/lollypop";
     rev = "refs/tags/${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-Ka/rYgWGuCQTzguJiyQpY5SPC1iB5XOVy/Gezj+DYpk=";
+    sha256 = "sha256-Rdp0gZjdj2tXOWarsTpqgvSZVXAQsCLfk5oUyalE/ZA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
The 1.4.36 release is broken for us:

```
Traceback (most recent call last):
  File "/nix/store/yqy14z7qhgr728k9myq7dilvk87nmsar-lollypop-1.4.36/bin/.lollypop-wrapped", line 46, in <module>
    from lollypop.application import Application
  File "/nix/store/yqy14z7qhgr728k9myq7dilvk87nmsar-lollypop-1.4.36/lib/python3.10/site-packages/lollypop/application.py", line 33, in <module>
    from lollypop.database import Database
  File "/nix/store/yqy14z7qhgr728k9myq7dilvk87nmsar-lollypop-1.4.36/lib/python3.10/site-packages/lollypop/database.py", line 21, in <module>
    from lollypop.database_upgrade import DatabaseAlbumsUpgrade
  File "/nix/store/yqy14z7qhgr728k9myq7dilvk87nmsar-lollypop-1.4.36/lib/python3.10/site-packages/lollypop/database_upgrade.py", line 24, in <module>
    from lollypop.helper_task import TaskHelper
  File "/nix/store/yqy14z7qhgr728k9myq7dilvk87nmsar-lollypop-1.4.36/lib/python3.10/site-packages/lollypop/helper_task.py", line 14, in <module>
    gi.require_version("Soup", "3.0")
  File "/nix/store/i9g6imnzqrnysfqj54jrdqb4ds3jh1kh-python3.10-pygobject-3.42.2/lib/python3.10/site-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available for version %s' %
ValueError: Namespace Soup not available for version 3.0
```

This doesn't revert #201181, but it does move the version to 1.4.35, up
from the original 1.4.34, but dowgrading from 1.4.36.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
