### PR TITLE
whipper: install man pages

### DIFF
--- a/pkgs/applications/audio/whipper/default.nix
+++ b/pkgs/applications/audio/whipper/default.nix
@@ -2,6 +2,7 @@
 , python3
 , fetchFromGitHub
 , fetchpatch
+, installShellFiles
 , libcdio-paranoia
 , cdrdao
 , libsndfile
@@ -35,6 +36,8 @@ in python3.pkgs.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = with python3.pkgs; [
+    installShellFiles
+
     setuptools-scm
     docutils
     setuptoolsCheckHook
@@ -65,12 +68,21 @@ in python3.pkgs.buildPythonApplication rec {
     export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
   '';
 
+  outputs = [ "out" "man" ];
+  postBuild = ''
+    make -C man
+  '';
+
   preCheck = ''
     # disable tests that require internet access
     # https://github.com/JoeLametta/whipper/issues/291
     substituteInPlace whipper/test/test_common_accurip.py \
       --replace "test_AccurateRipResponse" "dont_test_AccurateRipResponse"
     export HOME=$TMPDIR
+  '';
+
+  postInstall = ''
+    installManPage man/*.1
   '';
 
   passthru.tests.version = testers.testVersion {


### PR DESCRIPTION
###### Description of changes

This change builds the manpages with the project's Makefile (which uses `rst2man`),
and adds a `man` output to the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
