### PR TITLE
haskellPackages: remove unnecessary overrides from ghc-9.2.x

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -49,9 +49,6 @@ self: super: {
   # still the case when updating: https://gitlab.haskell.org/ghc/ghc/-/blob/0198841877f6f04269d6050892b98b5c3807ce4c/ghc.mk#L463
   xhtml = if self.ghc.hasHaddock or true then null else self.xhtml_3000_2_2_1;
 
-  # Tests fail because of typechecking changes
-  conduit = dontCheck super.conduit;
-
   # cabal-install needs most recent versions of Cabal and Cabal-syntax
   cabal-install = super.cabal-install.overrideScope (self: super: {
     Cabal = self.Cabal_3_8_1_0;
@@ -64,78 +61,17 @@ self: super: {
     process = self.process_1_6_16_0;
   });
 
-  doctest = dontCheck (doJailbreak super.doctest);
-
-  # Tests fail in GHC 9.2
-  extra = dontCheck super.extra;
-
   # Jailbreaks & Version Updates
-  assoc = doJailbreak super.assoc;
-  async = doJailbreak super.async;
-  base64-bytestring = doJailbreak super.base64-bytestring;
-  binary-instances = doJailbreak super.binary-instances;
-  ChasingBottoms = doJailbreak super.ChasingBottoms;
-  constraints = doJailbreak super.constraints;
-  cpphs = overrideCabal (drv: { postPatch = "sed -i -e 's,time >=1.5 && <1.11,time >=1.5 \\&\\& <1.12,' cpphs.cabal";}) super.cpphs;
-  data-fix = doJailbreak super.data-fix;
-  dec = doJailbreak super.dec;
-  ed25519 = doJailbreak super.ed25519;
-  ghc-byteorder = doJailbreak super.ghc-byteorder;
-  ghc-exactprint = overrideCabal (drv: {
-    # HACK: ghc-exactprint 1.4.1 is not buildable for GHC < 9.2,
-    # but hackage2nix evaluates the cabal file with GHC 8.10.*,
-    # causing the build-depends to be skipped. Since the dependency
-    # list hasn't changed much since 0.6.4, we can just reuse the
-    # normal expression.
-    inherit (super.ghc-exactprint) src version;
-    revision = null; editedCabalFile = null;
-    libraryHaskellDepends = [
-      self.fail
-      self.ordered-containers
-      self.data-default
-    ] ++ drv.libraryHaskellDepends or [];
-  }) super.ghc-exactprint;
-  hackage-security = doJailbreak super.hackage-security;
   hashable-time = doJailbreak super.hashable-time;
-  HTTP = overrideCabal (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; }) (doJailbreak super.HTTP);
-  integer-logarithms = overrideCabal (drv: { postPatch = "sed -i -e 's, <1.1, <1.3,' integer-logarithms.cabal"; }) (doJailbreak super.integer-logarithms);
-  indexed-traversable = doJailbreak super.indexed-traversable;
-  indexed-traversable-instances = doJailbreak super.indexed-traversable-instances;
-  lifted-async = doJailbreak super.lifted-async;
-  lukko = doJailbreak super.lukko;
-  lzma-conduit = doJailbreak super.lzma-conduit;
-  parallel = doJailbreak super.parallel;
-  path = doJailbreak super.path;
-  polyparse = overrideCabal (drv: { postPatch = "sed -i -e 's, <0.11, <0.12,' polyparse.cabal"; }) (doJailbreak super.polyparse);
-  primitive = doJailbreak super.primitive;
-  regex-posix = doJailbreak super.regex-posix;
-  resolv = doJailbreak super.resolv;
-  retrie = dontCheck super.retrie;
-  singleton-bool = doJailbreak super.singleton-bool;
+  retrie = doJailbreak (dontCheck super.retrie_1_2_1_1);
 
   # Depends on utf8-light which isn't maintained / doesn't support base >= 4.16
   # https://github.com/haskell-infra/hackage-trustees/issues/347
   # https://mail.haskell.org/pipermail/haskell-cafe/2022-October/135613.html
   language-javascript_0_7_0_0 = dontCheck super.language-javascript_0_7_0_0;
 
-  shelly = doJailbreak super.shelly;
-  splitmix = doJailbreak super.splitmix;
-  tasty-hspec = doJailbreak super.tasty-hspec;
   th-desugar = self.th-desugar_1_14;
-  time-compat = doJailbreak super.time-compat;
-  tomland = doJailbreak super.tomland;
-  type-equality = doJailbreak super.type-equality;
-  unordered-containers = doJailbreak super.unordered-containers;
   vector = dontCheck super.vector;
-  vector-binary-instances = doJailbreak super.vector-binary-instances;
-
-  hpack = overrideCabal (drv: {
-    # Cabal 3.6 seems to preserve comments when reading, which makes this test fail
-    # 2021-10-10: 9.2.1 is not yet supported (also no issue)
-    testFlags = [
-      "--skip=/Hpack/renderCabalFile/is inverse to readCabalFile/"
-    ] ++ drv.testFlags or [];
-  }) (doJailbreak super.hpack);
 
   # Apply patches from head.hackage.
   language-haskell-extract = appendPatch (pkgs.fetchpatch {
@@ -158,12 +94,9 @@ self: super: {
   # need bytestring >= 0.11 which is only bundled with GHC >= 9.2
   regex-rure = doDistribute (markUnbroken super.regex-rure);
   jacinda = doDistribute super.jacinda;
-  some = doJailbreak super.some;
-
-  implicit-hie-cradle = doJailbreak super.implicit-hie-cradle;
 
   # 2022-08-01: Tests are broken on ghc 9.2.4: https://github.com/wz1000/HieDb/issues/46
-  hiedb = doJailbreak (dontCheck super.hiedb);
+  hiedb = dontCheck super.hiedb;
 
   # 2022-02-05: The following plugins don‘t work yet on ghc9.2.
   # Compare: https://haskell-language-server.readthedocs.io/en/latest/supported-versions.html
@@ -177,7 +110,4 @@ self: super: {
   inline-c-cpp =
     (if isDarwin then appendConfigureFlags ["--ghc-option=-fcompact-unwind"] else x: x)
     super.inline-c-cpp;
-
-  relude = dontCheck super.relude;
-  hermes-json = doJailbreak super.hermes-json;
 }


### PR DESCRIPTION
###### Description of changes
I compiled each package and it turned out most overrides are not needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
