### PR TITLE
git-bug: tweaks; git-bug-migration: init at 0.3.4

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -126,6 +126,14 @@
       </listitem>
       <listitem>
         <para>
+          <literal>git-bug</literal> has been updated to at least
+          version 0.8.0, which includes backwards incompatible changes.
+          The <literal>git-bug-migration</literal> package can be used
+          to upgrade existing repositories.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The EC2 image module no longer fetches instance metadata in
           stage-1. This results in a significantly smaller initramfs,
           since network drivers no longer need to be included, and

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -42,6 +42,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `podman` now uses the `netavark` network stack. Users will need to delete all of their local containers, images, volumes, etc, by running `podman system reset --force` once before upgrading their systems.
 
+- `git-bug` has been updated to at least version 0.8.0, which includes backwards incompatible changes. The `git-bug-migration` package can be used to upgrade existing repositories.
+
 - The EC2 image module no longer fetches instance metadata in stage-1. This results in a significantly smaller initramfs, since network drivers no longer need to be included, and faster boots, since metadata fetching can happen in parallel with startup of other services.
   This breaks services which rely on metadata being present by the time stage-2 is entered. Anything which reads EC2 metadata from `/etc/ec2-metadata` should now have an `after` dependency on `fetch-ec2-metadata.service`
 

--- a/pkgs/applications/version-management/git-bug-migration/default.nix
+++ b/pkgs/applications/version-management/git-bug-migration/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub, git }:
+buildGoModule rec {
+  pname = "git-bug-migration";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "MichaelMure";
+    repo = "git-bug-migration";
+    rev = "v${version}";
+    hash = "sha256-IOBgrU3C0ZHD2wx9LRVgKEJzDlUj6z2UXlHGU3tdTdQ=";
+  };
+
+  vendorSha256 = "sha256-Hid9OK91LNjLmDHam0ZlrVQopVOsqbZ+BH2rfQi5lS0=";
+
+  checkInputs = [ git ];
+
+  ldflags = [
+    "-X main.GitExactTag=${version}"
+    "-X main.GitLastTag=${version}"
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    git config --global user.name 'Nixpkgs Test User'
+    git config --global user.email 'nobody@localhost'
+  '';
+
+  meta =  with lib; {
+    description = "Tool for upgrading repositories using git-bug to new versions";
+    homepage = "https://github.com/MichaelMure/git-bug-migration";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ DeeUnderscore ];
+  };
+}

--- a/pkgs/applications/version-management/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-bug/default.nix
@@ -1,42 +1,43 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "git-bug";
-  version = "0.8.0"; # the `rev` below pins the version of the source to get
-  rev = "v0.8.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "MichaelMure";
     repo = "git-bug";
+    rev = "v${version}";
     sha256 = "12byf6nsamwz0ssigan1z299s01cyh8bhgj86bibl90agd4zs9n8";
   };
 
   vendorSha256 = "sha256-32kNDoBE50Jx1Ef9YwhDk7nd3CaTSnHPlu7PgWPUGfE=";
 
+  nativeBuildInputs = [ installShellFiles ];
+
   doCheck = false;
 
+  excludedPackages = [ "doc" "misc" ];
+
   ldflags = [
-    "-X github.com/MichaelMure/git-bug/commands.GitCommit=${rev}"
+    "-X github.com/MichaelMure/git-bug/commands.GitCommit=v${version}"
     "-X github.com/MichaelMure/git-bug/commands.GitLastTag=${version}"
     "-X github.com/MichaelMure/git-bug/commands.GitExactTag=${version}"
   ];
 
   postInstall = ''
-    install -D -m 0644 misc/completion/bash/git-bug "$out/share/bash-completion/completions/git-bug"
-    install -D -m 0644 misc/completion/zsh/git-bug "$out/share/zsh/site-functions/git-bug"
-    install -D -m 0644 -t "$out/share/man/man1" doc/man/*
+    installShellCompletion \
+      --bash misc/completion/bash/git-bug \
+      --zsh misc/completion/zsh/git-bug \
+      --fish misc/completion/fish/git-bug
 
-    # not sure why the following executables are in $out/bin/
-    rm -f $out/bin/cmd
-    rm -f $out/bin/completion
-    rm -f $out/bin/doc
+    installManPage doc/man/*
   '';
 
   meta = with lib; {
     description = "Distributed bug tracker embedded in Git";
     homepage = "https://github.com/MichaelMure/git-bug";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ royneary ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ royneary DeeUnderscore ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1684,6 +1684,8 @@ with pkgs;
 
   git-bug = callPackage ../applications/version-management/git-bug { };
 
+  git-bug-migration = callPackage ../applications/version-management/git-bug-migration { };
+
   git-chglog = callPackage ../applications/version-management/git-chglog { };
 
   git-cinnabar = callPackage ../applications/version-management/git-cinnabar {


### PR DESCRIPTION
###### Description of changes
git-bug changelog: https://github.com/MichaelMure/git-bug/releases/tag/v0.8.0

git-bug includes backwards incompatible changes. [git-bug-migration](https://github.com/MichaelMure/git-bug-migration) is a separate tool for upgrading the bug database in existing repositories, so I'm packaging it here as well. Included is also a changelog hint about the migration tool. 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
