### PR TITLE
libint: expose tunable configuration options for integral generation

### DIFF
--- a/pkgs/development/libraries/libint/default.nix
+++ b/pkgs/development/libraries/libint/default.nix
@@ -1,12 +1,115 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool
-, python3, perl, gmpxx, mpfr, boost, eigen, gfortran, cmake
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, python3
+, perl
+, gmpxx
+, mpfr
+, boost
+, eigen
+, gfortran
+, cmake
 , enableFMA ? stdenv.hostPlatform.fmaSupport
 , enableFortran ? true
+, enableSSE ? (!enableFortran) && stdenv.hostPlatform.isx86_64
+
+  # Maximum angular momentum of basis functions
+  # 7 is required for def2/J auxiliary basis on 3d metals upwards
+, maxAm ? 7
+
+  # ERI derivative order for 4-, 3- and 2-centre ERIs.
+  # 2nd derivatives are defaults and allow gradients Hessians with density fitting
+  # Setting them to zero disables derivatives.
+, eriDeriv ? 2
+, eri3Deriv ? 2
+, eri2Deriv ? 2
+
+  # Angular momentum for derivatives of ERIs. Takes a list of length $DERIV_ORD+1.
+  # Starting from index 0, each index i specifies the supported angular momentum
+  # for the derivative order i, e.g. [6,5,4] supports ERIs for l=6, their first
+  # derivatives for l=5 and their second derivatives for l=4.
+, eriAm ? (builtins.genList (i: maxAm - 1 - i) (eriDeriv + 1))
+, eri3Am ? (builtins.genList (i: maxAm - i) (eri2Deriv + 1))
+, eri2Am ? (builtins.genList (i: maxAm - i) (eri2Deriv + 1))
+
+  # Same as above for optimised code. Higher optimisations take a long time.
+, eriOptAm ? (builtins.genList (i: maxAm - 3 - i) (eriDeriv + 1))
+, eri3OptAm ? (builtins.genList (i: maxAm - 3 - i) (eri2Deriv + 1))
+, eri2OptAm ? (builtins.genList (i: maxAm - 3 - i) (eri2Deriv + 1))
+
+  # One-Electron integrals of all kinds including multipole integrals.
+  # Libint does not build them and their derivatives by default.
+, enableOneBody ? false
+, oneBodyDerivOrd ? 2
+, multipoleOrd ? 4 # Maximum order of multipole integrals, 4=octopoles
+
+  # Whether to enable generic code if angular momentum is unsupported
+, enableGeneric ? true
+
+  # Support integrals over contracted Gaussian
+, enableContracted ? true
+
+  # Spherical harmonics/Cartesian orbital conventions
+, cartGaussOrd ? "standard" # Ordering of Cartesian basis functions, "standard" is CCA
+, shGaussOrd ? "standard" # Ordering of spherical harmonic basis functions. "standard" is -l to +l, "guassian" is 0, 1, -1, 2, -2, ...
+, shellSet ? "standard"
+, eri3PureSh ? false # Transformation of 3-centre ERIs into spherical harmonics
+, eri2PureSh ? false # Transformation of 2-centre ERIs into spherical harmonics
 }:
+
+# Check that Fortran bindings are not used together with SIMD real type
+assert (if enableFortran then !enableSSE else true);
+
+# Check that a possible angular momentum for basis functions is used
+assert (maxAm >= 1 && maxAm <= 8);
+
+# Check for valid derivative order in ERIs
+assert (eriDeriv >= 0 && eriDeriv <= 4);
+assert (eri2Deriv >= 0 && eri2Deriv <= 4);
+assert (eri3Deriv >= 0 && eri3Deriv <= 4);
+
+# Ensure valid arguments for generated angular momenta in ERI derivatives are used.
+assert (
+  builtins.length eriAm == eriDeriv + 1 &&
+  builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eriAm)
+);
+assert (
+  builtins.length eri3Am == eriDeriv + 1 &&
+  builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri3Am)
+);
+assert (
+  builtins.length eri2Am == eriDeriv + 1 &&
+  builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri2Am)
+);
+
+# Ensure valid arguments for generated angular momenta in optimised ERI derivatives are used.
+assert (
+  builtins.length eriOptAm == eriDeriv + 1 &&
+  builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eriOptAm)
+);
+assert (
+  builtins.length eri3OptAm == eriDeriv + 1 &&
+  builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri3OptAm)
+);
+assert (
+  builtins.length eri2OptAm == eriDeriv + 1 &&
+  builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri2OptAm)
+);
+
+# Ensure a valid derivative order for one-electron integrals
+assert (oneBodyDerivOrd >= 0 && oneBodyDerivOrd <= 4);
+
+# Check that valid basis shell orders are used, see https://github.com/evaleev/libint/wiki
+assert (builtins.elem cartGaussOrd [ "standard" "intv3" "gamess" "orca" "bagel" ]);
+assert (builtins.elem shGaussOrd [ "standard" "gaussian" ]);
+assert (builtins.elem shellSet [ "standard" "orca" ]);
 
 let
   pname = "libint";
-  version = "2.7.1";
+  version = "2.7.2";
 
   meta = with lib; {
     description = "Library for the evaluation of molecular integrals of many-body operators over Gaussian functions";
@@ -23,7 +126,7 @@ let
       owner = "evaleev";
       repo = pname;
       rev = "v${version}";
-      sha256 = "5nSeyT1DhFsA76Dt3dqYfhfBYD+iTl34O3lVeH6+OVw=";
+      hash = "sha256-lX+DVnhdOb8d7MX9umf33y88CNiGb3TYYlMZtQXfx+8=";
     };
 
     # Replace hardcoded "/bin/rm" with normal "rm"
