### PR TITLE
python3Packages.ariadne: init at 0.16.1

### DIFF
--- a/pkgs/development/python-modules/ariadne/default.nix
+++ b/pkgs/development/python-modules/ariadne/default.nix
@@ -1,0 +1,45 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, freezegun
+, graphql-core
+, lib
+, opentracing
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, snapshottest
+, starlette
+, typing-extensions
+, werkzeug
+}:
+
+buildPythonPackage rec {
+  pname = "ariadne";
+  version = "0.16.1";
+
+  src = fetchFromGitHub {
+    owner = "mirumee";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-HiIg+80vaMzQdqF2JKzP7oZzfpqSTrumXmUHGLT/wF8=";
+  };
+
+  propagatedBuildInputs = [ graphql-core starlette typing-extensions ];
+
+  checkInputs = [
+    freezegun
+    opentracing
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+    snapshottest
+    werkzeug
+  ];
+
+  meta = with lib; {
+    description = "Python library for implementing GraphQL servers using schema-first approach";
+    homepage = "https://ariadnegraphql.org";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -578,6 +578,8 @@ self: super: with self; {
 
   aria2p = callPackage ../development/python-modules/aria2p { };
 
+  ariadne = callPackage ../development/python-modules/ariadne { };
+
   arnparse = callPackage ../development/python-modules/arnparse { };
 
   arrayqueues = callPackage ../development/python-modules/arrayqueues { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
