### PR TITLE
haskellPackages.OrderedBits: set platforms=x86

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -584,6 +584,7 @@ supported-platforms:
   linux-namespaces:                             [ platforms.linux ]
   lxc:                                          [ platforms.linux ]
   midi-alsa:                                    [ platforms.linux ]
+  OrderedBits:                                  [ platforms.x86 ] # lacks implementations for non-x86: https://github.com/choener/OrderedBits/blob/401cbbe933b1635aa33e8e9b29a4a570b0a8f044/lib/Data/Bits/Ordered.hs#L316
   password:                                     [ platforms.x86 ] # uses scrypt, which requries x86
   password-instances:                           [ platforms.x86 ] # uses scrypt, which requries x86
   reactivity:                                   [ platforms.windows ]


### PR DESCRIPTION
###### Description of changes

The package doesn't support non-x86 architectures (aarch64)
```
Preprocessing library for OrderedBits-0.0.2.0..
Building library for OrderedBits-0.0.2.0..
[1 of 1] Compiling Data.Bits.Ordered ( lib/Data/Bits/Ordered.hs, dist/build/Data/Bits/Ordered.o, dist/build/Data/Bits/Ordered.dyn_o )

lib/Data/Bits/Ordered.hs:326:14: error:
    The INLINE pragma for ‘lsb’ lacks an accompanying binding
      (The INLINE pragma must be given where ‘lsb’ is declared)
    |
326 |   {-# Inline lsb  #-}
    |              ^^^
```
source code at
https://github.com/choener/OrderedBits/blob/master/lib/Data/Bits/Ordered.hs#L316

Should also avoid trying to build `PrimitiveArray` and other dependent packages on aarch64.

ZHF: #199919

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
