### PR TITLE
python27: mark as vulnerable/insecure

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -351,8 +351,14 @@ in with passthru; stdenv.mkDerivation ({
       license = lib.licenses.psfl;
       platforms = lib.platforms.all;
       maintainers = with lib.maintainers; [ fridh thiagokokada ];
-      # Higher priority than Python 3.x so that `/bin/python` points to `/bin/python2`
-      # in case both 2 and 3 are installed.
-      priority = -100;
+      knownVulnerabilities = [
+        "Python 2.7 has reached its end of life after 2020-01-01. See https://www.python.org/doc/sunset-python-2/."
+        # Quote: That means that we will not improve it anymore after that day,
+        # even if someone finds a security problem in it. You should upgrade to
+        # Python 3 as soon as you can. [..] So, in 2008, we announced that we
+        # would sunset Python 2 in 2015, and asked people to upgrade before
+        # then. Some did, but many did not. So, in 2014, we extended that
+        # sunset till 2020.
+      ];
     };
   } // crossCompileEnv)


### PR DESCRIPTION
###### Description of changes

Impacted packages:

| Package  | Maintainers |
|  -----   |  ---------  |
| `afl`    | @thoughtpolice @risicle |
| `cassandra{,_3_0,_3_11,_4}` | @roberth |
| `dia` | @7c6f434c |
| `dictdDBs.wiktionary` | @alyssais |
| `dictdDBs.wordnet` | N/A |
| `fcitx-engines.mozc` | @gebner @ericsagnes |
| `foundationdb{51,52,60}` | @thoughtpolice |
| `gnome2.gnome_python_desktop` | @cillianderoiste |
| `gnome2.gnome_python` | @qknight |
| `gnubg` | @ehmry |
| `hexio` | @leenaars |
| `linuxPackages.hyperv-daemons` | @peterhoeg |
| `manta` | @jbedo |
| `neard` | @jtojnar |
| `neuron-full` | @adevress |
| `palemoon` | @AndersonTorres @OPNA2608 |
| `pam_usb` | N/A |
| `platypus` | @jbedo |
| `rabbitmq-java-client` | N/A |
| `rethinkdb` | @thoughtpolice @bluescreen303 |
| `retrofe` | @hrdinka |
| `storm` | @edwtjo @vizanto |
| `strelka` | @jbedo |
| `trustedGrub` | N/A |
| `xtrlock-pam` | N/A |
| `z3_4_4_0` | @thoughtpolice @ttuegel |

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
