### PR TITLE
httm: init 0.17.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2182,6 +2182,12 @@
     githubId = 7435854;
     name = "Victor Calvert";
   };
+  CalvinBeck = {
+    email = "hobbes@ualberta.ca";
+    github = "Chobbes";
+    githubId = 5215874;
+    name = "Calvin Beck";
+  };
   cameronfyfe = {
     email = "cameron.j.fyfe@gmail.com";
     github = "cameronfyfe";

--- a/pkgs/tools/misc/httm/default.nix
+++ b/pkgs/tools/misc/httm/default.nix
@@ -1,0 +1,31 @@
+{stdenv, lib, fetchFromGitHub, rustPlatform}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "httm";
+  version = "0.17.5";
+
+  src = fetchFromGitHub {
+    owner = "kimono-koans";
+    repo = pname;
+    # Fix 0.17.5 branch, unfortunately tag upstream is wrong.
+    rev = "b9870590bac18178ad2b16b99f3ac6be21dbb2c6";
+    sha256 = "sha256-XkIpEqZzPrP4g2Nbk5TN9qaJoamg7LE2NLgYjx1ys2w=";
+  };
+
+  cargoSha256 = "sha256-S/Uc23HmM76kUVBpg3seDIUPo0lPcaP3BPB8u6tsEOM=";
+
+  postInstall =
+''
+install -dm 755 "$out/share/man/man1"
+gzip -c ./httm.1 > "$out/share/man/man1/httm.1.gz"
+install -m 555 ./scripts/ounce.bash "$out/bin/ounce"
+install -m 555 ./scripts/bowie.bash "$out/bin/bowie"
+'';
+
+  meta = with lib; {
+    description = "Interactive, file-level Time Machine-like tool for ZFS/btrfs";
+    homepage = "https://github.com/kimono-koans/httm";
+    license = licenses.mpl20;
+    maintainers = [ maintainers.CalvinBeck ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Added the httm package, a command line tool like time machine for managing snapshots of files in btrfs / zfs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
