### PR TITLE
miopen: init at 2.18.0-5.3.3

### DIFF
--- a/pkgs/development/compilers/llvm/rocm/llvm.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm.nix
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
     "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
     "-DLLVM_INSTALL_UTILS=ON" # Needed by rustc
     "-DLLVM_TARGETS_TO_BUILD=AMDGPU;${llvmNativeTarget}"
-    "-DLLVM_ENABLE_PROJECTS=clang;lld;compiler-rt"
+    "-DLLVM_ENABLE_PROJECTS=clang;lld;compiler-rt;clang-tools-extra"
   ]
   ++ lib.optionals enableManpages [
     "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"

--- a/pkgs/development/libraries/miopen/default.nix
+++ b/pkgs/development/libraries/miopen/default.nix
@@ -1,0 +1,215 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, writeScript
+, pkg-config
+, cmake
+, rocm-cmake
+, rocm-runtime
+, rocm-device-libs
+, rocm-comgr
+, rocm-opencl-runtime
+, rocblas
+, rocmlir
+, hip
+, clang
+, clang-ocl
+, llvm
+, miopengemm
+, composable_kernel
+, half
+, boost
+, sqlite
+, bzip2
+, texlive ? null
+, doxygen ? null
+, sphinx ? null
+, python3Packages ? null
+, zlib ? null
+, fetchurl ? null
+, buildDocs ? false
+, buildTests ? false
+# LFS isn't working, so we will manually fetch these
+# This isn't strictly required, but is recommended
+# https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1373
+, fetchKDBs ? true
+, useOpenCL ? false
+}:
+
+assert buildDocs -> texlive != null;
+assert buildDocs -> doxygen != null;
+assert buildDocs -> sphinx != null;
+assert buildDocs -> python3Packages != null;
+assert buildTests -> zlib != null;
+assert fetchKDBs -> fetchurl != null;
+
+let
+  latex = lib.optionalAttrs buildDocs (texlive.combine {
+    inherit (texlive) scheme-small
+    latexmk
+    tex-gyre
+    fncychap
+    wrapfig
+    capt-of
+    framed
+    needspace
+    tabulary
+    varwidth
+    titlesec;
+  });
+
+  kdbs = lib.optionalAttrs fetchKDBs import ./deps.nix {
+    inherit fetchurl;
+    mirror = "https://repo.radeon.com/rocm/miopen-kernel/rel-5.0";
+  };
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "miopen";
+  # We have to manually specify the repoVersion for now
+  # Find the github release or `-- MIOpen_VERSION= X.X.X` in the build log
+  repoVersion = "2.18.0";
+  rocmVersion = "5.3.3";
+  version = "${finalAttrs.repoVersion}-${finalAttrs.rocmVersion}";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildDocs [
+    "doc"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "MIOpen";
+    rev = "rocm-${finalAttrs.rocmVersion}";
+    hash = "sha256-5/JitdGJ0afzK4pGOOywRLsB3/Thc6/71sRkKIxf2Lg=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    rocm-cmake
+    hip
+    clang
+    llvm
+  ];
+
+  buildInputs = [
+    rocm-runtime
+    rocm-device-libs
+    rocm-comgr
+    rocm-opencl-runtime
+    rocblas
+    rocmlir
+    clang-ocl
+    miopengemm
+    composable_kernel
+    half
+    boost
+    sqlite
+    bzip2
+  ] ++ lib.optionals buildDocs [
+    latex
+    doxygen
+    sphinx
+    python3Packages.sphinx_rtd_theme
+    python3Packages.breathe
+    python3Packages.myst-parser
+  ] ++ lib.optionals buildTests [
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DMIOPEN_USE_MIOPENGEMM=ON"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals (!useOpenCL) [
+    "-DCMAKE_C_COMPILER=hipcc"
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    "-DMIOPEN_BACKEND=HIP"
+  ] ++ lib.optionals useOpenCL [
+    "-DCMAKE_C_COMPILER=${clang}/bin/clang"
+    "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"
+    "-DMIOPEN_BACKEND=OpenCL"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_TESTS=ON"
+    "-DMIOPEN_TEST_ALL=ON"
+    "-DMIOPEN_TEST_GFX900=ON"
+    "-DMIOPEN_TEST_GFX906=ON"
+    "-DMIOPEN_TEST_GFX908=ON"
+    "-DMIOPEN_TEST_GFX90A=ON"
+    "-DMIOPEN_TEST_GFX103X=ON"
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "enable_testing()" "" \
+      --replace "MIOPEN_HIP_COMPILER MATCHES \".*clang\\\\+\\\\+$\"" "true" \
+      --replace "/opt/rocm/hip" "${hip}" \
+      --replace "/opt/rocm/llvm" "${llvm}" \
+      --replace "3 REQUIRED PATHS /opt/rocm)" "3 REQUIRED PATHS ${hip})" \
+      --replace "hip REQUIRED PATHS /opt/rocm" "hip REQUIRED PATHS ${hip}" \
+      --replace "rocblas REQUIRED PATHS /opt/rocm" "rocblas REQUIRED PATHS ${rocblas}" \
+      --replace "miopengemm PATHS /opt/rocm" "miopengemm PATHS ${miopengemm}" \
+      --replace "set(MIOPEN_TIDY_ERRORS ALL)" "" # Fix clang-tidy at some point
+  '' + lib.optionalString (!buildTests) ''
+    substituteInPlace CMakeLists.txt \
+      --replace "add_subdirectory(test)" ""
+  '' + lib.optionalString fetchKDBs ''
+    cp -a ${kdbs.gfx1030_36} src/kernels/gfx1030_36.kdb
+    cp -a ${kdbs.gfx900_56} src/kernels/gfx900_56.kdb
+    cp -a ${kdbs.gfx900_64} src/kernels/gfx900_64.kdb
+    cp -a ${kdbs.gfx906_60} src/kernels/gfx906_60.kdb
+    cp -a ${kdbs.gfx906_64} src/kernels/gfx906_64.kdb
+    cp -a ${kdbs.gfx90878} src/kernels/gfx90878.kdb
+    cp -a ${kdbs.gfx90a68} src/kernels/gfx90a68.kdb
+    cp -a ${kdbs.gfx90a6e} src/kernels/gfx90a6e.kdb
+  '';
+
+  # Unfortunately, it seems like we have to call make on these manually
+  postBuild = lib.optionalString buildDocs ''
+    export HOME=$(mktemp -d)
+    make doc
+  '' + lib.optionalString buildTests ''
+    make -j$NIX_BUILD_CORES check
+  '';
+
+  postInstall = ''
+    rm $out/bin/install_precompiled_kernels.sh
+  '' + lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv bin/test_* $test/bin
+    patchelf --set-rpath ${lib.makeLibraryPath (finalAttrs.nativeBuildInputs ++ finalAttrs.buildInputs)}:$out/lib $test/bin/*
+  '';
+
+  postFixup = lib.optionalString (buildDocs && !useOpenCL) ''
+    export docDir=$doc/share/doc/miopen-hip
+  '' + lib.optionalString (buildDocs && useOpenCL) ''
+    export docDir=$doc/share/doc/miopen-opencl
+  '' + lib.optionalString buildDocs ''
+    mkdir -p $docDir
+    mv ../doc/html $docDir
+    mv ../doc/pdf/miopen.pdf $docDir
+  '';
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+    rocmVersion="$(curl -sL "https://api.github.com/repos/ROCmSoftwarePlatform/MIOpen/releases?per_page=1" | jq '.[0].tag_name | split("-") | .[1]' --raw-output)"
+    update-source-version miopen "$rocmVersion" --ignore-same-hash --version-key=rocmVersion
+  '';
+
+  meta = with lib; {
+    description = "Machine intelligence library for ROCm";
+    homepage = "https://github.com/ROCmSoftwarePlatform/MIOpen";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    broken = finalAttrs.rocmVersion != hip.version;
+    # MIOpen will produce a very large output due to KDBs fetched
+    # Also possibly in the future because of KDB generation
+    hydraPlatforms = [ ];
+  };
+})

--- a/pkgs/development/libraries/miopen/deps.nix
+++ b/pkgs/development/libraries/miopen/deps.nix
@@ -1,0 +1,45 @@
+{ fetchurl
+, mirror
+}:
+
+{
+  gfx1030_36 = fetchurl {
+    sha256 = "sha256-zEXDLkRWAHS15LDA5IRyqG5rO7HHPBiVgPlQ8JjSqNc=";
+    url = "${mirror}/gfx1030_36.kdb";
+  };
+
+  gfx900_56 = fetchurl {
+    sha256 = "sha256-ZTqUPhVKcQzjO6bxykvZMJk1VZh31dRVs+XqcxEtmeI=";
+    url = "${mirror}/gfx900_56.kdb";
+  };
+
+  gfx900_64 = fetchurl {
+    sha256 = "sha256-ZTqUPhVKcQzjO6bxykvZMJk1VZh31dRVs+XqcxEtmeI=";
+    url = "${mirror}/gfx900_64.kdb";
+  };
+
+  gfx906_60 = fetchurl {
+    sha256 = "sha256-U6pDo8ICfs6fVIEqRziWeE5/4Vzvu41JkcRVn3ou1e4=";
+    url = "${mirror}/gfx906_60.kdb";
+  };
+
+  gfx906_64 = fetchurl {
+    sha256 = "sha256-U6pDo8ICfs6fVIEqRziWeE5/4Vzvu41JkcRVn3ou1e4=";
+    url = "${mirror}/gfx906_64.kdb";
+  };
+
+  gfx90878 = fetchurl {
+    sha256 = "sha256-r7DRhNH+jHUXAu64b9vWsZzGD4w5oSHnxH0l2RN0qlQ=";
+    url = "${mirror}/gfx90878.kdb";
+  };
+
+  gfx90a68 = fetchurl {
+    sha256 = "sha256-NT//zIPTbzsPJyaVycxwU6BcMTzGc/d+Z4Ab9FImDko=";
+    url = "${mirror}/gfx90a68.kdb";
+  };
+
+  gfx90a6e = fetchurl {
+    sha256 = "sha256-ENZHbf+/MGYgSTpALKh2meuZPNhH5bG+WrW/jzvGpBs=";
+    url = "${mirror}/gfx90a6e.kdb";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14973,6 +14973,19 @@ with pkgs;
 
   rocthrust = callPackage ../development/libraries/rocthrust { };
 
+  miopen = callPackage ../development/libraries/miopen {
+    inherit (llvmPackages_rocm) clang llvm;
+    boost = boost.override { enableStatic = true; };
+  };
+
+  miopen-hip = miopen.override {
+    useOpenCL = false;
+  };
+
+  miopen-opencl = miopen.override {
+    useOpenCL = true;
+  };
+
   rtags = callPackage ../development/tools/rtags {
     inherit (darwin) apple_sdk;
   };


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
I wanted to get either a way to generate KDBs or more of them added to https://repo.radeon.com/rocm/miopen-kernel/rel-5.0/, but I don't think that's gonna happen for a while. So, doing the PR now.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
