### PR TITLE
nixos/alps: fixes for service hardening and Hydra failure

### DIFF
--- a/nixos/modules/services/web-apps/alps.nix
+++ b/nixos/modules/services/web-apps/alps.nix
@@ -98,11 +98,11 @@ in {
 
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/alps ${escapeShellArgs cfg.args}";
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
         DynamicUser = true;
-        ## This is desirable but would restrict bindIP to 127.0.0.1
-        #IPAddressAllow = "localhost";
-        #IPAddressDeny = "any";
         LockPersonality = true;
+        MemoryDenyWriteExecute = true;
         NoNewPrivileges = true;
         PrivateDevices = true;
         PrivateIPC = true;
@@ -122,8 +122,10 @@ in {
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
+        SocketBindAllow = cfg.port;
+        SocketBindDeny = "any";
         SystemCallArchitectures = "native";
-        SystemCallFilter = [ "@system-service @resources" "~@privileged @obsolete" ];
+        SystemCallFilter = [ "@system-service" "~@privileged @obsolete" ];
       };
     };
   };

--- a/nixos/tests/alps.nix
+++ b/nixos/tests/alps.nix
@@ -90,7 +90,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     };
   };
 
-  testScript = ''
+  testScript = { nodes, ... }: ''
     server.start()
     server.wait_for_unit("postfix.service")
     server.wait_for_unit("dovecot2.service")
@@ -99,6 +99,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     client.start()
     client.wait_for_unit("alps.service")
+    client.wait_for_open_port(${toString nodes.client.config.services.alps.port})
     client.succeed("test-alps-login")
   '';
 })


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: https://github.com/NixOS/nixpkgs/issues/199919

Follow up on: https://github.com/NixOS/nixpkgs/pull/201521

I think this is as good as it can get. A score of 1.2 is almost unbeatable.

<details>

<summary><strong><code>systemd-analyze security alps.service</code></strong></summary>

