### PR TITLE
boot: Development (& experimental) setup for SecureBoot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,7 @@
 /nixos/doc/manual/man-nixos-option.xml                @nbp
 /nixos/modules/installer/tools/nixos-option.sh        @nbp
 /nixos/modules/system                                 @dasJ
+/nixos/modules/system/activation/bootspec.nix         @grahamc @cole-h
 
 # NixOS integration test driver
 /nixos/lib/test-driver  @tfc

--- a/doc/builders/images.xml
+++ b/doc/builders/images.xml
@@ -10,4 +10,5 @@
  <xi:include href="images/ocitools.section.xml" />
  <xi:include href="images/snaptools.section.xml" />
  <xi:include href="images/portableservice.section.xml" />
+ <xi:include href="images/makediskimage.section.xml" />
 </chapter>

--- a/doc/builders/images/makediskimage.section.md
+++ b/doc/builders/images/makediskimage.section.md
@@ -1,0 +1,180 @@
+# `<nixpkgs/nixos/lib/make-disk-image.nix>` {#sec-make-disk-image}
+
+`<nixpkgs/nixos/lib/make-disk-image.nix>` is a function to create _disk image_ in multiple formats: raw, QCOW2 (QEMU image format), QCOW2-Compressed (compressed version), VDI (Virtual Box native format), VPC (VirtualPC).
+
+There are two operations mode for this function:
+
+- either, you want only a Nix store disk image, it can be done using `cptofs` without any virtual machine involved ;
+- either, you want a full NixOS install on the disk, it will start a virtual machine to perform various tasks such as partitionning, installation and bootloader installation.
+
+When NixOS tests are running, this function gets called to generate potentially two kinds of disk images:
+
+- a Nix-store only disk image: useful when the test _do not need_ bootloader
+- a full-fledged NixOS installation disk image: useful when the test _do need_ to test the bootloader
+
+## Features
+
+- whether to produce a Nix-store only image or not, **this can be incompatible with other options**
+- arbitrary NixOS configuration ;
+- multiple partition table layouts: EFI, legacy, legacy + GPT, hybrid, none ;
+- automatic or bound disk size: `diskSize` parameter, `additionalSpace` can be set when `diskSize` is `auto` to add a constant of disk space ;
+- boot partition size when partition table is `efi` or `hybrid` ;
+- arbitrary contents with permissions can be placed in the target filesystem using `contents`, incompatible with Nix-store only image
+- bootloaders are supported, incompatible with Nix-store only image
+- EFI variables can be mutated during image production and the result is exposed in `$out` ;
+- system management mode (SMM) can enabled during virtual machine operations ;
+- OVMF or EFI firmwares and variables templates can be customized ;
+- root filesystem `fsType` can be customized to whatever `mkfs.${fsType}` exist during operations ;
+- root filesystem label can be customized, defaults to `nix-store` if it's a nix store image, otherwise `nixpkgs/nixos`
+- a `/etc/nixpkgs/nixos/configuration.nix` can be provided through `configFile`, incompatible with a Nix-store only image
+- arbitrary code can be executed after the VM has finished its operations with `postVM`
+- the current nixpkgs can be realized as a channel in the disk image, which will change the hash of the image when the sources are updated ;
+- additional store paths can be provided through `additionalPaths`
+
+Images are **NOT** deterministic, please do not hesitate to try to fix this, source of determinisms are (not exhaustive) :
+
+- bootloader installation have timestamps ;
+- SQLite Nix store database contain registration times ;
+- UIDs / GIDs Nix mappings are in a non-deterministic order ;
+- `/etc/shadow` is in a non-deterministic order
+
+For more, read the function signature source code for documentation on arguments: <https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/make-disk-image.nix>.
+
+## Usage
+
+To produce a Nix-store only image:
+```nix
+let
+  pkgs = import <nixpkgs> {};
+  lib = pkgs.lib;
+  make-disk-image = import <nixpkgs/nixos/lib/make-disk-image.nix>;
+in
+  make-disk-image {
+    inherit pkgs lib;
+    config = {};
+    additionalPaths = [ ];
+    format = "qcow2";
+    onlyNixStore = true;
+    partitionTableType = "none";
+    installBootLoader = false;
+    touchEFIVars = false;
+    diskSize = "auto";
+    additionalSpace = "0M"; # Defaults to 512M.
+    copyChannel = false;
+  }
+```
+
+Some arguments can be left out, they are shown explicitly for the sake of the example.
+
+Building this derivation will provide a QCOW2 disk image containing only the Nix store and its registration information.
+
+To produce a NixOS installation image disk with UEFI and bootloader installed:
+```nix
+let
+  pkgs = import <nixpkgs> {};
+  lib = pkgs.lib;
+  make-disk-image = import <nixpkgs/nixos/lib/make-disk-image.nix>;
+  evalConfig = import <nixpkgs/nixos/lib/eval-config.nix>;
+in
+  make-disk-image {
+    inherit pkgs lib;
+    config = evalConfig {
+      modules = [
+        {
+          fileSystems."/" = { device = "/dev/vda"; fsType = "ext4"; autoFormat = true; };
+          boot.grub.device = "/dev/vda";
+        }
+      ];
+    };
+    format = "qcow2";
+    onlyNixStore = false;
+    partitionTableType = "legacy+gpt";
+    installBootLoader = true;
+    touchEFIVars = true;
+    diskSize = "auto";
+    additionalSpace = "0M"; # Defaults to 512M.
+    copyChannel = false;
+  }
+```
+
+## Technical details
+
+`make-disk-image` has a bit of magic to minimize the amount of work to do in a virtual machine.
+
+It relies on the [LKL (Linux Kernel Library) project](https://github.com/lkl/linux) which provides Linux kernel as userspace library.
+
+Note that Nix-store only image only need to run LKL tools to produce an image and will never spawn a virtual machine, whereas full images will always require a virtual machine, but also use LKL.
+
+### Image preparation phase
+
+Image preparation phase will produce the initial image layout in a folder:
+
+- devise a root folder based on `$PWD`
+- preparing the contents by copying and restoring ACLs in this root folder ;
+- load in the Nix store database all additional paths computed by `pkgs.closureInfo` in a temporary Nix store ;
+- run `nixos-install` in a temporary folder ;
+- transfer from the temporary store the additional paths registered to the installed NixOS ;
+- do fancy computations for the size of the disk image based on the apparent size of the root folder ;
+- partition the disk image using the corresponding script according to the partition table type ;
+- format the partitions if needed ;
+- use `cptofs` (LKL tool) to copy the root folder inside the disk image
+
+At this step, the disk image contains already the Nix store, it only needs to be converted to the desired format to be used.
+
+### Image conversion phase
+
+Using `qemu-img`, the disk image is converted from a raw format to the desired format: qcow2(-compressed), vdi, vpc.
+
+### Partitionning script based on layouts
+
+#### `none`
+
+No partition table layout is written.
+
+#### `legacy`
+
+This partition table type is composed of a MBR and one primary ext4 partition starting at 1MiB extending to the full disk image.
+
+It is unsuitable for UEFI.
+
+#### `legacy+gpt`
+
+This partition table type uses GPT and:
+
+- create a "no filesystem" partition from 1MiB to 2MiB ;
+- set `bios_grub` flag on this "no filesystem" partition, which is some sort of MBR ;
+- create a primary ext4 partition starting at 2MiB and extending to the full disk image ;
+- perform optimal alignments checks on each partition
+
+This partition has no ESP partition, it is unsuitable for EFI boot which requires an ESP partition, but it can work with CSM (Compatibility Support Module) which emulates BIOS for UEFI.
+
+#### `efi`
+
+This partition table type uses GPT and:
+
+- creates an FAT32 ESP partition from 8MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
+- create a primary ext4 partition starting after the boot one and extending to the full disk image
+
+#### `hybrid`
+
+This partition table type uses GPT and:
+
+- creates a "no filesystem" partition from 0 to 1MiB, set `bios_grub` flag on it ;
+- creates an FAT32 ESP partition from 8MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
+- creates a primary ext4 partition starting after the boot one and extending to the full disk image
+
+This partition could be booted by a BIOS able to understand GPT layouts and recognizing the MBR at the start.
+
+### How to run determinism analysis on results?
+
+Run your derivation with `--check` to rebuild it and verify it is the same.
+
+Once it fails, you will be left with two folders with one having `.check`.
+
+`diffoscope` is not able at the moment to diff two QCOW2 filesystems, it is advised to use raw format.
+
+But even with raw formats, `diffoscope` cannot diff the partition table and partitions recursively.
+
+For this, you can run `fdisk -l $image` and generate `dd if=$image of=$image-p$i.raw skip=$start count=$sectors` for each `(start, sectors)` listed in the `fdisk` output.
+
+With this, you will have each partition as a separate file and you can diffoscope pairs of them to use `diffoscope` ability to read filesystems.

--- a/nixos/doc/manual/from_md/configuration/bootloader-external.section.xml
+++ b/nixos/doc/manual/from_md/configuration/bootloader-external.section.xml
@@ -1,0 +1,41 @@
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-bootloader-external">
+  <title>External Bootloader Backends</title>
+  <para>
+    NixOS has support for several bootloader backends by default:
+    systemd-boot, grub, uboot, etc. The built-in bootloader backend
+    support is generic and supports most use cases. Some users may
+    prefer to create advanced workflows around managing the bootloader
+    and bootable entries.
+  </para>
+  <para>
+    You can replace the built-in bootloader support with your own
+    tooling using the <quote>external</quote> bootloader option.
+  </para>
+  <para>
+    Imagine you have created a new packaged called FooBoot. FooBoot
+    provides a program at
+    <literal>${pkgs.fooboot}/bin/fooboot-install</literal> which takes
+    the system closure’s path as its only argument and configures the
+    system’s bootloader.
+  </para>
+  <para>
+    You can enable FooBoot like this:
+  </para>
+  <programlisting language="bash">
+{ pkgs, ... }: {
+  boot.loader.external = {
+    enable = true;
+    installHook = &quot;${pkgs.fooboot}/bin/fooboot-install&quot;;
+  };
+}
+</programlisting>
+  <section>
+    <title>Developing Custom Bootloader Backends</title>
+    <para>
+      Bootloaders should use
+      <link xlink:href="https://github.com/NixOS/rfcs/pull/125">RFC-0125</link>’s
+      Bootspec format and synthesis tools to identify the key properties
+      for bootable system generations.
+    </para>
+  </section>
+</section>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1250,6 +1250,14 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
+          QEMU test architecture supports running System Management
+          Enforcement (SMM), useful to lock down UEFI authenticated
+          variables. At the moment, it seems to prevent any change to
+          UEFI platform, breaking disk production and tests, if enabled.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>nixos/lib/make-disk-image.nix</literal> can now
           mutate EFI variables, run user-provided EFI firmware or
           variable templates. As a result, NixOS tests have better

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -188,6 +188,14 @@
       </listitem>
       <listitem>
         <para>
+          Disk layout in NixOS tests has changed when using bootloaders:
+          instead of two disks <literal>/dev/vda</literal> and
+          <literal>/dev/vdb</literal>, there is only a unified
+          <literal>/dev/vda</literal> with multiple partitions.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>hardware.nvidia</literal> has a new option
           <literal>open</literal> that can be used to opt in the
           opensource version of NVIDIA kernel driver. Note that the
@@ -561,6 +569,21 @@
           Please convert any uses to
           <link linkend="opt-services.logrotate.settings">services.logrotate.settings</link>
           instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Disk layout in NixOS tests has changed when using bootloaders:
+          instead of two disks <literal>/dev/vda</literal> and
+          <literal>/dev/vdb</literal>, there is only a unified
+          <literal>/dev/vda</literal> with multiple partitions. This
+          require you to change <literal>/dev/vdc</literal> to
+          <literal>/dev/vdb</literal> and so on if you were using
+          <literal>emptyDiskImages</literal> which creates disks in
+          order, as <literal>/dev/vdb</literal> has disappeared, every
+          disk has to start over from <literal>/dev/vdb</literal> rather
+          than <literal>/dev/vdc</literal>, see the #191665 PR in
+          nixpkgs to learn about examples for your migration.
         </para>
       </listitem>
       <listitem>
@@ -1215,6 +1238,22 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
           breaking change. See
           <link xlink:href="https://git.freesoftwareextremist.com/bloat/commit/?id=887ed241d64ba5db3fd3d87194fb5595e5ad7d73">this
           upstream commit message</link> for details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>pkgs.OVMF.fd</literal> exposes
+          <literal>firmware</literal> and <literal>variables</literal>
+          which points to your host architecture binaries for the
+          correspoding UEFI artifacts.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>nixos/lib/make-disk-image.nix</literal> can now
+          mutate EFI variables, run user-provided EFI firmware or
+          variable templates. As a result, NixOS tests have better
+          support of UEFI platforms tests such as SecureBoot tests.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -72,6 +72,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - An image configuration and generator has been added for Linode images, largely based on the present GCE configuration and image.
 
+- Disk layout in NixOS tests has changed when using bootloaders: instead of two disks `/dev/vda` and `/dev/vdb`, there is only a unified `/dev/vda` with multiple partitions.
+
 - `hardware.nvidia` has a new option `open` that can be used to opt in the opensource version of NVIDIA kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [NVIDIA Releases Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for the official announcement.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
@@ -188,6 +190,10 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 - Deprecated settings `logrotate.paths` and `logrotate.extraConfig` have
   been removed. Please convert any uses to
   [services.logrotate.settings](#opt-services.logrotate.settings) instead.
+
+- Disk layout in NixOS tests has changed when using bootloaders: instead of two disks `/dev/vda` and `/dev/vdb`, there is only a unified `/dev/vda` with multiple partitions.
+  This require you to change `/dev/vdc` to `/dev/vdb` and so on if you were using `emptyDiskImages` which creates disks in order, as `/dev/vdb` has disappeared, every disk
+  has to start over from `/dev/vdb` rather than `/dev/vdc`, see the #191665 PR in nixpkgs to learn about examples for your migration.
 
 - The `isPowerPC` predicate, found on `platform` attrsets (`hostPlatform`, `buildPlatform`, `targetPlatform`, etc) has been removed in order to reduce confusion.  The predicate was was defined such that it matches only the 32-bit big-endian members of the POWER/PowerPC family, despite having a name which would imply a broader set of systems.  If you were using this predicate, you can replace `foo.isPowerPC` with `(with foo; isPower && is32bit && isBigEndian)`.
 
@@ -380,6 +386,11 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
   `~/.local/share/PrismLauncher/prismlauncher.cfg`.
 
 - The `bloat` package has been updated from unstable-2022-03-31 to unstable-2022-10-25, which brings a breaking change. See [this upstream commit message](https://git.freesoftwareextremist.com/bloat/commit/?id=887ed241d64ba5db3fd3d87194fb5595e5ad7d73) for details.
+
+- `pkgs.OVMF.fd` exposes `firmware` and `variables` which points to your host architecture binaries for the correspoding UEFI artifacts.
+
+- `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates.
+  As a result, NixOS tests have better support of UEFI platforms tests such as SecureBoot tests.
 
 - The `services.matrix-synapse` systemd unit has been hardened.
 

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -389,6 +389,9 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - `pkgs.OVMF.fd` exposes `firmware` and `variables` which points to your host architecture binaries for the correspoding UEFI artifacts.
 
+- QEMU test architecture supports running System Management Enforcement (SMM), useful to lock down UEFI authenticated variables.
+  At the moment, it seems to prevent any change to UEFI platform, breaking disk production and tests, if enabled.
+
 - `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates.
   As a result, NixOS tests have better support of UEFI platforms tests such as SecureBoot tests.
 

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -17,7 +17,7 @@
   # either "efi" or "hybrid"
   # This will be undersized slightly, as this is actually the offset of
   # the end of the partition. Generally it will be 1MiB smaller.
-  bootSize ? "256MiB"
+  bootSize ? "256M"
 
 , # The files and directories to be placed in the target file system.
   # This is a list of attribute sets {source, target, mode, user, group} where

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1199,6 +1199,7 @@
   ./system/boot/loader/grub/grub.nix
   ./system/boot/loader/grub/ipxe.nix
   ./system/boot/loader/grub/memtest.nix
+  ./system/boot/loader/external/external.nix
   ./system/boot/loader/init-script/init-script.nix
   ./system/boot/loader/loader.nix
   ./system/boot/loader/raspberrypi/raspberrypi.nix

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -28,6 +28,8 @@ let
             children);
         in
         ''
+          mkdir -p $out/bootspec
+
           ${pkgs.jq}/bin/jq '
             .toplevel = $toplevel |
             .init = $init
@@ -40,7 +42,7 @@ let
               --sort-keys \
               '.specialisation = ($ARGS.named | map_values(. | first))' \
               ${lib.concatStringsSep " " specialisationLoader} \
-            > $out/${filename}
+            > $out/bootspec/${filename}
         '';
     };
   };

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -1,0 +1,50 @@
+# Note that these schemas are defined by RFC-0125.
+# This document is considered a stable API, and is depended upon by external tooling.
+# Changes to the structure of the document, or the semantics of the values should go through an RFC.
+#
+# See: https://github.com/NixOS/rfcs/pull/125
+{ config, pkgs, lib, children }:
+let
+  schemas = {
+    v1 = rec {
+      filename = "boot.v1.json";
+      json =
+        pkgs.writeText filename
+          (builtins.toJSON
+            {
+              schemaVersion = 1;
+
+              kernel = "${config.boot.kernelPackages.kernel}/${config.system.boot.loader.kernelFile}";
+              kernelParams = config.boot.kernelParams;
+              initrd = "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}";
+              initrdSecrets = "${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets";
+              label = "NixOS ${config.system.nixos.codeName} ${config.system.nixos.label} (Linux ${config.boot.kernelPackages.kernel.modDirVersion})";
+
+              specialisation = lib.mapAttrs
+                (childName: childToplevel: {
+                  bootspec = "${childToplevel}/${filename}";
+                })
+                children;
+            });
+
+      generator = ''
+        ${pkgs.jq}/bin/jq '
+          .toplevel = $toplevel |
+          .init = $init
+          ' \
+          --sort-keys \
+          --arg toplevel "$out" \
+          --arg init "$out/init" \
+          < ${json} \
+          > $out/${filename}
+      '';
+    };
+  };
+in
+{
+  # This will be run as a part of the `systemBuilder` in ./top-level.nix. This
+  # means `$out` points to the output of `config.system.build.toplevel` and can
+  # be used for a variety of things (though, for now, it's only used to report
+  # the path of the `toplevel` itself and the `init` executable).
+  writer = schemas.v1.generator;
+}

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -19,6 +19,12 @@ let
               initrd = "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}";
               initrdSecrets = "${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets";
               label = "NixOS ${config.system.nixos.codeName} ${config.system.nixos.label} (Linux ${config.boot.kernelPackages.kernel.modDirVersion})";
+
+              extension = if config.boot.loader.efi.enable then {
+                esp = config.boot.loader.efi.efiSysMountPoint;
+                bootctl = "${config.systemd.package}/bin/bootctl";
+                osRelease = config.environment.etc."os-release".path;
+              } else {};
             });
 
       generator =

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -103,7 +103,9 @@ let
 
       echo -n "${toString config.system.extraDependencies}" > $out/extra-dependencies
 
