### PR TITLE
subunit, python310Packages.subunit: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/development/libraries/subunit/default.nix
+++ b/pkgs/development/libraries/subunit/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "subunit";
-  version = "1.4.0";
+  version = "1.4.2";
 
   src = fetchurl {
     url = "https://launchpad.net/subunit/trunk/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "1h7i5ifcx20qkya24j11nbwa829klw7dvnlljdgivgvcx6b20y80";
+    hash = "sha256-hlOOv6kIC97w7ICVsuXeWrsUbVu3tCSzEVKUHXYG2dI=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -9,30 +9,46 @@
 # python dependencies
 , fixtures
 , hypothesis
-, pytest
+, pytestCheckHook
+, setuptools
 , testscenarios
 , testtools
-, unittest2
 }:
 
 buildPythonPackage {
   inherit (subunit) name src meta;
+  format = "pyproject";
 
-  nativeBuildInputs = [ pkg-config ];
+  disabled = pythonOlder "3.6";
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "version=VERSION" 'version="${subunit.version}"'
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    setuptools
+  ];
+
   buildInputs = [ check cppunit ];
   propagatedBuildInputs = [ testtools ];
 
-  checkInputs = [ testscenarios hypothesis fixtures pytest unittest2 ];
+  checkInputs = [
+    testscenarios
+    hypothesis
+    fixtures
+    pytestCheckHook
+  ];
 
-  # requires unittest2, which no longer supported in 3.10
-  doCheck = pythonOlder "3.10";
-  # ignore tests which call shell code, or call methods which haven't been implemented
-  checkPhase = ''
-    pytest python/subunit \
-      --ignore=python/subunit/tests/test_{output_filter,test_protocol{,2}}.py
-  '';
+  pytestFlagsArray = [
+    "python/subunit"
+  ];
 
-  postPatch = ''
-    sed -i 's/version=VERSION/version="${subunit.version}"/' setup.py
-  '';
+  disabledTestPaths = [
+    # these tests require testtools and don't work with pytest
+    "python/subunit/tests/test_output_filter.py"
+    "python/subunit/tests/test_test_protocol.py"
+    "python/subunit/tests/test_test_protocol2.py"
+  ];
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/testing-cabal/subunit/blob/master/NEWS

Related to https://github.com/NixOS/nixpkgs/pull/154650 and https://github.com/NixOS/nixpkgs/pull/154264.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