```
  NAME                                                        DESCRIPTION                                                                                         EXPOSURE
✓ SystemCallFilter=~@swap                                     System call allow list defined for service, and @swap is not included                               
✗ SystemCallFilter=~@resources                                System call allow list defined for service, and @resources is included (e.g. ioprio_set is allowed)      0.2
✓ SystemCallFilter=~@reboot                                   System call allow list defined for service, and @reboot is not included                             
✓ SystemCallFilter=~@raw-io                                   System call allow list defined for service, and @raw-io is not included                             
✓ SystemCallFilter=~@privileged                               System call allow list defined for service, and @privileged is not included                         
✓ SystemCallFilter=~@obsolete                                 System call allow list defined for service, and @obsolete is not included                           
✓ SystemCallFilter=~@mount                                    System call allow list defined for service, and @mount is not included                              
✓ SystemCallFilter=~@module                                   System call allow list defined for service, and @module is not included                             
✓ SystemCallFilter=~@debug                                    System call allow list defined for service, and @debug is not included                              
✓ SystemCallFilter=~@cpu-emulation                            System call allow list defined for service, and @cpu-emulation is not included                      
✓ SystemCallFilter=~@clock                                    System call allow list defined for service, and @clock is not included                              
✓ RemoveIPC=                                                  Service user cannot leave SysV IPC objects around                                                   
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                                            0.1
✓ User=/DynamicUser=                                          Service runs under a transient non-root user identity                                               
✓ RestrictRealtime=                                           Service realtime scheduling access is restricted                                                    
✓ CapabilityBoundingSet=~CAP_SYS_TIME                         Service processes cannot change the system clock                                                    
✓ NoNewPrivileges=                                            Service processes cannot acquire new privileges                                                     
✓ AmbientCapabilities=                                        Service process does not receive ambient capabilities                                               
✓ SystemCallArchitectures=                                    Service may execute system calls only with native ABI                                               
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                                                    0.3
✓ ProtectSystem=                                              Service has strict read-only access to the OS file hierarchy                                        
✓ ProtectProc=                                                Service has restricted access to process tree (/proc hidepid=)                                      
✓ SupplementaryGroups=                                        Service has no supplementary groups                                                                 
✓ CapabilityBoundingSet=~CAP_SYS_RAWIO                        Service has no raw I/O access                                                                       
✓ CapabilityBoundingSet=~CAP_SYS_PTRACE                       Service has no ptrace() debugging abilities                                                         
✓ CapabilityBoundingSet=~CAP_SYS_(NICE|RESOURCE)              Service has no privileges to change resource use parameters                                         
✓ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has no network configuration privileges                                                     
✓ CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW) Service has no elevated networking privileges                                                       
✓ CapabilityBoundingSet=~CAP_AUDIT_*                          Service has no audit subsystem access                                                               
✓ CapabilityBoundingSet=~CAP_SYS_ADMIN                        Service has no administrator privileges                                                             
✓ PrivateTmp=                                                 Service has no access to other software's temporary files                                           
✓ CapabilityBoundingSet=~CAP_SYSLOG                           Service has no access to kernel logging                                                             
✓ ProtectHome=                                                Service has no access to home directories                                                           
✓ PrivateDevices=                                             Service has no access to hardware devices                                                           
✗ ProcSubset=                                                 Service has full access to non-process /proc files (/proc subset=)                                       0.1
✗ PrivateNetwork=                                             Service has access to the host's network                                                                 0.5
✗ DeviceAllow=                                                Service has a device ACL with some special devices: char-rtc:r                                           0.1
✓ KeyringMode=                                                Service doesn't share key material with other services                                              
✓ Delegate=                                                   Service does not maintain its own delegated control group subtree                                   
✓ PrivateUsers=                                               Service does not have access to other users                                                         
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                                         0.2
✓ NotifyAccess=                                               Service child processes cannot alter service state                                                  
✓ ProtectClock=                                               Service cannot write to the hardware clock or system clock                                          
✓ CapabilityBoundingSet=~CAP_SYS_PACCT                        Service cannot use acct()                                                                           
✓ CapabilityBoundingSet=~CAP_KILL                             Service cannot send UNIX signals to arbitrary processes                                             
✓ ProtectKernelLogs=                                          Service cannot read from or write to the kernel log ring buffer                                     
✓ CapabilityBoundingSet=~CAP_WAKE_ALARM                       Service cannot program timers that wake up the system                                               
✓ CapabilityBoundingSet=~CAP_(DAC_*|FOWNER|IPC_OWNER)         Service cannot override UNIX file/IPC permission checks                                             
✓ ProtectControlGroups=                                       Service cannot modify the control group file system                                                 
✓ CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE                  Service cannot mark files immutable                                                                 
✓ CapabilityBoundingSet=~CAP_IPC_LOCK                         Service cannot lock memory into RAM                                                                 
✓ ProtectKernelModules=                                       Service cannot load or read kernel modules                                                          
✓ CapabilityBoundingSet=~CAP_SYS_MODULE                       Service cannot load kernel modules                                                                  
✓ CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG                   Service cannot issue vhangup()                                                                      
✓ CapabilityBoundingSet=~CAP_SYS_BOOT                         Service cannot issue reboot()                                                                       
✓ CapabilityBoundingSet=~CAP_SYS_CHROOT                       Service cannot issue chroot()                                                                       
✓ PrivateMounts=                                              Service cannot install system mounts                                                                
✓ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND                    Service cannot establish wake locks                                                                 
✓ MemoryDenyWriteExecute=                                     Service cannot create writable executable memory mappings                                           
✓ RestrictNamespaces=~user                                    Service cannot create user namespaces                                                               
✓ RestrictNamespaces=~pid                                     Service cannot create process namespaces                                                            
✓ RestrictNamespaces=~net                                     Service cannot create network namespaces                                                            
✓ RestrictNamespaces=~uts                                     Service cannot create hostname namespaces                                                           
✓ RestrictNamespaces=~mnt                                     Service cannot create file system namespaces                                                        
✓ CapabilityBoundingSet=~CAP_LEASE                            Service cannot create file leases                                                                   
✓ CapabilityBoundingSet=~CAP_MKNOD                            Service cannot create device nodes                                                                  
✓ RestrictNamespaces=~cgroup                                  Service cannot create cgroup namespaces                                                             
✓ RestrictNamespaces=~ipc                                     Service cannot create IPC namespaces                                                                
✓ ProtectHostname=                                            Service cannot change system host/domainname                                                        
✓ CapabilityBoundingSet=~CAP_(CHOWN|FSETID|SETFCAP)           Service cannot change file ownership/access mode/capabilities                                       
✓ CapabilityBoundingSet=~CAP_SET(UID|GID|PCAP)                Service cannot change UID/GID identities/capabilities                                               
✓ LockPersonality=                                            Service cannot change ABI personality                                                               
✓ ProtectKernelTunables=                                      Service cannot alter kernel tunables (/proc/sys, …)                                                 
✓ RestrictAddressFamilies=~AF_PACKET                          Service cannot allocate packet sockets                                                              
✓ RestrictAddressFamilies=~AF_NETLINK                         Service cannot allocate netlink sockets                                                             
✓ RestrictAddressFamilies=~AF_UNIX                            Service cannot allocate local sockets                                                               
✓ RestrictAddressFamilies=~…                                  Service cannot allocate exotic sockets                                                              
✓ CapabilityBoundingSet=~CAP_MAC_*                            Service cannot adjust SMACK MAC                                                                     
✓ RestrictSUIDSGID=                                           SUID/SGID file creation by service is restricted                                                    
✗ UMask=                                                      Files created by service are world-readable by default                                                   0.1

→ Overall exposure level for alps.service: 1.2 OK :-)
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
