### PR TITLE
pythonPackages.executing: 0.8.2 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/executing/default.nix
+++ b/pkgs/development/python-modules/executing/default.nix
@@ -3,18 +3,20 @@
 , buildPythonPackage
 , fetchFromGitHub
 , setuptools-scm
+, pytestCheckHook
+, littleutils
 }:
 
 buildPythonPackage rec {
   pname = "executing";
-  version = "0.8.2";
+  version = "1.2.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "alexmojaki";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-CDZQ9DONn7M+2/GtmM2G6nQPpI9dOd0ca+2F1PGRwO4=";
+    sha256 = "sha256-3M3uSJ5xQ5Ciy8Lz21u9zjju/7SBSFHobCqSiJ6AP8M=";
   };
 
   nativeBuildInputs = [
@@ -25,10 +27,10 @@ buildPythonPackage rec {
     export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
   '';
 
-  # Tests appear to run fine (Ran 22 tests in 4.076s) with setuptoolsCheckPhase
-  # but crash with pytestCheckHook
   checkInputs = [
+    pytestCheckHook
     asttokens
+    littleutils
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/executing/default.nix
+++ b/pkgs/development/python-modules/executing/default.nix
@@ -12,7 +12,7 @@
 buildPythonPackage rec {
   pname = "executing";
   version = "1.2.0";
-  format = "setuptools";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "alexmojaki";

--- a/pkgs/development/python-modules/executing/default.nix
+++ b/pkgs/development/python-modules/executing/default.nix
@@ -5,6 +5,8 @@
 , setuptools-scm
 , pytestCheckHook
 , littleutils
+, pythonAtLeast
+, rich
 }:
 
 buildPythonPackage rec {
@@ -31,6 +33,8 @@ buildPythonPackage rec {
     pytestCheckHook
     asttokens
     littleutils
+  ] ++ lib.optionals (pythonAtLeast "3.11") [
+    rich
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds support for Python 3.11.

Commits: https://github.com/alexmojaki/executing/compare/v0.8.2...v1.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
