### PR TITLE
python3Packages.tensorflow: 2.10.0 -> 2.10.1, tensorflow-bin: 2.9.1 -> 2.9.3

### DIFF
--- a/pkgs/development/python-modules/pymanopt/default.nix
+++ b/pkgs/development/python-modules/pymanopt/default.nix
@@ -26,16 +26,18 @@ buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
-    # FIXME: Some numpy regression?
-    # Traceback (most recent call last):
-    #   File "/build/source/tests/manifolds/test_hyperbolic.py", line 270, in test_second_order_function_approximation
-    #     self.run_hessian_approximation_test()
-    #   File "/build/source/tests/manifolds/_manifold_tests.py", line 29, in run_hessian_approximation_test
-    #     assert np.allclose(np.linalg.norm(error), 0) or (2.95 <= slope <= 3.05)
-    # AssertionError
-    rm tests/manifolds/test_hyperbolic.py
+
+    # upstream themselves seem unsure about the robustness of these
+    # tests - see https://github.com/pymanopt/pymanopt/issues/219
+    grep -lr 'test_second_order_function_approximation' tests/ | while read -r fn ; do
+      substituteInPlace "$fn" \
+        --replace \
+          'test_second_order_function_approximation' \
+          'dont_test_second_order_function_approximation'
+    done
 
     nose2 tests -v
+
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/tensorflow/binary-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/binary-hashes.nix
@@ -1,51 +1,51 @@
 {
-version = "2.9.1";
+version = "2.9.3";
 linux_py_37_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.9.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-  sha256 = "1wpqjqx3zfyrclhs6kkqhq76kmb45h2jv2jdi89jrk8pfk3mcf2k";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+  sha256 = "0p1a4dlqj7kl4a3aad33r083f5pfspc0hm0x9a3b1qvvgaldww08";
 };
 linux_py_38_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-  sha256 = "1np06xy18z8k29q8vg5a8kmvxpbcz0grjjww3hcpb4kvy9rx01sw";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+  sha256 = "1zq39ls1asha4zkrfqvg5375mmryf20hc1fi243k8z077391ihhv";
 };
 linux_py_39_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-  sha256 = "1gy258wfgjf2f1lcpayvgx5cnncnqjcp2mj70mz50bm9mhmzl4kd";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+  sha256 = "16gz4bcw2gvwh3264wc8a2lyfr542avhgdrnmd0pxwszqg45rkdj";
 };
 linux_py_310_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-  sha256 = "0bh5xg4wfc86q1x7ph8bvdpa3arm6kmbvd4cg3d427sywkmdsrk6";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+  sha256 = "1a5s19x8ybncmpx8hr116bm6cvjar3b0sj8k8w2wrpxhh02sndwh";
 };
 linux_py_37_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.9.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-  sha256 = "1qsq7la0fpmk2hych7sy9k8mza1q7w05c4nmgq92cxgkmpa7d17x";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+  sha256 = "03zh1fzi7s5incxghgnk4hm9m9kg989pn420g532grzj1f85x23f";
 };
 linux_py_38_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-  sha256 = "0913znz5mg6mkryi24xhz4s7rwhxbx172fsk26lxl6w6qx219pfd";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+  sha256 = "1czajraildk4acwn3rd921wfarl1jwbnmfiwk57ijsx5s9q4d328";
 };
 linux_py_39_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-  sha256 = "01srcvpcwpgpvb9inlc2mwsmf5sj13rqb695rvm50ybkjrrac7l4";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+  sha256 = "0rk1ii9dqi856bgm596igbragvcwk3799cz05x6gyjkixdkbk5jj";
 };
 linux_py_310_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-  sha256 = "19g93jig1x389ybc25ifsh1grrsghn3w2xgk029289432bnlpzp4";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+  sha256 = "1q6pf6140qza16p1yxw2z3n7ndfq3by2k6wc45lhpx4bl1vs7my7";
 };
 mac_py_37_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.1-cp37-cp37m-macosx_10_14_x86_64.whl";
-  sha256 = "0b2hirjhqw4jl75h0ik1a9hgbkkq0b3gj4wkkp9vb6mi4116gxxi";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.3-cp37-cp37m-macosx_10_14_x86_64.whl";
+  sha256 = "05y3y18ggnrfzrcrzkxkb3djbhsm8001s1l1nmvvv9zq8v02b6hp";
 };
 mac_py_38_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.1-cp38-cp38-macosx_10_14_x86_64.whl";
