### PR TITLE
lssecret: init at `722013dc`

### DIFF
--- a/pkgs/misc/lssecret/default.nix
+++ b/pkgs/misc/lssecret/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, pkg-config
+, libsecret
+}:
+
+stdenv.mkDerivation rec {
+  name = "lssecret";
+  version = "unstable-2022-12-02";
+
+  src = fetchFromGitLab {
+    owner = "GrantMoyer";
+    repo = name;
+    rev = "20fd771a";
+    hash = "sha256-yU70WZj4EC/sFJxyq2SQ0YQ6RCQHYiW/aQiYWo7+ujk=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libsecret ];
+
+  makeFlags = ["DESTDIR=$(out)"];
+
+  meta = {
+    description = "A tool to list passwords and other secrets stored using the org.freedesktop.secrets dbus api";
+    homepage = "https://gitlab.com/GrantMoyer/lssecret";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5232,6 +5232,8 @@ with pkgs;
 
   long-shebang = callPackage ../misc/long-shebang { };
 
+  lssecret = callPackage ../misc/lssecret {};
+
   lowdown = callPackage ../tools/typesetting/lowdown { };
 
   numatop = callPackage ../os-specific/linux/numatop { };


### PR DESCRIPTION
###### Description of changes

Add [lssecret](https://gitlab.com/GrantMoyer/lssecret)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).