### PR TITLE
wine, winetricks: add updateScript

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -185,6 +185,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
 
   passthru = {
     inherit pkgArches;
+    inherit (src) updateScript;
     tests = { inherit (nixosTests) wine; };
   };
   meta = {

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -12,6 +12,15 @@ let fetchurl = args@{url, sha256, ...}:
   pkgs.fetchFromGitHub { inherit owner repo rev sha256; } // args;
     fetchFromGitLab = args@{domain, owner, repo, rev, sha256, ...}:
   pkgs.fetchFromGitLab { inherit domain owner repo rev sha256; } // args;
+
+    updateScriptPreamble = ''
+      set -eou pipefail
+      PATH=${with pkgs; lib.makeBinPath [ common-updater-scripts coreutils curl gnugrep gnused jq nix ]}
+      sources_file=${__curPos.file}
+      source ${./update-lib.sh}
+    '';
+
+    inherit (pkgs) writeShellScript;
 in rec {
 
   stable = fetchurl rec {
@@ -42,6 +51,24 @@ in rec {
       # Also look for root certificates at $NIX_SSL_CERT_FILE
       ./cert-path.patch
     ];
+
+    updateScript = writeShellScript "update-wine-stable" (''
+      ${updateScriptPreamble}
+      major=''${UPDATE_NIX_OLD_VERSION%.*}
+      latest_stable=$(get_latest_wine_version "$major.0")
+      latest_gecko=$(get_latest_lib_version wine-gecko)
+
+      # Can't use autobump on stable because we don't want the path
+      # <source/7.0/wine-7.0.tar.xz> to become <source/7.0.1/wine-7.0.1.tar.xz>.
+      if [[ "$UPDATE_NIX_OLD_VERSION" != "$latest_stable" ]]; then
+          set_version_and_sha256 stable "$latest_stable" "$(nix-prefetch-url "$wine_url_base/source/$major.0/wine-$latest_stable.tar.xz")"
+      fi
+
+      autobump stable.gecko32 "$latest_gecko"
+      autobump stable.gecko64 "$latest_gecko"
+
+      do_update
+    '');
   };
 
   unstable = fetchurl rec {
@@ -56,6 +83,23 @@ in rec {
       url = "https://dl.winehq.org/wine/wine-mono/${version}/wine-mono-${version}-x86.msi";
       sha256 = "sha256-ZBP/Mo679+x2icZI/rNUbYEC3thlB50fvwMxsUs6sOw=";
     };
+
+    updateScript = writeShellScript "update-wine-unstable" ''
+      ${updateScriptPreamble}
+      major=''${UPDATE_NIX_OLD_VERSION%.*}
+      latest_unstable=$(get_latest_wine_version "$major.x")
+      latest_mono=$(get_latest_lib_version wine-mono)
+
+      update_staging() {
+          staging_url=$(get_source_attr staging.url)
+          set_source_attr staging sha256 "\"$(to_sri "$(nix-prefetch-url --unpack "''${staging_url//$1/$2}")")\""
+      }
+
+      autobump unstable "$latest_unstable" "" update_staging
+      autobump unstable.mono "$latest_mono"
+
+      do_update
+    '';
   };
 
   staging = fetchFromGitHub rec {
@@ -81,6 +125,22 @@ in rec {
     inherit (unstable) gecko32 gecko64;
 
     inherit (unstable) mono;
+
+    updateScript = writeShellScript "update-wine-wayland" ''
+      ${updateScriptPreamble}
+      wayland_rev=$(get_source_attr wayland.rev)
+
+      latest_wayland_rev=$(curl -s 'https://gitlab.collabora.com/api/v4/projects/2847/repository/branches/wayland' | jq -r .commit.id)
+
+      if [[ "$wayland_rev" != "$latest_wayland_rev" ]]; then
+          latest_wayland=$(curl -s 'https://gitlab.collabora.com/alf/wine/-/raw/wayland/VERSION' | cut -f3 -d' ')
+          wayland_url=$(get_source_attr wayland.url)
+          set_version_and_sha256 wayland "$latest_wayland" "$(nix-prefetch-url --unpack "''${wayland_url/$wayland_rev/$latest_wayland_rev}")"
+          set_source_attr wayland rev "\"$latest_wayland_rev\""
+      fi
+
+      do_update
+    '';
   };
 
   winetricks = fetchFromGitHub rec {
@@ -90,5 +150,16 @@ in rec {
     owner = "Winetricks";
     repo = "winetricks";
     rev = version;
+
+    updateScript = writeShellScript "update-winetricks" ''
+      ${updateScriptPreamble}
+      winetricks_repourl=$(get_source_attr winetricks.gitRepoUrl)
+
+      latest_winetricks=$(list-git-tags --url="$winetricks_repourl" | grep -E '^[0-9]{8}$' | sort --reverse --numeric-sort | head -n 1)
+
+      autobump winetricks "$latest_winetricks" 'nix-prefetch-url --unpack'
+
+      do_update
+    '';
   };
 }

--- a/pkgs/applications/emulators/wine/update-lib.sh
+++ b/pkgs/applications/emulators/wine/update-lib.sh
@@ -1,0 +1,49 @@
+wine_url_base=https://dl.winehq.org/wine
+
+sed_exprs=()
+
+get_source_attr() {
+    nix-instantiate --eval --json -E "(let pkgs = import ./. {}; in pkgs.callPackage $sources_file { inherit pkgs; }).$1" | jq -r
+}
+
+set_source_attr() {
+    path="$1"
+    name="$2"
+    value="$3"
+    line=$(nix-instantiate --eval -E "(builtins.unsafeGetAttrPos \"$name\" (let pkgs = import ./. {}; in pkgs.callPackage $sources_file { inherit pkgs; }).$path).line")
+    sed_exprs+=(-e "${line}s@[^ ].*\$@$name = $value;@")
+}
+
+set_version_and_sha256() {
+    set_source_attr "$1" version "\"$2\""
+    set_source_attr "$1" sha256 "\"$(to_sri "$3")\""
+}
+
+get_latest_wine_version() {
+    list-directory-versions --pname=wine --url="$wine_url_base/source/$1" | grep -v 'diff\|rc\|tar' | sort --reverse --version-sort -u | head -n 1
+}
+
+get_latest_lib_version() {
+    curl -s "$wine_url_base/$1/" | grep -o 'href="[0-9.]*/"' | sed 's_^href="\(.*\)/"_\1_' | sort --reverse --version-sort -u | head -n 1
+}
+
+to_sri() {
+    nix --extra-experimental-features nix-command hash to-sri --type sha256 "$1"
+}
+
+autobump() {
+    attr="$1"
+    latest="$2"
+    fetcher="${3:-nix-prefetch-url}"
+    more="${4:-}"
+    version=$(get_source_attr "$attr.version")
+    if [[ "$version" != "$latest" ]]; then
+        url=$(get_source_attr "$attr.url")
+        set_version_and_sha256 "$attr" "$latest" "$($fetcher "${url//$version/$latest}")"
+        [[ -z "$more" ]] || $more "$version" "$latest"
+    fi
+}
+
+do_update() {
+    [[ "${#sed_exprs[@]}" -eq 0 ]] || sed -i "${sed_exprs[@]}" "$sources_file"
+}

--- a/pkgs/applications/emulators/wine/winetricks.nix
+++ b/pkgs/applications/emulators/wine/winetricks.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation rec {
       "$out/bin/winetricks"
   '';
 
+  passthru = {
+    inherit (src) updateScript;
+  };
+
   meta = {
     description = "A script to install DLLs needed to work around problems in Wine";
     license = lib.licenses.lgpl21;


### PR DESCRIPTION
###### Description of changes

This is an updateScript for Wine (stable, unstable/staging, and Wayland) and Winetricks.

I wasn't sure how to handle the fact that a single Wine derivation has many top-level attribute paths pointing to it, so I didn't do anything about it. Feedback from maintainers would be most welcome.

The updateScript for unstable also handles updating the staging patches; there is no separate updateScript for staging.

The stable and unstable/staging scripts won't update the major version of Wine; this has to be done manually. Also, the version of Mono used by stable Wine isn't ever updated, since it seems to be pinned to a particular version for reasons that I assume involve manual testing.

Despite these downsides, I hope that this patch makes it easier to keep all the Wine packages up-to-date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
