### PR TITLE
linux: cleanup common-config after drop of 4.9

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -53,8 +53,6 @@ let
       DEBUG_KERNEL              = yes;
       DEBUG_DEVRES              = no;
       DYNAMIC_DEBUG             = yes;
-      TIMER_STATS               = whenOlder "4.11" yes;
-      DEBUG_NX_TEST             = whenOlder "4.11" no;
       DEBUG_STACK_USAGE         = no;
       DEBUG_STACKOVERFLOW       = option no;
       RCU_TORTURE_TEST          = no;
@@ -109,10 +107,10 @@ let
       BLK_CGROUP_IOLATENCY = whenAtLeast "4.19" yes;
       BLK_CGROUP_IOCOST = whenAtLeast "5.4" yes;
       IOSCHED_DEADLINE = whenOlder "5.0" yes; # Removed in 5.0-RC1
-      MQ_IOSCHED_DEADLINE = whenAtLeast "4.11" yes;
-      BFQ_GROUP_IOSCHED = whenAtLeast "4.12" yes;
-      MQ_IOSCHED_KYBER = whenAtLeast "4.12" yes;
-      IOSCHED_BFQ = whenAtLeast "4.12" module;
+      MQ_IOSCHED_DEADLINE = yes;
+      BFQ_GROUP_IOSCHED = yes;
+      MQ_IOSCHED_KYBER = yes;
+      IOSCHED_BFQ = module;
     };
 
 
@@ -164,8 +162,8 @@ let
       IPV6_MROUTE_MULTIPLE_TABLES = yes;
       IPV6_PIMSM_V2               = yes;
       IPV6_FOU_TUNNEL             = module;
-      IPV6_SEG6_LWTUNNEL          = whenAtLeast "4.10" yes;
-      IPV6_SEG6_HMAC              = whenAtLeast "4.10" yes;
+      IPV6_SEG6_LWTUNNEL          = yes;
+      IPV6_SEG6_HMAC              = yes;
       IPV6_SEG6_BPF               = whenAtLeast "4.18" yes;
       NET_CLS_BPF                 = module;
       NET_ACT_BPF                 = module;
@@ -222,7 +220,7 @@ let
       INET_DIAG         = mkDefault module;
       INET_TCP_DIAG     = mkDefault module;
       INET_UDP_DIAG     = mkDefault module;
-      INET_RAW_DIAG     = whenAtLeast "4.14" (mkDefault module);
+      INET_RAW_DIAG     = mkDefault module;
       INET_DIAG_DESTROY = mkDefault yes;
 
       # enable multipath-tcp
@@ -231,7 +229,7 @@ let
       INET_MPTCP_DIAG = whenAtLeast "5.9" (mkDefault module);
 
       # Kernel TLS
-      TLS         = whenAtLeast "4.13" module;
+      TLS         = module;
       TLS_DEVICE  = whenAtLeast "4.18" yes;
 
       # infiniband
@@ -308,7 +306,7 @@ let
       DRM_I915_GVT_KVMGT = whenAtLeast "4.16" module;
     } // optionalAttrs (stdenv.hostPlatform.system == "aarch64-linux") {
       # enable HDMI-CEC on RPi boards
-      DRM_VC4_HDMI_CEC = whenAtLeast "4.14" yes;
+      DRM_VC4_HDMI_CEC = yes;
     };
 
     sound = {
@@ -321,8 +319,6 @@ let
       SND_HDA_CODEC_CA0132_DSP = whenOlder "5.7" yes; # Enable DSP firmware loading on Creative Soundblaster Z/Zx/ZxR/Recon
       SND_OSSEMUL         = yes;
       SND_USB_CAIAQ_INPUT = yes;
-      # Enable PSS mixer (Beethoven ADSP-16 and other compatible)
-      PSS_MIXER           = whenOlder "4.12" yes;
     # Enable Sound Open Firmware support
     } // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux" &&
                         versionAtLeast version "5.5") {
@@ -453,7 +449,6 @@ let
       CIFS_UPCALL       = yes;
       CIFS_ACL          = whenOlder "5.3" yes;
       CIFS_DFS_UPCALL   = yes;
-      CIFS_SMB2         = whenOlder "4.13" yes;
 
       CEPH_FSCACHE      = yes;
       CEPH_FS_POSIX_ACL = yes;
@@ -465,7 +460,7 @@ let
       SQUASHFS_LZO                 = yes;
       SQUASHFS_XZ                  = yes;
       SQUASHFS_LZ4                 = yes;
-      SQUASHFS_ZSTD                = whenAtLeast "4.14" yes;
+      SQUASHFS_ZSTD                = yes;
 
       # Native Language Support modules, needed by some filesystems
       NLS              = yes;
@@ -483,12 +478,10 @@ let
     };
 
     security = {
-      FORTIFY_SOURCE                   = whenAtLeast "4.13" (option yes);
+      FORTIFY_SOURCE                   = option yes;
 
       # https://googleprojectzero.blogspot.com/2019/11/bad-binder-android-in-wild-exploit.html
       DEBUG_LIST                       = yes;
-      # Detect writes to read-only module pages
-      DEBUG_SET_MODULE_RONX            = whenOlder "4.11" (option yes);
       HARDENED_USERCOPY                = yes;
       RANDOMIZE_BASE                   = option yes;
       STRICT_DEVMEM                    = mkDefault yes; # Filter access to /dev/mem
@@ -533,7 +526,6 @@ let
       MICROCODE       = yes;
       MICROCODE_INTEL = yes;
       MICROCODE_AMD   = yes;
-    } // optionalAttrs (versionAtLeast version "4.10") {
       # Write Back Throttling
       # https://lwn.net/Articles/682582/
       # https://bugzilla.kernel.org/show_bug.cgi?id=12309#c655
