### PR TITLE
bottles: 2022.10.14.1 -> 2022.11.14

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -14,7 +14,6 @@
 , gtk4
 , gtksourceview5
 , libadwaita
-, steam
 , cabextract
 , p7zip
 , xdpyinfo
@@ -26,45 +25,19 @@
 , mangohud
 , vkbasalt-cli
 , vmtouch
-, wine
-, bottlesExtraLibraries ? pkgs: [ ] # extra packages to add to steam.run multiPkgs
-, bottlesExtraPkgs ? pkgs: [ ] # extra packages to add to steam.run targetPkgs
 }:
-
-let
-  steam-run = (steam.override {
-    # required by wine runner `caffe`
-    extraLibraries = pkgs: with pkgs; [ libunwind libusb1 gnutls ]
-      ++ bottlesExtraLibraries pkgs;
-    extraPkgs = pkgs: [ ]
-      ++ bottlesExtraPkgs pkgs;
-  }).run;
-in
 python3Packages.buildPythonApplication rec {
-  pname = "bottles";
+  pname = "bottles-unwrapped";
   version = "2022.11.14";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
-    repo = pname;
+    repo = "bottles";
     rev = version;
     sha256 = "sha256-bigrJtqx9iZURYojwxlGe7xSGWS13wSaGcrTTROP9J8=";
   };
 
   patches = [ ./vulkan_icd.patch ];
