### PR TITLE
ferretdb: 0.7.1 -> 0.9.0

### DIFF
--- a/pkgs/servers/nosql/ferretdb/default.nix
+++ b/pkgs/servers/nosql/ferretdb/default.nix
@@ -5,29 +5,32 @@
 
 buildGoModule rec {
   pname = "ferretdb";
-  version = "0.7.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "FerretDB";
     repo = "FerretDB";
     rev = "v${version}";
-    sha256 = "sha256-i3XCYVJfZ2sF4XGOxaBZqBOw7nRdzcGKhNNdqQMccPU=";
+    sha256 = "sha256-+tmClWkW3uhBXuQzuSMJnzeA1rrkpLV0QLCzcKhbThw=";
   };
 
   postPatch = ''
-    echo ${version} > internal/util/version/gen/version.txt
+    echo v${version} > build/version/version.txt
+    echo nixpkgs     > build/version/package.txt
   '';
 
-  vendorSha256 = "sha256-qyAc5EVg8QPTnXQjqJGpT3waDrfn8iXz+O1iESCzCIc=";
+  vendorSha256 = "sha256-43FxDRcif8FDHyXdNL/FJEt5ZnCQ8r7d5Red3l9442Q=";
 
   CGO_ENABLED = 0;
 
   subPackages = [ "cmd/ferretdb" ];
 
+  tags = [ "ferretdb_tigris" ];
+
   meta = with lib; {
     description = "A truly Open Source MongoDB alternative";
-    homepage = "https://github.com/FerretDB/FerretDB";
+    homepage = "https://www.ferretdb.io/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ dit7ya ];
+    maintainers = with maintainers; [ dit7ya noisersup ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Tweak the build process to set correct version.

(puts on FerretDB developer hat) But I'm also a bit worried about how this package is built. `internal/util/version/gen/version.txt` was supposed to be an internal detail of our build process, not something packagers should rely on. I want to invite NixOS community members to [our community](https://github.com/FerretDB/FerretDB#community) to discuss how we could provide a stable ground for packagers in general and nixpkgs in particular.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
