### PR TITLE
zeal: unstable-2021-12-25 → unstable-2022-10-02

### DIFF
--- a/pkgs/data/documentation/zeal/default.nix
+++ b/pkgs/data/documentation/zeal/default.nix
@@ -1,16 +1,31 @@
-{ lib, fetchFromGitHub, cmake, extra-cmake-modules, pkg-config
-, qtbase, qtimageformats, qtwebengine, qtx11extras, mkDerivation
-, libarchive, libXdmcp, libpthreadstubs, xcbutilkeysyms  }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, pkg-config
+, qtbase
+, qtimageformats
+, qtwebengine
+, qtx11extras ? null # qt5 only
+, libarchive
+, libXdmcp
+, libpthreadstubs
+, wrapQtAppsHook
+, xcbutilkeysyms
+}:
 
-mkDerivation rec {
+let
+  isQt5 = lib.versions.major qtbase.version == "5";
+in stdenv.mkDerivation rec {
   pname = "zeal";
-  version = "0.6.999";
+  version = "0.6.20221022";
 
   src = fetchFromGitHub {
     owner = "zealdocs";
     repo = "zeal";
-    rev = "763edca12ccd6c67e51f10891d1ced8b2510904f";
-    sha256 = "sha256-1/wQXkRWvpRia8UDvvvmzHinPG8q2Tz9Uoeegej9uC8=";
+    rev = "7ea03e4bb9754020e902a2989f56f4bc42b85c82";
+    sha256 = "sha256-BozRLlws56i9P7Qtc5qPZWgJR5yhYqnLQsEdsymt5us=";
   };
 
   # we only need this if we are using a version that hasn't been released. We
@@ -22,13 +37,18 @@ mkDerivation rec {
       -e 's@^project.*@project(Zeal VERSION ${version})@'
   '';
 
-  nativeBuildInputs = [ cmake extra-cmake-modules pkg-config ];
+  nativeBuildInputs = [ cmake extra-cmake-modules pkg-config wrapQtAppsHook ];
 
-  buildInputs = [
-    qtbase qtimageformats qtwebengine qtx11extras
-    libarchive
-    libXdmcp libpthreadstubs xcbutilkeysyms
-  ];
+  buildInputs =
+    [
+      qtbase
+      qtimageformats
+      qtwebengine
+      libarchive
+      libXdmcp
+      libpthreadstubs
+      xcbutilkeysyms
+    ] ++ lib.optionals isQt5 [ qtx11extras ];
 
   meta = with lib; {
     description = "A simple offline API documentation browser";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27174,7 +27174,9 @@ with pkgs;
     inherit (plasma5Packages) breeze-icons;
   };
 
-  zeal = libsForQt5.callPackage ../data/documentation/zeal { };
+  zeal-qt5 = libsForQt5.callPackage ../data/documentation/zeal { };
+  zeal-qt6 = qt6Packages.callPackage ../data/documentation/zeal { };
+  zeal = zeal-qt5;
 
   zilla-slab = callPackage ../data/fonts/zilla-slab { };
 


### PR DESCRIPTION
Change of note: qt5 → qt6

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
