### PR TITLE
prefetch-npm-deps: fix hash stability

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -177,7 +177,7 @@ buildNpmPackage rec {
 
   patches = [ ./remove-prepack-script.patch ];
 
-  npmDepsHash = "sha256-s8SpZY/1tKZVd3vt7sA9vsqHvEaNORQBMrSyhWpj048=";
+  npmDepsHash = "sha256-tuEfyePwlOy2/mOPdXbqJskO6IowvAP4DWg8xSZwbJw=";
 
   NODE_OPTIONS = "--openssl-legacy-provider";
 

--- a/pkgs/applications/audio/open-stage-control/default.nix
+++ b/pkgs/applications/audio/open-stage-control/default.nix
@@ -16,7 +16,7 @@ buildNpmPackage rec {
     ./package-lock.json.patch
   ];
 
-  npmDepsHash = "sha256-SGLcFjPnmhFoeXtP4gfGr4Qa1dTaXwSnzkweEvYW/1k=";
+  npmDepsHash = "sha256-5KZXZ4agHcAh3gai5w9YodETIEGJtDq/kyEZOHb9dOc=";
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/pkgs/build-support/node/fetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-npm-deps/default.nix
@@ -84,7 +84,7 @@
             hash = "sha256-X9mCwPqV5yP0S2GonNvpYnLSLJMd/SUIked+hMRxDpA=";
           };
 
-          hash = "sha256-5Mg7KDJLMM5e/7BCHGinGAnBRft2ySQzvKW06p3u/0o=";
+          hash = "sha256-tEdElWJ+KBTxBobzXBpPopQSwK2usGW/it1+yfbVzBw=";
         };
 
         linkDependencies = makeTest {
@@ -107,7 +107,7 @@
             hash = "sha256-1fGNxYJi1I4cXK/jinNG+Y6tPEOhP3QAqWOBEQttS9E=";
           };
 
-          hash = "sha256-8xF8F74nHwL9KPN2QLsxnfvsk0rNCKOZniYJQCD5u/I=";
+          hash = "sha256-+KA8/orSBJ4EhuSyQO8IKSxsN/FAsYU3lOzq+awuxNQ=";
         };
       };
 

--- a/pkgs/build-support/node/fetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/fetch-npm-deps/src/main.rs
@@ -421,7 +421,7 @@ fn main() -> anyhow::Result<()> {
                 data = Command::new("tar")
                     .args([
                         "--sort=name",
-                        "--mtime=0",
+                        "--mtime=@0",
                         "--owner=0",
                         "--group=0",
                         "--numeric-owner",


### PR DESCRIPTION
###### Description of changes

I worked with @winterqt in Matrix DMs on figuring out an issue with non-reproducible hashes from prefetch-npm-deps after #200470 

It turns out GNU `tar` silently assumes `--mtime=0` means set mtime to current date at midnight local time rather than Unix epoch timestamp 0 (which led to different hashes when run on different days as well as different hashes when run in/out of sandbox if local time isn't UTC)

This corrects the tar call to use `--mtime=@0` which makes the cached tar files reproducible and fixes hash instability. I also recalculated all of the relevant hashes that this changed (only hosted git deps used this code branch so not all hashes needed to change)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>evcc</li>
    <li>open-stage-control</li>
    <li>prefetch-npm-deps</li>
  </ul>
</details>