### PR TITLE
wasabiwallet: 2.0.1.3 -> 2.0.2

### DIFF
--- a/pkgs/applications/blockchains/wasabiwallet/default.nix
+++ b/pkgs/applications/blockchains/wasabiwallet/default.nix
@@ -1,8 +1,11 @@
 { lib, stdenv
+, autoPatchelfHook
+, makeWrapper
 , fetchurl
 , makeDesktopItem
 , curl
 , dotnetCorePackages
+, lttng-ust_2_12
 , fontconfig
 , krb5
 , openssl
@@ -11,15 +14,18 @@
 }:
 
 let
-  dotnet-runtime = dotnetCorePackages.runtime_5_0;
-  libPath = lib.makeLibraryPath [
+  dotnet-runtime = dotnetCorePackages.runtime_6_0;
+  # These libraries are dynamically loaded by the application,
+  # and need to be present in LD_LIBRARY_PATH
+  runtimeLibs = [
     curl
-    dotnet-runtime
     fontconfig.lib
     krb5
     openssl
     stdenv.cc.cc.lib
     xorg.libX11
+    xorg.libICE
+    xorg.libSM
     zlib
   ];
 in
@@ -33,7 +39,6 @@ stdenv.mkDerivation rec {
   };
 
   dontBuild = true;
-  dontPatchELF = true;
 
   desktopItem = makeDesktopItem {
     name = "wasabi";
@@ -44,16 +49,19 @@ stdenv.mkDerivation rec {
     categories = [ "Network" "Utility" ];
   };
 
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  buildInputs = runtimeLibs ++ [
+    lttng-ust_2_12
+  ];
+
   installPhase = ''
     mkdir -p $out/opt/${pname} $out/bin $out/share/applications
     cp -Rv . $out/opt/${pname}
-    cd $out/opt/${pname}
-    for i in $(find . -type f -name '*.so') wassabee
-      do
-        patchelf --set-rpath ${libPath} $i
-      done
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" wassabee
-    ln -s $out/opt/${pname}/wassabee $out/bin/${pname}
+
+    makeWrapper "${dotnet-runtime}/bin/dotnet" "$out/bin/${pname}" \
+      --add-flags "$out/opt/${pname}/WalletWasabi.Fluent.Desktop.dll" \
+      --suffix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath runtimeLibs}"
+
     cp -v $desktopItem/share/applications/* $out/share/applications
   '';
 

--- a/pkgs/applications/blockchains/wasabiwallet/default.nix
+++ b/pkgs/applications/blockchains/wasabiwallet/default.nix
@@ -31,11 +31,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "wasabiwallet";
-  version = "2.0.1.3";
+  version = "2.0.2";
 
   src = fetchurl {
     url = "https://github.com/zkSNACKs/WalletWasabi/releases/download/v${version}/Wasabi-${version}.tar.gz";
-    sha256 = "sha256-cATqg/n4/BDQtuCVjHAx3EfMLmlX5EjeQ01gavy/L8o=";
+    sha256 = "sha256-0DFl+UFxQckRM2qXFqDpKaRQ5sIMUbNj7l3zKPKAOnQ=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Description of changes

https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.0.2

This release uses .NET 6 instead of .NET 5, which helps with https://github.com/NixOS/nixpkgs/issues/173115

I also had to change up the derivation a bit, since the previous package wasn't starting up for me, due to missing dependencies. I now generate a wrapper script which sets LD_LIBRARY_PATH, instead of trying to find and patch all binaries with `patchelf`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
