### PR TITLE
photoprism: add valid passthru test

### DIFF
--- a/pkgs/servers/photoprism/default.nix
+++ b/pkgs/servers/photoprism/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, stdenv, fetchFromGitHub, fetchzip, darktable, rawtherapee, ffmpeg, libheif, exiftool, nixosTests, makeWrapper }:
+{ pkgs, lib, stdenv, fetchFromGitHub, fetchzip, darktable, rawtherapee, ffmpeg, libheif, exiftool, makeWrapper, testers }:
 
 let
   version = "221102-905925b4d";
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.tests.photoprism = nixosTests.photoprism;
+  passthru.tests.version = testers.testVersion { package = pkgs.photoprism; };
 
   meta = with lib; {
     homepage = "https://photoprism.app";

--- a/pkgs/servers/photoprism/libtensorflow.nix
+++ b/pkgs/servers/photoprism/libtensorflow.nix
@@ -15,12 +15,14 @@ stdenv.mkDerivation rec {
         aarch64-linux = "sha256-qnj4vhSWgrk8SIjzIH1/4waMxMsxMUvqdYZPaSaUJRk=";
       }.${system};
 
-      url = let
-        systemName = {
-          x86_64-linux = "amd64";
-          aarch64-linux = "arm64";
-        }.${system};
-      in "https://dl.photoprism.app/tensorflow/${systemName}/libtensorflow-${systemName}-${version}.tar.gz";
+      url =
+        let
+          systemName = {
+            x86_64-linux = "amd64";
+            aarch64-linux = "arm64";
+          }.${system};
+        in
+        "https://dl.photoprism.app/tensorflow/${systemName}/libtensorflow-${systemName}-${version}.tar.gz";
     })
     # Upstream tensorflow tarball (with .h's photoprism's tarball is missing)
     (fetchurl {
@@ -49,13 +51,15 @@ stdenv.mkDerivation rec {
   '';
 
   # Patch library to use our libc, libstdc++ and others
-  patchPhase = let
-    rpath = lib.makeLibraryPath [ stdenv.cc.libc stdenv.cc.cc.lib ];
-  in ''
-    chmod -R +w lib
-    patchelf --set-rpath "${rpath}:$out/lib" lib/libtensorflow.so
-    patchelf --set-rpath "${rpath}" lib/libtensorflow_framework.so
-  '';
+  patchPhase =
+    let
+      rpath = lib.makeLibraryPath [ stdenv.cc.libc stdenv.cc.cc.lib ];
+    in
+    ''
+      chmod -R +w lib
+      patchelf --set-rpath "${rpath}:$out/lib" lib/libtensorflow.so
+      patchelf --set-rpath "${rpath}" lib/libtensorflow_framework.so
+    '';
 
   buildPhase = ''
     # Write pkg-config file.


### PR DESCRIPTION
###### Description of changes
@andir found in https://github.com/NixOS/nixpkgs/pull/199674#discussion_r1027007332 that the current passthru test `photoprism` referenced an invalid nixos test.

I changed the `photoprism` passthru test to a simple `version` test using `testVersion` for now.
I also ran `nixpkgs-fmt`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
