### PR TITLE
tmux: enable utf8proc everywhere

### DIFF
--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -7,7 +7,7 @@
 , ncurses
 , pkg-config
 , withSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isStatic, systemd
-, utf8proc
+, withUtf8proc ? true, utf8proc # gets Unicode updates faster than glibc
 , withUtempter ? stdenv.isLinux && !stdenv.hostPlatform.isMusl, libutempter
 }:
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     ncurses
     libevent
   ] ++ lib.optionals withSystemd [ systemd ]
-  ++ lib.optionals stdenv.isDarwin [ utf8proc ]
+  ++ lib.optionals withUtf8proc [ utf8proc ]
   ++ lib.optionals withUtempter [ libutempter ];
 
   configureFlags = [
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
   ] ++ lib.optionals withSystemd [ "--enable-systemd" ]
   ++ lib.optionals withUtempter [ "--enable-utempter" ]
-  ++ lib.optionals stdenv.isDarwin [ "--enable-utf8proc" ];
+  ++ lib.optionals withUtf8proc [ "--enable-utf8proc" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Currently, tmux does not render emoji from Unicode 15 (e.g. U+1FABF 🪿), because the `wcwidth` function from glibc does not know about the new characters. Support was added upstream but not released yet
(https://sourceware.org/git/?p=glibc.git;a=commit;h=7fe6734d28feb18acb3c50b13a5f5a52f66d39cf). Instead, tmux can use the `wcwidth` function from utf8proc, which has regular updates so that we don't have to wait 6 months for the new characters to be supported.

With this patch, tmux displays emoji 15 just fine.

Another option would be to take advantage of the fact that `glibcLocales` is a separate derivation and change its `src` to an unstable revision with the above commit, but that sounds a lot riskier (https://github.com/NixOS/nixpkgs/issues/202548). Using utf8proc is cheap.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
