### PR TITLE
androidenv: use emulator from the path that makes it find qemu

### DIFF
--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -312,6 +312,7 @@ rec {
           ln -s $i $out/bin
       done
 
+      # the emulator auto-linked from platform-tools does not find its local qemu, while this one does
       ${lib.optionalString includeEmulator ''
         rm $out/bin/emulator
         ln -s $out/libexec/android-sdk/emulator/emulator $out/bin

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -312,6 +312,11 @@ rec {
           ln -s $i $out/bin
       done
 
+      ${lib.optionalString includeEmulator ''
+        rm $out/bin/emulator
+        ln -s $out/libexec/android-sdk/emulator/emulator $out/bin
+      ''}
+
       # Write licenses
       mkdir -p licenses
       ${lib.concatMapStrings (licenseName:


### PR DESCRIPTION
###### Description of changes

The emulator looks for qemu in a path relative to itself. So the version in /tools/ is broken, and only the other version in /emulator/ is actually working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable: manually and only `emulator`, could not find related nixos tests (which makes sense given emulator was crashing failing to find qemu anyway)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