-
-  postPatch = ''
-    chmod +x build-aux/meson/postinstall.py
-    patchShebangs build-aux/meson/postinstall.py
-
-    substituteInPlace bottles/backend/wine/winecommand.py \
-      --replace \
-        "command = f\"{runner} {command}\"" \
-        "command = f\"{''' if runner == 'wine' or runner == 'wine64' else '${steam-run}/bin/steam-run '}{runner} {command}\"" \
-      --replace \
-        "command = f\"{_picked['entry_point']} {command}\"" \
-        "command = f\"${steam-run}/bin/steam-run {_picked['entry_point']} {command}\""
-    '';
 
   nativeBuildInputs = [
     blueprint-compiler
@@ -109,7 +82,6 @@ python3Packages.buildPythonApplication rec {
     gamescope
     mangohud
     vmtouch
-    wine
 
     # Undocumented (subprocess.Popen())
     lsb-release

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -19,9 +19,12 @@
 , p7zip
 , xdpyinfo
 , imagemagick
+, lsb-release
+, pciutils
 , procps
 , gamescope
 , mangohud
+, vkbasalt-cli
 , vmtouch
 , wine
 , bottlesExtraLibraries ? pkgs: [ ] # extra packages to add to steam.run multiPkgs
@@ -39,13 +42,13 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2022.10.14.1";
+  version = "2022.11.14";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-FO91GSGlc2f3TSLrlmRDPi5p933/Y16tdEpX4RcKhL0=";
+    sha256 = "sha256-bigrJtqx9iZURYojwxlGe7xSGWS13wSaGcrTTROP9J8=";
   };
 
   patches = [ ./vulkan_icd.patch ];
@@ -101,12 +104,17 @@ python3Packages.buildPythonApplication rec {
     p7zip
     xdpyinfo
     imagemagick
-    procps
+    vkbasalt-cli
 
     gamescope
     mangohud
     vmtouch
     wine
+
+    # Undocumented (subprocess.Popen())
+    lsb-release
+    pciutils
+    procps
   ];
 
   format = "other";

--- a/pkgs/applications/misc/bottles/fhsenv.nix
+++ b/pkgs/applications/misc/bottles/fhsenv.nix
@@ -1,0 +1,101 @@
+{ lib
+, buildFHSUserEnvBubblewrap
+, symlinkJoin
+, bottles-unwrapped
+, extraPkgs ? pkgs: [ ]
+, extraLibraries ? pkgs: [ ]
+}:
+
+let fhsEnv = {
+  targetPkgs = pkgs: with pkgs; [
+    bottles-unwrapped
+    vkbasalt
+  ] ++ extraPkgs pkgs;
+
+  multiPkgs =
+    let
+      xorgDeps = pkgs: with pkgs.xorg; [
+        libpthreadstubs
+        libSM
+        libX11
+        libXaw
+        libxcb
+        libXcomposite
+        libXcursor
+        libXdmcp
+        libXext
+        libXi
+        libXinerama
+        libXmu
+        libXrandr
+        libXrender
+        libXv
+        libXxf86vm
+      ];
+    in
+    pkgs: with pkgs; [
+      # https://wiki.winehq.org/Building_Wine
+      alsa-lib
+      cups
+      dbus
+      fontconfig
+      freetype
+      glib
+      gnutls
+      libglvnd
+      gsm
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      libgphoto2
+      libjpeg_turbo
+      libkrb5
+      libpcap
+      libpng
+      libpulseaudio
+      libtiff
+      libunwind
+      libusb1
+      libv4l
+      libxml2
+      mpg123
+      ocl-icd
+      openldap
+      samba4
+      sane-backends
+      SDL2
+      udev
+      vulkan-loader
+
+      # https://www.gloriouseggroll.tv/how-to-get-out-of-wine-dependency-hell/
+      alsa-plugins
+      dosbox
+      giflib
+      gtk3
+      libva
+      libxslt
+      ncurses
+      openal
+
+      # Steam runtime
+      libgcrypt
+      libgpg-error
+      p11-kit
+      zlib # Freetype
+    ] ++ xorgDeps pkgs
+    ++ extraLibraries pkgs;
+};
+in
+symlinkJoin {
+  name = "bottles";
+  paths = [
+    (buildFHSUserEnvBubblewrap (fhsEnv // { name = "bottles"; runScript = "bottles"; }))
+    (buildFHSUserEnvBubblewrap (fhsEnv // { name = "bottles-cli"; runScript = "bottles-cli"; }))
+  ];
+  postBuild = ''
+    mkdir -p $out/share
+    ln -s ${bottles-unwrapped}/share/applications $out/share
+    ln -s ${bottles-unwrapped}/share/icons $out/share
+  '';
+
+  inherit (bottles-unwrapped) meta;
+}

--- a/pkgs/applications/misc/bottles/vulkan_icd.patch
+++ b/pkgs/applications/misc/bottles/vulkan_icd.patch
@@ -1,13 +1,15 @@
 diff --git a/bottles/backend/utils/vulkan.py b/bottles/backend/utils/vulkan.py
-index 6673493..07f70d1 100644
+index 6673493..9191004 100644
 --- a/bottles/backend/utils/vulkan.py
 +++ b/bottles/backend/utils/vulkan.py
-@@ -29,6 +29,8 @@ class VulkanUtils:
+@@ -28,7 +28,9 @@ class VulkanUtils:
+         "/usr/share/vulkan",
          "/etc/vulkan",
          "/usr/local/share/vulkan",
-         "/usr/local/etc/vulkan"
-+        "/run/opengl-driver/share/vulkan/",
-+        "/run/opengl-driver-32/share/vulkan/",
+-        "/usr/local/etc/vulkan"
++        "/usr/local/etc/vulkan",
++        "/run/opengl-driver/share/vulkan",
++        "/run/opengl-driver-32/share/vulkan",
      ]
      if "FLATPAK_ID" in os.environ:
          __vk_icd_dirs += [

--- a/pkgs/tools/graphics/vkbasalt-cli/default.nix
+++ b/pkgs/tools/graphics/vkbasalt-cli/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, python3Packages
+, fetchFromGitLab
+, vkbasalt
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "vkbasalt-cli";
+  version = "3.1.1";
+
+  src = fetchFromGitLab {
+    owner = "TheEvilSkeleton";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-4MFqndnvwAsqyer9kMNuCZFP/Xdl7W//AyCe7n83328=";
+  };
+
+  postPatch = ''
+    substituteInPlace vkbasalt/lib.py \
+      --replace /usr ${vkbasalt}
+  '';
+
+  pythonImportsCheck = [ "vkbasalt.lib" ];
+
+  meta = with lib; {
+    description = "Command-line utility for vkBasalt";
+    homepage = "https://gitlab.com/TheEvilSkeleton/vkbasalt-cli";
+    license = with licenses; [ lgpl3Only gpl3Only ];
+    maintainers = with maintainers; [ martfont ];
+  };
+}

--- a/pkgs/tools/graphics/vkbasalt/default.nix
+++ b/pkgs/tools/graphics/vkbasalt/default.nix
@@ -26,8 +26,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 spirv-headers vulkan-headers ];
   mesonFlags = [ "-Dappend_libdir_vkbasalt=true" ];
 
-  # Include 32bit layer in 64bit build
   postInstall = lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
+    install -Dm 644 $src/config/vkBasalt.conf $out/share/vkBasalt/vkBasalt.conf
+    # Include 32bit layer in 64bit build
     ln -s ${vkbasalt32}/share/vulkan/implicit_layer.d/vkBasalt.json \
       "$out/share/vulkan/implicit_layer.d/vkBasalt32.json"
   '';

--- a/pkgs/tools/graphics/vkbasalt/default.nix
+++ b/pkgs/tools/graphics/vkbasalt/default.nix
@@ -8,11 +8,11 @@
 , libX11
 , spirv-headers
 , vulkan-headers
-, vkBasalt32
+, vkbasalt32
 }:
 
 stdenv.mkDerivation rec {
-  pname = "vkBasalt";
+  pname = "vkbasalt";
   version = "0.3.2.6";
 
   src = fetchFromGitHub {
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   # Include 32bit layer in 64bit build
   postInstall = lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-    ln -s ${vkBasalt32}/share/vulkan/implicit_layer.d/vkBasalt.json \
+    ln -s ${vkbasalt32}/share/vulkan/implicit_layer.d/vkBasalt.json \
       "$out/share/vulkan/implicit_layer.d/vkBasalt32.json"
   '';
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1563,6 +1563,7 @@ mapAliases ({
   virtmanager = virt-manager; # Added 2019-10-29
   virtmanager-qt = virt-manager-qt; # Added 2019-10-29
   virtviewer = throw "'virtviewer' has been renamed to/replaced by 'virt-viewer'"; # Converted to throw 2022-02-22
+  vkBasalt = vkbasalt; # Added 2022-11-22
   vnc2flv = throw "vnc2flv has been removed: abandoned by upstream"; # Added 2022-03-21
   vorbisTools = throw "'vorbisTools' has been renamed to/replaced by 'vorbis-tools'"; # Converted to throw 2022-02-22
   vtun = throw "vtune has been removed as it's unmaintained upstream"; # Added 2021-10-29

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27752,9 +27752,9 @@ with pkgs;
 
   bonzomatic = callPackage ../applications/editors/bonzomatic { };
 
-  bottles = callPackage ../applications/misc/bottles {
-    wine = null;
-  };
+  bottles = callPackage ../applications/misc/bottles/fhsenv.nix { };
+
+  bottles-unwrapped = callPackage ../applications/misc/bottles { };
 
   brave = callPackage ../applications/networking/browsers/brave { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12649,8 +12649,8 @@ with pkgs;
 
   vix = callPackage ../tools/misc/vix { };
 
-  vkBasalt = callPackage ../tools/graphics/vkBasalt {
-    vkBasalt32 = pkgsi686Linux.vkBasalt;
+  vkbasalt = callPackage ../tools/graphics/vkbasalt {
+    vkbasalt32 = pkgsi686Linux.vkbasalt;
   };
 
   vkmark = callPackage ../tools/graphics/vkmark { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12653,6 +12653,8 @@ with pkgs;
     vkbasalt32 = pkgsi686Linux.vkbasalt;
   };
 
+  vkbasalt-cli = callPackage ../tools/graphics/vkbasalt-cli { };
+
   vkmark = callPackage ../tools/graphics/vkmark { };
 
   vncrec = callPackage ../tools/video/vncrec { };


### PR DESCRIPTION
###### Description of changes
https://github.com/bottlesdevs/Bottles/releases/tag/2022.11.14

The performance problems are no more! Also, `steam-run` has been replaced with a proper FHS sandbox.

Problems to solve (the ones solved have been edited out):
- vkBasalt works, but because it's a Vulkan layer it **must** be installed with `environment.systemPackages` or `nix-env -i`, just having a path that links to it isn't enough. Unfortunately, without turning Bottles into a module, there is no way to make sure that vkBasalt is actually installed the proper way. This leaves a choice:
  - vkBasalt is supported (by putting it in `targetPkgs`), and in Bottles the checkbox to enable it will always be toggleable. However, if vkBasalt isn't installed the proper way, the checkbox won't do anything. (Partial solution: patch the text describing the option to inform that vkBasalt needs to be installed)
  - Don't support vkBasalt at all, in Bottles the checkbox will be forced off.
  - Create a Bottles module just for that.
- The new FHS sandbox needs more testing.
  - Also, should Bottles' option to use the Steam runtime be enableable (since it's not using `steam-run`)?

Fixes #203051.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
