### PR TITLE
python310Packages.tabula-py: build a self-contained package and fix missing pkg_resources

### DIFF
--- a/pkgs/development/python-modules/tabula-py/default.nix
+++ b/pkgs/development/python-modules/tabula-py/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , distro
 , fetchFromGitHub
-, jdk
+, jre
 , numpy
 , pandas
 , pytestCheckHook
@@ -25,6 +25,14 @@ buildPythonPackage rec {
     hash = "sha256-Dfi6LzrLDz9VVDmbeK1dEaWuQosD4tvAH13Q4Mp3smA=";
   };
 
+  patches = [
+    ./java-interpreter-path.patch
+  ];
+
+  postPatch = ''
+    sed -i 's|@JAVA@|${jre}/bin/java|g' $(find -name '*.py')
+  '';
+
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
@@ -39,7 +47,6 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    jdk
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/tabula-py/default.nix
+++ b/pkgs/development/python-modules/tabula-py/default.nix
@@ -8,6 +8,7 @@
 , pytestCheckHook
 , pythonOlder
 , setuptools-scm
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -34,6 +35,7 @@ buildPythonPackage rec {
     distro
     numpy
     pandas
+    setuptools
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/tabula-py/java-interpreter-path.patch
+++ b/pkgs/development/python-modules/tabula-py/java-interpreter-path.patch
@@ -1,0 +1,54 @@
+diff -ru origsource/tabula/io.py source/tabula/io.py
+--- origsource/tabula/io.py	2022-11-23 17:19:35.419837514 +0100
++++ source/tabula/io.py	2022-11-23 17:22:08.204194807 +0100
+@@ -79,7 +79,7 @@
+             )
+         )
+ 
+-    args = ["java"] + java_options + ["-jar", _jar_path()] + options.build_option_list()
++    args = ["@JAVA@"] + java_options + ["-jar", _jar_path()] + options.build_option_list()
+     if path:
+         args.append(path)
+ 
+diff -ru origsource/tabula/util.py source/tabula/util.py
+--- origsource/tabula/util.py	2022-11-23 17:19:35.422837521 +0100
++++ source/tabula/util.py	2022-11-23 17:21:41.514132392 +0100
+@@ -26,7 +26,7 @@
+ 
+     try:
+         res = subprocess.check_output(
+-            ["java", "-version"], stderr=subprocess.STDOUT
++            ["@JAVA@", "-version"], stderr=subprocess.STDOUT
+         ).decode()
+ 
+     except FileNotFoundError:
+diff -ru origsource/tests/test_read_pdf_table.py source/tests/test_read_pdf_table.py
+--- origsource/tests/test_read_pdf_table.py	2022-11-23 17:19:35.422837521 +0100
++++ source/tests/test_read_pdf_table.py	2022-11-23 17:21:22.008086776 +0100
+@@ -281,7 +281,7 @@
+ 
+         tabula.read_pdf(self.pdf_path, encoding="utf-8")
+ 
+-        target_args = ["java"]
++        target_args = ["@JAVA@"]
+         if platform.system() == "Darwin":
+             target_args += ["-Djava.awt.headless=true"]
+         target_args += [
+@@ -355,7 +355,7 @@
+ 
+         tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=False)
+ 
+-        target_args = ["java"]
++        target_args = ["@JAVA@"]
+         if platform.system() == "Darwin":
+             target_args += ["-Djava.awt.headless=true"]
+         target_args += [
+@@ -382,7 +382,7 @@
+ 
+         tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=True)
+ 
+-        target_args = ["java"]
++        target_args = ["@JAVA@"]
+         if platform.system() == "Darwin":
+             target_args += ["-Djava.awt.headless=true"]
+         target_args += [


### PR DESCRIPTION
###### Description of changes

Make tabula-py self-contained. Before this change tabula-py would require `java` to be present in user's environment and would use whatever version of `java` was present there.

Also, fix an issue with unavailable pkg_resources at usage time (I expect that `checkPhase` passed due to build-time dependencies including setuptools, but don't really understand it too well).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
