### PR TITLE
python310Packages.h5py: remove unittest2 and six

### DIFF
--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -1,6 +1,17 @@
-{ lib, fetchPypi, isPy27, buildPythonPackage, pythonOlder
-, numpy, hdf5, cython, six, pkgconfig, unittest2
-, mpi4py ? null, openssh, pytestCheckHook, cached-property }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, setuptools
+, numpy
+, hdf5
+, cython
+, pkgconfig
+, mpi4py ? null
+, openssh
+, pytestCheckHook
+, cached-property
+}:
 
 assert hdf5.mpiSupport -> mpi4py != null && hdf5.mpi == mpi4py.mpi;
 
@@ -10,7 +21,9 @@ let
 in buildPythonPackage rec {
   version = "3.7.0";
   pname = "h5py";
-  disabled = isPy27;
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -35,15 +48,22 @@ in buildPythonPackage rec {
 
   preBuild = if mpiSupport then "export CC=${mpi}/bin/mpicc" else "";
 
-  # tests now require pytest-mpi, which isn't available and difficult to package
-  doCheck = false;
-  checkInputs = lib.optional isPy27 unittest2 ++ [ pytestCheckHook openssh ];
-  nativeBuildInputs = [ pkgconfig cython ];
+  nativeBuildInputs = [
+    cython
+    pkgconfig
+    setuptools
+  ];
+
   buildInputs = [ hdf5 ]
     ++ lib.optional mpiSupport mpi;
-  propagatedBuildInputs = [ numpy six]
+
+  propagatedBuildInputs = [ numpy ]
     ++ lib.optionals mpiSupport [ mpi4py openssh ]
     ++ lib.optionals (pythonOlder "3.8") [ cached-property ];
+
+  # tests now require pytest-mpi, which isn't available and difficult to package
+  doCheck = false;
+  checkInputs = [ pytestCheckHook openssh ];
 
   pythonImportsCheck = [ "h5py" ];
 


### PR DESCRIPTION
###### Description of changes

Related to https://github.com/NixOS/nixpkgs/pull/154264 and https://github.com/NixOS/nixpkgs/pull/154650.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
