### PR TITLE
Add phpdoc to TreeSitter grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -62,6 +62,7 @@
   tree-sitter-perl = lib.importJSON ./tree-sitter-perl.json;
   tree-sitter-pgn = lib.importJSON ./tree-sitter-pgn.json;
   tree-sitter-php = lib.importJSON ./tree-sitter-php.json;
+  tree-sitter-phpdoc = lib.importJSON ./tree-sitter-phpdoc.json;
   tree-sitter-pioasm = lib.importJSON ./tree-sitter-pioasm.json;
   tree-sitter-prisma = lib.importJSON ./tree-sitter-prisma.json;
   tree-sitter-pug = lib.importJSON ./tree-sitter-pug.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-agda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-agda.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/tree-sitter/tree-sitter-agda",
+  "rev": "d710ff14d15ddee3764fd73a0837c6c4c8c913e9",
+  "date": "2019-09-20T18:06:06+08:00",
+  "path": "/nix/store/wqz9v9znaiwhhqi19hgig9bn0yvl4i9s-tree-sitter-agda",
+  "sha256": "1wpfj47l97pxk3i9rzdylqipy849r482fnj3lmx8byhalv7z1vm6",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fluent.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fluent.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/tree-sitter/tree-sitter-fluent",
+  "rev": "858fdd6f1e81992e00d3541bfb31bac9365d7a47",
+  "date": "2018-06-18T13:00:38-07:00",
+  "path": "/nix/store/zbj8abdlrqi9swm8qn8rhpqmjwcz145f-tree-sitter-fluent",
+  "sha256": "0528v9w0cs73p9048xrddb1wpdhr92sn1sw8yyqfrq5sq0danr9k",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "bee6b49543e34c2967c6294a4b05e8bd2bf2da59",
-  "date": "2022-09-30T18:11:21+02:00",
-  "path": "/nix/store/d6c30iv724f2kpcb969zskcxbh6fcrdz-tree-sitter-haskell",
-  "sha256": "069pyll6nvzakj5rhpd28md9dfzhcap2jwffqkwjyaavwcwar9gz",
+  "rev": "aee3725d02cf3bca5f307b35dd3a96a97e109b4e",
+  "date": "2022-11-19T03:13:19+01:00",
+  "path": "/nix/store/40szsli32ssyyxf78xy23yvan24b6df7-tree-sitter-haskell",
+  "sha256": "19yvvny7z18bxjwx3ajbz66vh5gv9ds0h2gbz134i0vp3d3fnshf",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-neorg/tree-sitter-norg",
-  "rev": "dfac5ad2740a79b18ae849590a924e7bad3f1b23",
-  "date": "2022-10-13T09:07:45+02:00",
-  "path": "/nix/store/9csv2xax6ris1wghj83gdf1sjvbh7jfq-tree-sitter-norg",
-  "sha256": "0jws376b7a2jqr0d32c20qh9v3d0wi8af95dprmfhi8pcvd5hzww",
+  "rev": "8ad20059c6f128861c4506fff866150ffee1d6f4",
+  "date": "2022-11-19T15:32:13+01:00",
+  "path": "/nix/store/h0wxvl5j5bwkad6bb7c55a9i82759cbi-tree-sitter-norg",
+  "sha256": "1wh2s8zrpyq3zi8i554jdpb4c2gs9kfnf3g2jmcrhvg79zg8ghnm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-phpdoc.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-phpdoc.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/claytonrcarter/tree-sitter-phpdoc",
+  "rev": "2f4d16c861b5a454b577d057f247f9902d7b47f5",
+  "date": "2022-10-15T08:08:45-04:00",
+  "path": "/nix/store/1bi89iv0vsl122fk558vnw4lhsyhsq34-tree-sitter-phpdoc",
+  "sha256": "1ah4gqb2kz0d5qwvyqjc9zwbjs8p5qka0laj9yfzfdhna03y52pf",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "4ae7bd67706d7e10afed827ce2ded884ab41650f",
-  "date": "2022-11-02T08:03:51+01:00",
-  "path": "/nix/store/k2fsslkwfsxscmcghiz6qqah9v275hy9-tree-sitter-viml",
-  "sha256": "082yw8qgi4fp9wfjfinnyh60f6rvp7fbyi88yaw6kdx4mjrnl0z6",
+  "rev": "55ff1b080c09edeced9b748cf4c16d0b49d17fb9",
+  "date": "2022-11-21T10:29:58+01:00",
+  "path": "/nix/store/dbsgb2p0yvpqaj7a114ndqdzm4mslp9i-tree-sitter-viml",
+  "sha256": "080vimv12rrvfc9qkfzs8bsa1asdrab9mgy4j16kmyzlyd27mj3c",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yang.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yang.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/hubro/tree-sitter-yang",
-  "rev": "8e9d175982afcefa3dac8ca20d40d1643accd2bd",
-  "date": "2021-07-29T23:07:25+02:00",
-  "path": "/nix/store/ark7nssjv3jzy1kw9anlma7li5k9zpnb-tree-sitter-yang",
-  "sha256": "044q9fikaxnrcrnfwc7cfjnwdg6v7jb6rg7mj556iryv0bkv48s1",
+  "rev": "2c0e6be8dd4dcb961c345fa35c309ad4f5bd3502",
+  "date": "2022-11-21T21:25:21+01:00",
+  "path": "/nix/store/ypd2cggg44l0sx0snvkgjbspkfcyscmf-tree-sitter-yang",
+  "sha256": "1vwcsp20dhccr2ag5s09j3jz9cnlkndb2hdn0h3va7md8ka0lhp8",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -358,6 +358,10 @@ let
       orga = "sourcegraph";
       repo = "tree-sitter-jsonnet";
     };
+    "tree-sitter-phpdoc" = {
+      orga = "claytonrcarter";
+      repo = "tree-sitter-phpdoc";
+    };
   };
 
   allGrammars =


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding [phpdoc](https://github.com/claytonrcarter/tree-sitter-phpdoc) to the main list of treesitter grammars, as nvim-treesitter already includes it.

A couple other grammars were also added/updated by the script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
