### PR TITLE
oscclip: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14305,6 +14305,12 @@
     githubId = 52011418;
     name = "Travis Davis";
   };
+  traxys = {
+    email = "quentin+dev@familleboyer.net";
+    github = "traxys";
+    githubId = 5623227;
+    name = "Quentin Boyer";
+  };
   TredwellGit = {
     email = "tredwell@tutanota.com";
     github = "TredwellGit";

--- a/pkgs/tools/misc/oscclip/default.nix
+++ b/pkgs/tools/misc/oscclip/default.nix
@@ -1,0 +1,34 @@
+{ fetchFromGitHub
+, python3Packages
+, stdenv
+, writeText
+, lib
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "oscclip";
+  version = "0.4.1";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "rumpelsepp";
+    repo = "oscclip";
+    rev = "v${version}";
+    sha256 = "sha256-WQvZn+SWamEqEXPutIZVDZTIczybtHUG9QsN8XxUeg8=";
+  };
+
+  nativeBuildInputs = with python3Packages; [ poetry-core ];
+
+  meta = with lib; {
+    description = "A program that allows to copy/paste from a terminal using osc-52 control sequences.";
+    longDescription = ''
+      oscclip provides two commands: osc-copy and osc-paste. These commands allow to interact with the clipboard through the terminal directly.
+      This means that they work through ssh sessions for example (given that the terminal supports osc-52 sequences).
+    '';
+    homepage = "https://github.com/rumpelsepp/oscclip";
+
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.traxys ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10303,6 +10303,8 @@ with pkgs;
 
   operator-sdk = callPackage ../development/tools/operator-sdk { };
 
+  oscclip = callPackage ../tools/misc/oscclip { };
+
   owncast = callPackage ../servers/owncast { };
 
   update-dotdee = with python3Packages; toPythonApplication update-dotdee;


### PR DESCRIPTION
###### Description of changes

This add the https://github.com/rumpelsepp/oscclip package, that allows to use osc-52 control sequences to copy/paste in a display manager (Xorg/wayland) agnostic way

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
