### PR TITLE
waylock: init at 0.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15893,4 +15893,10 @@
     github = "wuyoli";
     githubId = 104238274;
   };
+  jordanisaacs = {
+    name = "Jordan Isaacs";
+    email = "nix@jdisaacs.com";
+    github = "jordanisaacs";
+    githubId = 19742638;
+  };
 }

--- a/pkgs/applications/misc/waylock/default.nix
+++ b/pkgs/applications/misc/waylock/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig,
+  wayland,
+  pkg-config,
+  scdoc,
+  wayland-protocols,
+  libxkbcommon,
+  pam,
+}:
+stdenv.mkDerivation rec {
+  pname = "waylock";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "ifreund";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-yWjWcnGa4a+Dpc82H65yr8H7v88g/tDq0FSguubhbEI=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [zig wayland scdoc pkg-config];
+
+  buildInputs = [
+    wayland-protocols
+    libxkbcommon
+    pam
+  ];
+
+  dontConfigure = true;
+
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    zig build -Drelease-safe -Dman-pages --prefix $out install
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ifreund/waylock";
+    description = "A small screenlocker for Wayland compositors";
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [jordanisaacs];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29432,6 +29432,8 @@ with pkgs;
 
   waybar = callPackage ../applications/misc/waybar {};
 
+  waylock = callPackage ../applications/misc/waylock {};
+
   wayshot = callPackage ../tools/misc/wayshot { };
 
   waylevel = callPackage ../tools/misc/waylevel { };


### PR DESCRIPTION
###### Description of changes

Initialize [waylock](https://github.com/ifreund/waylock), a small screenlocker for wayland utilizing ext-session-lock-v1. Written by the creator of the river compositor. When using, ensure to install a waylock pam.d file. On NixOS use `security.pam.services.waylock = {}`. Also added myself as a new maintainer!

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Built it in nix packages and ran the binary on my personal system with sway (after including the necessary pam.d file). It worked successfully at locking/unlocking.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
