### PR TITLE
open-stage-control: fix npmDepsHash

### DIFF
--- a/pkgs/applications/audio/open-stage-control/default.nix
+++ b/pkgs/applications/audio/open-stage-control/default.nix
@@ -16,7 +16,7 @@ buildNpmPackage rec {
     ./package-lock.json.patch
   ];
 
-  npmDepsHash = "sha256-SGLcFjPnmhFoeXtP4gfGr4Qa1dTaXwSnzkweEvYW/1k=";
+  npmDepsHash = "sha256-4TmESCUgpCfu7MeO6UmdveKxraYAYTeG4eM8HPvHsP4=";
 
   nativeBuildInputs = [
     copyDesktopItems


### PR DESCRIPTION
###### Description of changes

EDIT: I'm marking this as WIP until an apparently hash instability problem is solved

It looks like the hash that 814a0bc changed `npmDepsHash` to wasn't correct for the final version of the `buildNpmPackage` fixes in #200470

This PR updates this hash to what now seems to be the stable hash

The build is currently failing in Hydra for 22.11 due to hash mismatch so this should be a part of ZHF

ZHF: #199919

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).