### PR TITLE
winbox: fix startup of the application

### DIFF
--- a/pkgs/tools/admin/winbox/default.nix
+++ b/pkgs/tools/admin/winbox/default.nix
@@ -5,9 +5,7 @@
 , makeWrapper
 , symlinkJoin
 , writeShellScriptBin
-
 , wine
-, use64 ? false
 }:
 
 let
@@ -17,18 +15,18 @@ let
   version = "3.37";
   name = "${pname}-${version}";
 
-  executable = fetchurl (if use64 then {
+  executable = fetchurl (if (wine.meta.mainProgram == "wine64") then {
     url = "https://download.mikrotik.com/winbox/${version}/winbox64.exe";
     sha256 = "0fbl0i5ga9afg8mklm9xqidcr388sca00slj401npwh9b3j9drmb";
   } else {
     url = "https://download.mikrotik.com/winbox/${version}/winbox.exe";
     sha256 = "1zla30bc755x5gfv9ff1bgjvpsjmg2d7jsjxnwwy679fry4n4cwl";
   });
+
   # This is from the winbox AUR package:
   # https://aur.archlinux.org/cgit/aur.git/tree/winbox64?h=winbox64&id=8edd93792af84e87592e8645ca09e9795931e60e
   wrapper = writeShellScriptBin pname ''
     export WINEPREFIX="''${WINBOX_HOME:-"''${XDG_DATA_HOME:-"''${HOME}/.local/share"}/winbox"}/wine"
-    export WINEARCH=${if use64 then "win64" else "win32"}
     export WINEDLLOVERRIDES="mscoree=" # disable mono
     export WINEDEBUG=-all
     if [ ! -d "$WINEPREFIX" ] ; then
@@ -36,7 +34,7 @@ let
       ${wine}/bin/wineboot -u
     fi
 
-    ${wine}/bin/wine ${executable} "$@"
+    ${wine}/bin/${wine.meta.mainProgram} ${executable} "$@"
   '';
 
   desktopItem = makeDesktopItem {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1478,7 +1478,6 @@ with pkgs;
 
   winbox = callPackage ../tools/admin/winbox {
     wine = wineWowPackages.staging;
-    use64 = true;
   };
 
   wwcd = callPackage ../tools/misc/wwcd { };


### PR DESCRIPTION
Hello,

I can't run Winbox with the current state of things:

```
$ NIXPKGS_ALLOW_UNFREE=1 nix shell .#winbox --impure
$ winbox
/nix/store/i9zwsxk7x6962rih4xzvhqgdq37d6blq-winbox-3.37/bin/winbox: line 11: 388601 Segmentation fault      (core dumped) /nix/store/jg8ahqq8lpbsyqdqvwqvfpcrvsq4cih4-wine-wow-7.20-staging/bin/wine /nix/store/1p1jv36pgbl3ga8lvrbkkw0ff3vszw8b-winbox64.exe "$@"
```

With this PR:

```
$ NIXPKGS_ALLOW_UNFREE=1 nix shell .#winbox --impure
$ winbox
creating Window Class routeros_null
creating Window Class routeros_connect
DPI=96
EMS=13
ERROR: bad bmp format id=2329
biPlanes=1, biBitCount=1, biCompression=0
ERROR: bad bmp format id=3329
biPlanes=1, biBitCount=1, biCompression=0
creating Window Class routeros_dbl_canvas
rescaleDPI starting-dpi=96, zoom=0 result=96
 discovery started
rescaning
connecting to 192.168.2.255
connecting to 169.254.255.255
connecting to 172.20.255.255
connecting to 172.21.255.255
connecting to 172.19.255.255
connecting to 172.17.255.255
loadConfig C:\users\devlin\AppData\Roaming\Mikrotik\Winbox\Addresses.cdb
ConnectWindow::destroyed
App::saveAllSettings
App::saveAllSettings done
saving settings to .\viw318f.tmp... for C:\users\devlin\AppData\Roaming\Mikrotik\Winbox\settings.cfg.viw
settings saved
exiting
WARNING: deleting font h=0xa0a0174
~Discovery
discovery stopped
```

The app works without any troubles.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
