### PR TITLE
libsForQt515.solid: patch binary search paths

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -128,7 +128,7 @@ let
       oxygen-icons5 = callPackage ./oxygen-icons5.nix {};
       prison = callPackage ./prison.nix {};
       qqc2-desktop-style = callPackage ./qqc2-desktop-style.nix {};
-      solid = callPackage ./solid.nix {};
+      solid = callPackage ./solid {};
       sonnet = callPackage ./sonnet.nix {};
       syntax-highlighting = callPackage ./syntax-highlighting.nix {};
       threadweaver = callPackage ./threadweaver.nix {};

--- a/pkgs/development/libraries/kde-frameworks/solid/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/solid/default.nix
@@ -6,6 +6,7 @@
 
 mkDerivation {
   pname = "solid";
+  patches = [ ./fix-search-path.patch ];
   nativeBuildInputs = [ bison extra-cmake-modules flex media-player-info ];
   buildInputs = [ qtdeclarative qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/solid/fix-search-path.patch
+++ b/pkgs/development/libraries/kde-frameworks/solid/fix-search-path.patch
@@ -1,0 +1,17 @@
+diff --git a/src/solid/devices/backends/fstab/fstabhandling.cpp b/src/solid/devices/backends/fstab/fstabhandling.cpp
+index ac2a628..7ee46cc 100644
+--- a/src/solid/devices/backends/fstab/fstabhandling.cpp
++++ b/src/solid/devices/backends/fstab/fstabhandling.cpp
+@@ -275,7 +275,11 @@ bool Solid::Backends::Fstab::FstabHandling::callSystemCommand(const QString &com
+                                                               const QObject *receiver,
+                                                               std::function<void(QProcess *)> callback)
+ {
+-    static const QStringList searchPaths{QStringLiteral("/sbin"), QStringLiteral("/bin"), QStringLiteral("/usr/sbin"), QStringLiteral("/usr/bin")};
++    static const QStringList searchPaths{QStringLiteral("/run/wrappers/bin"),
++                                         QStringLiteral("/sbin"),
++                                         QStringLiteral("/bin"),
++                                         QStringLiteral("/usr/sbin"),
++                                         QStringLiteral("/usr/bin")};
+     static const QString joinedPaths = searchPaths.join(QLatin1Char(':'));
+     const QString exec = QStandardPaths::findExecutable(commandName, searchPaths);
+     if (exec.isEmpty()) {


### PR DESCRIPTION
###### Description of changes

This adds `/run/wrappers/bin` to a hardcoded list of search paths. This is neccessary to mount filesystems configured in /etc/fstab in dolphin (for example network shares that are not always mounted).

Fixes #188098.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`): Tested mounting a network share in dolphin
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
