### PR TITLE
nixos/mastodon: Automatic db backup service

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -721,6 +721,6 @@ in {
     users.groups.${cfg.group}.members = lib.optional cfg.configureNginx config.services.nginx.user;
   };
 
-  meta.maintainers = with lib.maintainers; [ happy-river erictapen ];
+  meta.maintainers = with lib.maintainers; [ happy-river erictapen turion ];
 
 }

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -339,6 +339,29 @@ in {
             {option}`database.user`.
           '';
         };
+
+        automaticBackup = {
+          enable = lib.mkEnableOption (lib.mdDoc "Regularly backup the database.");
+
+          location = lib.mkOption {
+            type = lib.types.path;
+            default = "/var/lib/mastodon/backups";
+            description = lib.mdDoc ''
+              The directory in which to save the backups.
+            '';
+          };
+
+          startAt = lib.mkOption {
+            type = lib.types.str;
+            default = "daily";
+            example = "hourly";
+            description = lib.mdDoc ''
+              How often to create a backup.
+
+              The format is described in {manpage}`systemd.time(7)`.
+            '';
+          };
+        };
       };
 
       smtp = {
@@ -632,6 +655,10 @@ in {
         ${cfg.package}/bin/tootctl preview_cards remove --days=${olderThanDays}
       '';
       startAt = cfg.mediaAutoRemove.startAt;
+    };
+
+    services.postgresqlBackup = lib.mkIf cfg.database.automaticBackup.enable {
+      inherit (cfg.database.automaticBackup) startAt location;
     };
 
     services.nginx = lib.mkIf cfg.configureNginx {

--- a/nixos/tests/web-apps/mastodon.nix
+++ b/nixos/tests/web-apps/mastodon.nix
@@ -124,6 +124,9 @@ in
     server.succeed("su - mastodon -s /bin/sh -c 'mastodon-env tootctl ip_blocks remove 192.168.0.0/16'")
     client.succeed("curl --fail https://mastodon.local/about")
 
+    # Ensure backups work
+    server.wait_until_succeeds("[ '$(ls -A /var/lib/mastodon/backups)' ]")
+
     server.shutdown()
     client.shutdown()
   '';


### PR DESCRIPTION
###### Description of changes
 
Because of the recent 4.0 update, I looked into automatically creating db backups and wanted to share my solution. I took the `pg_dump` command from the 4.0 changelog. I didn't look into how the postgresql service supplies its own backup settings. Would that be a better path?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

CC @erictapen @Izorkin @happy-river 