### PR TITLE
[Backport release-22.05] sigi: 3.4.2 -> 3.5.0

### DIFF
--- a/pkgs/applications/misc/sigi/default.nix
+++ b/pkgs/applications/misc/sigi/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sigi";
-  version = "3.4.2";
+  version = "3.4.3";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-YlTawz09i7k5QxaybKSo4IhECs6UdDSNV+ylIJgKPt4=";
+    sha256 = "sha256-CDu/tllCwmt+UO4ae1uFkR4KKCWdxM4aW1O7oY59qHE=";
   };
 
-  cargoSha256 = "sha256-L4eIGxQTM+sZWXWZDGtSwsCT54CWLbyPQ9b+Jf6s94U=";
+  cargoSha256 = "sha256-pMOaw7Ra78aRisYF9ttbpjB/cbylpzZXw8DtBqn5Tjo=";
   nativeBuildInputs = [ installShellFiles ];
 
   # In case anything goes wrong.

--- a/pkgs/applications/misc/sigi/default.nix
+++ b/pkgs/applications/misc/sigi/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sigi";
-  version = "3.4.3";
+  version = "3.5.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-CDu/tllCwmt+UO4ae1uFkR4KKCWdxM4aW1O7oY59qHE=";
+    sha256 = "sha256-VUf5fCVOZCn0iY51eBS/fIvlxQF+BY+k75I+NY7yqzM=";
   };
 
-  cargoSha256 = "sha256-pMOaw7Ra78aRisYF9ttbpjB/cbylpzZXw8DtBqn5Tjo=";
+  cargoSha256 = "sha256-ivSVcpUDGK0dJDy+jY7BYQIFCXu/npV0MiNe3nlsUho=";
   nativeBuildInputs = [ installShellFiles ];
 
   # In case anything goes wrong.
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Organizing CLI for people who don't love organizing.";
-    homepage = "https://github.com/hiljusti/sigi";
+    homepage = "https://github.com/sigi-cli/sigi";
     license = licenses.gpl2;
     maintainers = with maintainers; [ hiljusti ];
   };


### PR DESCRIPTION
Backport release of:

* https://github.com/NixOS/nixpkgs/pull/192372
* https://github.com/NixOS/nixpkgs/pull/200806

The first PR was automated by a bot (see https://github.com/NixOS/nixpkgs/pull/192745), but I don't have permission to update that branch with the more recent commit.