### PR TITLE
[22.05] python3Packages.tensorflow: 2.8.1 -> 2.8.4, python3Packages.tensorflow-bin: 2.8.1 -> 2.8.4

### DIFF
--- a/pkgs/development/python-modules/tensorflow/binary-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/binary-hashes.nix
@@ -1,51 +1,51 @@
 {
-version = "2.8.1";
+version = "2.8.4";
 linux_py_37_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.8.1-cp37-cp37m-manylinux2010_x86_64.whl";
-  sha256 = "0m8imb75fxpbgy1kn8yr9khhyllbxs5nvglviwpn9yr9741l4szj";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.8.4-cp37-cp37m-manylinux2010_x86_64.whl";
+  sha256 = "00xjz7lcbi8hh02vh7pwdswm6gm56ggwaqharsdcwyni9mrmfwwi";
 };
 linux_py_38_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.8.1-cp38-cp38-manylinux2010_x86_64.whl";
-  sha256 = "01ppmal5nlmqqk0c5wv29b7rkbyqkjczbz30dli8g388yiq33hyg";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.8.4-cp38-cp38-manylinux2010_x86_64.whl";
+  sha256 = "1if9agdxsh11hc13zlphcl8ggdi6kj3g6lg1a0kya80mhg312p1l";
 };
 linux_py_39_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.8.1-cp39-cp39-manylinux2010_x86_64.whl";
-  sha256 = "1ifv4i1y0333srg149s8rv4j7nwxig8iq2mvy2ckq82dlm8z5inm";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.8.4-cp39-cp39-manylinux2010_x86_64.whl";
+  sha256 = "03rwg6pb43r8ci6h04mk6hs0rcgh68gn17n9rj9c3p4liglvmav8";
 };
 linux_py_310_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.8.1-cp310-cp310-manylinux2010_x86_64.whl";
-  sha256 = "1jcb3gcc9walmj7px3bbj25j9grmmckbaz0bl75zardd5j0spkrh";
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.8.4-cp310-cp310-manylinux2010_x86_64.whl";
+  sha256 = "1vylmw7r7w2hks2hslrw0l2f8yny0ar6yhaj2jw9ldg9chqr77my";
 };
 linux_py_37_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.8.1-cp37-cp37m-manylinux2010_x86_64.whl";
-  sha256 = "1fgdlharsggyyd3fgl03s51nn09v8qlp50j05s01zvcl03syxdvx";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.8.4-cp37-cp37m-manylinux2010_x86_64.whl";
+  sha256 = "1cq8im6pz23zsz6i9p3il513jqk9yhlqi49z9gq003qq4zn8bfgi";
 };
 linux_py_38_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.8.1-cp38-cp38-manylinux2010_x86_64.whl";
-  sha256 = "0hvvly7ivi0csar6454xyql3md35w4w2a6hqrcazcwn1wmlfxc87";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.8.4-cp38-cp38-manylinux2010_x86_64.whl";
+  sha256 = "1waladsmwqagzijaf0lqbsw2xs4n4hzl8qy0sh8713g5csb2dfi2";
 };
 linux_py_39_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.8.1-cp39-cp39-manylinux2010_x86_64.whl";
-  sha256 = "0zj9yb8crbbn2zdvga7452wn0d2pyl1qhnghz2vrz116f1p6awrh";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.8.4-cp39-cp39-manylinux2010_x86_64.whl";
+  sha256 = "0kw6g4lim9lpkk77x4jj5sx9ry0psab3i6q3mkik5ymfhnf2pryv";
 };
 linux_py_310_gpu = {
-  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.8.1-cp310-cp310-manylinux2010_x86_64.whl";
-  sha256 = "06a6mz04jzaa3kkmqpvkkn34sm6mskqpl9r2rksnc1l86wja6dp1";
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.8.4-cp310-cp310-manylinux2010_x86_64.whl";
+  sha256 = "0rc3xanvprrmn7l81yydw0qq9c3syrri1l2s3f1hpglkfcd8p1z5";
 };
 mac_py_37_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.8.1-cp37-cp37m-macosx_10_14_x86_64.whl";
