### PR TITLE
python310Packages.pyperf: 2.4.1 -> 2.5.0

### DIFF
--- a/pkgs/development/python-modules/pyperf/default.nix
+++ b/pkgs/development/python-modules/pyperf/default.nix
@@ -1,38 +1,41 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, six
-, statistics
+, fetchpatch
 , pythonOlder
-, nose
 , psutil
-, contextlib2
-, mock
-, unittest2
-, isPy27
-, python
+, unittestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pyperf";
-  version = "2.4.1";
+  version = "2.5.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-OM9ekMVvkGqDIM6CpQv6kskCuTr/1y5NyBWAEV81WFM=";
+    hash = "sha256-n9m+W1ciTmi1pbiPcSbxW2yGZ1c/YqCjn68U1v3ROQk=";
   };
 
-  checkInputs = [ nose psutil ] ++
-    lib.optionals isPy27 [ contextlib2 mock unittest2 ];
-  propagatedBuildInputs = [ six ] ++
-    lib.optionals (pythonOlder "3.4") [ statistics ];
+  patches = [
+    (fetchpatch {
+      name = "fix-pythonpath-in-tests.patch";
+      url = "https://github.com/psf/pyperf/commit/d373c5e56c0257d2d7abd705b676bea25cf66566.patch";
+      hash = "sha256-2q1fTf+uU3qj3BG8P5otX4f7mSTnQxm4sfmmgIUuszA=";
+    })
+  ];
 
-  # tests not included in pypi repository
-  doCheck = false;
+  propagatedBuildInputs = [
+    psutil
+  ];
 
-  checkPhase = ''
-    ${python.interpreter} -m nose
-  '';
+  checkInputs = [
+    unittestCheckHook
+  ];
+
+  unittestFlagsArray = [ "-s" "pyperf/tests/" "-v" ];
 
   meta = with lib; {
     description = "Python module to generate and modify perf";


### PR DESCRIPTION
###### Description of changes

https://github.com/psf/pyperf/releases/tag/2.5.0

This release formally adds support for Python 3.11. I also clean up Python 2 dependencies that are no longer needed.

Related to  https://github.com/NixOS/nixpkgs/pull/154264 and https://github.com/NixOS/nixpkgs/pull/154650.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
