### PR TITLE
gitui: 0.21.0 -> 0.22.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitui/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitui/default.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gitui";
-  version = "0.21.0";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "extrawurst";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-B/RKPYq1U40NV3AM/cQi2eQaK5vxynP3JA0DReSBuCo=";
+    sha256 = "sha256-ZLGA0LHdGPqIoNG2k4nunVWYlOnwRT8nqTSwUWGkfCU=";
   };
 
-  cargoSha256 = "sha256-r4kritS3v8GgFZfWeeyrsy6v3IlH3DByTU8Ir4FDngs=";
+  cargoSha256 = "sha256-ArJerq3gLzPm66RWDCvkpPFyh7ZyaoqLO/3zSjFTL04=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -31,6 +31,11 @@ rustPlatform.buildRustPackage rec {
 
   # Needed to get openssl-sys to use pkg-config.
   OPENSSL_NO_VENDOR = 1;
+
+  # The cargo config overrides linkers for some targets, breaking the build
+  # on e.g. `aarch64-linux`. These overrides are not required in the Nix
+  # environment: delete them.
+  postPatch = "rm .cargo/config";
 
   meta = with lib; {
     description = "Blazing fast terminal-ui for Git written in Rust";


### PR DESCRIPTION
###### Description of changes

This PR updates the `gitui` package to version `0.22.0`.

Changelog: https://github.com/extrawurst/gitui/releases/tag/v0.22.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
