### PR TITLE
lxi-tools: 1.21 -> 2.3

### DIFF
--- a/pkgs/development/libraries/liblxi/default.nix
+++ b/pkgs/development/libraries/liblxi/default.nix
@@ -1,20 +1,20 @@
 { lib, stdenv, fetchFromGitHub
-, pkg-config, autoreconfHook
+, meson, ninja, pkg-config, cmake
 , libtirpc, rpcsvc-proto, avahi, libxml2
 }:
 
 stdenv.mkDerivation rec {
   pname = "liblxi";
-  version = "1.13";
+  version = "1.18";
 
   src = fetchFromGitHub {
     owner = "lxi-tools";
     repo = "liblxi";
     rev = "v${version}";
-    sha256 = "129m0k2wrlgs25qkskynljddqspasla1x8iq51vmg38nhnilpqf6";
+    sha256 = "sha256-2tZWIN58J6zNHG3dahNfg5eNiS8ykWFQyRSyikuzdjE=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config rpcsvc-proto ];
+  nativeBuildInputs = [ meson ninja cmake pkg-config rpcsvc-proto ];
 
   buildInputs = [ libtirpc avahi libxml2 ];
 

--- a/pkgs/tools/networking/lxi-tools/default.nix
+++ b/pkgs/tools/networking/lxi-tools/default.nix
@@ -1,22 +1,38 @@
 { lib, stdenv, fetchFromGitHub
-, autoreconfHook, pkg-config
-, liblxi, readline, lua
+, meson, ninja, cmake, pkg-config
+, liblxi, readline, lua, bash-completion
+, wrapGAppsHook
+, glib, gtk4, gtksourceview5, libadwaita, json-glib
+, desktop-file-utils, appstream-glib
+, gsettings-desktop-schemas
 }:
 
 stdenv.mkDerivation rec {
   pname = "lxi-tools";
-  version = "1.21";
+  version = "2.3";
 
   src = fetchFromGitHub {
     owner = "lxi-tools";
     repo = "lxi-tools";
     rev = "v${version}";
-    sha256 = "0rkp6ywsw2zv7hpbr12kba79wkcwqin7xagxxhd968rbfkfdxlwc";
+    sha256 = "sha256-c53Jn/9xKsxQDsRWU2LKtNWs28AuG4t5OwYOAMxpcPA=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [
+    meson ninja cmake pkg-config
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ liblxi readline lua ];
+  buildInputs = [
+    liblxi readline lua bash-completion
+    glib gtk4 gtksourceview5 libadwaita json-glib
+    desktop-file-utils appstream-glib
+    gsettings-desktop-schemas
+  ];
+
+  postUnpack = "sed -i '/meson.add_install.*$/d' source/meson.build";
+
+  postInstall = "glib-compile-schemas $out/share/glib-2.0/schemas";
 
   meta = with lib; {
     description = "Tool for communicating with LXI compatible instruments";

--- a/pkgs/tools/networking/lxi-tools/default.nix
+++ b/pkgs/tools/networking/lxi-tools/default.nix
@@ -5,6 +5,7 @@
 , glib, gtk4, gtksourceview5, libadwaita, json-glib
 , desktop-file-utils, appstream-glib
 , gsettings-desktop-schemas
+, withGui ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -20,11 +21,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja cmake pkg-config
-    wrapGAppsHook
-  ];
+  ] ++ lib.optional withGui wrapGAppsHook;
 
   buildInputs = [
     liblxi readline lua bash-completion
+  ] ++ lib.optionals withGui [
     glib gtk4 gtksourceview5 libadwaita json-glib
     desktop-file-utils appstream-glib
     gsettings-desktop-schemas
@@ -32,7 +33,10 @@ stdenv.mkDerivation rec {
 
   postUnpack = "sed -i '/meson.add_install.*$/d' source/meson.build";
 
-  postInstall = "glib-compile-schemas $out/share/glib-2.0/schemas";
+  mesonFlags = lib.optional (!withGui) "-Dgui=false";
+
+  postInstall = lib.optionalString withGui
+    "glib-compile-schemas $out/share/glib-2.0/schemas";
 
   meta = with lib; {
     description = "Tool for communicating with LXI compatible instruments";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30204,6 +30204,7 @@ with pkgs;
   lv2-cpp-tools = callPackage ../applications/audio/lv2-cpp-tools { };
 
   lxi-tools = callPackage ../tools/networking/lxi-tools { };
+  lxi-tools-gui = callPackage ../tools/networking/lxi-tools { withGui = true; };
 
   lynx = callPackage ../applications/networking/browsers/lynx { };
 


### PR DESCRIPTION
###### Description of changes

Bump version on liblxi and lxi-tools.  Made building lxi-tools with gui optional and added top-level reference lxi-tools-gui for building lxi-tools with gui support.

Both liblxi and lxi-tools now uses the meson build system.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
