### PR TITLE
ananicy-cpp: unstable-2021-10-13 -> 1.0.1

### DIFF
--- a/pkgs/misc/ananicy-cpp/default.nix
+++ b/pkgs/misc/ananicy-cpp/default.nix
@@ -1,27 +1,27 @@
 { lib
-, gcc11Stdenv
+, stdenv
 , fetchFromGitLab
-, makeWrapper
 , cmake
+, pkg-config
 , spdlog
 , nlohmann_json
 , systemd
 }:
 
-gcc11Stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "ananicy-cpp";
-  version = "unstable-2021-10-13";
+  version = "1.0.1";
 
   src = fetchFromGitLab {
     owner = "ananicy-cpp";
     repo = "ananicy-cpp";
-    rev = "6a14fe7353221c89347eddbbcafb35cf5fee4758";
+    rev = "4d263de226de106bf32bdbf9c181a7185ffe5a52";
     sha256 = "sha256-V0QPXC17ZD2c4MK3DAkzoPgKOU5V5BjfQKUk7I6f8WM=";
   };
 
   nativeBuildInputs = [
-    makeWrapper
     cmake
+    pkg-config
   ];
 
   buildInputs = [
@@ -31,7 +31,7 @@ gcc11Stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DUSE_EXTERNAL_JSON=yON"
+    "-DUSE_EXTERNAL_JSON=ON"
     "-DUSE_EXTERNAL_SPDLOG=ON"
     "-DUSE_EXTERNAL_FMTLIB=ON"
   ];
@@ -41,6 +41,6 @@ gcc11Stdenv.mkDerivation rec {
     description = "Rewrite of ananicy in c++ for lower cpu and memory usage";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ artturin ];
+    maintainers = with maintainers; [ artturin vnepogodin ];
   };
 }

--- a/pkgs/misc/ananicy-cpp/default.nix
+++ b/pkgs/misc/ananicy-cpp/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     description = "Rewrite of ananicy in c++ for lower cpu and memory usage";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ artturin vnepogodin ];
+    maintainers = with maintainers; [ artturin ];
   };
 }


### PR DESCRIPTION
###### Description of changes

 - upstream release (https://gitlab.com/ananicy-cpp/ananicy-cpp/-/releases/v1.0.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
