### PR TITLE
cpu-x: 4.5.1 -> 4.5.2

### DIFF
--- a/pkgs/applications/misc/cpu-x/default.nix
+++ b/pkgs/applications/misc/cpu-x/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cpu-x";
-  version = "4.5.1";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "X0rg";
     repo = "CPU-X";
     rev = "v${version}";
-    sha256 = "sha256-rmRfKw2KMLsO3qfy2QznCIugvM2CLSxBUDgIzONYULk=";
+    sha256 = "sha256-VPmwnzoOBNLDYZsoEknbcX7QP2Tcm08pL/rw1uCK8xM=";
   };
 
   nativeBuildInputs = [ cmake pkg-config wrapGAppsHook nasm makeWrapper ];

--- a/pkgs/applications/misc/cpu-x/default.nix
+++ b/pkgs/applications/misc/cpu-x/default.nix
@@ -9,6 +9,11 @@
 , libXtst
 }:
 
+# Known issues:
+# - The daemon can't be started from the GUI, because pkexec requires a shell
+#   registered in /etc/shells. The nix's bash is not in there when running
+#   cpu-x from nixpkgs.
+
 stdenv.mkDerivation rec {
   pname = "cpu-x";
   version = "4.5.2";
@@ -40,7 +45,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Free software that gathers information on CPU, motherboard and more";
-    homepage = src.meta.homepage;
+    homepage = "https://thetumultuousunicornofdarkness.github.io/CPU-X";
     license = licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ viraptor ];


### PR DESCRIPTION
###### Description of changes

Update the version, update homepage as requested by upstream, annotate a known issue with pkexec.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