@@ -548,7 +540,7 @@ let
       CGROUP_DEVICE  = yes;
       CGROUP_HUGETLB = yes;
       CGROUP_PERF    = yes;
-      CGROUP_RDMA    = whenAtLeast "4.11" yes;
+      CGROUP_RDMA    = yes;
 
       MEMCG                    = yes;
       MEMCG_SWAP               = whenOlder "6.1" yes;
@@ -578,8 +570,7 @@ let
       FTRACE_SYSCALLS       = yes;
       SCHED_TRACER          = yes;
       STACK_TRACER          = yes;
-      UPROBE_EVENT          = { optional = true; tristate = whenOlder "4.11" "y";};
-      UPROBE_EVENTS         = { optional = true; tristate = whenAtLeast "4.11" "y";};
+      UPROBE_EVENTS         = option yes;
       BPF_SYSCALL           = yes;
       BPF_UNPRIV_DEFAULT_OFF = whenBetween "5.10" "5.16" yes;
       BPF_EVENTS            = yes;
@@ -594,8 +585,6 @@ let
       PARAVIRT_SPINLOCKS  = option yes;
 
       KVM_ASYNC_PF                      = yes;
-      KVM_COMPAT                        = whenOlder "4.12" (option yes);
-      KVM_DEVICE_ASSIGNMENT             = whenOlder "4.12" (option yes);
       KVM_GENERIC_DIRTYLOG_READ_PROTECT = yes;
       KVM_GUEST                         = yes;
       KVM_MMIO                          = yes;
@@ -644,7 +633,6 @@ let
       MEDIA_USB_SUPPORT        = yes;
       MEDIA_ANALOG_TV_SUPPORT  = yes;
       VIDEO_STK1160_COMMON     = module;
-      VIDEO_STK1160_AC97       = whenOlder "4.11" yes;
     };
 
     "9p" = {
@@ -760,7 +748,7 @@ let
       DRAGONRISE_FF      = yes;
       GREENASIA_FF       = yes;
       HOLTEK_FF          = yes;
-      JOYSTICK_PSXPAD_SPI_FF = whenAtLeast "4.14" yes;
+      JOYSTICK_PSXPAD_SPI_FF = yes;
       LOGIG940_FF        = yes;
       NINTENDO_FF        = whenAtLeast "5.16" yes;
       PLAYSTATION_FF     = whenAtLeast "5.12" yes;
@@ -806,16 +794,16 @@ let
 
       BLK_DEV_INTEGRITY       = yes;
 
-      BLK_SED_OPAL = whenAtLeast "4.14" yes;
+      BLK_SED_OPAL = yes;
 
       BSD_PROCESS_ACCT_V3 = yes;
 
-      SERIAL_DEV_BUS = whenAtLeast "4.11" yes; # enables support for serial devices
-      SERIAL_DEV_CTRL_TTYPORT = whenAtLeast "4.11" yes; # enables support for TTY serial devices
+      SERIAL_DEV_BUS = yes; # enables support for serial devices
+      SERIAL_DEV_CTRL_TTYPORT = yes; # enables support for TTY serial devices
 
       BT_HCIBTUSB_MTK = whenAtLeast "5.3" yes; # MediaTek protocol support
       BT_HCIUART_QCA = yes; # Qualcomm Atheros protocol support
-      BT_HCIUART_SERDEV = whenAtLeast "4.12" yes; # required by BT_HCIUART_QCA
+      BT_HCIUART_SERDEV = yes; # required by BT_HCIUART_QCA
       BT_HCIUART = module; # required for BT devices with serial port interface (QCA6390)
       BT_HCIUART_BCSP = option yes;
       BT_HCIUART_H4   = option yes; # UART (H4) protocol support
@@ -895,8 +883,8 @@ let
       SCSI_LOGGING = yes; # SCSI logging facility
       SERIAL_8250  = yes; # 8250/16550 and compatible serial support
 
-      SLAB_FREELIST_HARDENED = whenAtLeast "4.14" yes;
-      SLAB_FREELIST_RANDOM   = whenAtLeast "4.10" yes;
+      SLAB_FREELIST_HARDENED = yes;
+      SLAB_FREELIST_RANDOM   = yes;
 
       SLIP_COMPRESSED = yes; # CSLIP compressed headers
       SLIP_SMART      = yes;
@@ -972,7 +960,7 @@ let
       NR_CPUS = freeform "384";
     } // optionalAttrs (stdenv.hostPlatform.system == "armv7l-linux" || stdenv.hostPlatform.system == "aarch64-linux") {
       # Enables support for the Allwinner Display Engine 2.0
-      SUN8I_DE2_CCU = whenAtLeast "4.13" yes;
+      SUN8I_DE2_CCU = yes;
 
       # See comments on https://github.com/NixOS/nixpkgs/commit/9b67ea9106102d882f53d62890468071900b9647
       CRYPTO_AEGIS128_SIMD = whenAtLeast "5.4" no;


### PR DESCRIPTION
linux-4.9 was dropped on 8d9133c67d25c15348ec12720ee2ce90762d4d4c / #200218

next lowest version in nixpkgs is 4.14 so cleaning up options

###### Description of changes

whenOlder < 4.14 x  => remove option
whenAtLeast <= 4.14 => remove conditional

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
