### PR TITLE
libyuv: fix libyuv.so not linking against libjpeg

### DIFF
--- a/pkgs/development/libraries/libyuv/default.nix
+++ b/pkgs/development/libraries/libyuv/default.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libjpeg ];
 
-  NIX_CFLAGS_LINK = lib.optional stdenv.isDarwin "-ljpeg";
+  patches = [
+    ./link-library-against-libjpeg.patch
+  ];
 
   meta = with lib; {
     homepage = "https://chromium.googlesource.com/libyuv/libyuv";

--- a/pkgs/development/libraries/libyuv/link-library-against-libjpeg.patch
+++ b/pkgs/development/libraries/libyuv/link-library-against-libjpeg.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 636531ee..af1b0e4e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,6 +39,7 @@ INCLUDE ( FindJPEG )
+ if (JPEG_FOUND)
+   include_directories( ${JPEG_INCLUDE_DIR} )
+   target_link_libraries( yuvconvert ${JPEG_LIBRARY} )
++  target_link_libraries( ${ly_lib_shared} ${JPEG_LIBRARY} )
+   add_definitions( -DHAVE_JPEG )
+ endif()


### PR DESCRIPTION
###### Description of changes

tldr: Programs depending on `kimageformats` can't display AVIF image without this fix.

`libyuv` doesn't link its main library (libyuv.so) against `libjpeg` correctly,
which draws `libavif` unusable on doing certain operations, and which in turn
breaks AVIF support of `kimageformats`.

I wasn't aware of the QT_PLUGIN_PATH shenanigans when I opened #196268, so this bug
didn't got caught back then :(

Built and tested `qimgv` (properly).

See also:
- https://github.com/archlinux/svntogit-community/commit/9093aacd4a61
- https://src.fedoraproject.org/rpms/libyuv/blob/main/f/libyuv-0006-Link-main-library-against-libjpeg.patch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
