### PR TITLE
supabase-cli: init at 1.27.0

### DIFF
--- a/pkgs/development/tools/supabase-cli/default.nix
+++ b/pkgs/development/tools/supabase-cli/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "supabase-cli";
+  version = "1.27.0";
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "sha256-gAfgqOeJ1cQ5Igxcut0FXkzhK38Q/mUTXfFaZE0dNCs=";
+  };
+
+  vendorSha256 = "sha256-RO9dZP236Kt8SSpZFF7KRksrjgwiEkPxE5DIMUK69Kw=";
+
+  ldflags = [ "-s" "-w" "-X" "github.com/supabase/cli/cmd.version=${version}" ];
+
+  doCheck = false; # tests are trying to connect to localhost
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    rm $out/bin/{codegen,docgen,listdep}
+    mv $out/bin/{cli,supabase}
+
+    installShellCompletion --cmd supabase \
+      --bash <($out/bin/supabase completion bash) \
+      --fish <($out/bin/supabase completion fish) \
+      --zsh <($out/bin/supabase completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "A CLI for interacting with supabase";
+    homepage = "https://github.com/supabase/cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gerschtli ];
+    mainProgram = "supabase";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17859,6 +17859,8 @@ with pkgs;
 
   summon = callPackage ../development/tools/summon { };
 
+  supabase-cli = callPackage ../development/tools/supabase-cli { };
+
   svlint = callPackage ../development/tools/analysis/svlint { };
 
   svls = callPackage ../development/tools/misc/svls { };


### PR DESCRIPTION
###### Description of changes

Adds the Supabase CLI, nice tool for local development with supabase projects.

Closes https://github.com/NixOS/nixpkgs/pull/179624

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
