### PR TITLE
teamviewer: 15.29.7 -> 15.35.7

### DIFF
--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -50,10 +50,10 @@ mkDerivation rec {
       $out/share/teamviewer/tv_bin/xdg-utils \
       $out/share/teamviewer/tv_bin/script/{teamviewer_setup,teamviewerd.sysv,teamviewerd.service,teamviewerd.*.conf,tv-delayed-start.sh}
 
-    # Teamviewer packages its own qt library files
-    # most of them can be replaced by nixpkgs libraries, but the following need to be used beginning at version 15.35.7 because
-    # teamviewer will not start without them. Either stalling at startup or even segfaulting. In the logfiles, some missing qt libraries
-    # can be observed, although they are present from nixpkgs. AutoPatchElf will automatically choose the included libraries, if present.
+    # Teamviewer packages its own qt library files.
+    # Most of them can be replaced by nixpkgs libraries, but the following need to be used beginning at version 15.35.7
+    # because teamviewer will not start without them, either stalling at startup or even segfaulting. In the logfiles, some missing qt libraries
+    # can be observed, although they are present from nixpkgs. AutoPatchelfHook will automatically choose the included libraries, if present.
     # See https://github.com/NixOS/nixpkgs/pull/202024
 
     # delete all library files except "qt" folder
@@ -66,7 +66,7 @@ mkDerivation rec {
     find $out/share/teamviewer/tv_bin/RTlib/qt/qml -depth -maxdepth 1 -mindepth 1 -type d ! \( -name "QtQuick" -o -name "QtQuick.2" \) -execdir rm -rf {} +
 
     # delete all folders except "platforms" from the plugins directory
-    # it contains libqxcb.so from qtbase which seems to be incompatible from our nixpkgs version
+    # it contains libqxcb.so from qtbase which seems to be incompatible with our nixpkgs version
     find $out/share/teamviewer/tv_bin/RTlib/qt/plugins -depth -maxdepth 1 -mindepth 1 -type d ! -name "platforms" -execdir rm -rf {} +
 
     ln -s $out/share/teamviewer/tv_bin/script/teamviewer $out/bin
@@ -114,9 +114,8 @@ mkDerivation rec {
 
   makeWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath [ getconf coreutils ]}"
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus icu63]}"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus icu63 ]}"
   ];
