### PR TITLE
mediaelch: switch from qt5 to qt6

### DIFF
--- a/pkgs/applications/misc/mediaelch/default.nix
+++ b/pkgs/applications/misc/mediaelch/default.nix
@@ -1,22 +1,25 @@
 { lib
-, mkDerivation
+, stdenv
 , fetchFromGitHub
 
-, qmake
+, cmake
 , qttools
+, wrapQtAppsHook
 
 , curl
 , ffmpeg
 , libmediainfo
 , libzen
+, qt5compat
 , qtbase
 , qtdeclarative
 , qtmultimedia
 , qtsvg
+, qtwayland
 , quazip
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "mediaelch";
   version = "2.8.18";
 
@@ -28,20 +31,35 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ qmake qttools ];
-
-  buildInputs = [ curl ffmpeg libmediainfo libzen qtbase qtdeclarative qtmultimedia qtsvg ];
-
-  qmakeFlags = [
-    "USE_EXTERN_QUAZIP=${quazip}/include/quazip5"
+  nativeBuildInputs = [
+    cmake
+    qttools
+    wrapQtAppsHook
   ];
 
-  postPatch = ''
-    substituteInPlace MediaElch.pro --replace "/usr" "$out"
-  '';
+  buildInputs = [
+    curl
+    ffmpeg
+    libmediainfo
+    libzen
+    qt5compat
+    qtbase
+    qtdeclarative
+    qtmultimedia
+    qtsvg
+    qtwayland
+    quazip
+  ];
 
+
+  cmakeFlags = [
+    "-DDISABLE_UPDATER=ON"
+    "-DUSE_EXTERN_QUAZIP=ON"
+    "-DMEDIAELCH_FORCE_QT6=ON"
+  ];
+
+  # libmediainfo.so.0 is loaded dynamically
   qtWrapperArgs = [
-    # libmediainfo.so.0 is loaded dynamically
     "--prefix LD_LIBRARY_PATH : ${libmediainfo}/lib"
   ];
 

--- a/pkgs/applications/misc/mediaelch/default.nix
+++ b/pkgs/applications/misc/mediaelch/default.nix
@@ -10,7 +10,7 @@
 , ffmpeg
 , libmediainfo
 , libzen
-, qt5compat
+, qt5compat ? null # qt6 only
 , qtbase
 , qtdeclarative
 , qtmultimedia
@@ -18,7 +18,9 @@
 , qtwayland
 , quazip
 }:
-
+let
+  qtVersion = lib.versions.major qtbase.version;
+in
 stdenv.mkDerivation rec {
   pname = "mediaelch";
   version = "2.8.18";
@@ -42,20 +44,21 @@ stdenv.mkDerivation rec {
     ffmpeg
     libmediainfo
     libzen
-    qt5compat
     qtbase
     qtdeclarative
     qtmultimedia
     qtsvg
     qtwayland
     quazip
+  ] ++ lib.optional (qtVersion == "6") [
+    qt5compat
   ];
 
 
   cmakeFlags = [
     "-DDISABLE_UPDATER=ON"
     "-DUSE_EXTERN_QUAZIP=ON"
-    "-DMEDIAELCH_FORCE_QT6=ON"
+    "-DMEDIAELCH_FORCE_QT${qtVersion}=ON"
   ];
 
   # libmediainfo.so.0 is loaded dynamically

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30388,7 +30388,7 @@ with pkgs;
 
   media-downloader = callPackage ../applications/video/media-downloader { };
 
-  mediaelch = libsForQt5.callPackage ../applications/misc/mediaelch { };
+  mediaelch = qt6Packages.callPackage ../applications/misc/mediaelch { };
 
   mediainfo = callPackage ../applications/misc/mediainfo { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30388,7 +30388,9 @@ with pkgs;
 
   media-downloader = callPackage ../applications/video/media-downloader { };
 
-  mediaelch = qt6Packages.callPackage ../applications/misc/mediaelch { };
+  mediaelch = mediaelch-qt5;
+  mediaelch-qt5 = libsForQt5.callPackage ../applications/misc/mediaelch { };
+  mediaelch-qt6 = qt6Packages.callPackage ../applications/misc/mediaelch { };
 
   mediainfo = callPackage ../applications/misc/mediainfo { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
