### PR TITLE
tor-browser-bundle-bin: 11.5.7 -> 11.5.8

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -87,7 +87,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "11.5.7";
+  version = "11.5.8";
 
   lang = "en-US";
 
@@ -99,7 +99,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "sha256-K50T9Fe6tMuP1J5gfwK9f/25ZeakQ9vsJi4IOPa6fMk=";
+      sha256 = "sha256-/KK9oTijk5dEziAwp5966NaM2V4k1mtBjTJq88Ct7N0=";
     };
 
     i686-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "sha256-tbL/iTI3vR0gdMcLwOoWlfIDZNefIKA2hfvWKNNM9vE=";
+      sha256 = "sha256-TGdJ5yIeo0YQ4XSsb9lv3vuW6qEjhFe7KBmkjYO6fAc=";
     };
   };
 in


### PR DESCRIPTION
###### Description of changes

https://blog.torproject.org/new-release-tor-browser-1158/

Various bug and security fixes:

> Tor Browser 11.5.8 backports the following security updates from Firefox ESR 102.5 to to Firefox ESR 91.13 on Windows, macOS and Linux:
> 
>    * [CVE-2022-43680: In libexpat through 2.4.9, there is a use-after free caused by overeager destruction of a shared DTD in XML_ExternalEntityParserCreate in out-of-memory situations.](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-43680)
>    * [CVE-2022-45403: Service Workers might have learned size of cross-origin media files](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45403)
>    * [CVE-2022-45404: Fullscreen notification bypass](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45404)
>    * [CVE-2022-45405: Use-after-free in InputStream implementation](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45405)
>    * [CVE-2022-45406: Use-after-free of a JavaScript Realm](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45406)
>    * [CVE-2022-45408: Fullscreen notification bypass via windowName](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45408)
>    * [CVE-2022-45409: Use-after-free in Garbage Collection](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45409)
>    * [CVE-2022-45410: ServiceWorker-intercepted requests bypassed SameSite cookie policy](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45410)
>    * [CVE-2022-45411: Cross-Site Tracing was possible via non-standard override headers](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45411)
>    * [CVE-2022-45412: Symlinks may resolve to partially uninitialized buffers](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45412)
>    * [CVE-2022-45416: Keystroke Side-Channel Leakage](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45416)
>    * [CVE-2022-45420: Iframe contents could be rendered outside the iframe](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45420)
>    * [CVE-2022-45421: Memory safety bugs fixed in Firefox 107 and Firefox ESR 102.5](https://www.mozilla.org/en-US/security/advisories/mfsa2022-48/#CVE-2022-45421)

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Pings

@lourkeur @FliegendeWurst 