-      ${bootSpec.writer}
+      ${optionalString (!config.boot.isContainer) ''
+        ${bootSpec.writer}
+      ''}
 
       ${config.system.extraSystemBuilderCmds}
     '';

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -22,6 +22,14 @@ let
         "${config.system.boot.loader.kernelFile}";
       initrdPath = "${config.system.build.initialRamdisk}/" +
         "${config.system.boot.loader.initrdFile}";
+
+      bootSpec = import ./bootspec.nix {
+        inherit
+          config
+          pkgs
+          lib
+          children;
+      };
     in ''
       mkdir $out
 
@@ -94,6 +102,8 @@ let
       ''}
 
       echo -n "${toString config.system.extraDependencies}" > $out/extra-dependencies
+
+      ${bootSpec.writer}
 
       ${config.system.extraSystemBuilderCmds}
     '';

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -3,6 +3,10 @@
 with lib;
 
 let
+  children =
+    mapAttrs
+      (childName: childConfig: childConfig.configuration.system.build.toplevel)
+      config.specialisation;
   systemBuilder =
     let
       kernelPath = "${config.boot.kernelPackages.kernel}/" +

--- a/nixos/modules/system/boot/loader/efi.nix
+++ b/nixos/modules/system/boot/loader/efi.nix
@@ -4,6 +4,11 @@ with lib;
 
 {
   options.boot.loader.efi = {
+    enable = mkOption {
+      default = false;
+      type = types.bool;
+      description = lib.mdDoc "Enable UEFI booting";
+    };
 
     canTouchEfiVariables = mkOption {
       default = false;

--- a/nixos/modules/system/boot/loader/external/external.md
+++ b/nixos/modules/system/boot/loader/external/external.md
@@ -1,0 +1,26 @@
+# External Bootloader Backends {#sec-bootloader-external}
+
+NixOS has support for several bootloader backends by default: systemd-boot, grub, uboot, etc.
+The built-in bootloader backend support is generic and supports most use cases.
+Some users may prefer to create advanced workflows around managing the bootloader and bootable entries.
+
+You can replace the built-in bootloader support with your own tooling using the "external" bootloader option.
+
+Imagine you have created a new packaged called FooBoot.
+FooBoot provides a program at `${pkgs.fooboot}/bin/fooboot-install` which takes the system closure's path as its only argument and configures the system's bootloader.
+
+You can enable FooBoot like this:
+
+```nix
+{ pkgs, ... }: {
+  boot.loader.external = {
+    enable = true;
+    installHook = "${pkgs.fooboot}/bin/fooboot-install";
+  };
+}
+```
+
+## Developing Custom Bootloader Backends
+
+Bootloaders should use [RFC-0125](https://github.com/NixOS/rfcs/pull/125)'s Bootspec format and synthesis tools to identify the key properties for bootable system generations.
+

--- a/nixos/modules/system/boot/loader/external/external.nix
+++ b/nixos/modules/system/boot/loader/external/external.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.boot.loader.external;
+in
+{
+  meta = {
+    maintainers = with maintainers; [ cole-h grahamc ];
+    # Don't edit the docbook xml directly, edit the md and generate it:
+    # `pandoc external.md -t docbook --top-level-division=chapter --extract-media=media -f markdown+smart > external.xml`
+    doc = ./external.xml;
+  };
+
+  options.boot.loader.external = {
+    enable = mkEnableOption "use an external tool to install your bootloader";
+
+    installHook = mkOption {
+      type = with types; path;
+      description = ''
+        The full path to a program of your choosing which performs the bootloader installation process.
+
+        The program will be called with an argument pointing to the output of the system's toplevel.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    boot.loader = {
+      grub.enable = mkDefault false;
+      systemd-boot.enable = mkDefault false;
+      supportsInitrdSecrets = false;
+    };
+
+    system.build.installBootLoader = cfg.installHook;
+  };
+}

--- a/nixos/modules/system/boot/loader/external/external.nix
+++ b/nixos/modules/system/boot/loader/external/external.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.boot.loader.external;
-  nib = pkgs.writeShellScriptBin "nixos-install-bootloader" "nixos-install-bootloader" ''
+  nib = pkgs.writeShellScriptBin "nixos-install-bootloader" ''
     ${if cfg.passBootspec then
     ''
       echo "Passing bootspec to bootloader installer"

--- a/nixos/modules/system/boot/loader/external/external.xml
+++ b/nixos/modules/system/boot/loader/external/external.xml
@@ -1,0 +1,41 @@
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-bootloader-external">
+  <title>External Bootloader Backends</title>
+  <para>
+    NixOS has support for several bootloader backends by default:
+    systemd-boot, grub, uboot, etc. The built-in bootloader backend
+    support is generic and supports most use cases. Some users may
+    prefer to create advanced workflows around managing the bootloader
+    and bootable entries.
+  </para>
+  <para>
+    You can replace the built-in bootloader support with your own
+    tooling using the <quote>external</quote> bootloader option.
+  </para>
+  <para>
+    Imagine you have created a new packaged called FooBoot. FooBoot
+    provides a program at
+    <literal>${pkgs.fooboot}/bin/fooboot-install</literal> which takes
+    the system closure’s path as its only argument and configures the
+    system’s bootloader.
+  </para>
+  <para>
+    You can enable FooBoot like this:
+  </para>
+  <programlisting language="bash">
+{ pkgs, ... }: {
+  boot.loader.external = {
+    enable = true;
+    installHook = &quot;${pkgs.fooboot}/bin/fooboot-install&quot;;
+  };
+}
+</programlisting>
+  <section xml:id="developing-custom-bootloader-backends">
+    <title>Developing Custom Bootloader Backends</title>
+    <para>
+      Bootloaders should use
+      <link xlink:href="https://github.com/NixOS/rfcs/pull/125">RFC-0125</link>’s
+      Bootspec format and synthesis tools to identify the key properties
+      for bootable system generations.
+    </para>
+  </section>
+</chapter>

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -55,6 +55,11 @@ let
 
   };
 
+  selectPartitionTableLayout = { useEFIBoot, useDefaultFilesystems }:
+  if useDefaultFilesystems then
+    if useEFIBoot then "efi" else "legacy"
+  else "none";
+
   driveCmdline = idx: { file, driveExtraOpts, deviceExtraOpts, ... }:
     let
       drvId = "drive${toString idx}";
@@ -98,7 +103,6 @@ let
   addDeviceNames =
     imap1 (idx: drive: drive // { device = driveDeviceName idx; });
 
-
   # Shell script to start the VM.
   startVM =
     ''
@@ -111,8 +115,22 @@ let
       NIX_DISK_IMAGE=$(readlink -f "''${NIX_DISK_IMAGE:-${config.virtualisation.diskImage}}")
 
       if ! test -e "$NIX_DISK_IMAGE"; then
-          ${qemu}/bin/qemu-img create -f qcow2 "$NIX_DISK_IMAGE" \
-            ${toString config.virtualisation.diskSize}M
+          echo "Disk image do not exist, creating the virtualisation disk image..."
+          # If we are using a bootloader and default filesystems layout.
+          # We have to reuse the system image layout as a backing image format (CoW)
+          # And we can write on the top of it, this way.
+          # Otherwise, if we are not using the default filesystem layout, maybe, we want the raw disk
+          # and we do boot using the system image direct kernels (useBootLoader == false),
+          # but we want to perform operations in the postDeviceCommands
+          # to format the raw disk, etc. So we will not depend on the system image layout as a backing image format.
+          # Also, if we are not using a bootloader, we can use the size parameter as we are not using CoW anymore.
+          # CoW prevent size to be affected to an image, TODO: is this a bug?
+          ${qemu}/bin/qemu-img create \
+          ${concatStringsSep " \\\n" ([ "-f qcow2" ]
+          ++ optional (cfg.useBootLoader && cfg.useDefaultFilesystems) "-F qcow2 -b ${systemImage}/nixos.qcow2"
+          ++ optional (!cfg.useBootLoader) "-o size=${toString config.virtualisation.diskSize}M"
+          ++ [ "$NIX_DISK_IMAGE" ])}
+          echo "Virtualisation disk image created."
       fi
 
       # Create a directory for storing temporary data of the running VM.
@@ -152,17 +170,13 @@ let
 
       ${lib.optionalString cfg.useBootLoader
       ''
-        # Create a writable copy/snapshot of the boot disk.
-        # A writable boot disk can be booted from automatically.
-        ${qemu}/bin/qemu-img create -f qcow2 -F qcow2 -b ${bootDisk}/disk.img "$TMPDIR/disk.img"
-
-        NIX_EFI_VARS=$(readlink -f "''${NIX_EFI_VARS:-${cfg.efiVars}}")
+        NIX_EFI_VARS=$(readlink -f "''${NIX_EFI_VARS:-${config.system.name}-efi-vars.fd}")
 
         ${lib.optionalString cfg.useEFIBoot
         ''
           # VM needs writable EFI vars
           if ! test -e "$NIX_EFI_VARS"; then
-            cp ${bootDisk}/efi-vars.fd "$NIX_EFI_VARS"
+            cp ${systemImage}/efi-vars.fd "$NIX_EFI_VARS"
             chmod 0644 "$NIX_EFI_VARS"
           fi
         ''}
@@ -203,91 +217,21 @@ let
   # in the MBR.  Used when the `useBootLoader' option is set.
   # Uses `runInLinuxVM` to create the image in a throwaway VM.
   # See note [Disk layout with `useBootLoader`].
-  # FIXME: use nixos/lib/make-disk-image.nix.
-  bootDisk =
-    pkgs.vmTools.runInLinuxVM (
-      pkgs.runCommand "nixos-boot-disk"
-        { preVM =
-            ''
-              mkdir $out
-              diskImage=$out/disk.img
-              ${qemu}/bin/qemu-img create -f qcow2 $diskImage "60M"
-              ${if cfg.useEFIBoot then ''
-                efiVars=$out/efi-vars.fd
-                cp ${cfg.efi.variables} $efiVars
-                chmod 0644 $efiVars
-              '' else ""}
-            '';
-          buildInputs = [ pkgs.util-linux ];
-          QEMU_OPTS = "-nographic -serial stdio -monitor none"
-                      + lib.optionalString cfg.useEFIBoot (
-                        " -drive if=pflash,format=raw,unit=0,readonly=on,file=${cfg.efi.firmware}"
-                      + " -drive if=pflash,format=raw,unit=1,file=$efiVars");
-        }
-        ''
-          # Create a /boot EFI partition with 60M and arbitrary but fixed GUIDs for reproducibility
-          ${pkgs.gptfdisk}/bin/sgdisk \
-            --set-alignment=1 --new=1:34:2047 --change-name=1:BIOSBootPartition --typecode=1:ef02 \
-            --set-alignment=512 --largest-new=2 --change-name=2:EFISystem --typecode=2:ef00 \
-            --attributes=1:set:1 \
-            --attributes=2:set:2 \
-            --disk-guid=97FD5997-D90B-4AA3-8D16-C1723AEA73C1 \
-            --partition-guid=1:1C06F03B-704E-4657-B9CD-681A087A2FDC \
-            --partition-guid=2:970C694F-AFD0-4B99-B750-CDB7A329AB6F \
-            --hybrid 2 \
-            --recompute-chs /dev/vda
+  systemImage = import ../../lib/make-disk-image.nix {
+    inherit pkgs config lib;
+    additionalPaths = [ regInfo ];
+    format = "qcow2";
+    onlyNixStore = false;
+    partitionTableType = selectPartitionTableLayout { inherit (cfg) useDefaultFilesystems useEFIBoot; };
+    installBootLoader = cfg.useBootLoader && cfg.useDefaultFilesystems;
+    touchEFIVars = cfg.useEFIBoot;
+    diskSize = "auto";
+    additionalSpace = "0M";
+    copyChannel = false;
+  };
 
-          ${optionalString (config.boot.loader.grub.device != "/dev/vda")
-            # In this throwaway VM, we only have the /dev/vda disk, but the
-            # actual VM described by `config` (used by `switch-to-configuration`
-            # below) may set `boot.loader.grub.device` to a different device
-            # that's nonexistent in the throwaway VM.
-            # Create a symlink for that device, so that the `grub-install`
-            # by `switch-to-configuration` will hit /dev/vda anyway.
-            ''
-              ln -s /dev/vda ${config.boot.loader.grub.device}
-            ''
-          }
-
-          ${pkgs.dosfstools}/bin/mkfs.fat -F16 /dev/vda2
-          export MTOOLS_SKIP_CHECK=1
-          ${pkgs.mtools}/bin/mlabel -i /dev/vda2 ::boot
-
-          # Mount /boot; load necessary modules first.
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_cp437.ko.xz || true
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_iso8859-1.ko.xz || true
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/fat.ko.xz || true
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/vfat.ko.xz || true
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/efivarfs/efivarfs.ko.xz || true
-          mkdir /boot
-          mount /dev/vda2 /boot
-
-          ${optionalString config.boot.loader.efi.canTouchEfiVariables ''
-            mount -t efivarfs efivarfs /sys/firmware/efi/efivars
-          ''}
-
-          # This is needed for GRUB 0.97, which doesn't know about virtio devices.
-          mkdir /boot/grub
-          echo '(hd0) /dev/vda' > /boot/grub/device.map
-
-          # This is needed for systemd-boot to find ESP, and udev is not available here to create this
-          mkdir -p /dev/block
-          ln -s /dev/vda2 /dev/block/254:2
-
-          # Set up system profile (normally done by nixos-rebuild / nix-env --set)
-          mkdir -p /nix/var/nix/profiles
-          ln -s ${config.system.build.toplevel} /nix/var/nix/profiles/system-1-link
-          ln -s /nix/var/nix/profiles/system-1-link /nix/var/nix/profiles/system
-
-          # Install bootloader
-          touch /etc/NIXOS
-          export NIXOS_INSTALL_BOOTLOADER=1
-          ${config.system.build.toplevel}/bin/switch-to-configuration boot
-
-          umount /boot
-        '' # */
-    );
-
+  # This image is supposed to have no side-effects on the boot disk.
+  # It should be used when you do not need the bootloader.
   storeImage = import ../../lib/make-disk-image.nix {
     inherit pkgs config lib;
     additionalPaths = [ regInfo ];
@@ -295,10 +239,15 @@ let
     onlyNixStore = true;
     partitionTableType = "none";
     installBootLoader = false;
+    touchEFIVars = false;
     diskSize = "auto";
     additionalSpace = "0M";
     copyChannel = false;
   };
+
+  OVMF_fd = (pkgs.OVMF.override {
+    secureBoot = cfg.useSecureBoot;
+  }).fd;
 
 in
 
@@ -306,6 +255,7 @@ in
   imports = [
     ../profiles/qemu-guest.nix
     (mkRenamedOptionModule [ "virtualisation" "pathsInNixDB" ] [ "virtualisation" "additionalPaths" ])
+    (mkRemovedOptionModule [ "virtualisation" "efiVars" ] "This option was removed, it is possible to provide a template UEFI variable with `virtualisation.efi.variables` ; if this option is important to you, open an issue")
   ];
 
   options = {
@@ -360,10 +310,35 @@ in
     virtualisation.bootDevice =
       mkOption {
         type = types.path;
+        default = lookupDriveDeviceName "root" cfg.qemu.drives;
+        defaultText = literalExpression ''lookupDriveDeviceName "root" cfg.qemu.drives'';
         example = "/dev/vda";
         description =
           lib.mdDoc ''
-            The disk to be used for the root filesystem.
+            The disk to be used for the boot filesystem.
+            By default, it is the same disk as the root filesystem.
+          '';
+        };
+
+    virtualisation.rootDevice =
+      mkOption {
+        type = types.path;
+        default =
+          if (cfg.useBootLoader && cfg.bootDevice == options.virtualisation.bootDevice.default)
+          then "${cfg.bootDevice}2"
+          else
+            if !cfg.useBootLoader then cfg.bootDevice else null;
+        defaultText = ''if (cfg.useBootLoader && !hasPrefix "/dev/mapper/" ''${cfg.bootDevice}) then "''${cfg.bootDevice}2" else cfg.bootDevice;'';
+        example = "/dev/vda2";
+        description =
+          lib.mdDoc ''
+            The disk or partition to be used for the root filesystem.
+            By default :
+
+            - the boot disk in case you're **NOT** using a bootloader (`useBootLoader == false`)
+            - the second partition of the boot disk in case you're using a bootloader (`useBootLoader == true` && boot device is the default one).
+
+            In case you are not using a default boot device, you have to set explicitly your root device.
           '';
       };
 
@@ -755,17 +730,16 @@ in
           '';
       };
 
-    virtualisation.efiVars =
+    virtualisation.useSecureBoot =
       mkOption {
-        type = types.str;
-        default = "./${config.system.name}-efi-vars.fd";
-        defaultText = literalExpression ''"./''${config.system.name}-efi-vars.fd"'';
+        type = types.bool;
+        default = false;
         description =
           lib.mdDoc ''
-            Path to nvram image containing UEFI variables.  The will be created
-            on startup if it does not exist.
+            Enable Secure Boot support in the EFI firmware.
           '';
       };
+
 
     virtualisation.bios =
       mkOption {
@@ -822,27 +796,7 @@ in
             ${opt.writableStore} = false;
         '';
 
-    # Note [Disk layout with `useBootLoader`]
-    #
-    # If `useBootLoader = true`, we configure 2 drives:
-    # `/dev/?da` for the root disk, and `/dev/?db` for the boot disk
-    # which has the `/boot` partition and the boot loader.
-    # Concretely:
-    #
-    # * The second drive's image `disk.img` is created in `bootDisk = ...`
-    #   using a throwaway VM. Note that there the disk is always `/dev/vda`,
-    #   even though in the final VM it will be at `/dev/*b`.
-    # * The disks are attached in `virtualisation.qemu.drives`.
-    #   Their order makes them appear as devices `a`, `b`, etc.
-    # * `fileSystems."/boot"` is adjusted to be on device `b`.
-
-    # If `useBootLoader`, GRUB goes to the second disk, see
-    # note [Disk layout with `useBootLoader`].
-    boot.loader.grub.device = mkVMOverride (
-      if cfg.useBootLoader
-        then driveDeviceName 2 # second disk
-        else cfg.bootDevice
-    );
+    boot.loader.grub.device = mkVMOverride cfg.bootDevice;
     boot.loader.grub.gfxmodeBios = with cfg.resolution; "${toString x}x${toString y}";
 
     boot.initrd.kernelModules = optionals (cfg.useNixStoreImage && !cfg.writableStore) [ "erofs" ];
@@ -857,9 +811,9 @@ in
       ''
         # If the disk image appears to be empty, run mke2fs to
         # initialise.
-        FSTYPE=$(blkid -o value -s TYPE ${cfg.bootDevice} || true)
+        FSTYPE=$(blkid -o value -s TYPE ${cfg.rootDevice} || true)
         if test -z "$FSTYPE"; then
-            mke2fs -t ext4 ${cfg.bootDevice}
+            mke2fs -t ext4 ${cfg.rootDevice}
         fi
       '';
 
@@ -905,7 +859,7 @@ in
       optional cfg.writableStore "overlay"
       ++ optional (cfg.qemu.diskInterface == "scsi") "sym53c8xx";
 
-    virtualisation.bootDevice = mkDefault (driveDeviceName 1);
+    # TODO: needed? virtualisation.bootDevice = mkDefault (driveDeviceName 1);
 
     virtualisation.additionalPaths = [ config.system.build.toplevel ];
 
@@ -978,6 +932,7 @@ in
         file = ''"$NIX_DISK_IMAGE"'';
         driveExtraOpts.cache = "writeback";
         driveExtraOpts.werror = "report";
+        deviceExtraOpts.bootindex = mkIf cfg.useBootLoader "1";
       }]
       (mkIf cfg.useNixStoreImage [{
         name = "nix-store";
@@ -985,16 +940,6 @@ in
         deviceExtraOpts.bootindex = if cfg.useBootLoader then "3" else "2";
         driveExtraOpts.format = if cfg.writableStore then "qcow2" else "raw";
       }])
-      (mkIf cfg.useBootLoader [
-        # The order of this list determines the device names, see
-        # note [Disk layout with `useBootLoader`].
-        {
-          name = "boot";
-          file = ''"$TMPDIR"/disk.img'';
-          driveExtraOpts.media = "disk";
-          deviceExtraOpts.bootindex = "1";
-        }
-      ])
       (imap0 (idx: _: {
         file = "$(pwd)/empty${toString idx}.qcow2";
         driveExtraOpts.werror = "report";
@@ -1025,7 +970,8 @@ in
     in
       mkVMOverride (cfg.fileSystems //
       optionalAttrs cfg.useDefaultFilesystems {
-        "/".device = cfg.bootDevice;
+        # cfg.useBootLoader -> [ boot partition ; root partition ] layout on *root* disk
+        "/".device = cfg.rootDevice;
         "/".fsType = "ext4";
         "/".autoFormat = true;
       } //
@@ -1055,7 +1001,7 @@ in
       optionalAttrs cfg.useBootLoader {
         # see note [Disk layout with `useBootLoader`]
         "/boot" = {
-          device = "${lookupDriveDeviceName "boot" cfg.qemu.drives}2"; # 2 for e.g. `vdb2`, as created in `bootDisk`
+          device = "${lookupDriveDeviceName "root" cfg.qemu.drives}1"; # 1 for e.g. `vda1`, as created in `systemImage`
           fsType = "vfat";
           noCheck = true; # fsck fails on a r/o filesystem
         };

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -212,13 +212,13 @@ let
 
   regInfo = pkgs.closureInfo { rootPaths = config.virtualisation.additionalPaths; };
 
-
   # Generate a hard disk image containing a /boot partition and GRUB
   # in the MBR.  Used when the `useBootLoader' option is set.
   # Uses `runInLinuxVM` to create the image in a throwaway VM.
   # See note [Disk layout with `useBootLoader`].
   systemImage = import ../../lib/make-disk-image.nix {
     inherit pkgs config lib;
+    inherit (cfg.efi) systemManagementModeEnforcement;
     additionalPaths = [ regInfo ];
     format = "qcow2";
     onlyNixStore = false;
@@ -228,6 +228,7 @@ let
     diskSize = "auto";
     additionalSpace = "0M";
     copyChannel = false;
+    OVMF = cfg.efi.OVMF;
   };
 
   # This image is supposed to have no side-effects on the boot disk.
@@ -244,10 +245,6 @@ let
     additionalSpace = "0M";
     copyChannel = false;
   };
-
-  OVMF_fd = (pkgs.OVMF.override {
-    secureBoot = cfg.useSecureBoot;
-  }).fd;
 
 in
 
@@ -693,10 +690,24 @@ in
         };
 
     virtualisation.efi = {
+      OVMF = mkOption {
+        type = types.package;
+        default = (pkgs.OVMF.override {
+          systemManagementModeSupport = cfg.efi.systemManagementModeEnforcement;
+          secureBoot = cfg.useSecureBoot;
+        }).fd;
+        defaultText = ''(pkgs.OVMF.override {
+          systemManagementModeSupport = cfg.efi.systemManagementModeEnforcement;
+          secureBoot = cfg.useSecureBoot;
+        }).fd;'';
+        description =
+        lib.mdDoc "OVMF firmware package, defaults to OVMF configured with secure boot and system management mode if needed.";
+      };
+
       firmware = mkOption {
         type = types.path;
-        default = pkgs.OVMF.firmware;
-        defaultText = "pkgs.OVMF.firmware";
+        default = cfg.efi.OVMF.firmware;
+        defaultText = "cfg.efi.OVMF.firmware";
         description =
           lib.mdDoc ''
             Firmware binary for EFI implementation, defaults to OVMF.
@@ -705,12 +716,24 @@ in
 
       variables = mkOption {
         type = types.path;
-        default = pkgs.OVMF.variables;
-        defaultText = "pkgs.OVMF.variables";
+        default = cfg.efi.OVMF.variables;
+        defaultText = "cfg.efi.OVMF.variables";
         description =
           lib.mdDoc ''
             Platform-specific flash binary for EFI variables, implementation-dependent to the EFI firmware.
             Defaults to OVMF.
+          '';
+        };
+
+      systemManagementModeEnforcement = mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          lib.mdDoc ''
+            Enable system management mode enforcement for QEMU which prevent the OS from arbitrary accessing the UEFI variables memory.
+            It enforces to use the SMM API to perform any changes, useful in SecureBoot contexts.
+
+            WARNING: OVMF implementation seems broken.
           '';
       };
     };
@@ -777,6 +800,20 @@ in
         ]));
 
     warnings =
+      optional (cfg.efi.systemManagementModeEnforcement)
+        ''
+          You have enabled ${opt.efi.systemManagementModeEnforcement} = true.
+
+          This will enable system management mode for QEMU (cfi.pflash01, secure=on)
+          and if you're using the default OVMF image, it will build a SMM-enabled firmware
+          for UEFI.
+
+          This will lock down UEFI authenticated variables to ensure an actually secure
+          SecureBoot for example.
+
+          WARNING: currently, SMM seems to be broken and will cause boot failures and silent hung tasks.
+        ''
+      ++
       optional (
         cfg.writableStore &&
         cfg.useNixStoreImage &&
@@ -916,7 +953,13 @@ in
       ])
       (mkIf cfg.useEFIBoot [
         "-drive if=pflash,format=raw,unit=0,readonly=on,file=${cfg.efi.firmware}"
-        "-drive if=pflash,format=raw,unit=1,file=$NIX_EFI_VARS"
+        "-drive if=pflash,format=raw,unit=1,readonly=off,file=$NIX_EFI_VARS"
+      ])
+      (mkIf cfg.efi.systemManagementModeEnforcement [
+        # SMM requires Q35 machine.
+        "-machine type=q35,accel=kvm,smm=on"
+        # Enforce SMM usage for authenticated variables in UEFI
+        "-global driver=cfi.pflash01,property=secure,value=on"
       ])
       (mkIf (cfg.bios != null) [
         "-bios ${cfg.bios}/bios.bin"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -566,6 +566,7 @@ in {
   sddm = handleTest ./sddm.nix {};
   seafile = handleTest ./seafile.nix {};
   searx = handleTest ./searx.nix {};
+  secureboot = handleTest ./secureboot.nix {};
   service-runner = handleTest ./service-runner.nix {};
   sfxr-qt = handleTest ./sfxr-qt.nix {};
   shadow = handleTest ./shadow.nix {};

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -63,7 +63,7 @@ in makeTest {
         # Small root disk for installer
         512
       ];
-      virtualisation.bootDevice = "/dev/vdb";
+      virtualisation.rootDevice = "/dev/vdb";
     };
   };
 

--- a/nixos/tests/lvm2/systemd-stage-1.nix
+++ b/nixos/tests/lvm2/systemd-stage-1.nix
@@ -79,7 +79,7 @@ in import ../make-test-python.nix ({ pkgs, ... }: {
       kernelPackages = lib.mkIf (kernelPackages != null) kernelPackages;
     };
 
-    specialisation.boot-lvm.configuration.virtualisation.bootDevice = "/dev/test_vg/test_lv";
+    specialisation.boot-lvm.configuration.virtualisation.rootDevice = "/dev/test_vg/test_lv";
   };
 
   testScript = ''

--- a/nixos/tests/secureboot.nix
+++ b/nixos/tests/secureboot.nix
@@ -1,0 +1,39 @@
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+
+let
+  common = {
+    virtualisation.useBootLoader = true;
+    virtualisation.useEFIBoot = true;
+    virtualisation.useSecureBoot = true;
+    boot.loader.systemd-boot.enable = true;
+    boot.loader.efi.canTouchEfiVariables = true;
+    environment.systemPackages = [ pkgs.efibootmgr pkgs.sbsigntool pkgs.sbctl ];
+  };
+in
+{
+  basic = makeTest {
+    name = "secureboot-installation-prevent-reboot";
+    meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+
+    nodes.machine = common;
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed("sbctl create-keys")
+      machine.succeed("sbctl enroll-keys --yes-this-might-brick-my-machine")
+      machine.shutdown()
+      # Now we cannot reboot because we did not sign our boot files!
+      # machine.sleep(1)
+      # Test for Linux Boot Manager
+      # assert ('Not Found' in machine.get_screen_text())
+    '';
+  };
+}

--- a/nixos/tests/secureboot.nix
+++ b/nixos/tests/secureboot.nix
@@ -8,16 +8,19 @@ with pkgs.lib;
 
 let
   common = {
-    virtualisation.useBootLoader = true;
-    virtualisation.useEFIBoot = true;
-    virtualisation.useSecureBoot = true;
+    virtualisation = {
+      useBootLoader = true;
+      useEFIBoot = true;
+      useSecureBoot = true;
+      efi.systemManagementModeEnforcement = false; # Investigate why it breaks everything.
+    };
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;
     environment.systemPackages = [ pkgs.efibootmgr pkgs.sbsigntool pkgs.sbctl ];
   };
 in
 {
-  basic = makeTest {
+  prevent-reboot = makeTest {
     name = "secureboot-installation-prevent-reboot";
     meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
 

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -107,7 +107,7 @@ in
       )
 
       output = machine.succeed("/run/current-system/bin/switch-to-configuration boot")
-      assert "updating systemd-boot from (000.0-1-notnixos) to " in output
+      assert "updating systemd-boot from 000.0-1-notnixos to " in output
     '';
   };
 

--- a/nixos/tests/systemd-initrd-btrfs-raid.nix
+++ b/nixos/tests/systemd-initrd-btrfs-raid.nix
@@ -21,14 +21,14 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
       fileSystems = lib.mkVMOverride {
         "/".fsType = lib.mkForce "btrfs";
       };
-      virtualisation.bootDevice = "/dev/vdc";
+      virtualisation.rootDevice = "/dev/vdb";
     };
   };
 
   testScript = ''
     # Create RAID
-    machine.succeed("mkfs.btrfs -d raid0 /dev/vdc /dev/vdd")
-    machine.succeed("mkdir -p /mnt && mount /dev/vdc /mnt && echo hello > /mnt/test && umount /mnt")
+    machine.succeed("mkfs.btrfs -d raid0 /dev/vdb /dev/vdc")
+    machine.succeed("mkdir -p /mnt && mount /dev/vdb /mnt && echo hello > /mnt/test && umount /mnt")
 
     # Boot from the RAID
     machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-btrfs-raid.conf")
@@ -38,7 +38,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
 
     # Ensure we have successfully booted from the RAID
     assert "(initrd)" in machine.succeed("systemd-analyze")  # booted with systemd in stage 1
-    assert "/dev/vdc on / type btrfs" in machine.succeed("mount")
+    assert "/dev/vdb on / type btrfs" in machine.succeed("mount")
     assert "hello" in machine.succeed("cat /test")
     assert "Total devices 2" in machine.succeed("btrfs filesystem show")
   '';

--- a/nixos/tests/systemd-initrd-luks-keyfile.nix
+++ b/nixos/tests/systemd-initrd-luks-keyfile.nix
@@ -27,11 +27,11 @@ in {
     specialisation.boot-luks.configuration = {
       boot.initrd.luks.devices = lib.mkVMOverride {
         cryptroot = {
-          device = "/dev/vdc";
+          device = "/dev/vdb";
           keyFile = "/etc/cryptroot.key";
         };
       };
-      virtualisation.bootDevice = "/dev/mapper/cryptroot";
+      virtualisation.rootDevice = "/dev/mapper/cryptroot";
       boot.initrd.secrets."/etc/cryptroot.key" = keyfile;
     };
   };
@@ -39,7 +39,7 @@ in {
   testScript = ''
     # Create encrypted volume
     machine.wait_for_unit("multi-user.target")
-    machine.succeed("cryptsetup luksFormat -q --iter-time=1 -d ${keyfile} /dev/vdc")
+    machine.succeed("cryptsetup luksFormat -q --iter-time=1 -d ${keyfile} /dev/vdb")
 
     # Boot from the encrypted disk
     machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-luks.conf")

--- a/nixos/tests/systemd-initrd-luks-password.nix
+++ b/nixos/tests/systemd-initrd-luks-password.nix
@@ -19,10 +19,10 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     specialisation.boot-luks.configuration = {
       boot.initrd.luks.devices = lib.mkVMOverride {
         # We have two disks and only type one password - key reuse is in place
-        cryptroot.device = "/dev/vdc";
-        cryptroot2.device = "/dev/vdd";
+        cryptroot.device = "/dev/vdb";
+        cryptroot2.device = "/dev/vdc";
       };
-      virtualisation.bootDevice = "/dev/mapper/cryptroot";
+      virtualisation.rootDevice = "/dev/mapper/cryptroot";
       # test mounting device unlocked in initrd after switching root
       virtualisation.fileSystems."/cryptroot2".device = "/dev/mapper/cryptroot2";
     };
@@ -31,9 +31,9 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
   testScript = ''
     # Create encrypted volume
     machine.wait_for_unit("multi-user.target")
+    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdb -")
     machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdc -")
-    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdd -")
-    machine.succeed("echo -n supersecret | cryptsetup luksOpen   -q               /dev/vdd cryptroot2")
+    machine.succeed("echo -n supersecret | cryptsetup luksOpen   -q               /dev/vdc cryptroot2")
     machine.succeed("mkfs.ext4 /dev/mapper/cryptroot2")
 
     # Boot from the encrypted disk

--- a/nixos/tests/systemd-initrd-swraid.nix
+++ b/nixos/tests/systemd-initrd-swraid.nix
@@ -20,18 +20,18 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
       services.swraid = {
         enable = true;
         mdadmConf = ''
-          ARRAY /dev/md0 devices=/dev/vdc,/dev/vdd
+          ARRAY /dev/md0 devices=/dev/vdb,/dev/vdc
         '';
       };
       kernelModules = [ "raid0" ];
     };
 
-    specialisation.boot-swraid.configuration.virtualisation.bootDevice = "/dev/disk/by-label/testraid";
+    specialisation.boot-swraid.configuration.virtualisation.rootDevice = "/dev/disk/by-label/testraid";
   };
 
   testScript = ''
     # Create RAID
-    machine.succeed("mdadm --create --force /dev/md0 -n 2 --level=raid0 /dev/vdc /dev/vdd")
+    machine.succeed("mdadm --create --force /dev/md0 -n 2 --level=raid0 /dev/vdb /dev/vdc")
     machine.succeed("mkfs.ext4 -L testraid /dev/md0")
     machine.succeed("mkdir -p /mnt && mount /dev/md0 /mnt && echo hello > /mnt/test && umount /mnt")
 

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -3,6 +3,7 @@
 , secureBoot ? false
 , httpSupport ? false
 , tpmSupport ? false
+, systemManagementModeSupport ? false
 }:
 
 assert csmSupport -> seabios != null;
@@ -41,6 +42,7 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
 
   buildFlags =
     lib.optionals secureBoot [ "-D SECURE_BOOT_ENABLE=TRUE" ]
+    ++ lib.optionals systemManagementModeSupport [ "-D SMM_REQUIRE" ]
     ++ lib.optionals csmSupport [ "-D CSM_ENABLE" "-D FD_SIZE_2MB" ]
     ++ lib.optionals httpSupport [ "-D NETWORK_HTTP_ENABLE=TRUE" "-D NETWORK_HTTP_BOOT_ENABLE=TRUE" ]
     ++ lib.optionals tpmSupport [ "-D TPM_ENABLE" "-D TPM2_ENABLE" "-D TPM2_CONFIG_ENABLE"];


### PR DESCRIPTION
###### Description of changes

This is a PR being worked on, which should introduce a new stub (*) after systemd-boot, to boot a NixOS system with SecureBoot while keeping the nice properties about having a small ESP and many generations.

(*): So the idea has came while discussing it with @nikstur @blitz 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
