### PR TITLE
odin: 0.13.0 -> dev-2023-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1429,6 +1429,12 @@
     githubId = 453170;
     name = "Alastair Pharo";
   };
+  astavie = {
+    email = "astavie@pm.me";
+    github = "astavie";
+    githubId = 7745457;
+    name = "Astavie";
+  };
   astro = {
     email = "astro@spaceboyz.net";
     github = "astro";

--- a/pkgs/development/compilers/odin/default.nix
+++ b/pkgs/development/compilers/odin/default.nix
@@ -1,31 +1,43 @@
 { lib
 , fetchFromGitHub
-, llvmPackages
+, llvmPackages_13
 , makeWrapper
 , libiconv
+, MacOSX-SDK
+, which
 }:
 
 let
+  llvmPackages = llvmPackages_13;
   inherit (llvmPackages) stdenv;
 in stdenv.mkDerivation rec {
   pname = "odin";
-  version = "0.13.0";
+  version = "dev-2023-05";
 
   src = fetchFromGitHub {
     owner = "odin-lang";
     repo = "Odin";
-    rev = "v${version}";
-    sha256 = "ke2HPxVtF/Lh74Tv6XbpM9iLBuXLdH1+IE78MAacfYY=";
+    rev = version;
+    sha256 = "sha256-qEewo2h4dpivJ7D4RxxBZbtrsiMJ7AgqJcucmanbgxY=";
   };
 
   nativeBuildInputs = [
-    makeWrapper
+    makeWrapper which
   ];
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;
 
-  postPatch = ''
-    sed -i 's/^GIT_SHA=.*$/GIT_SHA=/' Makefile
+  LLVM_CONFIG = "${llvmPackages.llvm.dev}/bin/llvm-config";
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    sed -i src/main.cpp \
+      -e 's|-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk|-syslibroot ${MacOSX-SDK}|'
+  '' + ''
+    sed -i build_odin.sh \
+      -e 's/^GIT_SHA=.*$/GIT_SHA=/' \
+      -e 's/LLVM-C/LLVM/' \
+      -e 's/framework System/lSystem/'
+    patchShebangs build_odin.sh
   '';
 
   dontConfigure = true;
@@ -37,21 +49,26 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp odin $out/bin/odin
-    cp -r core $out/bin/core
 
-    wrapProgram $out/bin/odin --prefix PATH : ${lib.makeBinPath (with llvmPackages; [
-      bintools
-      llvm
-      clang
-      lld
-    ])}
+    mkdir -p $out/share
+    cp -r core $out/share/core
+    cp -r vendor $out/share/vendor
+
+    wrapProgram $out/bin/odin \
+      --prefix PATH : ${lib.makeBinPath (with llvmPackages; [
+        bintools
+        llvm
+        clang
+        lld
+      ])} \
+      --set-default ODIN_ROOT $out/share
   '';
 
   meta = with lib; {
     description = "A fast, concise, readable, pragmatic and open sourced programming language";
     homepage = "https://odin-lang.org/";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ luc65r ];
-    platforms = platforms.x86_64;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ luc65r astavie ];
+    platforms = platforms.x86_64 ++ [ "aarch64-darwin" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27596,7 +27596,9 @@ with pkgs;
 
   octomap = callPackage ../development/libraries/octomap { };
 
-  odin = callPackage ../development/compilers/odin { };
+  odin = callPackage ../development/compilers/odin {
+    inherit (pkgs.darwin.apple_sdk_11_0) MacOSX-SDK;
+  };
 
   odp-dpdk = callPackage ../os-specific/linux/odp-dpdk { };
 


### PR DESCRIPTION
###### Description of changes

updated odin package from 0.13.0 to dev-2023-05

since may 2021 odin has moved to monthly dev releases

I plan on keeping this up to date monthly for the foreseeable future as I use odin a lot

https://github.com/odin-lang/Odin/releases/
https://github.com/odin-lang/Odin/releases/tag/dev-2022-11

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
