### PR TITLE
peering-manager: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1133,6 +1133,7 @@
   ./services/web-apps/onlyoffice.nix
   ./services/web-apps/pict-rs.nix
   ./services/web-apps/peertube.nix
+  ./services/web-apps/peering-manager.nix
   ./services/web-apps/plantuml-server.nix
   ./services/web-apps/plausible.nix
   ./services/web-apps/pgpkeyserver-lite.nix

--- a/nixos/modules/services/web-apps/peering-manager.nix
+++ b/nixos/modules/services/web-apps/peering-manager.nix
@@ -1,0 +1,265 @@
+{ config, lib, pkgs, buildEnv, ... }:
+
+with lib;
+
+let
+  cfg = config.services.peering-manager;
+  configFile = pkgs.writeTextFile {
+    name = "configuration.py";
+    text = ''
+      ALLOWED_HOSTS = ['*']
+      DATABASE = {
+        'NAME': 'peering-manager',
+        'USER': 'peering-manager',
+        'HOST': '/run/postgresql',
+      }
+
+      # Redis database settings. Redis is used for caching and for queuing background tasks such as webhook events. A separate
+      # configuration exists for each. Full connection details are required in both sections, and it is strongly recommended
+      # to use two separate database IDs.
+      REDIS = {
+        'tasks': {
+          'UNIX_SOCKET_PATH': '${config.services.redis.servers.peering-manager.unixSocket}',
+          'DATABASE': 0,
+        },
+        'caching': {
+          'UNIX_SOCKET_PATH': '${config.services.redis.servers.peering-manager.unixSocket}',
+          'DATABASE': 1,
+        }
+      }
+
+      with open("${cfg.secretKeyFile}", "r") as file:
+        SECRET_KEY = file.readline()
+    '' + lib.optionalString (cfg.peeringdbApiKeyFile != null) ''
+      with open("${cfg.peeringdbApiKeyFile}", "r") as file:
+        PEERINGDB_API_KEY = file.readline()
+    '' + ''
+
+      ${cfg.extraConfig}
+    '';
+  };
+  pkg = (pkgs.peering-manager.overrideAttrs (old: {
+    postInstall = ''
+      ln -s ${configFile} $out/opt/peering-manager/peering_manager/configuration.py
+    '' + optionalString cfg.enableLdap ''
+      ln -s ${cfg.ldapConfigPath} $out/opt/peering-manager/peering_manager/ldap_config.py
+    '';
+  })).override {
+    inherit (cfg) plugins;
+  };
+  peeringManagerManageScript = with pkgs; (writeScriptBin "peering-manager-manage" ''
+    #!${stdenv.shell}
+    export PYTHONPATH=${pkg.pythonPath}
+    sudo -u peering-manager ${pkg}/bin/peering-manager "$@"
+  '');
+
+in {
+  options.services.peering-manager = {
+    enable = mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Enable Peering Manager.
+
+        This module requires a reverse proxy that serves `/static` separately.
+        See this [example](https://github.com/peering-manager-community/peering-manager/blob/develop/contrib/nginx.conf/) on how to configure this.
+      '';
+    };
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = "[::1]";
+      description = lib.mdDoc ''
+        Address the server will listen on.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8001;
+      description = lib.mdDoc ''
+        Port the server will listen on.
+      '';
+    };
+
+    plugins = mkOption {
+      type = types.functionTo (types.listOf types.package);
+      default = _: [];
+      defaultText = literalExpression ''
+        python3Packages: with python3Packages; [];
+      '';
+      description = lib.mdDoc ''
+        List of plugin packages to install.
+      '';
+    };
+
+    secretKeyFile = mkOption {
+      type = types.path;
+      description = lib.mdDoc ''
+        Path to a file containing the secret key.
+      '';
+    };
+
+    peeringdbApiKeyFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      description = lib.mdDoc ''
+        Path to a file containing the PeeringDB API key.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = lib.mdDoc ''
+        Additional lines of configuration appended to the `configuration.py`.
+        See the [documentation](https://peering-manager.readthedocs.io/en/stable/configuration/optional-settings/) for more possible options.
+      '';
+    };
+
+    enableLdap = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Enable LDAP-Authentication for Peering Manager.
+
+        This requires a configuration file being pass through `ldapConfigPath`.
+      '';
+    };
+
+    ldapConfigPath = mkOption {
+      type = types.path;
+      description = lib.mdDoc ''
+        Path to the Configuration-File for LDAP-Authentification, will be loaded as `ldap_config.py`.
+        See the [documentation](https://peering-manager.readthedocs.io/en/stable/setup/6-ldap/#configuration) for possible options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.peering-manager.plugins = mkIf cfg.enableLdap (ps: [ ps.django-auth-ldap ]);
+
+    system.build.peeringManagerPkg = pkg;
+
+    services.redis.servers.peering-manager.enable = true;
+
+    services.postgresql = {
+      enable = true;
+      ensureDatabases = [ "peering-manager" ];
+      ensureUsers = [
+        {
+          name = "peering-manager";
+          ensurePermissions = {
+            "DATABASE \"peering-manager\"" = "ALL PRIVILEGES";
+          };
+        }
+      ];
+    };
+
+    environment.systemPackages = [ peeringManagerManageScript ];
+
+    systemd.targets.peering-manager = {
+      description = "Target for all Peering Manager services";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" "redis-peering-manager.service" ];
+    };
+
+    systemd.services = let
+      defaultServiceConfig = {
+        WorkingDirectory = "/var/lib/peering-manager";
+        User = "peering-manager";
+        Group = "peering-manager";
+        StateDirectory = "peering-manager";
+        StateDirectoryMode = "0750";
+        Restart = "on-failure";
+      };
+    in {
+      peering-manager-migration = {
+        description = "Peering Manager migrations";
+        wantedBy = [ "peering-manager.target" ];
+
+        environment = {
+          PYTHONPATH = pkg.pythonPath;
+        };
+
+        serviceConfig = defaultServiceConfig // {
+          Type = "oneshot";
+          ExecStart = ''
+            ${pkg}/bin/peering-manager migrate
+          '';
+        };
+      };
+
+      peering-manager = {
+        description = "Peering Manager WSGI Service";
+        wantedBy = [ "peering-manager.target" ];
+        after = [ "peering-manager-migration.service" ];
+
+        preStart = ''
+          ${pkg}/bin/peering-manager remove_stale_contenttypes --no-input
+        '';
+
+        environment = {
+          PYTHONPATH = pkg.pythonPath;
+        };
+
+        serviceConfig = defaultServiceConfig // {
+          ExecStart = ''
+            ${pkg.python.pkgs.gunicorn}/bin/gunicorn peering_manager.wsgi \
+              --bind ${cfg.listenAddress}:${toString cfg.port} \
+              --pythonpath ${pkg}/opt/peering-manager
+          '';
+        };
+      };
+
+      peering-manager-rq = {
+        description = "Peering Manager Request Queue Worker";
+        wantedBy = [ "peering-manager.target" ];
+        after = [ "peering-manager.service" ];
+
+        environment = {
+          PYTHONPATH = pkg.pythonPath;
+        };
+
+        serviceConfig = defaultServiceConfig // {
+          ExecStart = ''
+            ${pkg}/bin/peering-manager rqworker high default low
+          '';
+        };
+      };
+
+      peering-manager-housekeeping = {
+        description = "Peering Manager housekeeping job";
+        after = [ "peering-manager.service" ];
+
+        environment = {
+          PYTHONPATH = pkg.pythonPath;
+        };
+
+        serviceConfig = defaultServiceConfig // {
+          Type = "oneshot";
+          ExecStart = ''
+            ${pkg}/bin/peering-manager housekeeping
+          '';
+        };
+      };
+    };
+
+    systemd.timers.peering-manager-housekeeping = {
+      description = "Run Peering Manager housekeeping job";
+      wantedBy = [ "timers.target" ];
+
+      timerConfig = {
+        OnCalendar = "daily";
+      };
+    };
+
+    users.users.peering-manager = {
+      home = "/var/lib/peering-manager";
+      isSystemUser = true;
+      group = "peering-manager";
+    };
+    users.groups.peering-manager = {};
+    users.groups."${config.services.redis.servers.peering-manager.user}".members = [ "peering-manager" ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -488,6 +488,7 @@ in {
   parsedmarc = handleTest ./parsedmarc {};
   pdns-recursor = handleTest ./pdns-recursor.nix {};
   peerflix = handleTest ./peerflix.nix {};
+  peering-manager = handleTest ./web-apps/peering-manager.nix {};
   peertube = handleTestOn ["x86_64-linux"] ./web-apps/peertube.nix {};
   pgadmin4 = handleTest ./pgadmin4.nix {};
   pgadmin4-standalone = handleTest ./pgadmin4-standalone.nix {};

--- a/nixos/tests/web-apps/peering-manager.nix
+++ b/nixos/tests/web-apps/peering-manager.nix
@@ -1,0 +1,40 @@
+import ../make-test-python.nix ({ lib, pkgs, ... }: {
+  name = "peering-manager";
+
+  meta = with lib.maintainers; {
+    maintainers = [ yuka ];
+  };
+
+  nodes.machine = { ... }: {
+    services.peering-manager = {
+      enable = true;
+      secretKeyFile = pkgs.writeText "secret" ''
+        abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+      '';
+    };
+  };
+
+  testScript = { nodes }: ''
+    machine.start()
+    machine.wait_for_unit("peering-manager.target")
+    machine.wait_until_succeeds("journalctl --since -1m --unit peering-manager --grep Listening")
+
+    print(machine.succeed(
+        "curl -sSfL http://[::1]:8001"
+    ))
+    with subtest("Home screen loads"):
+        machine.succeed(
+            "curl -sSfL http://[::1]:8001 | grep '<title>Home - Peering Manager</title>'"
+        )
+    with subtest("checks succeed"):
+        machine.succeed(
+            "systemctl stop peering-manager peering-manager-rq"
+        )
+        machine.succeed(
+            "sudo -u postgres psql -c 'ALTER USER \"peering-manager\" WITH SUPERUSER;'"
+        )
+        machine.succeed(
+            "cd ${nodes.machine.config.system.build.peeringManagerPkg}/opt/peering-manager ; peering-manager-manage test --no-input"
+        )
+  '';
+})

--- a/pkgs/servers/web-apps/peering-manager/default.nix
+++ b/pkgs/servers/web-apps/peering-manager/default.nix
@@ -1,0 +1,100 @@
+{ python3
+, fetchFromGitHub
+, fetchpatch
+, nixosTests
+
+, plugins ? ps: []
+}:
+
+let
+  py = python3.override {
+    packageOverrides = final: prev: {
+      django = final.django_4;
+      drf-nested-routers = prev.drf-nested-routers.overridePythonAttrs (oldAttrs: {
+        patches = [
+          # all for django 4 compat
+          (fetchpatch {
+            url = "https://github.com/alanjds/drf-nested-routers/commit/59764cc356f7f593422b26845a9dfac0ad196120.diff";
+            hash = "sha256-mq3vLHzQlGl2EReJ5mVVQMMcYgGIVt/T+qi1STtQ0aI=";
+          })
+          (fetchpatch {
+            url = "https://github.com/alanjds/drf-nested-routers/commit/723a5729dd2ffcb66fe315f229789ca454986fa4.diff";
+            hash = "sha256-UCbBjwlidqsJ9vEEWlGzfqqMOr0xuB2TAaUxHsLzFfU=";
+          })
+          (fetchpatch {
+            url = "https://github.com/alanjds/drf-nested-routers/commit/38e49eb73759bc7dcaaa9166169590f5315e1278.diff";
+            hash = "sha256-IW4BLhHHhXDUZqHaXg46qWoQ89pMXv0ZxKjOCTnDcI0=";
+          })
+        ];
+      });
+    };
+  };
+
+in py.pkgs.buildPythonApplication rec {
+  pname = "peering-manager";
+  version = "1.7.3";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-vrRMdqEpsps4ZKgunMhznJr/TQ9+WVMNYFu76ZU7iMI=";
+  };
+
+  patches = [
+    ./redis-unix-sock.patch
+  ];
+
+  format = "other";
+
+  propagatedBuildInputs = with py.pkgs; [
+    django
+    djangorestframework
+    django-cacheops
+    django-debug-toolbar
+    django-filter
+    django-postgresql-netfields
+    django-prometheus
+    django-rq
+    django-tables2
+    django-taggit
+    drf-spectacular
+    jinja2
+    markdown
+    napalm
+    packaging
+    psycopg2
+    pynetbox
+    pyyaml
+    requests
+    tzdata
+  ] ++ plugins py.pkgs;
+
+  buildPhase = ''
+    runHook preBuild
+    cp peering_manager/configuration{.example,}.py
+    python3 manage.py collectstatic --no-input
+    rm -f peering_manager/configuration.py
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/opt/peering-manager
+    cp -r . $out/opt/peering-manager
+    chmod +x $out/opt/peering-manager/manage.py
+    makeWrapper $out/opt/peering-manager/manage.py $out/bin/peering-manager \
+      --prefix PYTHONPATH : "$PYTHONPATH"
+    runHook postInstall
+  '';
+
+  passthru = {
+    # PYTHONPATH of all dependencies used by the package
+    python = py;
+    pythonPath = py.pkgs.makePythonPath propagatedBuildInputs;
+
+    tests = {
+      inherit (nixosTests) peering-manager;
+    };
+  };
+}

--- a/pkgs/servers/web-apps/peering-manager/redis-unix-sock.patch
+++ b/pkgs/servers/web-apps/peering-manager/redis-unix-sock.patch
@@ -1,0 +1,47 @@
+commit 1e64a7f6ca456249305f6a3c90f9acf84af194db
+Author: Yureka <yuka@yuka.dev>
+Date:   Tue Nov 29 14:03:08 2022 +0100
+
+    support unix sockets for redis connections
+
+diff --git a/peering_manager/settings.py b/peering_manager/settings.py
+index 739d6ff..b5edf4d 100644
+--- a/peering_manager/settings.py
++++ b/peering_manager/settings.py
+@@ -270,6 +270,7 @@ TASKS_REDIS_PASSWORD = TASKS_REDIS.get("PASSWORD", "")
+ TASKS_REDIS_DATABASE = TASKS_REDIS.get("DATABASE", 0)
+ TASKS_REDIS_DEFAULT_TIMEOUT = TASKS_REDIS.get("DEFAULT_TIMEOUT", 300)
+ TASKS_REDIS_SSL = TASKS_REDIS.get("SSL", False)
++TASKS_REDIS_UNIX_SOCKET_PATH = TASKS_REDIS.get("UNIX_SOCKET_PATH", "")
+ if "DEFAULT_TIMEOUT" in TASKS_REDIS:
+     warnings.warn(
+         "DEFAULT_TIMEOUT is no longer supported under REDIS configuration. Set RQ_DEFAULT_TIMEOUT instead."
+@@ -294,6 +295,7 @@ CACHING_REDIS_PASSWORD = CACHING_REDIS.get("PASSWORD", "")
+ CACHING_REDIS_DATABASE = CACHING_REDIS.get("DATABASE", 0)
+ CACHING_REDIS_DEFAULT_TIMEOUT = CACHING_REDIS.get("DEFAULT_TIMEOUT", 300)
+ CACHING_REDIS_SSL = CACHING_REDIS.get("SSL", False)
++CACHING_REDIS_UNIX_SOCKET_PATH = CACHING_REDIS.get("UNIX_SOCKET_PATH", "")
+ 
+ if CACHING_REDIS_USING_SENTINEL:
+     CACHEOPS_SENTINEL = {
+@@ -301,6 +303,8 @@ if CACHING_REDIS_USING_SENTINEL:
+         "service_name": CACHING_REDIS_SENTINEL_SERVICE,
+         "db": CACHING_REDIS_DATABASE,
+     }
++elif CACHING_REDIS_UNIX_SOCKET_PATH != "":
++    CACHEOPS_REDIS = f"unix://{CACHING_REDIS_UNIX_SOCKET_PATH}?db={CACHING_REDIS_DATABASE}"
+ else:
+     REDIS_CACHE_CON_STRING = "rediss://" if CACHING_REDIS_SSL else "redis://"
+     if CACHING_REDIS_PASSWORD:
+@@ -334,6 +338,11 @@ if TASKS_REDIS_USING_SENTINEL:
+         "SOCKET_TIMEOUT": None,
+         "CONNECTION_KWARGS": {"socket_connect_timeout": TASKS_REDIS_DEFAULT_TIMEOUT},
+     }
++elif TASKS_REDIS_UNIX_SOCKET_PATH != "":
++    RQ_PARAMS = {
++        "UNIX_SOCKET_PATH": TASKS_REDIS_UNIX_SOCKET_PATH,
++        "DB": TASKS_REDIS_DATABASE,
++    }
+ else:
+     RQ_PARAMS = {
+         "HOST": TASKS_REDIS_HOST,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23775,6 +23775,8 @@ with pkgs;
 
   hyp = callPackage ../servers/http/hyp { };
 
+  peering-manager = callPackage ../servers/web-apps/peering-manager { };
+
   podgrab = callPackage ../servers/misc/podgrab { };
 
   portunus = callPackage ../servers/portunus { };


### PR DESCRIPTION
###### Description of changes



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### TODO

- [x] Fix readthedocs links
- [x] Use unix socket for redis and postgres
- [x] Test/fix ldap
- [x] Fix collectstatic when secret is not in the nix store