### PR TITLE
git-remote-ipld: init at unstable-2022-06-21

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-remote-ipld/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-ipld/default.nix
@@ -1,0 +1,37 @@
+{ buildGoModule
+, fetchFromGitHub
+, fetchpatch
+, lib
+}:
+
+buildGoModule rec {
+  pname = "git-remote-ipld";
+  version = "unstable-2022-06-21";
+
+  src = fetchFromGitHub {
+    owner = "ipfs-shipyard";
+    repo = pname;
+    rev = "304abe54d48e49b87b40f962749d5a96a2c6edd7";
+    hash = "sha256-9DgbRdH+2bFLgTSBdyMGTyns8AjASQAvj1WLlX6nVTU=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-nil-shell.patch";
+      url = "https://github.com/ipfs-shipyard/git-remote-ipld/commit/2b44cb286bcc601b46d5d1f9e9150e227ab96e47.patch";
+      hash = "sha256-eBz9x7z4hEUJRYAIvLvNQvOXuodLeh8gCJ4QdG+TFuY=";
+    })
+  ];
+
+  # needs IPFS daemon
+  doCheck = false;
+
+  vendorHash = "sha256-LpQYi8pqMIiNjDyXiNSEF8kwciK6eQq/yyPsgsArHko=";
+
+  meta = with lib; {
+    description = "Git remote helper for the IPFS network using IPLD";
+    homepage = "https://github.com/ipfs-shipyard/git-remote-ipld";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7150,6 +7150,8 @@ with pkgs;
 
   git-remote-gcrypt = callPackage ../applications/version-management/git-and-tools/git-remote-gcrypt { };
 
+  git-remote-ipld = callPackage ../applications/version-management/git-and-tools/git-remote-ipld { };
+
   git-remote-hg = callPackage ../applications/version-management/git-and-tools/git-remote-hg { };
 
   git-reparent = callPackage ../applications/version-management/git-and-tools/git-reparent { };


### PR DESCRIPTION
###### Description of changes

[Git-remote-ipld](https://github.com/ipfs-shipyard/git-remote-ipld) is a git-remote helper to push and pull from IPLD trees

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
