### PR TITLE
trival-builders: add pre and post build hooks to runCommandWith

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -78,7 +78,12 @@ rec {
     }: buildCommand:
     stdenv.mkDerivation ({
       enableParallelBuilding = true;
-      inherit buildCommand name;
+      inherit name;
+      buildCommand = ''
+        runHook preBuild
+        ${buildCommand}
+        runHook postBuild
+      '';
       passAsFile = [ "buildCommand" ]
         ++ (derivationArgs.passAsFile or []);
     }


### PR DESCRIPTION
###### Description of changes

This PR proposes executing the `preBuild` and `postBuild` hooks automatically with the `pkgs.runCommand` variants. The reasoning behind this is to allow upstream callers to add `preBuild` and `postBuild` to `derivationArgs` and receive the expected result. The alternative would be that every invocation of `runCommand*` would need to manually call the hooks; for example, using `writeTextFile ` would have to manually prepend/append the hook invocations to the `text` argument. Performing this execution earlier down the stack seems more beneficial. 

Unfortunately, there are a lot of things that touch `runCommand`, and I don't appear to have enough RAM locally to test the change. I was, however, able to do a basic sanity check in the REPL:

```
nix-repl> t = outputs.legacyPackages.x86_64-linux.runCommand "test" { postBuild = "echo 'test1' >> $out"; } "touch $out; echo 'test' >$out"
nix-repl> :b t
❯ cat /nix/store/ygakm6wkgr1758fqv2qw44grgqnqs06c-test
test
test1
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
