### PR TITLE
dockerTools: prefer local builds

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -547,10 +547,14 @@ rec {
           pure = writeText "${baseName}-config.json" (builtins.toJSON {
             inherit created config;
             architecture = defaultArch;
+            preferLocalBuild = true;
             os = "linux";
           });
           impure = runCommand "${baseName}-config.json"
-            { nativeBuildInputs = [ jq ]; }
+            {
+              nativeBuildInputs = [ jq ];
+              preferLocalBuild = true;
+            }
             ''
               jq ".created = \"$(TZ=utc date --iso-8601="seconds")\"" ${pure} > $out
             '';
@@ -925,6 +929,7 @@ rec {
           {
             inherit fromImage maxLayers created;
             imageName = lib.toLower name;
+            preferLocalBuild = true;
             passthru.imageTag =
               if tag != null
               then tag
@@ -1015,6 +1020,7 @@ rec {
         result = runCommand "stream-${baseName}"
           {
             inherit (conf) imageName;
+            preferLocalBuild = true;
             passthru = passthru // {
               inherit (conf) imageTag;
 

--- a/pkgs/build-support/references-by-popularity/default.nix
+++ b/pkgs/build-support/references-by-popularity/default.nix
@@ -5,6 +5,7 @@ path: runCommand "closure-paths"
 {
   exportReferencesGraph.graph = path;
   __structuredAttrs = true;
+  preferLocalBuild = true;
   PATH = "${coreutils}/bin:${python3}/bin";
   builder = builtins.toFile "builder"
     ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the `preferLocalBuild = true;` attribute to 4 derivations in `pkgs/build-support/docker/default.nix` and 1 in `pkgs/build-support/references-by-popularity/default.nix`.

All these derivations are quick to finish but take as inputs all the runtime closure of the container image we're building.

Setting `preferLocalBuild = true;` prevents dependencies being copied between remote builders, which is in the majority of cases much more expensive than building the slim derivations locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
