### PR TITLE
bitwig-studio: fix crash when creating user color palette via importing a JPEG image

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -41,7 +41,25 @@ stdenv.mkDerivation rec {
   dontWrapGApps = true; # we only want $gappsWrapperArgs here
 
   buildInputs = with xorg; [
-    alsa-lib cairo freetype gdk-pixbuf glib gtk3 libxcb xcbutil xcbutilwm zlib libXtst libxkbcommon pipewire pulseaudio libjack2 libX11 libglvnd libXcursor stdenv.cc.cc.lib
+    alsa-lib
+    cairo
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libglvnd
+    libjack2
+    libxcb
+    libXcursor
+    libX11
+    libXtst
+    libxkbcommon
+    pipewire
+    pulseaudio
+    stdenv.cc.cc.lib
+    xcbutil
+    xcbutilwm
+    zlib
   ];
 
   installPhase = ''

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -1,8 +1,25 @@
-{ stdenv, fetchurl, alsa-lib, cairo, dpkg, freetype
-, gdk-pixbuf, glib, gtk3, lib, xorg
-, libglvnd, libjack2, ffmpeg
-, libxkbcommon, xdg-utils, zlib, pipewire, pulseaudio
-, wrapGAppsHook, makeWrapper }:
+{ stdenv
+, fetchurl
+, alsa-lib
+, cairo
+, dpkg
+, ffmpeg
+, freetype
+, gdk-pixbuf
+, glib
+, gtk3
+, lib
+, libglvnd
+, libjack2
+, libxkbcommon
+, makeWrapper
+, pipewire
+, pulseaudio
+, wrapGAppsHook
+, xdg-utils
+, xorg
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "bitwig-studio";

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -11,6 +11,7 @@
 , lib
 , libglvnd
 , libjack2
+, libjpeg
 , libxkbcommon
 , makeWrapper
 , pipewire
@@ -49,6 +50,8 @@ stdenv.mkDerivation rec {
     gtk3
     libglvnd
     libjack2
+    # libjpeg8 is required for converting jpeg's to colour palettes
+    libjpeg
     libxcb
     libXcursor
     libX11

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27553,7 +27553,9 @@ with pkgs;
     inherit bitwig-studio1;
   };
   bitwig-studio3 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio3.nix { };
-  bitwig-studio4 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio4.nix { };
+  bitwig-studio4 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio4.nix {
+    libjpeg = libjpeg.override { enableJpeg8 = true; };
+  };
 
   bitwig-studio = bitwig-studio4;
 


### PR DESCRIPTION
###### Description of changes

Bitwig Studio has a hidden little feature to generate a color palette for your clips from an image. You can see an example of the feature in this timestamped video: https://youtu.be/GT0sX61LcMI?t=31

Only PNG and JPEG files are supported when choosing an image. Upon testing this out, I noticed that while PNGs worked fine, JPEGs caused Bitwig Studio to crash with the following traceback:

<details>

<summary>traceback</summary>

```
[2022-11-19 02:24:04.174 notifications info] Update Available - v4.4.3: A new release of Bitwig Studio is available.
(Your upgrade plan includes this version.)
[2022-11-19 02:24:26.377 float-main-app fatal] Application crashing in subsystem GUI Event Thread:
        java.lang.UnsatisfiedLinkError: /nix/store/4n8313q7knq82j86wl89sk49qadkfm1b-bitwig-studio-4.4.2/libexec/lib/jre/lib/libjavajpeg.so: libjpeg.so.8: cannot open shared object file: No such file or directory
        at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
        at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(Unknown Source)
        at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(Unknown Source)
        at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(Unknown Source)
        at java.base/jdk.internal.loader.NativeLibraries.findFromPaths(Unknown Source)
        at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(Unknown Source)
        at java.base/java.lang.ClassLoader.loadLibrary(Unknown Source)
        at java.base/java.lang.Runtime.loadLibrary0(Unknown Source)
        at java.base/java.lang.System.loadLibrary(Unknown Source)
        at java.desktop/com.sun.imageio.plugins.jpeg.JPEGImageReader$1.run(Unknown Source)
        at java.desktop/com.sun.imageio.plugins.jpeg.JPEGImageReader$1.run(Unknown Source)
        at java.base/java.security.AccessController.doPrivileged(Unknown Source)
        at java.desktop/com.sun.imageio.plugins.jpeg.JPEGImageReader.initStatic(Unknown Source)
        at java.desktop/com.sun.imageio.plugins.jpeg.JPEGImageReader.<clinit>(Unknown Source)
        at java.desktop/com.sun.imageio.plugins.jpeg.JPEGImageReaderSpi.createReaderInstance(Unknown Source)
        at java.desktop/javax.imageio.spi.ImageReaderSpi.createReaderInstance(Unknown Source)
        at java.desktop/javax.imageio.ImageIO$ImageReaderIterator.next(Unknown Source)
        at java.desktop/javax.imageio.ImageIO$ImageReaderIterator.next(Unknown Source)
        at java.desktop/javax.imageio.ImageIO.read(Unknown Source)
        at java.desktop/javax.imageio.ImageIO.read(Unknown Source)
        at bKW.jdu(SourceFile:269)
        at bKW.Das(SourceFile:256)
        at bKX.f1U(SourceFile:102)
        at bKX.CuJ(SourceFile:85)
        at bKW.jdu(SourceFile:194)
        at com.bitwig.windowing_system.wzo.ejI(SourceFile:273)
        at com.bitwig.windowing_system.wzo.Das(SourceFile:263)
        at com.bitwig.x11_windowing_system.X11FileDialog.jdu(SourceFile:23)
        at com.bitwig.x11_windowing_system.ltD.run(SourceFile:248)
        at dAU.run(SourceFile:25)
        at cCu.jdu(SourceFile:1072)
        at com.bitwig.flt.app.Jrg.jdu(SourceFile:2384)
        at cCu.wCf(SourceFile:1038)
        at cCu.Das(SourceFile:992)
        at com.bitwig.flt.app.kbj.Das(SourceFile:1996)
        at cCu.rEx(SourceFile:720)
        at com.bitwig.flt.app.BitwigStudioMain.main(SourceFile:206)

Child process with PID 1600879 exited with error code: 1
```

</details>

Mainly, it is looking for `libjpeg.so.8`. This PR adds a dependency and `buildInput` on `libjpeg` and sets the argument `enableJpeg8` to `true`, which builds `libjpeg` with ABI support for libjpeg8.

Testing the generation of a color palette from a JPEG in Bitwig Studio now works! 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Recommended to review commit-by-commit. I took the liberty of organising the list of imports and buildInputs in separate commits.