### PR TITLE
systems/architecture: bump default architecture to x86-64-v2 

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -28,6 +28,12 @@ rec {
     znver1         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx" "avx2"          "fma"        ];
     znver2         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx" "avx2"          "fma"        ];
     znver3         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx" "avx2"          "fma"        ];
+    # Microarchitecture levels
+    # https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
+    x86-64         = [ ];
+    x86-64-v2      = [ "sse3" "ssse3" "sse4_1" "sse4_2"                                                  ];
+    x86-64-v3      = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx" "avx2"          "fma"        ];
+    x86-64-v4      = [ "sse3" "ssse3" "sse4_1" "sse4_2"               "avx" "avx2" "avx512" "fma"        ];
     # other
     armv5te        = [ ];
     armv6          = [ ];

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -5,6 +5,7 @@ rec {
   features = rec {
     default        = x86-64-v2;
     # x86_64 Intel
+    nehalem        = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes"                                    ];
     westmere       = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes"                                    ];
     sandybridge    = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];
     ivybridge      = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];
@@ -49,7 +50,8 @@ rec {
     default        = [ "x86-64-v2"   ];
     x86-64         = [ ];
     x86-64-v2      = [ "x86-64"      ] ++ inferiors.x86-64;
-    westmere       = [ "x86-64-v2"   ] ++ inferiors.x86-64-v2;
+    nehalem        = [ "x86-64-v2"   ] ++ inferiors.x86-64-v2;
+    westmere       = [ "nehalem"     ] ++ inferiors.nehalem;
     sandybridge    = [ "westmere"    ] ++ inferiors.westmere;
     ivybridge      = [ "sandybridge" ] ++ inferiors.sandybridge;
     x86-64-v3      = [ "ivybridge"   ] ++ inferiors.ivybridge;

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -2,8 +2,8 @@
 
 rec {
   # gcc.arch to its features (as in /proc/cpuinfo)
-  features = {
-    default        = [ ];
+  features = rec {
+    default        = x86-64-v2;
     # x86_64 Intel
     westmere       = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes"                                    ];
     sandybridge    = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -46,14 +46,18 @@ rec {
   # a superior CPU has all the features of an inferior and is able to build and test code for it
   inferiors = {
     # x86_64 Intel
-    default        = [ ];
-    westmere       = [ ];
+    default        = [ "x86-64-v2"   ];
+    x86-64         = [ ];
+    x86-64-v2      = [ "x86-64"      ] ++ inferiors.x86-64;
+    westmere       = [ "x86-64-v2"   ] ++ inferiors.x86-64-v2;
     sandybridge    = [ "westmere"    ] ++ inferiors.westmere;
     ivybridge      = [ "sandybridge" ] ++ inferiors.sandybridge;
-    haswell        = [ "ivybridge"   ] ++ inferiors.ivybridge;
+    x86-64-v3      = [ "ivybridge"   ] ++ inferiors.ivybridge;
+    haswell        = [ "x86-64-v3"   ] ++ inferiors.x86-64-v3;
     broadwell      = [ "haswell"     ] ++ inferiors.haswell;
     skylake        = [ "broadwell"   ] ++ inferiors.broadwell;
-    skylake-avx512 = [ "skylake"     ] ++ inferiors.skylake;
+    x86-64-v4      = [ "skylake"     ] ++ inferiors.skylake;
+    skylake-avx512 = [ "x86-64-v4"   ] ++ inferiors.x86-64-v4;
 
     # x86_64 AMD
     # TODO: fill this (need testing)

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -16,6 +16,12 @@ rec {
       autoModules = true;
       target = "bzImage";
     };
+    gcc = {
+      # this should match the microarchitecture level of lib.systems.architectures.features.default
+      # but nehalem is used instead of x86-64-v2 because as of writting the bootstrapping gcc in stage 0 does not understand it
+      arch = "nehalem";
+      tune = "generic";
+    };
   };
 
   pc_simplekernel = lib.recursiveUpdate pc {

--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -10,7 +10,16 @@
       In addition to numerous new and upgraded packages, this release
       has the following highlights:
     </para>
-    <itemizedlist spacing="compact">
+    <itemizedlist>
+      <listitem>
+        <para>
+          On x86 platforms nixpkgs is now build by default with the
+          <literal>x86_64-v2</literal> microarchitecture level. This
+          means any x86 processor that does not support SSE4.2 and AES
+          instructions is no longer supported by the precompiled binary
+          cache.
+        </para>
+      </listitem>
       <listitem>
         <para>
           Cinnamon has been updated to 5.6, see

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -8,6 +8,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- On x86 platforms nixpkgs is now build by default with the `x86_64-v2` microarchitecture level.
+  This means any x86 processor that does not support SSE4.2 and AES instructions is no longer supported by the precompiled binary cache.
+
 - Cinnamon has been updated to 5.6, see [the pull request](https://github.com/NixOS/nixpkgs/pull/201328#issue-1449910204) for what is changed.
 
 ## New Services {#sec-release-23.05-new-services}

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -8,7 +8,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- On x86 platforms nixpkgs is now build by default with the `x86_64-v2` microarchitecture level.
+- On x86 platforms nixpkgs is now built by default with the `x86_64-v2` microarchitecture level.
   This means any x86 processor that does not support SSE4.2 and AES instructions is no longer supported by the precompiled binary cache.
 
 - Cinnamon has been updated to 5.6, see [the pull request](https://github.com/NixOS/nixpkgs/pull/201328#issue-1449910204) for what is changed.

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -25,6 +25,22 @@ let
     nixpkgs = nixpkgsSrc;
   }) [ "unstable" ];
 
+  nixpkgs-unoptimised' = builtins.removeAttrs (import ../pkgs/top-level/release.nix {
+    inherit supportedSystems;
+    nixpkgs = nixpkgsSrc;
+    # default value plus empty gcc.arch/gcc.tune
+    nixpkgsArgs = {
+      config = {
+        allowUnfree = false;
+        gcc = {
+          arch = null;
+          tune = null;
+        };
+        inHydra = true;
+      };
+    };
+  }) [ "unstable" ];
+
 in rec {
 
   nixos = {
@@ -62,6 +78,31 @@ in rec {
 
   nixpkgs = {
     inherit (nixpkgs')
+      apacheHttpd
+      cmake
+      cryptsetup
+      emacs
+      gettext
+      git
+      imagemagick
+      jdk
+      linux
+      mariadb
+      nginx
+      nodejs
+      openssh
+      php
+      postgresql
+      python
+      rsyslog
+      stdenv
+      subversion
+      tarball
+      vim;
+  };
+
+  nixpkgs-unoptimised = {
+    inherit (nixpkgs-unoptimised')
       apacheHttpd
       cmake
       cryptsetup

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -413,7 +413,10 @@ else let
       enableParallelChecking = attrs.enableParallelChecking or true;
     } // lib.optionalAttrs (hardeningDisable != [] || hardeningEnable != [] || stdenv.hostPlatform.isMusl) {
       NIX_HARDENING_ENABLE = enabledHardeningOptions;
-    } // lib.optionalAttrs (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform ? gcc.arch) {
+    } // lib.optionalAttrs (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform ? gcc.arch
+      # ignore x86-64-v1/2, nehalem and westmere to allow a smoother transition when bumping the default gcc.arch.
+      # This silently assumes that any x86 machines supports them at least!
+      && lib.all (x: stdenv.hostPlatform.gcc.arch != x) [ "x86-64" "x86-64-v2" "nehalem" "westmere" ]) {
       requiredSystemFeatures = attrs.requiredSystemFeatures or [] ++ [ "gccarch-${stdenv.hostPlatform.gcc.arch}" ];
     } // lib.optionalAttrs (stdenv.buildPlatform.isDarwin) {
       inherit __darwinAllowLocalNetworking;


### PR DESCRIPTION
Compile everything by default with SSE4.2 to gain free performance.
This also removes support for any CPU older than ~~westmere~~ Nehalem.
Nehalem was chosen because the bootstrap gcc is to old to know westmere.

TODO:
- [x] Do we want to enable this?
- [x] Do all the hydra builders support this?
- [x] Write a changelog entry

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
