### PR TITLE
teamviewer: remove qtwebkit

### DIFF
--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchurl, autoPatchelfHook, makeWrapper, xdg-utils, dbus
-, qtbase, qtwebkit, qtwebengine, qtx11extras, qtquickcontrols, getconf, glibc
+, qtbase, qtwebengine, qtx11extras, qtquickcontrols, getconf, glibc
 , libXrandr, libX11, libXext, libXdamage, libXtst, libSM, libXfixes, coreutils
 , wrapQtAppsHook
 }:
@@ -21,7 +21,7 @@ mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapQtAppsHook ];
-  buildInputs = [ dbus getconf qtbase qtwebkit qtwebengine qtx11extras libX11 ];
+  buildInputs = [ dbus getconf qtbase qtwebengine qtx11extras libX11 ];
   propagatedBuildInputs = [ qtquickcontrols ];
 
   installPhase = ''


### PR DESCRIPTION
###### Description of changes

due to https://github.com/NixOS/nixpkgs/pull/201028 and the deprecation of qtwebkit teamviewer refuses to evaluate.

qtwebkit isn't needed for teamviewer and is therefore removed.

Ping @ maintainers:

@jagajaga @jraygauthier

Note: I also tried to update to the newest version 15.35.7. Teamviewer builds but for some reason doesn't start. In the logs I can find these (new) errors:
`QML load error: qrc:/ui/MessageBox/MessageBoxQt.qml:3:1: module "QtQuick.Dialogs" is not installed, Errorcode=11`
I've tried various other qt-packages, but to no avail. ~~Only adding `qtwebkit`back helped.~~

Also, [officially](https://community.teamviewer.com/English/kb/articles/6318-how-to-install-teamviewer-for-linux) teamviewer doesn'trequire Qt to be installed: 
``` 
Note: As of TeamViewer 15.19 Qt is not required to be installed. Below TeamViewer 15.19 Qt 5.6 is recommended for the best experience.
``` 
Thats only partly true. It packages its own version of Qt.

Doing a `dirdiff`  of the two packages (15.29.4 and 15.35.7)  don't yield any obvious differences concerning Qt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
