### PR TITLE
vulkan-caps-viewer: 3.25 -> 3.27

### DIFF
--- a/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
+++ b/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
@@ -10,16 +10,16 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-caps-viewer";
-  version = "3.25";
+  version = "3.27";
 
   src = fetchFromGitHub {
     owner = "SaschaWillems";
     repo = "VulkanCapsViewer";
-    rev = if version == "3.25" then "${version}_fixed" else version;
-    hash = "sha256-JQMnR9WNR8OtcgVfE5iZebdvZ/JmZNDchET5cK/Bruc=";
+    rev = version;
+    hash = "sha256-B/FBX63JnBdshNLVMPA0qGnm0c/RGilIahX3VjJnpkI=";
     # Note: this derivation strictly requires vulkan-header to be the same it was developed against.
-    # To help they put in a git-submodule.
-    # It works with older vulkan-loaders.
+    # To help us, they've put it in a git-submodule.
+    # The result will work with any vulkan-loader version.
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Description of changes

Release: https://github.com/SaschaWillems/VulkanCapsViewer/releases/tag/3.27
Changes: https://github.com/SaschaWillems/VulkanCapsViewer/compare/3.25...3.27

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
