### PR TITLE
lemminx: init at 0.22.0

### DIFF
--- a/pkgs/development/tools/lemminx/default.nix
+++ b/pkgs/development/tools/lemminx/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchurl, unzip, zlib, autoPatchelfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "lemminx";
+  version = "0.22.0";
+
+  src = fetchurl {
+    url = "https://github.com/redhat-developer/vscode-xml/releases/download/${version}/lemminx-linux.zip";
+    sha256 = "sha256-cbRqdgYHHClnlTWgA1vBdbAT6EzD7ygvfM9Zppl5czo=";
+  };
+
+  nativeBuildInputs = [ unzip autoPatchelfHook ];
+  buildInputs = [ zlib ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp lemminx-linux $out/bin/lemminx
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/eclipse/lemminx";
+    description = "XML Language server";
+    longDescription = ''
+      LemMinX is a XML language specific implementation of the Language Server Protocol and can be used
+      with any editor that supports the protocol, to offer good support for the XML Language.
+    '';
+    license = lib.licenses.epl20;
+    maintainers = with maintainers; [ tshaynik ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17336,6 +17336,8 @@ with pkgs;
 
   lemon = callPackage ../development/tools/parsing/lemon { };
 
+  lemminx = callPackage ../development/tools/lemminx { };
+
   lenmus = callPackage ../applications/misc/lenmus { };
 
   lightningcss = callPackage ../development/tools/lightningcss { };


### PR DESCRIPTION
Add LemMinX LSP server for XML

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds LemMinX, a Language Server Protocol server for XML: https://github.com/eclipse/lemminx/

The build process is a complex build with Maven and GraalVM, so this PR is pulling a pre-build binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
