### PR TITLE
borgbackup: Don't error out on changes files warning

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1062,6 +1062,14 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
+          The <literal>borgbackup</literal> package was patched not to
+          exit with an error, when files changed during the backup.
+          Instead it will just emit a warning, when such an issue is
+          encountered.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>xplr</literal> package has been updated from
           0.18.0 to 0.19.0, which brings some breaking changes. See the
           <link xlink:href="https://github.com/sayanarijit/xplr/releases/tag/v0.19.0">upstream

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -334,6 +334,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - `firefox`, `thunderbird` and `librewolf` come with enabled Wayland support by default. The `firefox-wayland`, `firefox-esr-wayland`, `thunderbird-wayland` and `librewolf-wayland` attributes are obsolete and have been aliased to their generic attribute.
 
+- The `borgbackup` package was patched not to exit with an error, when files changed during the backup. Instead it will just emit a warning, when such an issue is encountered.
+
 - The `xplr` package has been updated from 0.18.0 to 0.19.0, which brings some breaking changes. See the [upstream release notes](https://github.com/sayanarijit/xplr/releases/tag/v0.19.0) for more details.
 
 - Configuring multiple GitHub runners is now possible through `services.github-runners.<name>`. The option `services.github-runner` remains.

--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -22,6 +22,12 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-1zBodEPxvrYCsdcrrjYxj2+WVIGPzcUEWFQOxXnlcmA=";
   };
 
+  patches = [
+    # Don't exit with an error on changed files warning
+    # https://github.com/NixOS/nixpkgs/issues/177733
+    ./dont-error-on-changed-files.patch
+  ];
+
   postPatch = ''
     # sandbox does not support setuid/setgid/sticky bits
     substituteInPlace src/borg/testsuite/archiver.py \

--- a/pkgs/tools/backup/borgbackup/dont-error-on-changed-files.patch
+++ b/pkgs/tools/backup/borgbackup/dont-error-on-changed-files.patch
@@ -1,0 +1,21 @@
+diff --git a/src/borg/archiver.py b/src/borg/archiver.py
+index 8afc4079..766ec12a 100644
+--- a/src/borg/archiver.py
++++ b/src/borg/archiver.py
+@@ -565,7 +565,7 @@ def create_inner(archive, cache, fso):
+                         self.print_warning('%s: %s', path, e)
+                         status = 'E'
+                     if status == 'C':
+-                        self.print_warning('%s: file changed while we backed it up', path)
++                        print(f'{path}: file changed while we backed it up', file=sys.stderr)
+                     self.print_file_status(status, path)
+                 if args.paths_from_command:
+                     rc = proc.wait()
+@@ -827,7 +827,7 @@ def _rec_walk(self, *, path, parent_fd, name, fso, cache, matcher,
+             self.print_warning('%s: %s', path, e)
+             status = 'E'
+         if status == 'C':
+-            self.print_warning('%s: file changed while we backed it up', path)
++            print(f'{path}: file changed while we backed it up', file=sys.stderr)
+         if not recurse_excluded_dir:
+             self.print_file_status(status, path)


### PR DESCRIPTION
When a backup includes files that change relatively often, like a maildir or a journal, the chance that it will come across a file that changed during the backup. Ideally that would not be the case and it can and should be worked around e.g. by using snapshots.

Now when people find themselves in such a pickle they will notice their borgbackup systemd unit will often reach a failed state. This is problematic because it makes users that monitor on failed units enter a numb state, because of spurious failures, which will ultimately make you miss more serious ones.

This is very much a band-aid and we should ideally follow-up on cleaner solutions outlined in #177733.

(I don't think this warrants closing #177733, because this is mostly a work-around intended to improve production usage)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
