### PR TITLE
mononoki: 1.3 -> 1.5

### DIFF
--- a/pkgs/data/fonts/mononoki/default.nix
+++ b/pkgs/data/fonts/mononoki/default.nix
@@ -1,22 +1,22 @@
 { lib, fetchzip }:
 
-let
-  version = "1.3";
-in fetchzip {
-  name = "mononoki-${version}";
-
-  url = "https://github.com/madmalik/mononoki/releases/download/${version}/mononoki.zip";
+fetchzip {
+  pname = "mononoki";
+  version = "1.5";
+  url = "https://github.com/madmalik/mononoki/releases/download/1.5/mononoki.zip";
+  sha256 = "IM+D1AONLuOFy1wq114IsXKehJIliOgALKbRbIj/cX8=";
+  stripRoot = false;
 
   postFetch = ''
-    mkdir -p $out/share/fonts/mononoki
-    unzip -j $downloadedFile -d $out/share/fonts/mononoki
+    mkdir -pv $out/share/fonts/{opentype,truetype}
+    cp -v $out/*.otf $out/share/fonts/opentype
+    cp -v $out/*.ttf $out/share/fonts/truetype
   '';
 
-  sha256 = "sha256-K2uOpJRmQ1NcDZfh6rorCF0MvGHFCsSW8J7Ue9OC/OY=";
-
   meta = with lib; {
-    homepage = "https://github.com/madmalik/mononoki";
     description = "A font for programming and code review";
+    homepage = "https://madmalik.github.io/mononoki/";
+    maintainers = with maintainers; [ totoroot ];
     license = licenses.ofl;
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Description of changes

Update mononoki font from version 1.3 to 1.5

[Changes made with 1.4](https://github.com/madmalik/mononoki/tree/1.4)
[Changes made with 1.5](https://github.com/madmalik/mononoki/tree/1.5)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->