-  sha256 = "0qkikqwy9w0l6jyfp3m369kqbz4h6wjgiai51037dd5pis9swr0x";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.8.4-cp37-cp37m-macosx_10_14_x86_64.whl";
+  sha256 = "18hjj9i4hfxxy40d3r988ibwxqwcnzb98j5vyrmgbqxzyyd207c1";
 };
 mac_py_38_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.8.1-cp38-cp38-macosx_10_14_x86_64.whl";
-  sha256 = "0zafzd8209hl0p1hfk5s01j110cvcyp2v5mnxbi6r8h3i3zh364v";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.8.4-cp38-cp38-macosx_10_14_x86_64.whl";
+  sha256 = "1g9swlyylz1dkbwr9b8n03hf48wpy7ihdjv5hzdi6fpap8g56j89";
 };
 mac_py_39_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.8.1-cp39-cp39-macosx_10_14_x86_64.whl";
-  sha256 = "0870xia60kasxbpn9fw2kjcwqn5c8gi3icjzl8zwwifvbf7qlzmj";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.8.4-cp39-cp39-macosx_10_14_x86_64.whl";
+  sha256 = "1q1adx79bl16mrsv86lvs6x8d7nwbxhxbasqjajbwaylcqqfzfv3";
 };
 mac_py_310_cpu = {
-  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.8.1-cp310-cp310-macosx_10_14_x86_64.whl";
-  sha256 = "0wwdzygpb8v32axg75lrljrdlygiqqv49zyq1id5z80fzhcxsijh";
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.8.4-cp310-cp310-macosx_10_14_x86_64.whl";
+  sha256 = "0csqnzkqbx54mzx68zqb44v9m5697vbp41bnk3m5nnjlcrjj2ncc";
 };
 }

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -76,7 +76,7 @@ let
 
   tfFeature = x: if x then "1" else "0";
 
-  version = "2.8.1";
+  version = "2.8.4";
   variant = if cudaSupport then "-gpu" else "";
   pname = "tensorflow${variant}";
 
@@ -189,7 +189,7 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      hash = "sha256-+ZUS+uB8nzktq4B7PvhtHztT4OvWzvbdMb00dDCAGgM=";
+      hash = "sha256-MFqsVdSqbNDNZSQtCQ4/4DRpJPG35I0La4MLtRp37Rk=";
     };
 
     # On update, it can be useful to steal the changes from gentoo
@@ -363,11 +363,12 @@ let
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
       sha256 = if cudaSupport then
         "sha256-dQEyfueuQPcGvbhuh8Al45np3nRLDw2PCfC2lEqAH50="
+      else if stdenv.isDarwin then
+        "sha256-yfnZVtKWqNQGvlfq2owXhem0LmzDYriVfYgf1ZRlaDo="
+      else if stdenv.isAarch64 then
+        "sha256-cTIYZgqJQlqhK3JBRl1D8Jpayyuvp79Nud8XfnLPgKA="
       else
-        if stdenv.isDarwin then
-          "sha256-yfnZVtKWqNQGvlfq2owXhem0LmzDYriVfYgf1ZRlaDo="
-        else
-          "sha256:12i1ix2xwq77f3h8qr4h57g0aazrdsjjqa536cpwx3n1mvl5p6qi";
+        "sha256-EZtb6K7Bjs4vM6MoLKVu+SsF3imQZIzgcOdg3kWPIYo=";
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/prefetcher.sh
+++ b/pkgs/development/python-modules/tensorflow/prefetcher.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version="2.8.1"
+version="2.8.4"
 
 bucket="https://storage.googleapis.com/tensorflow"
 


### PR DESCRIPTION
###### Description of changes

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41883
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41911
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41909
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41908
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41901
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41907
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41900
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41899
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41898
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41896
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41897
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41894
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41895
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41891
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41893
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41889
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41890
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41887
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41888
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41886
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41880
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41884
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41885

See #201997 for unstable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
