### PR TITLE
airgeddon: 11.02 -> 11.10

### DIFF
--- a/pkgs/tools/networking/airgeddon/default.nix
+++ b/pkgs/tools/networking/airgeddon/default.nix
@@ -24,7 +24,8 @@
 , util-linux
 , ccze
   # Optionals
-  # Missing in nixpkgs: beef, hostapd-wpe, asleap
+  # Missing in nixpkgs: beef, hostapd-wpe
+, asleap
 , bettercap
 , bully
 , crunch
@@ -84,6 +85,7 @@ let
     pixiewps
     reaverwps-t6x
   ] ++ lib.optionals supportHashCracking [
+    asleap
     crunch
     hashcat
     hcxdumptool
@@ -109,13 +111,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "airgeddon";
-  version = "11.02";
+  version = "11.10";
 
   src = fetchFromGitHub {
     owner = "v1s1t0r1sh3r3";
     repo = "airgeddon";
     rev = "v${version}";
-    hash = "sha256-k3xQndF1m3fnn7nCb2T/wGxbUPJ83wOV33Ky0FbToVg=";
+    hash = "sha256-0x13QmT61lcPc7b3OYs13g6AISWRipvxbSFb7XyQA5U=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

- Changes: https://github.com/v1s1t0r1sh3r3/airgeddon/compare/v11.02...v11.10
- Added "asleap" which I didn't note was already in repos.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

![screenshot](https://user-images.githubusercontent.com/1368952/203787484-71ce3045-db64-4c01-8d30-f74f819f3f5b.png)