@@ -52,23 +155,36 @@ let
 
     buildInputs = [ boost eigen ];
 
-    preConfigure = "./autogen.sh";
+    configureFlags = with lib; [
+      "--with-max-am=${builtins.toString maxAm}"
+      "--with-eri-max-am=${concatStringsSep "," (builtins.map builtins.toString eriAm)}"
+      "--with-eri3-max-am=${concatStringsSep "," (builtins.map builtins.toString eri3Am)}"
+      "--with-eri2-max-am=${concatStringsSep "," (builtins.map builtins.toString eri2Am)}"
+      "--with-eri-opt-am=${concatStringsSep "," (builtins.map builtins.toString eriOptAm)}"
+      "--with-eri3-opt-am=${concatStringsSep "," (builtins.map builtins.toString eri3OptAm)}"
+      "--with-eri2-opt-am=${concatStringsSep "," (builtins.map builtins.toString eri2OptAm)}"
+      "--with-cartgauss-ordering=${cartGaussOrd}"
+      "--with-shgauss-ordering=${shGaussOrd}"
+      "--with-shell-set=${shellSet}"
+    ]
+    ++ optional enableFMA "--enable-fma"
+    ++ optional (eriDeriv > 0) "--enable-eri=${builtins.toString eriDeriv}"
+    ++ optional (eri2Deriv > 0) "--enable-eri2=${builtins.toString eri2Deriv}"
+    ++ optional (eri3Deriv > 0) "--enable-eri3=${builtins.toString eri3Deriv}"
+    ++ lists.optionals enableOneBody [
+      "--enable-1body=${builtins.toString oneBodyDerivOrd}"
+      "--enable-1body-property-derivs"
+    ]
+    ++ optional (multipoleOrd > 0) "--with-multipole-max-order=${builtins.toString multipoleOrd}"
+    ++ optional enableGeneric "--enable-generic"
+    ++ optional enableContracted "--enable-contracted-ints"
+    ++ optional eri3PureSh "--enable-eri3-pure-sh"
+    ++ optional eri2PureSh "--enable-eri2-pure-sh"
+    ;
 
-    configureFlags = [
-      "--enable-eri=2"
-      "--enable-eri3=2"
-      "--enable-eri2=2"
-      "--with-eri-max-am=7,5,4"
-      "--with-eri-opt-am=3"
-      "--with-eri3-max-am=7"
-      "--with-eri2-max-am=7"
-      "--with-g12-max-am=5"
-      "--with-g12-opt-am=3"
-      "--with-g12dkh-max-am=5"
-      "--with-g12dkh-opt-am=3"
-      "--enable-contracted-ints"
-      "--enable-shared"
-    ] ++ lib.optional enableFMA "--enable-fma";
+    preConfigure = ''
+      ./autogen.sh
+    '';
 
     makeFlags = [ "export" ];
 
@@ -98,11 +214,9 @@ let
     # AVX support is advertised, but does not work in 2.6 (possibly in 2.7).
     # Fortran interface is incompatible with changing the LIBINT2_REALTYPE.
     cmakeFlags = [
-      (if enableFortran
-        then "-DENABLE_FORTRAN=ON"
-        else "-DLIBINT2_REALTYPE=libint2::simd::VectorSSEDouble"
-      )
-    ];
+      "-DLIBINT2_SHGAUSS_ORDERING=${shGaussOrd}"
+    ] ++ lib.optional enableFortran "-DENABLE_FORTRAN=ON"
+    ++ lib.optional enableSSE "-DLIBINT2_REALTYPE=libint2::simd::VectorSSEDouble";
 
     # Can only build in the source-tree. A lot of preprocessing magic fails otherwise.
     dontUseCmakeBuildDir = true;
@@ -110,4 +224,5 @@ let
     inherit meta;
   };
 
-in codeComp
+in
+codeComp

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9075,6 +9075,28 @@ with pkgs;
   libinsane = callPackage ../development/libraries/libinsane { };
 
   libint = callPackage ../development/libraries/libint {};
+  libintPsi4 = callPackage ../development/libraries/libint {
+    enableFortran = false;
+    enableSSE = false;
+    maxAm = 6;
+    eriDeriv = 2;
+    eri3Deriv = 2;
+    eri2Deriv = 2;
+    eriAm = [ 6 5 4 ];
+    eri3Am = [ 6 5 4 ];
+    eri2Am = [ 6 5 4 ];
+    eriOptAm = [ 3 2 2 ];
+    eri3OptAm = [ 3 2 2 ];
+    eri2OptAm = [ 3 2 2 ];
+    enableOneBody = true;
+    oneBodyDerivOrd = 2;
+    enableGeneric = false;
+    enableContracted = false;
+    cartGaussOrd = "standard";
+    shGaussOrd = "gaussian";
+    eri2PureSh = false;
+    eri3PureSh = false;
+  };
 
   libipfix = callPackage ../development/libraries/libipfix { };
 


### PR DESCRIPTION
###### Description of changes

Libint for integrals in quantum chemistry can be built in a variety of ways. Up to now, only one has been supported suitable for CP2K included in Nixpkgs. However, other quantum chemistry programmes require very different settings. This PR exposes the majority of libints configuration options within reasonable constraints, so that multiple versions can be built. More integrals are built by default now (for example one-electron integrals and multipole integrals).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

