### PR TITLE
git-team: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-team/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-team/default.nix
@@ -1,49 +1,39 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, fetchpatch
+, go-mockery
 , installShellFiles
 }:
 
 buildGoModule rec {
   pname = "git-team";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "hekmekk";
     repo = "git-team";
     rev = "v${version}";
-    hash = "sha256-pHKfehPyy01uVN6kjjPGtdkltw7FJ+HmIlwGs4iRhVo=";
+    hash = "sha256-LZR30zqwit/xydQbpGm1LXd/tno/sTCaftgjVkVS6ZY=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "1-update-dependencies-for-go-1.18.patch";
-      url = "https://github.com/hekmekk/git-team/commit/d8632d9938379293521f9b3f2a93df680dd13a31.patch";
-      hash = "sha256-hlmjPf3qp8WPNSH+GgkqATDiKIRzo+t81Npkptw8vgI=";
-    })
-    (fetchpatch {
-      name = "2-update-dependencies-for-go-1.18.patch";
-      url = "https://github.com/hekmekk/git-team/commit/f6acc96c2ffe76c527f2f2897b368cbb631d738c.patch";
-      hash = "sha256-Pe+UAK9N1NpXhFGYv9l1iZ1/fCCqnT8OSgKdt/vUqO4=";
-    })
-    (fetchpatch {
-      name = "3-update-dependencies-for-go-1.18.patch";
-      url = "https://github.com/hekmekk/git-team/commit/2f38137298e4749a8dfe37e085015360949e73ad.patch";
-      hash = "sha256-+6C8jp/qwYVmbL+SpV9FJIVyBRvX4tXBcoHMB//nNTk=";
-    })
+  vendorHash = "sha256-NTOUL1oE2IhgLyYYHwRCMW5yCxIRxUwqkfuhSSBXf6A=";
+
+  nativeBuildInputs = [
+    go-mockery
+    installShellFiles
   ];
 
-  vendorSha256 = "sha256-GdwksPmYEGTq/FkG/rvn3o0zMKU1cSkpgZ+GrfVgLWM=";
-
-  nativeBuildInputs = [ installShellFiles ];
+  preBuild = ''
+    mockery --dir=src/ --all --keeptree
+  '';
 
   postInstall = ''
-    go run main.go --generate-man-page > ${pname}.1
-    installManPage ${pname}.1
+    go run main.go --generate-man-page > git-team.1
+    installManPage git-team.1
 
-    # Currently only bash completions are provided
-    installShellCompletion --cmd git-team --bash <($out/bin/git-team completion bash)
+    installShellCompletion --cmd git-team \
+      --bash <($out/bin/git-team completion bash) \
+      --zsh <($out/bin/git-team completion zsh)
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Co-authored-by: Jan Schmitt <git@smittie.de>

https://github.com/hekmekk/git-team/blob/main/CHANGELOG.md#180---2022-10-28
https://github.com/hekmekk/git-team/blob/main/CHANGELOG.md#171---2022-10-09

This supersedes https://github.com/NixOS/nixpkgs/pull/201227.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
