### PR TITLE
ocamlPackages.calendar: 2.5 → 3.0

### DIFF
--- a/pkgs/development/ocaml-modules/calendar/default.nix
+++ b/pkgs/development/ocaml-modules/calendar/default.nix
@@ -1,27 +1,25 @@
-{ stdenv, lib, fetchurl, ocaml, findlib }:
+{ lib, buildDunePackage, fetchFromGitHub, re }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml-calendar";
-  version = "2.5";
+buildDunePackage rec {
+  pname = "calendar";
+  version = "3.0.0";
+  minimalOCamlVersion = "4.03";
 
-  src = fetchurl {
-    url = "https://forge.ocamlcore.org/frs/download.php/915/calendar-${version}.tar.bz2";
-    sha256 = "04pvhwb664g3s644c7v7419a3kvf5s3pynkhmk5j59dvlfm1yf0f";
+  src = fetchFromGitHub {
+    owner = "ocaml-community";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-+VQzi6pEMqzV1ZR84Yjdu4jsJEWtx+7bd6PQGX7TiEs=";
   };
 
-  nativeBuildInputs = [ ocaml findlib ];
+  propagatedBuildInputs = [ re ];
 
   strictDeps = true;
 
-  createFindlibDestdir = true;
-
   meta = {
-    homepage = "https://forge.ocamlcore.org/projects/calendar/";
-    description = "An Objective Caml library managing dates and times";
-    license = "LGPL";
-    platforms = ocaml.meta.platforms or [ ];
-    maintainers = [
-      lib.maintainers.gal_bolle
-    ];
+    inherit (src.meta) homepage;
+    description = "A library for handling dates and times";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.gal_bolle ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
