### PR TITLE
mongoc: 1.8.0 -> 1.23.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1071,6 +1071,12 @@
     githubId = 56009;
     name = "Arcadio Rubio García";
   };
+  archer-65 = {
+    email = "mario.liguori.056@gmail.com";
+    github = "archer-65";
+    githubId = 76066109;
+    name = "Mario Liguori";
+  };
   archseer = {
     email = "blaz@mxxn.io";
     github = "archseer";

--- a/pkgs/development/libraries/mongoc/default.nix
+++ b/pkgs/development/libraries/mongoc/default.nix
@@ -1,19 +1,36 @@
-{ lib, stdenv, fetchzip, perl, pkg-config, libbson
-, openssl, which, zlib, snappy
+{
+  lib,
+  stdenv,
+  fetchzip,
+  cmake,
+  pkg-config,
+  perl,
+  openssl,
+  zlib,
+  cyrus_sasl,
+  libbson,
+  snappy,
 }:
-
 stdenv.mkDerivation rec {
   pname = "mongoc";
-  version = "1.8.0";
+  version = "1.23.1";
 
   src = fetchzip {
     url = "https://github.com/mongodb/mongo-c-driver/releases/download/${version}/mongo-c-driver-${version}.tar.gz";
     sha256 = "1vnnk3pwbcmwva1010bl111kdcdx3yb2w7j7a78hhvrm1k9r1wp8";
   };
 
-  nativeBuildInputs = [ pkg-config which perl ];
-  buildInputs = [ openssl zlib ];
-  propagatedBuildInputs = [ libbson snappy ];
+  # https://github.com/NixOS/nixpkgs/issues/25585
+  preFixup = ''rm -rf "$(pwd)" '';
+
+  nativeBuildInputs = [cmake pkg-config perl];
+  buildInputs = [openssl zlib cyrus_sasl];
+  propagatedBuildInputs = [libbson snappy];
+
+  # -DMONGOC_TEST_USE_CRYPT_SHARED=OFF
+  # The `mongodl.py` script is causing issues, and you also need to disabled sandboxing for it. However, it is used only to run some tests.
+  # https://www.mongodb.com/community/forums/t/problem-downloading-crypt-shared-when-installing-the-mongodb-c-driver/189370
+  cmakeFlags = ["-DCMAKE_BUILD_TYPE=Release" "-DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF" "-DMONGOC_TEST_USE_CRYPT_SHARED=OFF"];
 
   enableParallelBuilding = true;
 
@@ -22,6 +39,7 @@ stdenv.mkDerivation rec {
     homepage = "http://mongoc.org";
     license = licenses.asl20;
     mainProgram = "mongoc-stat";
+    maintainers = with maintainers; [archer-65];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

This change updates `mongo-c-driver` version to 1.23.1 from 1.8.0.

Some tests (read `mongodl.py`) are disabled for the following reasons:
- Need to disable sandbox during build
- `mongodl.py` does not provide "support" for `NixOS`, the build fails in any case

However, the script named above is not necessary to build `mongoc`, read [here](https://www.mongodb.com/community/forums/t/problem-downloading-crypt-shared-when-installing-the-mongodb-c-driver/189370)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
