### PR TITLE
python3Packages.pyrender: init at 0.1.45

### DIFF
--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage rec {
   pname = "pyopengl";
   version = "3.1.6";
+  format = "setuptools";
 
   src = fetchPypi {
     pname = "PyOpenGL";
@@ -24,7 +25,20 @@ buildPythonPackage rec {
     substituteInPlace OpenGL/platform/glx.py \
       --replace "'GL'" "'${pkgs.libGL}/lib/libGL${ext}'" \
       --replace "'GLU'" "'${pkgs.libGLU}/lib/libGLU${ext}'" \
-      --replace "'glut'" "'${pkgs.freeglut}/lib/libglut${ext}'"
+      --replace "'glut'" "'${pkgs.freeglut}/lib/libglut${ext}'" \
+      --replace "'GLESv1_CM'," "'${pkgs.libGL}/lib/libGLESv1_CM${ext}'," \
+      --replace "'GLESv2'," "'${pkgs.libGL}/lib/libGLESv2${ext}',"
+    substituteInPlace OpenGL/platform/egl.py \
+      --replace "('OpenGL','GL')" "('${pkgs.libGL}/lib/libOpenGL${ext}', '${pkgs.libGL}/lib/libGL${ext}')" \
+      --replace "'GLU'," "'${pkgs.libGLU}/lib/libGLU${ext}'," \
+      --replace "'glut'," "'${pkgs.freeglut}/lib/libglut${ext}'," \
+      --replace "'GLESv1_CM'," "'${pkgs.libGL}/lib/libGLESv1_CM${ext}'," \
+      --replace "'GLESv2'," "'${pkgs.libGL}/lib/libGLESv2${ext}'," \
+      --replace "'EGL'," "'${pkgs.libGL}/lib/libEGL${ext}',"
+    substituteInPlace OpenGL/platform/darwin.py \
+      --replace "'OpenGL'," "'${pkgs.libGL}/lib/libGL${ext}'," \
+      --replace "'GLUT'," "'${pkgs.freeglut}/lib/libglut${ext}',"
+    # TODO: patch 'gle' in OpenGL/platform/egl.py
   '' + ''
     # https://github.com/NixOS/nixpkgs/issues/76822
     # pyopengl introduced a new "robust" way of loading libraries in 3.1.4.
@@ -41,7 +55,10 @@ buildPythonPackage rec {
   # Tests have many dependencies
   # Extension types could not be found.
   # Should run test suite from $out/${python.sitePackages}
-  doCheck = false;
+  doCheck = false; # does not affect pythonImportsCheck
+
+  # OpenGL looks for libraries during import, making this a somewhat decent test of the flaky patching above.
+  pythonImportsCheck = "OpenGL";
 
   meta = with lib; {
     homepage = "https://pyopengl.sourceforge.net/";

--- a/pkgs/development/python-modules/pyrender/default.nix
+++ b/pkgs/development/python-modules/pyrender/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, fetchpatch
+, freetype-py
+, imageio
+, networkx
+, numpy
+, pillow
+, pyglet
+, pyopengl
+, scipy
+, six
+, trimesh
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyrender";
+  version = "0.1.45";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "mmatl";
+    repo = "pyrender";
+    rev = "refs/tags/${version}";
+    hash = "sha256-V2G8QWXMxFDQpT4XDOJhIFI2V9VhDQCaXYBb/QVLxgM=";
+  };
+
+  patches = [
+    (fetchpatch { # yet to be tagged
+      name = "relax-pyopengl.patch";
+      url = "https://github.com/mmatl/pyrender/commit/7c613e8aed7142df9ff40767a8f10b7a19b6255c.patch";
+      hash = "sha256-SXRV9RC3PfQGjjIQ+n97HZrSDPae3rAHnTBiHXSFLaY=";
+    })
+  ];
+
+  # trimesh too new
+  # issue: https://github.com/mmatl/pyrender/issues/203
+  # mega pr: https://github.com/mmatl/pyrender/pull/216
+  # relevant pr commit: https://github.com/mmatl/pyrender/pull/216/commits/5069aeb957addff8919f05dc9be4040f55bff329
+  # the commit does not apply as a patch when cherry picked, hence the substituteInPlace
+  postPatch = ''
+    substituteInPlace tests/unit/test_meshes.py \
+      --replace \
+        "bm = trimesh.load('tests/data/WaterBottle.glb').dump()[0]" \
+        'bm = trimesh.load("tests/data/WaterBottle.glb").geometry["WaterBottle"]'
+  '';
+
+  propagatedBuildInputs = [
+    freetype-py
+    imageio
+    networkx
+    numpy
+    pillow
+    pyglet
+    pyopengl
+    scipy
+    six
+    trimesh
+  ];
+
+  env.PYOPENGL_PLATFORM = "egl"; # enables headless rendering during check
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # does not work inside sandbox, no GPU
+    "tests/unit/test_offscreen.py"
+  ];
+
+  pythonImportsCheck = [ "pyrender" ];
+
+  meta = with lib; {
+    homepage = "https://pyrender.readthedocs.io/en/latest/";
+    description = "Easy-to-use glTF 2.0-compliant OpenGL renderer for visualization of 3D scenes";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8312,6 +8312,8 @@ self: super: with self; {
 
   pyre-extensions = callPackage ../development/python-modules/pyre-extensions { };
 
+  pyrender = callPackage ../development/python-modules/pyrender { };
+
   pyrevolve = callPackage ../development/python-modules/pyrevolve { };
 
   pyrfxtrx = callPackage ../development/python-modules/pyrfxtrx { };


### PR DESCRIPTION
###### Description of changes

PyRender is really nice to have when working with 3D triangle meshes and point clouds.

This pr also does a fixup of pyopengl, possibly fixing #217275.
The deleted check works when build without sandbox on nixos.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
