### PR TITLE
retroarch: 1.12.0 -> 1.13.0; libretro: unstable-2022-10-18 -> unstable-2022-11-21

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -6,7 +6,6 @@
 , cmake
 , curl
 , fetchFromGitHub
-, fetchpatch
 , ffmpeg
 , fluidsynth
 , gettext
@@ -50,7 +49,7 @@ let
   mkLibretroCore =
     { core
     , src ? (getCoreSrc core)
-    , version ? "unstable-2022-10-18"
+    , version ? "unstable-2022-11-21"
     , ...
     }@args:
     import ./mkLibretroCore.nix ({
@@ -796,11 +795,6 @@ in
   puae = mkLibretroCore {
     core = "puae";
     makefile = "Makefile";
-    # https://github.com/libretro/libretro-uae/pull/529
-    patches = fetchpatch {
-      url = "https://github.com/libretro/libretro-uae/commit/90ba4c9bb940e566781c3590553270ad69cf212e.patch";
-      sha256 = "sha256-9xkRravvyFZc0xsIj0OSm2ux5BqYogfQ1TDnH9l6jKw=";
-    };
     meta = {
       description = "Amiga emulator based on WinUAE";
       license = lib.licenses.gpl2Only;

--- a/pkgs/applications/emulators/retroarch/default.nix
+++ b/pkgs/applications/emulators/retroarch/default.nix
@@ -45,12 +45,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "retroarch-bare";
-  version = "1.12.0";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "RetroArch";
-    hash = "sha256-doLWNA8aTAllxx3zABtvZaegBQEPIi8276zbytPSdBU=";
+    hash = "sha256-eEe0mM9gUWgEzoRH1Iuet20US9eXNtCVSBi2kX1njVw=";
     rev = "v${version}";
   };
 

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -38,8 +38,8 @@
     "beetle-psx": {
         "owner": "libretro",
         "repo": "beetle-psx-libretro",
-        "rev": "bd6b9ef3049fe3f70a18ee6f752a935ae83c2f2b",
-        "sha256": "CXcLMOF6IXUrp14nyTQ5KK2LR+FyWcF0UcvHTxEVSo0="
+        "rev": "798fab9d5bc82dde26442d9b4861d377d4689e31",
+        "sha256": "wHCUSMdPbIudmNm4XXW/zH6TDz7x9DrMNV/L8H3aO/w="
     },
     "beetle-saturn": {
         "owner": "libretro",
@@ -129,8 +129,8 @@
     "dolphin": {
         "owner": "libretro",
         "repo": "dolphin",
-        "rev": "9810e29a1f3633d32b6643b97a1147d83311d73a",
-        "sha256": "iIaVSJSC3mD1k751vQvWI6x0C/HhfjEaMwfX53FpZv4="
+        "rev": "a8188dbc4e63d6c0867ed2196f5125130955f012",
+        "sha256": "gf9OjeDazDPDnQ9S2+hV4CNxPAkCCaEhJDZF97a1//U="
     },
     "dosbox": {
         "owner": "libretro",
@@ -141,8 +141,8 @@
     "eightyone": {
         "owner": "libretro",
         "repo": "81-libretro",
-        "rev": "73f6cca62dabc84df946aea71cf457ce5ae5ea9d",
-        "sha256": "oovIKMZXxtLc+zmbguagTVoMPngokdN3xTBnb/+KUjY="
+        "rev": "340a51b250fb8fbf1a9e5d3ad3924044250064e0",
+        "sha256": "Cz3gPwbME8lDMKju3dn8hM8O2u9h9+8EUg7Nf6a7epA="
     },
     "fbalpha2012": {
         "owner": "libretro",
@@ -153,14 +153,14 @@
     "fbneo": {
         "owner": "libretro",
         "repo": "fbneo",
-        "rev": "758f24740d81ff833c1868befd98ccd11909255f",
-        "sha256": "VhfsvohRWICWqKWry0fgUS76kiXBsnjY9DytxEvulKA="
+        "rev": "a12455af75e60765da134b83051700e0fbe3803a",
+        "sha256": "ujO9KVn7o6xueeEr5GHfOy7NimwNIvYxgMM9xJvtjvo="
     },
     "fceumm": {
         "owner": "libretro",
         "repo": "libretro-fceumm",
-        "rev": "3d3cc53c0177e296af2427c29bbb31902b26f3b8",
-        "sha256": "Z5LqP6IBq0H6uM0027PSkW6JLvVDA/4CrO6bI478Z1o="
+        "rev": "8c3f690e61a1d65dfb25510426ae88eeae93e1ae",
+        "sha256": "vzPrAEII8SWj3Ki2OaZb0/9gbQDz04rp2dXf2LE1sXg="
     },
     "flycast": {
         "owner": "libretro",
@@ -189,8 +189,8 @@
     "genesis-plus-gx": {
         "owner": "libretro",
         "repo": "Genesis-Plus-GX",
-        "rev": "5cdb31854074de1662266a0a675866ea7b787b42",
-        "sha256": "vMswSKM5aYlPZu5y4Z1L/+eaPBdQaLPPMKoC7B/xzqc="
+        "rev": "3abf975785fe77267a399cc583ccf1469e081b86",
+        "sha256": "QdiWKS7j80Sw0L+hf6efmQ40lQi/f95pFLQfoohoUKg="
     },
     "gpsp": {
         "owner": "libretro",
@@ -219,8 +219,8 @@
     "mame": {
         "owner": "libretro",
         "repo": "mame",
-        "rev": "0d935696dce53a13eaf0705f4a108ee348f3c613",
-        "sha256": "HnJ3eHzTpR7Lsi1ATn3B314y0KNKJ0+qNGcDbFvmZEA="
+        "rev": "57622367cb780013690d6ef23b2066b500f6ce92",
+        "sha256": "0iR1JGAhwYXXLnv8BDW1bsxfFywEI82aov2+MHw5w6Q="
     },
     "mame2000": {
         "owner": "libretro",
@@ -231,14 +231,14 @@
     "mame2003": {
         "owner": "libretro",
         "repo": "mame2003-libretro",
-        "rev": "cb0c89304b2cd584cda7105c6be4e69fa304f0e0",
-        "sha256": "ob/aUh5NZCfQvpA+nEs2QhVXeNBBVZesX/xQfatY9wU="
+        "rev": "dbdda8e7189d63061ac42f502c0cd2dc7f1f8651",
+        "sha256": "XED/gunYOc+NnQ8YORw/ALP2eCTyvRdIxPiFpNf5nuA="
     },
     "mame2003-plus": {
         "owner": "libretro",
         "repo": "mame2003-plus-libretro",
-        "rev": "d88d5c118e8d7075ec0a4e6deebb4cd3f18a8dd1",
-        "sha256": "9offucQMCpMqo4StYscS6kivXCYHy4Sn+Cs/3MoNwsw="
+        "rev": "5dd4a30500edc0b00c712750093aa287c9bb4ce2",
+        "sha256": "Nvm5U6rpsDZdUJONtvZ6YmztuupLaXz2QT0SBJtzO/4="
     },
     "mame2010": {
         "owner": "libretro",
@@ -285,14 +285,14 @@
     "mgba": {
         "owner": "libretro",
         "repo": "mgba",
-        "rev": "199a03e719436018779fe9299706c597fb2e9231",
-        "sha256": "3Q3MBzezCvl1Er45AeUM/QI0a+JiGn/PfYpqMaaiuds="
+        "rev": "ec5ecb26deba8d7ac830fc66ade9fac0eeaeb4ae",
+        "sha256": "kDDs+M7TPu6UhFnj9+XGI9whQFQ5/+7fSb0YUN7oMsg="
     },
     "mupen64plus": {
         "owner": "libretro",
         "repo": "mupen64plus-libretro-nx",
-        "rev": "c10546e333d57eb2e5a6ccef1e84cb6f9274c526",
-        "sha256": "dbS32slJBfz8DHeIQy20lAYw0+ig0LRgIaGfqW082xs="
+        "rev": "1b67122ff6a923c93a56ff94273e3768a6da5dff",
+        "sha256": "qORxhy7hXVdGUkQumOmGVXnF1kW0BShMNBVlaRu3a1w="
     },
     "neocd": {
         "owner": "libretro",
@@ -303,8 +303,8 @@
     "nestopia": {
         "owner": "libretro",
         "repo": "nestopia",
-        "rev": "a9ee6ca84f04990e209880fe47144e62b14253db",
-        "sha256": "q3pD2Cm/a62x3xW8JymU9w82zHlT0BoPlaSfzjZzh/c="
+        "rev": "5c360e55d5437ecd3520568ee44cf1af63d4696a",
+        "sha256": "+1QQc4gVZ5ZHt/I0bjRkW+kbPaeGUNrjbrzUoVz4drM="
     },
     "np2kai": {
         "owner": "AZO234",
@@ -316,8 +316,8 @@
     "nxengine": {
         "owner": "libretro",
         "repo": "nxengine-libretro",
-        "rev": "aa32afb8df8461920037bdbbddbff00bf465c6de",
-        "sha256": "Ic5YsNLoEZJ/vkjthwypwLN3ntB/5EX8bU92V80S7R4="
+        "rev": "e271c6262d73f07e5d92d285503f1c049801c51a",
+        "sha256": "PfzHV6/nGUdbnfZ8+aHuoIQhvKcxdbuKnjIMWIIFt7Q="
     },
     "o2em": {
         "owner": "libretro",
@@ -346,8 +346,8 @@
     "pcsx_rearmed": {
         "owner": "libretro",
         "repo": "pcsx_rearmed",
-        "rev": "5ced3945423cda0010597b27b7da6bce77b12baa",
-        "sha256": "8O2XyEr40HqQf8mHxmvB6/UT837HZw8SrKBy/JH66p4="
+        "rev": "a4e249a1373cf6269e1e4e0d60105e72210e67d3",
+        "sha256": "NOz2NQonVWEhEhAgSFHSWv6bmuTPcw0R9ihISlGwkb0="
     },
     "picodrive": {
         "owner": "libretro",
@@ -359,15 +359,15 @@
     "play": {
         "owner": "jpd002",
         "repo": "Play-",
-        "rev": "1126c39cd8ebf56af347c475139d4db97fc7cc19",
-        "sha256": "H/cYFWl8rA/ZdoygEjr7h1y6Z0n29Z+OCzzVMvIuVyo=",
+        "rev": "ad3b855c6d8cc62c85e2a5d2f659159fdfaa8d80",
+        "sha256": "+uTf/xv2JHuNGx0bxFNXf0akRzonzRMT7gSvT2n12+o=",
         "fetchSubmodules": true
     },
     "ppsspp": {
         "owner": "hrydgard",
         "repo": "ppsspp",
-        "rev": "4af4b0dddc638b00205d9943f17a2806e438fe83",
-        "sha256": "5n+Mg2ZDTJd5fk1OZAiYnCT13G3LAWahXPA+MwaOF08=",
+        "rev": "e654f6937a02f4a2ac8cce3574ab4f2db99f77d4",
+        "sha256": "LTqRA3KMV/VuQH0eTWjpOqy0U944c4ofPNEsexf93Kc=",
         "fetchSubmodules": true
     },
     "prboom": {
@@ -385,8 +385,8 @@
     "puae": {
         "owner": "libretro",
         "repo": "libretro-uae",
-        "rev": "4d8ebafe3f91c4998e8d73940e9558d863ecf93b",
-        "sha256": "dzfZFm7L+Qe3WwSYiMLp3cQm8zk0pWVB68nBe/H1Hvc="
+        "rev": "d9a8dfbde7f6967fea3cffe09cd87e1d79a1a3fd",
+        "sha256": "uMn9ejknjwGmbc0JOu/xl30z3ff7vpxtA3qr2sv0glI="
     },
     "quicknes": {
         "owner": "libretro",
@@ -415,8 +415,8 @@
     "snes9x": {
         "owner": "snes9xgit",
         "repo": "snes9x",
-        "rev": "28be1a196d2c59ed4b6489d487187569a7370aff",
-        "sha256": "FW4ynSS+R1ygQaCS0UrWGktfHGtcy0P/Mp/BXKfmII0="
+        "rev": "3c4982edddfdba482204ed48cf0b1d41ccae5493",
+        "sha256": "d4luyBSU/4PdsDd2jLwWSyckBPAqXMJ3C1sNmLO+E6U="
     },
     "snes9x2002": {
         "owner": "libretro",
@@ -439,8 +439,8 @@
     "stella": {
         "owner": "stella-emu",
         "repo": "stella",
-        "rev": "7193c405327e0f2156d24d53836162f4b44af079",
-        "sha256": "A9icQON+0WrknjGp/0wiFNSWs2ot2s0X5lucCdk4O/s="
+        "rev": "fa49e034101a22344c7bd01648d514b6cc61ac7f",
+        "sha256": "Svv+j7/9PvZ6djk2kfpbr9iUC8xqX8B4Plnf43Hj62A="
     },
     "stella2014": {
         "owner": "libretro",
@@ -451,8 +451,8 @@
     "swanstation": {
         "owner": "libretro",
         "repo": "swanstation",
-        "rev": "ff0b451a573885a5b3a4f291f7b22f3ffc667a17",
-        "sha256": "jz8tkvgonc4icRt12tt1BBCCiwec0ucix7Hp7PNPl8E="
+        "rev": "27a224fc9e86e0f061504878d1c0cbf3fd6891af",
+        "sha256": "5kW9/4gMfyvo3ExlJVivx8LhW5as3Mq5fhlNrIFDUVM="
     },
     "tgbdual": {
         "owner": "libretro",
@@ -494,8 +494,8 @@
     "virtualjaguar": {
         "owner": "libretro",
         "repo": "virtualjaguar-libretro",
-        "rev": "263c979be4ca757c43fb525bd6f0887998e57041",
-        "sha256": "6Q6Y0IFUWS9ZPhnAK3EUo4hMGPdBn8eNEYCK/zLgAKU="
+        "rev": "2cc06899b839639397b8b30384a191424b6f529d",
+        "sha256": "7FiU5/n1hVePttkz7aVfXXx88+zX06/5SJk3EaRYvhQ="
     },
     "yabause": {
         "owner": "libretro",

--- a/pkgs/applications/emulators/retroarch/libretro-core-info.nix
+++ b/pkgs/applications/emulators/retroarch/libretro-core-info.nix
@@ -5,12 +5,12 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "libretro-core-info";
-  version = "1.12.0";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "libretro-core-info";
-    hash = "sha256-ByATDM0V40UJxigqVLyTWkHY5tiCC2dvZebksl8GsUI=";
+    hash = "sha256-rTq2h+IGJduBkP4qCACmm3T2PvbZ0mOmwD1jLkJ2j/Q=";
     rev = "v${version}";
   };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New release: https://www.libretro.com/index.php/retroarch-1-13-0-release/

Substitute PR https://github.com/NixOS/nixpkgs/pull/201980.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
