### PR TITLE
picard: 2.8.3 -> 2.8.4

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -19,23 +19,14 @@ let
 in
 pythonPackages.buildPythonApplication rec {
   pname = "picard";
-  version = "2.8.3";
+  version = "2.8.4";
 
   src = fetchFromGitHub {
     owner = "metabrainz";
     repo = pname;
-    rev = "refs/tags/release-${version}";
-    sha256 = "sha256-KUHciIlwaKXvyCCkAzdh1vpe9cunDizrMUl0SoCpxgY=";
+    rev = "release-${version}";
+    sha256 = "sha256-ygZkj7hZNm7XyqDEI7l49d36ZgCTwFiAuYZjlF9d5+8=";
   };
-
-  patches = [
-    # fix for tests failing with newer mutagen, remove after >2.8.3
-    # https://tickets.metabrainz.org/browse/PICARD-2583
-    (fetchpatch {
-      url = "https://github.com/metabrainz/picard/commit/76c2dff6b61140bbc7675c9e9f62a086b885e539.patch";
-      hash = "sha256-V1/oq1tEcb1mtqbYAA9o7mJcw16vRO0IK3GGmJkwO1Q=";
-    })
-  ];
 
   nativeBuildInputs = [ gettext qt5.wrapQtAppsHook qt5.qtbase ]
   ++ lib.optionals (pyqt5.multimediaEnabled) [
@@ -71,6 +62,7 @@ pythonPackages.buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://picard.musicbrainz.org/";
+    changelog = "https://picard.musicbrainz.org/changelog/";
     description = "The official MusicBrainz tagger";
     maintainers = with maintainers; [ ehmry ];
     license = licenses.gpl2Plus;


### PR DESCRIPTION


###### Description of changes
https://picard.musicbrainz.org/changelog/#release-2.8.4

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
