### PR TITLE
haskellPackages.haskell-language-server: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1611,7 +1611,7 @@ self: super: {
   });
 
   # For -f-auto see cabal.project in haskell-language-server.
-  ghc-lib-parser-ex = disableCabalFlag "auto" super.ghc-lib-parser-ex;
+  ghc-lib-parser-ex = addBuildDepend self.ghc-lib-parser (disableCabalFlag "auto" super.ghc-lib-parser-ex);
 
   # 2021-05-08: Tests fail: https://github.com/haskell/haskell-language-server/issues/1809
   hls-eval-plugin = dontCheck super.hls-eval-plugin;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -98,14 +98,6 @@ self: super: {
   # 2022-08-01: Tests are broken on ghc 9.2.4: https://github.com/wz1000/HieDb/issues/46
   hiedb = dontCheck super.hiedb;
 
-  # 2022-02-05: The following plugins don‘t work yet on ghc9.2.
-  # Compare: https://haskell-language-server.readthedocs.io/en/latest/supported-versions.html
-  haskell-language-server = super.haskell-language-server.override {
-    hls-haddock-comments-plugin = null;
-    hls-splice-plugin = null;
-    hls-tactics-plugin = null;
-  };
-
   # https://github.com/fpco/inline-c/pull/131
   inline-c-cpp =
     (if isDarwin then appendConfigureFlags ["--ghc-option=-fcompact-unwind"] else x: x)

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -192,10 +192,7 @@ in {
     hls-ormolu-plugin = null;
     hls-rename-plugin = null;
     hls-stylish-haskell-plugin = null;
-    hls-tactics-plugin = null;
-    hls-haddock-comments-plugin = null;
     hls-retrie-plugin = null;
-    hls-splice-plugin = null;
   };
 
   # https://github.com/tweag/ormolu/issues/941


### PR DESCRIPTION
Required after the switch to GHC 9.2.4 in hackage2nix.

Note that the situation with Cabal flags is not optimal: since flags may add or remove dependencies (e.g. here the `auto` flag [controls](https://hackage.haskell.org/package/ghc-lib-parser-ex-9.2.0.4/dependencies) whether `ghc-lib-parser` is included if GHC 9.2 is used), we should tell hackage2nix that we want to disable the `auto` flag instead of doing it in `configuration-common.nix`. Then it could add the correct dependencies and also add the flag to the generated `configureFlags` itself.

EDIT: found https://github.com/NixOS/cabal2nix/blob/master/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal/Flags.hs, should we add `| name == "ghc-lib-parser-ex" = [disable "auto"]` in there?