### PR TITLE
haskellPackages: adopt maintainership of core haskell infra pkgs from peti

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -298,6 +298,9 @@ package-maintainers:
     - ghcide
     - haskell-language-server
     - hedgehog
+    - hledger
+    - hledger-ui
+    - hledger-web
     - hlint
     - hmatrix
     - hspec-discover
@@ -305,6 +308,7 @@ package-maintainers:
     - matrix-client
     - neuron
     - optics
+    - pandoc
     - paths
     - postgresql-simple
     - reflex-dom
@@ -336,8 +340,6 @@ package-maintainers:
     - funcmp
     - git-annex
     - hledger-interest
-    - hledger-ui
-    - hledger-web
     - hopenssl
     - hsdns
     - hsemail

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -332,13 +332,9 @@ package-maintainers:
   pacien:
     - ldgallery-compiler
   peti:
-    - cabal-install
-    - cabal2nix
     - cabal2spec
-    - distribution-nixpkgs
     - funcmp
     - git-annex
-    - hackage-db
     - hledger
     - hledger-interest
     - hledger-ui
@@ -347,8 +343,6 @@ package-maintainers:
     - hsdns
     - hsemail
     - hsyslog
-    - jailbreak-cabal
-    - language-nix
     - logging-facade-syslog
     - nix-paths
     - pandoc
@@ -401,9 +395,15 @@ package-maintainers:
     - zre
   sternenseemann:
     # also maintain upstream package
+    - cabal2nix
+    - distribution-nixpkgs
+    - hackage-db
+    - language-nix
+    - jailbreak-cabal
     - spacecookie
     - gopher-proxy
     # other packages I can help out for
+    - cabal-install
     - systemd
     - fast-logger
     - flat

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -335,7 +335,6 @@ package-maintainers:
     - cabal2spec
     - funcmp
     - git-annex
-    - hledger
     - hledger-interest
     - hledger-ui
     - hledger-web
@@ -345,7 +344,6 @@ package-maintainers:
     - hsyslog
     - logging-facade-syslog
     - nix-paths
-    - pandoc
     - structured-haskell-mode
     - titlecase
     - xmonad
@@ -404,6 +402,8 @@ package-maintainers:
     - gopher-proxy
     # other packages I can help out for
     - cabal-install
+    - hledger
+    - pandoc
     - systemd
     - fast-logger
     - flat


### PR DESCRIPTION
As discussed on matrix we should probably reduce the noise for peti somewhat. I have already adopted some packages that essentially belong to @NixOS/haskell and it mostly matters that *someone* is pinged. Also empirically I work the most on cabal2nix & friends :)

My proposal would be to leave the packages peti is (sole) hackage maintainer for in his hand, since there is not much we can do anyways. He seems to be monitoring GitHub notifications at least occasionally.

This means we leave…

* funcmp
* cabal2spec
* hopenssl
* hsdns
* hsemail
* hsyslog
* logging-facade-syslog
* nix-paths (this should maybe be adopted by someone?)
* titlecase

as they are. We need people willing to adopt:

* [x] git-annex (has 1 maintainer already)
* [x] hledger (has 1 maintainer already)
* [ ] hledger-interest
* [x] hledger-ui
* [x] hledger-web
* [x] pandoc (has 1 maintainer already)
* [ ] structured-haskell-mode
* [ ] xmonad
* [ ] xmonad-contrib

I have adopted hledger as well as I use it occasionally, but more help would be nice I don't use any of the other packages and am not interested in a cutting edge hledger, maybe @DamienCassou? Same for pandoc, I guess, maybe @jtojnar?

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
