### PR TITLE
[22.05] python3Packages.pillow: add patch for CVE-2022-45198, test for CVE-2022-45199

### DIFF
--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -3,6 +3,8 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
+, fetchpatch
+, fetchurl
 , isPyPy
 , defusedxml, olefile, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
 , libxcb, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
@@ -21,6 +23,51 @@ import ./generic.nix (rec {
     inherit version;
     sha256 = "f401ed2bbb155e1ade150ccc63db1a4f6c1909d3d378f7d1235a44e90d75fb97";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-45198.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/c9f1b35e981075110a23487a8d4a6cbb59a588ea.patch";
+      hash = "sha256-jaITGw3bc+ntcYgt8NG9H4cgDWCqYKFKqkL4SeqRB6w=";
+    })
+    # this is only the test-case added from the CVE-2022-45199, as
+    # a means to "prove" that 9.1.0 isn't vulnerable
+    (fetchpatch {
+      name = "CVE-2022-45199-test.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/2444cddab2f83f28687c7c20871574acbb6dbcf3.patch";
+      excludes = [
+        "docs/releasenotes/9.3.0.rst"
+        # the "fix"
+        "src/PIL/TiffImagePlugin.py"
+      ];
+      hash = "sha256-P63rLbY2AOEXVDcOCUzwHRH8JmgieAIfGgiXPK7P4O0=";
+    })
+  ];
+
+  # patching mechanism doesn't work with binary files, but the commits contain
+  # example images needed for the accompanying tests, so invent our own mechanism
+  # to put these in place
+  extraPostPatch = lib.concatMapStrings ({commit, sha256, path}: let
+      src = fetchurl {
+        inherit sha256;
+        url = "https://github.com/python-pillow/Pillow/raw/${commit}/${path}";
+      };
+      dest = path;
+    in ''
+      cp ${src} ${dest}
+    ''
+  ) [
+    { # needed by CVE-2022-45198.patch
+      commit = "c9f1b35e981075110a23487a8d4a6cbb59a588ea";
+      sha256 = "sha256-5sijTgmHSsE2P6zwGCHPrtP0lPpZbwtXj66H2sVi7nk=";
+      path = "Tests/images/decompression_bomb_extents.gif";
+    }
+    { # needed by CVE-2022-45199-test.patch
+      commit = "2444cddab2f83f28687c7c20871574acbb6dbcf3";
+      sha256 = "sha256-yqns5o9ETaNDxqf+oqpK53DQO7KhuuScKJoiDTvew5s=";
+      path = "Tests/images/oom-225817ca0f8c663be7ab4b9e717b02c661e66834.tif";
+    }
+  ];
 
   passthru.tests = {
     inherit imageio matplotlib pilkit pydicom reportlab;

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -4,19 +4,21 @@
 , src
 , meta
 , passthru ? {}
+, patches ? []
+, extraPostPatch ? ""
 , ...
 }@args:
 
 with args;
 
 buildPythonPackage rec {
-  inherit pname version src meta passthru;
+  inherit pname version src meta passthru patches;
 
   # Disable imagefont tests, because they don't work well with infinality:
   # https://github.com/python-pillow/Pillow/issues/1259
   postPatch = ''
     rm Tests/test_imagefont.py
-  '';
+  '' + extraPostPatch;
 
   # Disable darwin tests which require executables: `iconutil` and `screencapture`
   disabledTests = lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-45198

9.1.0 doesn't actually appear vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2022-45199, but I've included the test part of that patch anyway to "prove" as much.

Both already addressed in unstable.

Successfully built `passthru.tests` on indicated platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