-  sha256 = "0da6csvldvxg47r932wbx5z6w3hf1d107p9blayzrjchdwhqs16z";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.3-cp38-cp38-macosx_10_14_x86_64.whl";
+  sha256 = "0qgzqdfv4q5bl6hd932jd6zfp47abva59nyrgxw19kiz0gzq3lw9";
 };
 mac_py_39_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.1-cp39-cp39-macosx_10_14_x86_64.whl";
-  sha256 = "1fa0nf4pj5sl5shifaahr8n30q86k6hdsg0qwvan0hyg75fh9bc1";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.3-cp39-cp39-macosx_10_14_x86_64.whl";
+  sha256 = "1zjvjyvz0lshvqf5sc80bxkdwnk8b43abwmzsm9m6dyl8waj5d5r";
 };
 mac_py_310_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.1-cp310-cp310-macosx_10_14_x86_64.whl";
-  sha256 = "0baq0djx8vhn8d75wyf82m6iqgfxwcrgg4xcvlr20m4x9bmysxrc";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.9.3-cp310-cp310-macosx_10_14_x86_64.whl";
+  sha256 = "0pncslab7m9d89syaad7n3fgxygkr07d5prir225a42kym8slni8";
 };
 }

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -76,7 +76,7 @@ let
 
   tfFeature = x: if x then "1" else "0";
 
-  version = "2.10.0";
+  version = "2.10.1";
   variant = if cudaSupport then "-gpu" else "";
   pname = "tensorflow${variant}";
 
@@ -190,7 +190,7 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      hash = "sha256-Y6cujiMoQXKQlsLBr7d0T278ltdd00IfsTRycJbRVN4=";
+      hash = "sha256-AYHUtJEXYZdVDigKZo7mQnV+PDeQg8mi45YH18qXHZA=";
     };
 
     # On update, it can be useful to steal the changes from gentoo
@@ -369,13 +369,14 @@ let
     fetchAttrs = {
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
       sha256 = if cudaSupport then
-        "sha256-KtVReqHL3zxE8TPrqIerSOt59Mgke/ftoFZKMzgX/u8="
+        "sha256-SudzMTxfifKJJso6haCgOD2dXeAhYSXHA2nzq1ErTHg="
+      else if stdenv.isDarwin then
+        # FIXME: this checksum is currently wrong, since the tensorflow dependency fetch is broken on darwin
+        "sha256-j2k9Q+k41444nP1VjjkkNjXRov1uAda4RCMDMAthjr0="
+      else if stdenv.isAarch64 then
+        "sha256-ZbCNZSHF9of+KGTNEqFdKQ44MVNto/rTyo2XEsKXISg="
       else
-        if stdenv.isDarwin then
-          # FIXME: this checksum is currently wrong, since the tensorflow dependency fetch is broken on darwin
-          "sha256-j2k9Q+k41nq5nP1VjjkkNjXRov1uAda4RCMDMAthjr0="
-        else
-          "sha256-zH3xNFEU2JR0Ww8bpD4mCiorGtao0WVPP4vklVMgS4A=";
+        "sha256-bwZwK24DlUevN5gIdKmBkq1dJpn0i2H4hq+IN77BzjE=";
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -423,7 +423,7 @@ let
       license = licenses.asl20;
       maintainers = with maintainers; [ jyp abbradar ];
       platforms = with platforms; linux ++ darwin;
-      broken = !(xlaSupport -> cudaSupport);
+      broken = stdenv.isDarwin || !(xlaSupport -> cudaSupport);
     } // lib.optionalAttrs stdenv.isDarwin {
       timeout = 86400; # 24 hours
       maxSilent = 14400; # 4h, double the default of 7200s

--- a/pkgs/development/python-modules/tensorflow/prefetcher.sh
+++ b/pkgs/development/python-modules/tensorflow/prefetcher.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version="2.9.1"
+version="2.9.3"
 
 bucket="https://storage.googleapis.com/tensorflow"
 


### PR DESCRIPTION
###### Description of changes

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41883
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41911
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41909
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41908
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41901
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41907
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41900
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41899
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41898
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41896
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41897
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41894
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41895
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41891
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41893
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41889
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41890
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41887
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41888
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41886
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41880
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41884
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41885

:sweat_drops: 

Similar bumps are available for versions in stable, but this can't just be backported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