-
 
   postFixup = ''
     wrapProgram $out/share/teamviewer/tv_bin/teamviewerd ''${makeWrapperArgs[@]}

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -1,18 +1,36 @@
-{ mkDerivation, lib, fetchurl, autoPatchelfHook, makeWrapper, xdg-utils, dbus
-, qtbase, qtwebengine, qtx11extras, qtquickcontrols, getconf, glibc
-, libXrandr, libX11, libXext, libXdamage, libXtst, libSM, libXfixes, coreutils
+{ mkDerivation
+, lib
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, xdg-utils
+, dbus
+, qtbase
+, qtwebengine
+, qtx11extras
+, getconf
+, glibc
+, libXrandr
+, libX11
+, libXext
+, libXdamage
+, libXtst
+, libSM
+, libXfixes
+, coreutils
 , wrapQtAppsHook
+, icu63
 }:
 
 mkDerivation rec {
   pname = "teamviewer";
   # teamviewer itself has not development files but the dev output removes propagated other dev outputs from runtime
   outputs = [ "out" "dev" ];
-  version = "15.29.4";
+  version = "15.35.7";
 
   src = fetchurl {
     url = "https://dl.tvcdn.de/download/linux/version_15x/teamviewer_${version}_amd64.deb";
-    sha256 = "sha256-jkFqOtU+D62S7QmNPvz58Z8wJ79lkN11pWQrtNdD+Uk=";
+    sha256 = "sha256-KNUhe0c6Th2pW7+Lmo62FYdOv+8t7Z5/eQkYPN8eusc=";
   };
 
   unpackPhase = ''
@@ -21,8 +39,7 @@ mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapQtAppsHook ];
-  buildInputs = [ dbus getconf qtbase qtwebengine qtx11extras libX11 ];
-  propagatedBuildInputs = [ qtquickcontrols ];
+  buildInputs = [ dbus getconf qtbase qtwebengine qtx11extras libX11 icu63 ];
 
   installPhase = ''
     mkdir -p $out/share/teamviewer $out/bin $out/share/applications
@@ -30,9 +47,27 @@ mkDerivation rec {
     rm -R \
       $out/share/teamviewer/logfiles \
       $out/share/teamviewer/config \
-      $out/share/teamviewer/tv_bin/RTlib \
       $out/share/teamviewer/tv_bin/xdg-utils \
       $out/share/teamviewer/tv_bin/script/{teamviewer_setup,teamviewerd.sysv,teamviewerd.service,teamviewerd.*.conf,tv-delayed-start.sh}
+
+    # Teamviewer packages its own qt library files
+    # most of them can be replaced by nixpkgs libraries, but the following need to be used beginning at version 15.35.7 because
+    # teamviewer will not start without them. Either stalling at startup or even segfaulting. In the logfiles, some missing qt libraries
+    # can be observed, although they are present from nixpkgs. AutoPatchElf will automatically choose the included libraries, if present.
+    # See https://github.com/NixOS/nixpkgs/pull/202024
+
+    # delete all library files except "qt" folder
+    find $out/share/teamviewer/tv_bin/RTlib -depth  -maxdepth 1 ! -type d -execdir rm -rf {} +
+
+    # remove all other folders except "qml" and "plugins" from the qml directory
+    find $out/share/teamviewer/tv_bin/RTlib/qt -depth -maxdepth 1 -mindepth 1 -type d ! \( -name "qml" -o -name "plugins" \) -execdir rm -rf {} +
+
+    # keep "QtQuick" and "QtQuick.2" directory
+    find $out/share/teamviewer/tv_bin/RTlib/qt/qml -depth -maxdepth 1 -mindepth 1 -type d ! \( -name "QtQuick" -o -name "QtQuick.2" \) -execdir rm -rf {} +
+
+    # delete all folders except "platforms" from the plugins directory
+    # it contains libqxcb.so from qtbase which seems to be incompatible from our nixpkgs version
+    find $out/share/teamviewer/tv_bin/RTlib/qt/plugins -depth -maxdepth 1 -mindepth 1 -type d ! -name "platforms" -execdir rm -rf {} +
 
     ln -s $out/share/teamviewer/tv_bin/script/teamviewer $out/bin
     ln -s $out/share/teamviewer/tv_bin/teamviewerd $out/bin
@@ -79,8 +114,9 @@ mkDerivation rec {
 
   makeWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath [ getconf coreutils ]}"
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus ]}"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus icu63]}"
   ];
+
 
   postFixup = ''
     wrapProgram $out/share/teamviewer/tv_bin/teamviewerd ''${makeWrapperArgs[@]}
@@ -100,6 +136,6 @@ mkDerivation rec {
     license = licenses.unfree;
     description = "Desktop sharing application, providing remote support and online meetings";
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ jagajaga jraygauthier ];
+    maintainers = with maintainers; [ jagajaga jraygauthier gador ];
   };
 }

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -39,7 +39,7 @@ mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapQtAppsHook ];
-  buildInputs = [ dbus getconf qtbase qtwebengine qtx11extras libX11 icu63 ];
+  buildInputs = [ qtbase qtwebengine qtx11extras icu63 ];
 
   installPhase = ''
     mkdir -p $out/share/teamviewer $out/bin $out/share/applications


### PR DESCRIPTION
###### Description of changes

teamviewer started to pack its own qt libraries.
Starting with this version, some of our nixpkgs libraries do not work nicely with teamviewer anymore. There seem to be subtle differences. Therefore to make teamviewer work again, we use the bare minimum of the included libraries for teamviewer to make it work.

Unfortunatly upstream does not provide informative changelogs which made these changes a guessing game in dependencies.

It comes down to libqxcb.so and QtQuick which needs to be used from the included libraries.

This commit also adds gador as maintainer.

Ping at maintainer:
@jagajaga @jraygauthier

Some of the testing/failure was already discussed in #202024

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - ~~and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
  - tested manually in a VM
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
