### PR TITLE
Enpass: 6.6.1.809 -> 6.8.5.1173

### DIFF
--- a/pkgs/tools/security/enpass/data.json
+++ b/pkgs/tools/security/enpass/data.json
@@ -1,8 +1,8 @@
 {
   "amd64": {
-    "path": "pool/main/e/enpass/enpass_6.6.1.809_amd64.deb",
-    "sha256": "b1b9bd67653c3163bd80b340150ecf123552cbe4af23c350fbadea8ffd7939ba",
-    "version": "6.6.1.809"
+    "path": "pool/main/e/enpass/enpass_6.8.5.1173_amd64.deb",
+    "sha256": "5855e617041d73682320f3643eb4136c93eef2beaf3be9d37cbadfc76d719b5b",
+    "version": "6.8.5.1173"
   },
   "i386": {
     "path": "pool/main/e/enpass/enpass_5.6.9_i386.deb",

--- a/pkgs/tools/security/enpass/default.nix
+++ b/pkgs/tools/security/enpass/default.nix
@@ -14,7 +14,7 @@ let
 
   data = all_data.${system_map.${stdenv.hostPlatform.system} or (throw "Unsupported platform")};
 
-  baseUrl = "http://repo.sinew.in";
+  baseUrl = "https://apt.enpass.io";
 
   # used of both wrappers and libpath
   libPath = lib.makeLibraryPath (with xorg; [

--- a/pkgs/tools/security/enpass/default.nix
+++ b/pkgs/tools/security/enpass/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, dpkg, xorg
 , glib, libGLU, libGL, libpulseaudio, zlib, dbus, fontconfig, freetype
 , gtk3, pango
-, makeWrapper , python3Packages, lib
+, makeWrapper , python3Packages, lib, libcap
 , lsof, curl, libuuid, cups, mesa, xz, libxkbcommon
 }:
 
@@ -32,12 +32,17 @@ let
     libXrender
     libXScrnSaver
     libxcb
+    libcap
     glib
     gtk3
     pango
     curl
     libuuid
     cups
+    xcbutilwm         # libxcb-icccm.so.4
+    xcbutilimage      # libxcb-image.so.0
+    xcbutilkeysyms    # libxcb-keysyms.so.1
+    xcbutilrenderutil # libxcb-render-util.so.0
     xz
     libxkbcommon
   ]);


### PR DESCRIPTION
###### Description of changes

This PR does 3 things:
1. Update the base URL to https://apt.enpass.io (The previous URL didn't even use SSL).
2. Add missing libraries
3. Update enpass to the newest available Version

This superseeds #178715

See changelog for details: https://www.enpass.io/release-notes/linux/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
