### PR TITLE
qt6: only move dev tools to dev output

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -240,7 +240,6 @@ stdenv.mkDerivation rec {
 
     # Move development tools to $dev
     moveQtDevTools
-    moveToOutput bin "$dev"
     moveToOutput libexec "$dev"
 
     # fixup .pc file (where to find 'moc' etc.)

--- a/pkgs/development/libraries/qt-6/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttools.nix
@@ -15,4 +15,28 @@ qtModule {
   NIX_CFLAGS_COMPILE = [
     "-DNIX_OUTPUT_DEV=\"${placeholder "dev"}\""
   ];
+
+  devTools = [
+    "bin/qcollectiongenerator"
+    "bin/linguist"
+    "bin/assistant"
+    "bin/qdoc"
+    "bin/lconvert"
+    "bin/designer"
+    "bin/qtattributionsscanner"
+    "bin/lrelease"
+    "bin/lrelease-pro"
+    "bin/pixeltool"
+    "bin/lupdate"
+    "bin/lupdate-pro"
+    "bin/qtdiag"
+    "bin/qhelpgenerator"
+    "bin/qtplugininfo"
+    "bin/qthelpconverter"
+    "bin/lprodump"
+    "bin/qdistancefieldgenerator"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "bin/macdeployqt"
+  ];
+
 }

--- a/pkgs/development/libraries/qt-6/patches/cmake.patch
+++ b/pkgs/development/libraries/qt-6/patches/cmake.patch
@@ -1,4 +1,4 @@
-commit 4f497c358e0386b65df1c1d636aadf72f8647134
+commit bd8f6ecea0663bdd150aa48941cbd47d25874396
 Author: Nick Cao <nickcao@nichi.co>
 Date:   Tue Apr 19 13:49:59 2022 +0800
 
@@ -13,10 +13,10 @@ Date:   Tue Apr 19 13:49:59 2022 +0800
     generated cmake files to point to the corrected pathes.
 
 diff --git a/Source/cmExportFileGenerator.cxx b/Source/cmExportFileGenerator.cxx
-index 8b0f64e23b..03291e2ee2 100644
+index 5a33349b19..677a6084d6 100644
 --- a/Source/cmExportFileGenerator.cxx
 +++ b/Source/cmExportFileGenerator.cxx
-@@ -6,6 +6,7 @@
+@@ -7,6 +7,7 @@
  #include <cstring>
  #include <sstream>
  #include <utility>
@@ -24,7 +24,7 @@ index 8b0f64e23b..03291e2ee2 100644
  
  #include <cm/memory>
  
-@@ -325,9 +326,23 @@ static void prefixItems(std::string& exportDirs)
+@@ -330,9 +331,21 @@ static void prefixItems(std::string& exportDirs)
    for (std::string const& e : entries) {
      exportDirs += sep;
      sep = ";";
@@ -34,8 +34,6 @@ index 8b0f64e23b..03291e2ee2 100644
 +    if (!cmSystemTools::FileIsFullPath(e)) {
 +      if (std::getenv("dev")) {
 +        if (cmHasLiteralPrefix(e, "include") || cmHasLiteralPrefix(e, "./include")) {
-+          exportDirs += std::getenv("dev");
-+        } else if (cmHasLiteralPrefix(e, "bin") || cmHasLiteralPrefix(e, "./bin")) {
 +          exportDirs += std::getenv("dev");
 +        } else if (cmHasLiteralPrefix(e, "mkspecs") || cmHasLiteralPrefix(e, "./mkspecs")) {
 +          exportDirs += std::getenv("dev");
@@ -52,18 +50,18 @@ index 8b0f64e23b..03291e2ee2 100644
      exportDirs += e;
    }
 diff --git a/Source/cmExportInstallFileGenerator.cxx b/Source/cmExportInstallFileGenerator.cxx
-index 4a3c565bce..5afa9e5e50 100644
+index adccdfeece..ba248305bd 100644
 --- a/Source/cmExportInstallFileGenerator.cxx
 +++ b/Source/cmExportInstallFileGenerator.cxx
-@@ -5,6 +5,7 @@
+@@ -6,6 +6,7 @@
  #include <memory>
  #include <sstream>
  #include <utility>
 +#include <cstdlib>
  
  #include "cmExportSet.h"
- #include "cmGeneratedFileStream.h"
-@@ -263,7 +264,7 @@ void cmExportInstallFileGenerator::LoadConfigFiles(std::ostream& os)
+ #include "cmFileSet.h"
+@@ -266,7 +267,7 @@ void cmExportInstallFileGenerator::LoadConfigFiles(std::ostream& os)
  
  void cmExportInstallFileGenerator::ReplaceInstallPrefix(std::string& input)
  {
@@ -72,7 +70,7 @@ index 4a3c565bce..5afa9e5e50 100644
  }
  
  bool cmExportInstallFileGenerator::GenerateImportFileConfig(
-@@ -381,9 +382,24 @@ void cmExportInstallFileGenerator::SetImportLocationProperty(
+@@ -382,9 +383,22 @@ void cmExportInstallFileGenerator::SetImportLocationProperty(
    // Construct the installed location of the target.
    std::string dest = itgen->GetDestination(config);
    std::string value;
@@ -82,8 +80,6 @@ index 4a3c565bce..5afa9e5e50 100644
 -    value = "${_IMPORT_PREFIX}/";
 +    if (std::getenv("dev")) {
 +      if (cmHasLiteralPrefix(dest, "include") || cmHasLiteralPrefix(dest, "./include")) {
-+        value = std::getenv("dev");
-+      } else if (cmHasLiteralPrefix(dest, "bin") || cmHasLiteralPrefix(dest, "./bin")) {
 +        value = std::getenv("dev");
 +      } else if (cmHasLiteralPrefix(dest, "mkspecs") || cmHasLiteralPrefix(dest, "./mkspecs")) {
 +        value = std::getenv("dev");
@@ -100,18 +96,16 @@ index 4a3c565bce..5afa9e5e50 100644
    value += dest;
    value += "/";
 diff --git a/Source/cmGeneratorExpression.cxx b/Source/cmGeneratorExpression.cxx
-index 840f5112d6..7bb4ab41aa 100644
+index f988e54a19..cc5c7ac9fd 100644
 --- a/Source/cmGeneratorExpression.cxx
 +++ b/Source/cmGeneratorExpression.cxx
-@@ -197,7 +197,22 @@ static void prefixItems(const std::string& content, std::string& result,
+@@ -192,7 +192,20 @@ static void prefixItems(const std::string& content, std::string& result,
      sep = ";";
      if (!cmSystemTools::FileIsFullPath(e) &&
          cmGeneratorExpression::Find(e) != 0) {
 -      result += prefix;
 +      if (std::getenv("dev")) {
 +        if (cmHasLiteralPrefix(e, "include") || cmHasLiteralPrefix(e, "./include")) {
-+          result += std::getenv("dev");
-+        } else if (cmHasLiteralPrefix(e, "bin") || cmHasLiteralPrefix(e, "./bin")) {
 +          result += std::getenv("dev");
 +        } else if (cmHasLiteralPrefix(e, "mkspecs") || cmHasLiteralPrefix(e, "./mkspecs")) {
 +          result += std::getenv("dev");

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (args // {
   postInstall = ''
     if [ ! -z "$dev" ]; then
       mkdir "$dev"
-      for dir in bin libexec mkspecs
+      for dir in libexec mkspecs
       do
         moveToOutput "$dir" "$dev"
       done


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
fixes https://github.com/NixOS/nixpkgs/issues/202622
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
