### PR TITLE
citations: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1677,6 +1677,15 @@
     githubId = 214787;
     name = "Herwig Hochleitner";
   };
+  benediktbroich = {
+    name = "Benedikt Broich";
+    email = "b.broich@posteo.de";
+    github = "BenediktBroich";
+    githubId = 32903896;
+    keys = [{
+      fingerprint = "CB5C 7B3C 3E6F 2A59 A583  A90A 8A60 0376 7BE9 5976";
+    }];
+  };
   benesim = {
     name = "Benjamin Isbarn";
     email = "benjamin.isbarn@gmail.com";

--- a/pkgs/applications/misc/citations/default.nix
+++ b/pkgs/applications/misc/citations/default.nix
@@ -1,0 +1,74 @@
+{ darwin
+, desktop-file-utils
+, fetchFromGitLab
+, gettext
+, glib
+, gtk4
+, gtksourceview5
+, lib
+, libadwaita
+, meson
+, ninja
+, pkg-config
+, poppler
+, rustPlatform
+, stdenv
+, testers
+, wrapGAppsHook4
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "citations";
+  version = "0.5.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
+    hash = "sha256-QPK6Nw0tDdttUDFKMgThTYMTxGXsn5OReqf1LNAai7g=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    src = finalAttrs.src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}";
+    hash = "sha256-Kounxi4JxoU4+rWMWNB8rzTyG3MDKYD0OzYfAHwm6bY=";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gettext
+    glib
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustPlatform.rust.cargo
+    rustPlatform.rust.rustc
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    gtksourceview5
+    libadwaita
+    poppler
+  ] ++ lib.optional stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Foundation
+  ];
+
+  doCheck = true;
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "citations --help";
+  };
+
+  meta = with lib; {
+    description = "Manage your bibliographies using the BibTeX format";
+    homepage = "https://apps.gnome.org/app/org.gnome.World.Citations";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ benediktbroich ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1943,6 +1943,8 @@ with pkgs;
 
   cen64 = callPackage ../applications/emulators/cen64 { };
 
+  citations = callPackage ../applications/misc/citations { };
+
   citra-canary = callPackage ../applications/emulators/citra {
     branch = "canary";
   };


### PR DESCRIPTION
###### Description of changes

Add a new package named citations. 

[Homepage](https://apps.gnome.org/de/app/org.gnome.World.Citations)
[Source](https://gitlab.gnome.org/World/citations)

###### How to test this change?
Build: `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 202605"`
Run application: `citations `
Run test: `nix-build -A citations.passthru.tests` or `nix-build -A citations.passthru.tests.version`

WARNING! DON'T open a existing .bib file without a backup. The Application does not support comments and might be lost.

Example Testing
1) `touch test.bib`
2) Open the database file. 
3) Add citations using the ui
4) Open the database file with a text editor to see the bibtex format

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
