### PR TITLE
noto-fonts-lgc-plus: init at 20201206-phase3

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -32,7 +32,7 @@ let
   inherit (lib)
     getBin optionalString literalExpression
     mkRemovedOptionModule mkRenamedOptionModule
-    mkDefault mkIf mkMerge mkOption types;
+    mkDefault mkIf mkMerge mkOption mkPackageOption types;
 
   ini = pkgs.formats.ini { };
 
@@ -196,6 +196,11 @@ in
       type = types.listOf types.package;
       default = [];
       example = literalExpression "[ pkgs.plasma5Packages.oxygen ]";
+    };
+
+    notoPackage = mkPackageOption pkgs "Noto fonts" {
+      default = [ "noto-fonts" ];
+      example = "noto-fonts-lgc-plus";
     };
 
     # Internally allows configuring kdeglobals globally
@@ -396,7 +401,7 @@ in
       # Enable GTK applications to load SVG icons
       services.xserver.gdk-pixbuf.modulePackages = [ pkgs.librsvg ];
 
-      fonts.fonts = with pkgs; [ noto-fonts hack-font ];
+      fonts.fonts = with pkgs; [ cfg.notoPackage hack-font ];
       fonts.fontconfig.defaultFonts = {
         monospace = [ "Hack" "Noto Sans Mono" ];
         sansSerif = [ "Noto Sans" ];

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -11,20 +11,42 @@
 , imagemagick
 , zopfli
 , buildPackages
+, variants ? [ ]
 }:
-
 let
