### PR TITLE
systrayhelper: 0.0.5 -> unstable-2021-05-20

### DIFF
--- a/pkgs/tools/misc/systrayhelper/default.nix
+++ b/pkgs/tools/misc/systrayhelper/default.nix
@@ -1,18 +1,18 @@
-{ lib, pkg-config, libappindicator-gtk3, buildGoPackage, fetchFromGitHub }:
+{ lib, pkg-config, libappindicator-gtk3, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "systrayhelper";
-  version = "0.0.5";
-  rev = "ded1f2ed4d30f6ca2c89a13db0bd3046c6d6d0f9";
-
-  goPackagePath = "github.com/ssbc/systrayhelper";
+  version = "unstable-2021-05-20";
+  rev = "da47887f050cf0f22d9348cb4493df9ffda2a229";
 
   src = fetchFromGitHub {
-    rev = "v${version}";
     owner = "ssbc";
     repo = "systrayhelper";
-    sha256 = "0bn3nf43m89qmh8ds5vmv0phgdz32idz1zisr47jmvqm2ky1a45s";
+    rev = rev;
+    hash = "sha256-9ejpARZghXhb3EJDvNcidg5QM8Z+P91ICGuA89ksqeA=";
   };
+
+  vendorHash = null;
 
   # re date: https://github.com/NixOS/nixpkgs/pull/45997#issuecomment-418186178
   # > .. keep the derivation deterministic. Otherwise, we would have to rebuild it every time.
@@ -27,11 +27,13 @@ buildGoPackage rec {
   nativeBuildInputs = [ pkg-config libappindicator-gtk3 ];
   buildInputs = [ libappindicator-gtk3 ];
 
+  doCheck = false; # Display required
+
   meta = with lib; {
     description = "A systray utility written in go, using json over stdio for control and events";
-    homepage    = "https://github.com/ssbc/systrayhelper";
+    homepage = "https://github.com/ssbc/systrayhelper";
     maintainers = with maintainers; [ cryptix ];
-    license     = licenses.mit;
+    license = licenses.mit;
     # It depends on the inputs, i guess? not sure about solaris, for instance. go supports it though
     # I hope nix can figure this out?! ¯\\_(ツ)_/¯
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
