### PR TITLE
gnome.gnome-keyring: add a patch to fix 100% CPU usage regression

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-keyring/default.nix
@@ -66,6 +66,10 @@ stdenv.mkDerivation rec {
   # - https://github.com/NixOS/nixpkgs/issues/51121
   doCheck = false;
 
+  patches = [
+    ./gnome-keyring-100percent-cpu.patch
+  ];
+
   postPatch = ''
     patchShebangs build
   '';

--- a/pkgs/desktops/gnome/core/gnome-keyring/gnome-keyring-100percent-cpu.patch
+++ b/pkgs/desktops/gnome/core/gnome-keyring/gnome-keyring-100percent-cpu.patch
@@ -1,0 +1,21 @@
+--- gnome-keyring-42.1/pam/gkr-pam-module.c.orig	2022-11-22 12:43:07.114557165 +0530
++++ gnome-keyring-42.1/pam/gkr-pam-module.c	2022-11-22 12:43:46.080649882 +0530
+@@ -378,7 +378,7 @@
+ 	}
+ 
+ 	/* Try valiantly to close unnecessary file descriptors */
+-	for (i = STDERR; i < 64; ++i)
++	for (i = STDERR + 1; i < 64; ++i)
+ 		close (i);
+ 	    
+ 	/* Close unnecessary file descriptors */
+--- gnome-keyring-42.1/daemon/gkd-main.c.orig	2022-11-22 12:42:18.482433965 +0530
++++ gnome-keyring-42.1/daemon/gkd-main.c	2022-11-22 12:42:40.758490397 +0530
+@@ -701,6 +701,7 @@
+ 	}
+ 
+ 	/* Here we are in the resulting daemon or background process. */
++	close( wakeup_fds[0] );
+ 	return wakeup_fds[1];
+ }
+ 


### PR DESCRIPTION
###### Description of changes

The patch is adapted from one shared at upstream bugtracker[0]

References:
[0] https://gitlab.gnome.org/GNOME/glib/-/issues/2795#note_1584100

Fixes #202313

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
