### PR TITLE
pulumiPackages.pulumi-language-nodejs: init at 3.47.0

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/default.nix
+++ b/pkgs/tools/admin/pulumi-packages/default.nix
@@ -7,5 +7,6 @@ in
   pulumi-aws-native = callPackage' ./pulumi-aws-native.nix { };
   pulumi-azure-native = callPackage' ./pulumi-azure-native.nix { };
   pulumi-language-python = callPackage ./pulumi-language-python.nix { };
+  pulumi-language-nodejs = callPackage ./pulumi-language-nodejs.nix { };
   pulumi-random = callPackage' ./pulumi-random.nix { };
 }

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildGoModule
+, pulumi
+, nodejs
+}:
+buildGoModule rec {
+  inherit (pulumi) version src;
+
+  pname = "pulumi-language-nodejs";
+
+  sourceRoot = "${src.name}/sdk";
+
+  vendorHash = "sha256-IZIdLmNGMFjRdkLPoE9UyON3pX/GBIgz/rv108v8iLY=";
+
+  subPackages = [
+    "nodejs/cmd/pulumi-language-nodejs"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
+  ];
+
+  checkInputs = [
+    nodejs
+  ];
+
+  postInstall = ''
+    cp nodejs/dist/pulumi-resource-pulumi-nodejs $out/bin
+    cp nodejs/dist/pulumi-analyzer-policy $out/bin
+  '';
+}


### PR DESCRIPTION
###### Description of changes

I'm currently using this in a local flake and wanted to contribute it upstream to allow JavaScript and TypeScript users to use the nix packaged Pulumi tool.

First time contributor, so would love any help getting this PR in better shape or running any tests.

Notifying maintainers of pulumi-bin: @ghuntley @peterromfeldhk @jlesquembre @cpcloud

Notifying maintainers of pulumi:
@Trundle @veehaitch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Closes #186174