### PR TITLE
python310Packages.pywbem: remove unittest2

### DIFF
--- a/pkgs/development/python-modules/pywbem/default.nix
+++ b/pkgs/development/python-modules/pywbem/default.nix
@@ -1,12 +1,32 @@
-{ lib, buildPythonPackage, fetchPypi, libxml2
-, m2crypto, ply, pyyaml, six, pbr, pythonOlder, nocasedict, nocaselist, yamlloader, requests-mock
-, httpretty, lxml, mock, pytest, requests, decorator, unittest2
-, FormEncode, testfixtures, pytz
+{ lib
+, buildPythonPackage
+, fetchPypi
+, libxml2
+, m2crypto
+, ply
+, pyyaml
+, six
+, pbr
+, pythonOlder
+, nocasedict
+, nocaselist
+, yamlloader
+, requests-mock
+, httpretty
+, lxml
+, mock
+, pytest
+, requests
+, decorator
+, FormEncode
+, testfixtures
+, pytz
 }:
 
 buildPythonPackage rec {
   pname = "pywbem";
   version = "1.5.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -35,7 +55,6 @@ buildPythonPackage rec {
     requests
     requests-mock
     testfixtures
-    unittest2
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Since [pywbem 1.0](https://github.com/pywbem/pywbem/blob/bbac75a0d223341806f5da3efb909c7416fc7c1e/docs/changes.rst#pywbem-100b1), support for Python 2.6 was dropped, and the `unitest2` dependency was removed.

Related to https://github.com/NixOS/nixpkgs/pull/154650 and https://github.com/NixOS/nixpkgs/pull/154264.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