-  mkNoto = { pname, weights }:
+  notoLongDescription = ''
+    When text is rendered by a computer, sometimes characters are
+    displayed as “tofu”. They are little boxes to indicate your device
+    doesn’t have a font to display the text.
+
+    Google has been developing a font family called Noto, which aims to
+    support all languages with a harmonious look and feel. Noto is
+    Google’s answer to tofu. The name noto is to convey the idea that
+    Google’s goal is to see “no more tofu”.  Noto has multiple styles and
+    weights, and freely available to all.
+
+    This package also includes the Arimo, Cousine, and Tinos fonts.
+  '';
+in
+rec {
+  mkNoto =
+    { pname
+    , weights
+    , variants ? [ ]
+    , longDescription ? notoLongDescription
+    }:
     stdenvNoCC.mkDerivation rec {
       inherit pname;
-      version = "v20201206-phase3";
+      version = "20201206-phase3";
 
       src = fetchFromGitHub {
         owner = "googlefonts";
         repo = "noto-fonts";
-        rev = version;
+        rev = "v${version}";
         hash = "sha256-x60RvCRFLoGe0CNvswROnDkIsUFbWH+/laN8q2qkUPk=";
       };
+
+      _variants = map (variant: builtins.replaceStrings [ " " ] [ "" ] variant) variants;
 
       installPhase = ''
         # We copy in reverse preference order -- unhinted first, then
@@ -33,29 +55,24 @@ let
         #
         # TODO: install OpenType, variable versions?
         local out_ttf=$out/share/fonts/truetype/noto
+      '' + (if _variants == [ ] then ''
         install -m444 -Dt $out_ttf archive/unhinted/*/*-${weights}.ttf
         install -m444 -Dt $out_ttf archive/hinted/*/*-${weights}.ttf
         install -m444 -Dt $out_ttf unhinted/*/*/*-${weights}.ttf
         install -m444 -Dt $out_ttf hinted/*/*/*-${weights}.ttf
-      '';
+      '' else ''
+        for variant in $_variants; do
+          install -m444 -Dt $out_ttf archive/unhinted/$variant/*-${weights}.ttf
+          install -m444 -Dt $out_ttf archive/hinted/$variant/*-${weights}.ttf
+          install -m444 -Dt $out_ttf unhinted/*/$variant/*-${weights}.ttf
+          install -m444 -Dt $out_ttf hinted/*/$variant/*-${weights}.ttf
+        done
+      '');
 
       meta = with lib; {
         description = "Beautiful and free fonts for many languages";
         homepage = "https://www.google.com/get/noto/";
-        longDescription =
-        ''
-          When text is rendered by a computer, sometimes characters are
-          displayed as “tofu”. They are little boxes to indicate your device
-          doesn’t have a font to display the text.
-
-          Google has been developing a font family called Noto, which aims to
-          support all languages with a harmonious look and feel. Noto is
-          Google’s answer to tofu. The name noto is to convey the idea that
-          Google’s goal is to see “no more tofu”.  Noto has multiple styles and
-          weights, and freely available to all.
-
-          This package also includes the Arimo, Cousine, and Tinos fonts.
-        '';
+        inherit longDescription;
         license = licenses.ofl;
         platforms = platforms.all;
         maintainers = with maintainers; [ mathnerd314 emily ];
@@ -100,12 +117,32 @@ let
         maintainers = with maintainers; [ mathnerd314 emily ];
       };
     };
-in
 
-{
   noto-fonts = mkNoto {
     pname = "noto-fonts";
     weights = "{Regular,Bold,Light,Italic,BoldItalic,LightItalic}";
+  };
+
+  noto-fonts-lgc-plus = mkNoto {
+    pname = "noto-fonts-lgc-plus";
+    weights = "{Regular,Bold,Light,Italic,BoldItalic,LightItalic}";
+    variants = [
+      "Noto Sans"
+      "Noto Serif"
+      "Noto Sans Display"
+      "Noto Serif Display"
+      "Noto Sans Mono"
+      "Noto Music"
+      "Noto Sans Symbols"
+      "Noto Sans Symbols 2"
+      "Noto Sans Math"
+    ];
+    longDescription = ''
+      This package provides the Noto Fonts, but only for latin, greek
+      and cyrillic scripts, as well as some extra fonts. To create a
+      custom Noto package with custom variants, see the `mkNoto`
+      helper function.
+    '';
   };
 
   noto-fonts-extra = mkNoto {
@@ -127,64 +164,66 @@ in
     sha256 = "sha256-1w66Ge7DZjbONGhxSz69uFhfsjMsDiDkrGl6NsoB7dY=";
   };
 
-  noto-fonts-emoji = let
-    version = "2.038";
-    emojiPythonEnv =
-      buildPackages.python3.withPackages (p: with p; [ fonttools nototools ]);
-  in stdenvNoCC.mkDerivation {
-    pname = "noto-fonts-emoji";
-    inherit version;
+  noto-fonts-emoji =
+    let
+      version = "2.038";
+      emojiPythonEnv =
+        buildPackages.python3.withPackages (p: with p; [ fonttools nototools ]);
+    in
+    stdenvNoCC.mkDerivation {
+      pname = "noto-fonts-emoji";
+      inherit version;
 
-    src = fetchFromGitHub {
-      owner = "googlefonts";
-      repo = "noto-emoji";
-      rev = "v${version}";
-      sha256 = "1rgmcc6nqq805iqr8kvxxlk5cf50q714xaxk3ld6rjrd69kb8ix9";
+      src = fetchFromGitHub {
+        owner = "googlefonts";
+        repo = "noto-emoji";
+        rev = "v${version}";
+        sha256 = "1rgmcc6nqq805iqr8kvxxlk5cf50q714xaxk3ld6rjrd69kb8ix9";
+      };
+
+      depsBuildBuild = [
+        buildPackages.stdenv.cc
+        pkg-config
+        cairo
+      ];
+
+      nativeBuildInputs = [
+        imagemagick
+        zopfli
+        pngquant
+        which
+        emojiPythonEnv
+      ];
+
+      postPatch = ''
+        patchShebangs *.py
+        patchShebangs third_party/color_emoji/*.py
+        # remove check for virtualenv, since we handle
+        # python requirements using python.withPackages
+        sed -i '/ifndef VIRTUAL_ENV/,+2d' Makefile
+
+        # Make the build verbose so it won't get culled by Hydra thinking that
+        # it somehow got stuck doing nothing.
+        sed -i 's;\t@;\t;' Makefile
+      '';
+
+      enableParallelBuilding = true;
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/share/fonts/noto
+        cp NotoColorEmoji.ttf $out/share/fonts/noto
+        runHook postInstall
+      '';
+
+      meta = with lib; {
+        description = "Color and Black-and-White emoji fonts";
+        homepage = "https://github.com/googlefonts/noto-emoji";
+        license = with licenses; [ ofl asl20 ];
+        platforms = platforms.all;
+        maintainers = with maintainers; [ mathnerd314 sternenseemann ];
+      };
     };
-
-    depsBuildBuild = [
-      buildPackages.stdenv.cc
-      pkg-config
-      cairo
-    ];
-
-    nativeBuildInputs = [
-      imagemagick
-      zopfli
-      pngquant
-      which
-      emojiPythonEnv
-    ];
-
-    postPatch = ''
-      patchShebangs *.py
-      patchShebangs third_party/color_emoji/*.py
-      # remove check for virtualenv, since we handle
-      # python requirements using python.withPackages
-      sed -i '/ifndef VIRTUAL_ENV/,+2d' Makefile
-
-      # Make the build verbose so it won't get culled by Hydra thinking that
-      # it somehow got stuck doing nothing.
-      sed -i 's;\t@;\t;' Makefile
-    '';
-
-    enableParallelBuilding = true;
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/share/fonts/noto
-      cp NotoColorEmoji.ttf $out/share/fonts/noto
-      runHook postInstall
-    '';
-
-    meta = with lib; {
-      description = "Color and Black-and-White emoji fonts";
-      homepage = "https://github.com/googlefonts/noto-emoji";
-      license = with licenses; [ ofl asl20 ];
-      platforms = platforms.all;
-      maintainers = with maintainers; [ mathnerd314 sternenseemann ];
-    };
-  };
 
   noto-fonts-emoji-blob-bin =
     let

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -15,15 +15,15 @@
 
 let
   mkNoto = { pname, weights }:
-    stdenvNoCC.mkDerivation {
+    stdenvNoCC.mkDerivation rec {
       inherit pname;
-      version = "2020-01-23";
+      version = "v20201206-phase3";
 
       src = fetchFromGitHub {
         owner = "googlefonts";
         repo = "noto-fonts";
-        rev = "f4726a2ec36169abd02a6d8abe67c8ff0236f6d8";
-        sha256 = "0zc1r7zph62qmvzxqfflsprazjf6x1qnwc2ma27kyzh6v36gaykw";
+        rev = version;
+        hash = "sha256-x60RvCRFLoGe0CNvswROnDkIsUFbWH+/laN8q2qkUPk=";
       };
 
       installPhase = ''
@@ -33,10 +33,10 @@ let
         #
         # TODO: install OpenType, variable versions?
         local out_ttf=$out/share/fonts/truetype/noto
-        install -m444 -Dt $out_ttf phaseIII_only/unhinted/ttf/*/*-${weights}.ttf
-        install -m444 -Dt $out_ttf phaseIII_only/hinted/ttf/*/*-${weights}.ttf
-        install -m444 -Dt $out_ttf unhinted/*/*-${weights}.ttf
-        install -m444 -Dt $out_ttf hinted/*/*-${weights}.ttf
+        install -m444 -Dt $out_ttf archive/unhinted/*/*-${weights}.ttf
+        install -m444 -Dt $out_ttf archive/hinted/*/*-${weights}.ttf
+        install -m444 -Dt $out_ttf unhinted/*/*/*-${weights}.ttf
+        install -m444 -Dt $out_ttf hinted/*/*/*-${weights}.ttf
       '';
 
       meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26683,7 +26683,9 @@ with pkgs;
   nordzy-icon-theme = callPackage ../data/icons/nordzy-icon-theme { };
 
   inherit (callPackages ../data/fonts/noto-fonts {})
+    mkNoto
     noto-fonts
+    noto-fonts-lgc-plus
     noto-fonts-cjk-sans
     noto-fonts-cjk-serif
     noto-fonts-emoji


### PR DESCRIPTION
###### Description of changes
This is an effort to save users from installing every single noto-font on their system, making font selection in some programs almost unusable.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
