### PR TITLE
duckstation: unstable-2022-07-08 -> 2022-11-18

### DIFF
--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -7,28 +7,27 @@
 , makeDesktopItem
 , curl
 , extra-cmake-modules
-, libevdev
 , libpulseaudio
 , libXrandr
 , mesa # for libgbm
 , ninja
 , pkg-config
 , qtbase
+, qtsvg
 , qttools
 , vulkan-loader
-#, wayland # Wayland doesn't work correctly this version
+, wayland
 , wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "duckstation";
-  version = "unstable-2022-07-08";
-
+  version = "unstable-2022-11-18";
   src = fetchFromGitHub {
     owner = "stenzek";
     repo = pname;
-    rev = "82965f741e81e4d2f7e1b2abdc011e1f266bfe7f";
-    sha256 = "sha256-D8Ps/EQRcHLsps/KEUs56koeioOdE/GPA0QJSrbSdYs=";
+    rev = "8d7aea5e19859ed483699cc4a5dbd47165c7be8b";
+    sha256 = "sha256-92Wn1ZEEZszmVK/KrJqjDuQf/lyD8/VScfTI/St5dY4=";
   };
 
   nativeBuildInputs = [
@@ -44,18 +43,18 @@ stdenv.mkDerivation rec {
   buildInputs = [
     SDL2
     curl
-    libevdev
     libpulseaudio
     libXrandr
     mesa
     qtbase
+    qtsvg
     vulkan-loader
-    #wayland
+    wayland
   ];
 
   cmakeFlags = [
     "-DUSE_DRMKMS=ON"
-    #"-DUSE_WAYLAND=ON"
+    "-DUSE_WAYLAND=ON"
   ];
 
   desktopItems = [
@@ -80,7 +79,7 @@ stdenv.mkDerivation rec {
     cp -r bin $out/share/duckstation
     ln -s $out/share/duckstation/duckstation-qt $out/bin/
 
-    install -Dm644 ../extras/icons/icon-256px.png $out/share/pixmaps/duckstation.png
+    install -Dm644 bin/resources/images/duck.png $out/share/pixmaps/duckstation.png
 
     runHook postInstall
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1553,7 +1553,7 @@ with pkgs;
 
   dosbox-staging = callPackage ../applications/emulators/dosbox-staging { };
 
-  duckstation = libsForQt5.callPackage ../applications/emulators/duckstation {};
+  duckstation = qt6Packages.callPackage ../applications/emulators/duckstation {};
 
   dynamips = callPackage ../applications/emulators/dynamips { };
 


### PR DESCRIPTION
###### Description of changes
https://github.com/stenzek/duckstation/releases/tag/latest
Briefly tested a game, both on XWayland and Wayland.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
