### PR TITLE
i2p: 1.9.0 -> 2.0.0

### DIFF
--- a/pkgs/applications/blockchains/feather/default.nix
+++ b/pkgs/applications/blockchains/feather/default.nix
@@ -1,0 +1,99 @@
+{ lib, stdenv, cmake, ccache
+, fetchFromGitHub
+, qtbase, qtsvg
+, qtwebsockets
+, wrapQtAppsHook
+, qrencode, zbar
+, unbound, boost
+, libzip, hidapi
+, protobuf, makeDesktopItem
+, tor, libgcrypt
+, libsodium, expat
+, openssl, pkg-config
+, zlib, git, monero-cli
+}:
+
+
+stdenv.mkDerivation rec {
+  pname = "feather";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "feather-wallet";
+    repo = "feather";
+    rev = version;
+    sha256 = "sha256-0cVuOYinhHKfeiQcZX3vvSsd+jTbTxFRh0qHhxXF76Y=";
+    fetchSubmodules = true;
+  };
+
+
+  nativeBuildInputs = [
+    cmake ccache
+    wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    qtbase qtsvg qtwebsockets
+    qrencode unbound
+    libzip hidapi boost
+    protobuf libgcrypt tor
+    openssl libsodium expat
+    libgcrypt zbar zlib
+  ];
+
+
+  polyseed = fetchFromGitHub {
+    owner = "tevador";
+    repo = "polyseed";
+    rev = "e38516561c647522e2e2608f13eabdeab61d9a5d";
+    sha256 = "sha256-Eg9Nj95OYXQ9tSPTtk4xiefZDfp+zF6G/RWGxR16owA=";
+  };
+
+  singleapplication = fetchFromGitHub {
+    owner = "itay-grudev";
+    repo = "SingleApplication";
+    rev = "3e8e85d1a487e433751711a8a090659684d42e3b";
+    sha256 = "sha256-4UeJgSzXChzRi9azjG9k6pYRLok5Fan9b84BCCesLBs=";
+  };
+
+  postUnpack = ''
+    cp -r ${monero-cli.source}/* source/monero
+    cp -r ${polyseed}/* source/src/third-party/polyseed
+    cp -r ${singleapplication}/* source/src/third-party/singleapplication
+    chmod -R +w source/monero
+    chmod -R +w source/src/third-party
+  '';
+
+  cmakeFlags = [
+    "-DTOR_DIR=${tor}/bin"
+    "-DTOR_VERSION=${tor.version}"
+  ];
+
+  desktopItem = makeDesktopItem rec {
+    name = "feather";
+    exec = name;
+    icon = name;
+    desktopName = "Feather";
+    genericName = "Wallet";
+    categories  = [ "Network" "Utility" ];
+  };
+
+  postInstall = ''
+    # install desktop entry
+    install -Dm644 -t $out/share/applications \
+      ${desktopItem}/share/applications/*
+    # install icons
+    install -Dm644 $src/src/assets/images/feather.png \
+      $out/share/pixmaps/feather.png
+  '';
+
+  meta = with lib; {
+    description  = "A free Monero desktop wallet";
+    homepage     = "https://featherwallet.org";
+    license      = licenses.bsd3;
+    platforms    = [ "x86_64-linux" ];
+    maintainers  = with maintainers; [ gp2112 ];
+  };
+
+}

--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "i2p";
-  version = "1.9.0";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "https://files.i2p-projekt.de/${version}/i2psource_${version}.tar.bz2";
-    sha256 = "sha256-V/YYFQmMNVk9ft4wX5i5AVxMYTxyIxrQhOaAaj4qo3E=";
+    sha256 = "sha256-HVCDHnKo8TnMQ9VYTBnKSFgNcvGJSDdom/ZEwpnfkJk=";
   };
 
   buildInputs = [ jdk ant gettext which ];

--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -51,6 +51,6 @@ stdenv.mkDerivation rec {
     ];
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
-    maintainers = with maintainers; [ joelmo ];
+    maintainers = with maintainers; [ joelmo gp2112 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33349,6 +33349,8 @@ with pkgs;
 
   faraday = callPackage ../applications/blockchains/faraday { };
 
+  feather = libsForQt5.callPackage ../applications/blockchains/feather { };
+
   fulcrum = libsForQt5.callPackage ../applications/blockchains/fulcrum { };
 
   go-ethereum = callPackage ../applications/blockchains/go-ethereum {


### PR DESCRIPTION
###### Description of changes

- i2ptunnel: Support SHA-256 digest proxy authentication (RFC 7616)
- SSU2: Connection migration
- SSU2: Immediate acks
- SSU2: Enable by default

Full release description: https://geti2p.net/en/blog/post/2022/11/21/2.0.0-Release

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
