### PR TITLE
Adding ability to set image architecture when creating OCI images using DockerTools

### DIFF
--- a/doc/builders/images/dockertools.section.md
+++ b/doc/builders/images/dockertools.section.md
@@ -62,6 +62,8 @@ The above example will build a Docker image `redis/latest` from the given base i
 
 - `config` is used to specify the configuration of the containers that will be started off the built image in Docker. The available options are listed in the [Docker Image Specification v1.2.0](https://github.com/moby/moby/blob/master/image/spec/v1.2.md#image-json-field-descriptions).
 
+- `architecture` is _optional_ and used to specify the image architecture, this is useful for multi-architecture builds that don't need cross compiling. If not specified it will default to `hostPlatform`.
+
 - `diskSize` is used to specify the disk size of the VM used to build the image in megabytes. By default it's 1024 MiB.
 
 - `buildVMMemorySize` is used to specify the memory size of the VM to build the image in megabytes. By default it's 512 MiB.
@@ -140,6 +142,8 @@ Create a Docker image with many of the store paths being on their own layer to i
     *Default:* `[]`
 
 `config` _optional_
+
+`architecture` is _optional_ and used to specify the image architecture, this is useful for multi-architecture builds that don't need cross compiling. If not specified it will default to `hostPlatform`.
 
 : Run-time configuration of the container. A full list of the options are available at in the [Docker Image Specification v1.2.0](https://github.com/moby/moby/blob/master/image/spec/v1.2.md#image-json-field-descriptions).
 

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -420,18 +420,18 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         )
 
     with subtest("Ensure correct architecture is present in manifests."):
-        docker.succeed(
-            "docker load --input='${examples.build-image-with-architecture}'",
-            "docker inspect build-image-with-architecture "
-              + "| ${pkgs.jq}/bin/jq -er '.[] | select(.Architecture=="arm64").Architecture'",
-            "docker rmi build-image-with-architecture",
-        )
-        docker.succeed(
-            "${examples.layered-image-with-architecture} | docker load",
-            "docker inspect layered-image-with-architecture "
-              + "| ${pkgs.jq}/bin/jq -er '.[] | select(.Architecture=="arm64").Architecture'",
-            "docker rmi layered-image-with-architecture",
-        )
+        docker.succeed("""
+            docker load --input='${examples.build-image-with-architecture}'
+            docker inspect build-image-with-architecture \
+              | ${pkgs.jq}/bin/jq -er '.[] | select(.Architecture=="arm64").Architecture'
+            docker rmi build-image-with-architecture
+        """)
+        docker.succeed("""
+            ${examples.layered-image-with-architecture} | docker load
+            docker inspect layered-image-with-architecture \
+              | ${pkgs.jq}/bin/jq -er '.[] | select(.Architecture=="arm64").Architecture'
+            docker rmi layered-image-with-architecture
+        """)
 
     with subtest("etc"):
         docker.succeed("${examples.etc} | docker load")

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -419,6 +419,20 @@ import ./make-test-python.nix ({ pkgs, ... }: {
             "docker rmi layered-image-with-path",
         )
 
+    with subtest("Ensure correct architecture is present in manifests."):
+        docker.succeed(
+            "docker load --input='${examples.build-image-with-architecture}'",
+            "docker inspect ${examples.build-image-with-architecture} "
+              + "| ${pkgs.jq}/bin/jq -er '.[] | select(.Architecture=="arm64").Architecture'",
+            "docker rmi build-image-with-architecture",
+        )
+        docker.succeed(
+            "${examples.layered-image-with-architecture} | docker load",
+            "docker inspect ${examples.layered-image-with-architecture} "
+              + "| ${pkgs.jq}/bin/jq -er '.[] | select(.Architecture=="arm64").Architecture'",
+            "docker rmi layered-image-with-architecture",
+        )
+
     with subtest("etc"):
         docker.succeed("${examples.etc} | docker load")
         docker.succeed("docker run --rm etc | grep localhost")

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -422,13 +422,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     with subtest("Ensure correct architecture is present in manifests."):
         docker.succeed(
             "docker load --input='${examples.build-image-with-architecture}'",
-            "docker inspect ${examples.build-image-with-architecture} "
+            "docker inspect build-image-with-architecture "
               + "| ${pkgs.jq}/bin/jq -er '.[] | select(.Architecture=="arm64").Architecture'",
             "docker rmi build-image-with-architecture",
         )
         docker.succeed(
             "${examples.layered-image-with-architecture} | docker load",
-            "docker inspect ${examples.layered-image-with-architecture} "
+            "docker inspect layered-image-with-architecture "
               + "| ${pkgs.jq}/bin/jq -er '.[] | select(.Architecture=="arm64").Architecture'",
             "docker rmi layered-image-with-architecture",
         )

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -101,8 +101,8 @@ rec {
     , imageDigest
     , sha256
     , os ? "linux"
-    , arch ? defaultArch
-
+    , # Image architecture, defaults to the architecture of the `hostPlatform` when unset
+      arch ? defaultArch
       # This is used to set name to the pulled image
     , finalImageName ? imageName
       # This used to set a tag to the pulled image
@@ -514,6 +514,8 @@ rec {
       keepContentsDirlinks ? false
     , # Docker config; e.g. what command to run on the container.
       config ? null
+    , # Image architecture, defaults to the architecture of the `hostPlatform` when unset
+      architecture ? defaultArch
     , # Optional bash script to run on the files prior to fixturizing the layer.
       extraCommands ? ""
     , uid ? 0
@@ -546,8 +548,7 @@ rec {
       baseJson =
         let
           pure = writeText "${baseName}-config.json" (builtins.toJSON {
-            inherit created config;
-            architecture = defaultArch;
+            inherit created config architecture;
             preferLocalBuild = true;
             os = "linux";
           });
@@ -838,6 +839,8 @@ rec {
       contents ? [ ]
     , # Docker config; e.g. what command to run on the container.
       config ? { }
+    , # Image architecture, defaults to the architecture of the `hostPlatform` when unset
+      architecture ? defaultArch
     , # Time of creation of the image. Passing "now" will make the
       # created date be the time of building.
       created ? "1970-01-01T00:00:01Z"
@@ -869,8 +872,7 @@ rec {
 
         streamScript = writePython3 "stream" { } ./stream_layered_image.py;
         baseJson = writeText "${baseName}-base.json" (builtins.toJSON {
-          inherit config;
-          architecture = defaultArch;
+          inherit config architecture;
           os = "linux";
         });
 

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -74,7 +74,7 @@ let
   # Reference: https://github.com/opencontainers/image-spec/blob/master/config.md#properties
   # For the mapping from Nixpkgs system parameters to GOARCH, we can reuse the
   # mapping from the go package.
-  defaultArch = go.GOARCH;
+  defaultArchitecture = go.GOARCH;
 
 in
 rec {
@@ -102,7 +102,7 @@ rec {
     , sha256
     , os ? "linux"
     , # Image architecture, defaults to the architecture of the `hostPlatform` when unset
-      arch ? defaultArch
+      arch ? defaultArchitecture
       # This is used to set name to the pulled image
     , finalImageName ? imageName
       # This used to set a tag to the pulled image
@@ -515,7 +515,7 @@ rec {
     , # Docker config; e.g. what command to run on the container.
       config ? null
     , # Image architecture, defaults to the architecture of the `hostPlatform` when unset
-      architecture ? defaultArch
+      architecture ? defaultArchitecture
     , # Optional bash script to run on the files prior to fixturizing the layer.
       extraCommands ? ""
     , uid ? 0
@@ -840,7 +840,7 @@ rec {
     , # Docker config; e.g. what command to run on the container.
       config ? { }
     , # Image architecture, defaults to the architecture of the `hostPlatform` when unset
-      architecture ? defaultArch
+      architecture ? defaultArchitecture
     , # Time of creation of the image. Passing "now" will make the
       # created date be the time of building.
       created ? "1970-01-01T00:00:01Z"

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -92,7 +92,7 @@ rec {
     ];
 
     extraCommands = ''
-      mkdir -p tmp
+      mkdir -p tmp/nginx_client_body
 
       # nginx still tries to read this directory even if error_log
       # directive is specifying another file :/

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -700,6 +700,21 @@ rec {
     contents = [ pkgs.bashInteractive ./test-dummy ];
   };
 
+  build-image-with-architecture = buildImage {
+    name = "build-image-with-architecture";
+    tag = "latest";
+    architecture = "arm64";
+    # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
+    copyToRoot = [ pkgs.bashInteractive ./test-dummy ];
+  };
+
+  layered-image-with-architecture = pkgs.dockerTools.streamLayeredImage {
+    name = "layered-image-with-architecture";
+    tag = "latest";
+    architecture = "arm64";
+    contents = [ pkgs.bashInteractive ./test-dummy ];
+  };
+
   # ensure that caCertificates builds
   image-with-certs = buildImage {
     name = "image-with-certs";


### PR DESCRIPTION
###### Description of changes
Adding ability to set image architecture when creating OCI images using DockerTools.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Adding optional `arch` parameter for `buildImage` and `streamLayeredImage` to allow specifying image architecture for multi-architecture builds that don't require cross-compiling.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This fixes https://github.com/NixOS/nixpkgs/issues/200725
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
