### PR TITLE
nixos/prometheus-nginxlog-exporter: define types of inner options

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/nginxlog.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/nginxlog.nix
@@ -7,7 +7,27 @@ in {
   port = 9117;
   extraOpts = {
     settings = mkOption {
-      type = types.attrs;
+      type = types.submodule {
+        options = {
+          consul = mkOption {
+            default = null;
+            type = types.nullOr (types.attrsOf types.anything);
+            description = ''
+              Consul integration options. For more information see the [example config](https://github.com/martin-helmich/prometheus-nginxlog-exporter#configuration-file).
+
+              This is disabled by default.
+            '';
+          };
+          namespaces = mkOption {
+            default = [];
+            type = types.listOf (types.attrsOf types.anything);
+
+            description = ''
+              Namespaces to collect the metrics for. For more information see the [example config](https://github.com/martin-helmich/prometheus-nginxlog-exporter#configuration-file).
+            '';
+          };
+        };
+      };
       default = {};
       description = ''
         All settings of nginxlog expressed as an Nix attrset.


### PR DESCRIPTION
###### Description of changes

Add a little bit of typing to `services.prometheus.exporters.nginxlog.settings`. Using `types.attrs` here does not allow one to merge multiple definitions, e.g.:

```nix
lib.mkMerge [
  {
    services.prometheus.exporters.nginxlog.settings.namespaces = [
      {
        name = "domain1";
      }
    ];
  }

  {
    services.prometheus.exporters.nginxlog.settings.namespaces = [
      {
        name = "domain2";
      }
    ];
  }
]
```

results in lists not getting merged, but one overriding the other, and the config file ends up with only one of the namespaces.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
