### PR TITLE
pythonPackages.pip: make package reproducible

### DIFF
--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     mkdir -p $out/bin
-  '';
+  '' + pip.postPatch;
 
   nativeBuildInputs = [ makeWrapper unzip ];
   buildInputs = [ python ];

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -27,6 +27,12 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ bootstrapped-pip ];
 
+  postPatch = ''
+    # Remove vendored Windows PE binaries
+    # Note: These are unused but make the package unreproducible.
+    find -type f -name '*.exe' -delete
+  '';
+
   # pip detects that we already have bootstrapped_pip "installed", so we need
   # to force it a little.
   pipInstallFlags = [ "--ignore-installed" ];


### PR DESCRIPTION
###### Description of changes

This fixes #201146 by removing the vendored Windows PE binaries.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested the package is reproducible and builds
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
