### PR TITLE
gpxsee: 11.6 -> 11.9

### DIFF
--- a/pkgs/applications/misc/gpxsee/default.nix
+++ b/pkgs/applications/misc/gpxsee/default.nix
@@ -1,16 +1,33 @@
-{ lib, stdenv, fetchFromGitHub, nix-update-script, substituteAll
-, qmake, qttools, qttranslations, qtlocation, qtpbfimageplugin, wrapQtAppsHook
+{ lib
+, stdenv
+, fetchFromGitHub
+, qmake
+, nix-update-script
+, substituteAll
+, qtbase
+, qttools
+, qttranslations
+, qtlocation ? null # qt5 only
+, qtpositioning ? null # qt6 only
+, qtpbfimageplugin
+, qtsvg
+, qt5compat ? null # qt6 only
+, wrapQtAppsHook
 }:
 
+let
+  isQt6 = lib.versions.major qtbase.version == "6";
+
+in
 stdenv.mkDerivation rec {
   pname = "gpxsee";
-  version = "11.6";
+  version = "11.9";
 
   src = fetchFromGitHub {
     owner = "tumic0";
     repo = "GPXSee";
     rev = version;
-    hash = "sha256-kwEltkLcMCZlUJyE+nyy70WboVO1FgMw0cH1hxLVtKQ=";
+    hash = "sha256-R/Kuk4nRJg3ozNNmzzNDnGcsmBmlk0g9d+F8JwLFz98=";
   };
 
   patches = (substituteAll {
@@ -19,7 +36,15 @@ stdenv.mkDerivation rec {
     inherit qttranslations;
   });
 
-  buildInputs = [ qtlocation qtpbfimageplugin ];
+  buildInputs = [ qtpbfimageplugin ]
+    ++ (if isQt6 then [
+    qtbase
+    qtpositioning
+    qtsvg
+    qt5compat
+  ] else [
+    qtlocation
+  ]);
 
   nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
 
@@ -49,5 +74,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ womfoo sikmir ];
     platforms = platforms.unix;
+    broken = isQt6 && stdenv.isDarwin;
   };
 }

--- a/pkgs/development/libraries/qt-6/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttools.nix
@@ -3,9 +3,16 @@
 , lib
 , qtbase
 , qtdeclarative
+, substituteAll
 }:
 
 qtModule {
   pname = "qttools";
   qtInputs = [ qtbase qtdeclarative ];
+  patches = [
+    ../patches/qttools-paths.patch
+  ];
+  NIX_CFLAGS_COMPILE = [
+    "-DNIX_OUTPUT_DEV=\"${placeholder "dev"}\""
+  ];
 }

--- a/pkgs/development/libraries/qt-6/patches/qttools-paths.patch
+++ b/pkgs/development/libraries/qt-6/patches/qttools-paths.patch
@@ -1,0 +1,27 @@
+diff --git a/src/linguist/shared/runqttool.cpp b/src/linguist/shared/runqttool.cpp
+index d355b9dc..94fef33f 100644
+--- a/src/linguist/shared/runqttool.cpp
++++ b/src/linguist/shared/runqttool.cpp
+@@ -20,9 +20,21 @@ class FMT {
+     Q_DECLARE_TR_FUNCTIONS(Linguist)
+ };
+
++static QString qtBasePath(QLibraryInfo::LibraryPath location)
++{
++  switch (location) {
++    case QLibraryInfo::BinariesPath:
++      return QLatin1String(NIX_OUTPUT_DEV) + QLatin1String("/bin");
++    case QLibraryInfo::LibraryExecutablesPath:
++      return QLatin1String(NIX_OUTPUT_DEV) + QLatin1String("/libexec");
++    default:
++      return QLibraryInfo::path(location);
++  }
++}
++
+ static QString qtToolFilePath(const QString &toolName, QLibraryInfo::LibraryPath location)
+ {
+-    QString filePath = QLibraryInfo::path(location) + QLatin1Char('/') + toolName;
++    QString filePath = qtBasePath(location) + QLatin1Char('/') + toolName;
+ #ifdef Q_OS_WIN
+     filePath.append(QLatin1String(".exe"));
+ #endif

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29143,7 +29143,11 @@ with pkgs;
 
   gpxlab = libsForQt5.callPackage ../applications/misc/gpxlab { };
 
-  gpxsee = libsForQt5.callPackage ../applications/misc/gpxsee { };
+  gpxsee-qt5 = libsForQt5.callPackage ../applications/misc/gpxsee { };
+
+  gpxsee-qt6 = qt6Packages.callPackage ../applications/misc/gpxsee { };
+
+  gpxsee = gpxsee-qt5;
 
   gspell = callPackage ../development/libraries/gspell { };
 

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -28,6 +28,8 @@ in
 
   inherit (kdeFrameworks) kcoreaddons;
 
+  qtpbfimageplugin = callPackage ../development/libraries/qtpbfimageplugin { };
+
   quazip = callPackage ../development/libraries/quazip { };
 
   qxlsx = callPackage ../development/libraries/qxlsx { };


### PR DESCRIPTION
###### Description of changes

- qtpbfimageplugin: build with qt6 too
- gpxsee: 11.6 -> 11.9
  
Also a fix for the location of `lrelease` and friends from qttools. Thanks @NickCao !!

Further to https://github.com/NixOS/nixpkgs/pull/201440

Closes #202293

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
