### PR TITLE
msmtp: need ping from inetutils on darwin

### DIFF
--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -10,6 +10,7 @@
 , gnugrep
 , gnutls
 , gsasl
+, inetutils
 , libidn2
 , netcat-gnu
 , texinfo
@@ -102,15 +103,22 @@ let
           gnugrep
           netcat-gnu
           which
-        ] ++ optionals withSystemd [ systemd ];
+        ]
+        ++ optionals stdenv.isDarwin [ inetutils ]
+        ++ optionals withSystemd [ systemd ];
         execer = [
           "cannot:${getBin binaries}/bin/msmtp"
           "cannot:${getBin netcat-gnu}/bin/nc"
-        ] ++ optionals withSystemd [
+        ]
+        ++ optionals stdenv.isDarwin [
+          "cannot:${getBin inetutils}/bin/ping"
+        ]
+        ++ optionals withSystemd [
           "cannot:${getBin systemd}/bin/systemd-cat"
         ];
         fix."$MSMTP" = [ "msmtp" ];
-        fake.external = [ "ping" ]
+        fake.external = [ ]
+          ++ optionals stdenv.isLinux [ "ping" ]
           ++ optionals (!withSystemd) [ "systemd-cat" ];
       };
 


### PR DESCRIPTION
###### Description of changes

Further to #195532.

This is untested but was faster than explaining what I meant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
