### PR TITLE
`lib`: Working with nested attrsets of packages

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -125,6 +125,44 @@ rec {
   */
   concatMapAttrs = f: flip pipe [ (mapAttrs f) attrValues (foldl' mergeAttrs { }) ];
 
+  /*
+    `joinAttrsRecursive <joinPath> <upTo>` flattens nested attribute sets by
+    joining the attribute paths using the user-supplied `<joinPath>` function,
+    up to paths where `<upTo>` returns `true`.
+
+    Type:
+      joinAttrsRecursive ::
+        (listOf str -> str) ->
+        (listOf str -> attrs -> bool) ->
+        attrs ->
+        attrs
+
+    Example:
+      joinAttrsRecursive
+        (concatStringsSep ".")
+        (_path: isDerivation)
+        {
+          a.b.c = pkg "one";
+          a.b.d = pkg "two";
+          a.e = pkg "three" // { f = pkg "four"; };
+        };
+      => {
+        "a.b.c" = pkg "one";
+        "a.b.d" = pkg "two";
+        "a.e" = pkg "three" // { f = pkg "four"; };
+      };
+
+  */
+  joinAttrsRecursive = joinNames: stop:
+    let
+      go = prefix: v:
+        if (!isAttrs v) || stop prefix v then
+          { ${joinNames prefix} = v; }
+        else
+          concatMapAttrs
+            (name: value: go (prefix ++ [name]) value)
+            v;
+    in go [];
 
   /* Update or set specific paths of an attribute set.
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -78,7 +78,7 @@ let
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
+      filterAttrsRecursive foldlAttrs foldAttrs joinAttrsRecursive collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList concatMapAttrs mapAttrsRecursive mapAttrsRecursiveCond
       genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -113,7 +113,10 @@ let
     inherit (self.customisation) overrideDerivation makeOverridable
       callPackageWith callPackagesWith extendDerivation hydraJob
       makeScope makeScopeWithSplicing;
-    inherit (self.derivations) lazyDerivation;
+    inherit (self.derivations)
+      getDerivationsChildStrict
+      lazyDerivation
+      ;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
       hiPrioSet getLicenseFromSpdxId getExe;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -116,6 +116,7 @@ let
     inherit (self.derivations)
       getDerivationsChildStrict
       lazyDerivation
+      joinDerivationsLeafStrictSep
       ;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1592,6 +1592,53 @@ runTests {
     expected = derivation;
   };
 
+  # getDerivationsChildStrict
+
+  test_getDerivationsChildStrict = {
+    expr = getDerivationsChildStrict {
+      a = pkg "a";
+      b = {
+        c = pkg "bc";
+      };
+      d = recurseIntoAttrs {
+        e = pkg "de";
+      };
+    };
+    expected = {
+      a = pkg "a";
+      d = {
+        e = pkg "de";
+      };
+    };
+  };
+
+  test_getDerivationsChildStrict_singleton = {
+    expr = getDerivationsChildStrict (pkg "a");
+    expected = pkg "a";
+  };
+
+
+  test_getDerivationsChildStrict_fun = let f = x: x; in {
+    expr = getDerivationsChildStrict {
+      a = pkg "a";
+      b = {
+        c = pkg "bc";
+      };
+      d = recurseIntoAttrs {
+        e = pkg "de";
+        inherit f;
+      };
+      inherit f;
+    };
+    expected = {
+      a = pkg "a";
+      d = {
+        e = pkg "de";
+      };
+    };
+  };
+
+
   testTypeDescriptionInt = {
     expr = (with types; int).description;
     expected = "signed integer";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1708,6 +1708,7 @@ runTests {
     };
   };
 
+  # type .description
 
   testTypeDescriptionInt = {
     expr = (with types; int).description;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -23,6 +23,12 @@ let
     inherit expected;
   };
 
+  pkg = name: derivation {
+    system = "fake-system";
+    builder = "/fake";
+    inherit name;
+  };
+
 in
 
 runTests {
@@ -535,6 +541,30 @@ runTests {
       foo = "bar";
       foobar = "baz";
       foobarbaz = "baz";
+    };
+  };
+
+  test_joinAttrsRecursive = {
+    expr = joinAttrsRecursive (concatStringsSep ".") (_path: isDerivation) {
+      a.b.c = pkg "abc";
+      a.b.d = pkg "abd";
+      a.e = pkg "e" // { f = pkg "f"; };
+    };
+    expected = {
+      "a.b.c" = pkg "abc";
+      "a.b.d" = pkg "abd";
+      "a.e" = pkg "e" // { f = pkg "f"; };
+    };
+  };
+
+  test_joinAttrsRecursive_empty = {
+    expr =
+      joinAttrsRecursive
+        (concatStringsSep ".")
+        (path: assert path == []; isDerivation)
+        (pkg "abc");
+    expected = {
+      "" = pkg "abc";
     };
   };
 


### PR DESCRIPTION
###### Description of changes

Functions for
 - extracting derivations the way nix-build does (or should)
 - flattening attribute sets
 - flattening attribute set trees of derivations (increasingly common since flakes)

TODO
 - [ ] validate in practice

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
