### PR TITLE
ocamlPackages.integers: 0.5.1 → 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/integers/default.nix
+++ b/pkgs/development/ocaml-modules/integers/default.nix
@@ -1,17 +1,19 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml }:
+{ lib, fetchFromGitHub, buildDunePackage
+, stdlib-shims
+}:
 
 buildDunePackage rec {
   pname = "integers";
-  version = "0.5.1";
-
-  useDune2 = lib.versionAtLeast ocaml.version "4.08";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "ocamllabs";
     repo = "ocaml-integers";
     rev = version;
-    sha256 = "0by5pc851fk7ccxqy1w2qc5jwn9z8whyqhs5gxlm5986vr9msnyi";
+    sha256 = "sha256-zuUgP1jOiVT0q6GisGpkqx7nybWbARgnAcU8NYqvCzA=";
   };
+
+  propagatedBuildInputs = [ stdlib-shims ];
 
   meta = {
     description = "Various signed and unsigned integer types for OCaml";


### PR DESCRIPTION
###### Description of changes

Support for latest OCaml.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
