### PR TITLE
dotty: use preFixup instead of fixupPhase

### DIFF
--- a/pkgs/development/compilers/scala/bare.nix
+++ b/pkgs/development/compilers/scala/bare.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
     mv * $out
   '';
 
-  fixupPhase = ''
+  # Use preFixup instead of fixupPhase
+  # because we want the default fixupPhase as well
+  preFixup = ''
         bin_files=$(find $out/bin -type f ! -name common)
         for f in $bin_files ; do
           wrapProgram $f --set JAVA_HOME ${jre} --prefix PATH : '${ncurses.dev}/bin'


### PR DESCRIPTION
###### Description of changes

Scalac defers to a file called `.scalac-wrapped`, which contains a `#!/usr/bin/env` shebang. I believe this is because we override the `fixupPhase` and therefore lose the default fixupPhase

Honestly I don't know how to just run the default fixupPhase in addition to the custom bit. If there's a convenient "`defaultFixupPhase`" macro I can invoke pls lmk

Anyways, the long and short of this is that before this change, `scalac` couldn't be invoked in nix derivations, only in a users environment. This should change it so that it can be :)

```bash
cat /nix/store/2ibxpfnn9lyyxrabhk4qv4x8f5sa20g4-scala-bare-3.2.0/bin/.scalac-wrapped | head
#!/usr/bin/env bash

# Try to autodetect real location of the script
if [ -z "${PROG_HOME-}" ] ; then
  ## resolve links - $0 may be a link to PROG_HOME
  PRG="$0"
```

###### Things done

I have verified that the `scalac` produced by this script is able to compile a simple "hello world" program

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
