### PR TITLE
process-compose: 0.24.1 -> 0.28.0

### DIFF
--- a/pkgs/applications/misc/process-compose/default.nix
+++ b/pkgs/applications/misc/process-compose/default.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "process-compose";
-  version = "0.24.1";
+  version = "0.28.0";
 
   src = fetchFromGitHub {
     owner = "F1bonacc1";
     repo = pname;
     rev = "v${version}";
-    sha256 = "TKLLq6I+Mcvdz51m8nydTWcslBcQlJCJFoJ10SgfVWU=";
+    sha256 = "7UVCGyFay0yQAcO1NKb1+vsNqX1v9Hf5NUgjnHlgnG0=";
   };
 
-  ldflags = [ "-X main.version=v${version}" ];
+  ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -37,6 +37,5 @@ buildGoModule rec {
     homepage = "https://github.com/F1bonacc1/process-compose";
     license = licenses.asl20;
     maintainers = with maintainers; [ thenonameguy ];
-    mainProgram = "process-compose";
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/F1bonacc1/process-compose/releases/tag/v0.28.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
