### PR TITLE
dar: cleanup

### DIFF
--- a/pkgs/tools/backup/dar/default.nix
+++ b/pkgs/tools/backup/dar/default.nix
@@ -1,10 +1,24 @@
-args @ { lib, stdenv, llvmPackages_12, fetchurl
-, which
-, attr, e2fsprogs
-, curl, libargon2, librsync, libthreadar
-, gpgme, libgcrypt, openssl
-, bzip2, lz4, lzo, xz, zlib
-, CoreFoundation
+args @ {
+  lib,
+  stdenv,
+  llvmPackages_12, # Anything newer than 11
+  fetchurl,
+  which,
+  attr,
+  e2fsprogs,
+  curl,
+  libargon2,
+  librsync,
+  libthreadar,
+  gpgme,
+  libgcrypt,
+  openssl,
+  bzip2,
+  lz4,
+  lzo,
+  xz,
+  zlib,
+  CoreFoundation,
 }:
 
 let
@@ -27,9 +41,18 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which ];
 
   buildInputs = [
-    curl librsync libthreadar
-    gpgme libargon2 libgcrypt openssl
-    bzip2 lz4 lzo xz zlib
+    curl
+    librsync
+    libthreadar
+    gpgme
+    libargon2
+    libgcrypt
+    openssl
+    bzip2
+    lz4
+    lzo
+    xz
+    zlib
   ] ++ lib.optionals stdenv.isLinux [
     attr
     e2fsprogs

--- a/pkgs/tools/backup/dar/default.nix
+++ b/pkgs/tools/backup/dar/default.nix
@@ -2,7 +2,7 @@ args @ {
   lib,
   stdenv,
   llvmPackages_12, # Anything newer than 11
-  fetchurl,
+  fetchzip,
   which,
   attr,
   e2fsprogs,
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
   version = "2.7.7";
   pname = "dar";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "mirror://sourceforge/dar/${pname}-${version}.tar.gz";
-    sha256 = "sha256-wD4vUu/WWi8Ee2C77aJGDLUlFl4b4y8RC2Dgzs4/LMk=";
+    sha256 = "sha256-643hU28Vl0QaqdKoKdQ1Z/j5drE59/jw5xkVO/g+MSw=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/backup/dar/default.nix
+++ b/pkgs/tools/backup/dar/default.nix
@@ -1,4 +1,4 @@
-{ lib, gccStdenv, fetchurl
+args @ { lib, stdenv, llvmPackages_12, fetchurl
 , which
 , attr, e2fsprogs
 , curl, libargon2, librsync, libthreadar
@@ -10,9 +10,9 @@
 with lib;
 
 let
-  # Fails to build with clang on Darwin:
+  # Fails to build with clang-11 on Darwin:
   # error: exception specification of overriding function is more lax than base version
-  stdenv = gccStdenv;
+  stdenv = if args.stdenv.isDarwin then llvmPackages_12.stdenv else args.stdenv;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/backup/dar/default.nix
+++ b/pkgs/tools/backup/dar/default.nix
@@ -7,8 +7,6 @@ args @ { lib, stdenv, llvmPackages_12, fetchurl
 , CoreFoundation
 }:
 
-with lib;
-
 let
   # Fails to build with clang-11 on Darwin:
   # error: exception specification of overriding function is more lax than base version
@@ -32,10 +30,10 @@ stdenv.mkDerivation rec {
     curl librsync libthreadar
     gpgme libargon2 libgcrypt openssl
     bzip2 lz4 lzo xz zlib
-  ] ++ optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     attr
     e2fsprogs
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     CoreFoundation
   ];
 
@@ -47,20 +45,20 @@ stdenv.mkDerivation rec {
     "--enable-threadar"
   ];
 
+  hardeningDisable = [ "format" ];
+
+  enableParallelBuilding = true;
+
   postInstall = ''
     # Disable html help
     rm -r "$out"/share/dar
   '';
 
-  enableParallelBuilding = true;
-
-  hardeningDisable = [ "format" ];
-
-  meta = {
+  meta = with lib; {
     homepage = "http://dar.linux.free.fr";
     description = "Disk ARchiver, allows backing up files into indexed archives";
     maintainers = with maintainers; [ izorkin ];
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
