### PR TITLE
treewide: remove -march=native

### DIFF
--- a/pkgs/applications/misc/glava/default.nix
+++ b/pkgs/applications/misc/glava/default.nix
@@ -55,8 +55,6 @@ in
 
       substituteInPlace Makefile \
         --replace 'unknown' 'v${version}'
-
-      export CFLAGS="-march=native"
     '';
 
     makeFlags = optional (!enableGlfw) "DISABLE_GLFW=1";

--- a/pkgs/applications/misc/opentrack/aruco.nix
+++ b/pkgs/applications/misc/opentrack/aruco.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ opencv4 ];
 
-  NIX_CFLAGS_COMPILE = "-Wall -Wextra -Wpedantic -ffast-math -march=native -O3";
+  NIX_CFLAGS_COMPILE = "-Wall -Wextra -Wpedantic -ffast-math -O3";
 
   preInstall = ''
     mkdir -p $out/include/aruco

--- a/pkgs/applications/misc/opentrack/default.nix
+++ b/pkgs/applications/misc/opentrack/default.nix
@@ -42,7 +42,7 @@ in
     nativeBuildInputs = [cmake pkg-config ninja copyDesktopItems];
     buildInputs = [qtbase qttools opencv4 procps eigen libXdmcp libevdev aruco];
 
-    NIX_CFLAGS_COMPILE = "-Wall -Wextra -Wpedantic -ffast-math -march=native -O3";
+    NIX_CFLAGS_COMPILE = "-Wall -Wextra -Wpedantic -ffast-math -O3";
     dontWrapQtApps = true;
 
     cmakeFlags = [

--- a/pkgs/applications/video/mlv-app/aarch64-flags.patch
+++ b/pkgs/applications/video/mlv-app/aarch64-flags.patch
@@ -7,7 +7,7 @@ index ebdc552..3e37573 100644
  # Linux
  linux-g++*{
 -    QMAKE_CFLAGS += -O3 -fopenmp -msse4.1 -mssse3 -msse3 -msse2 -msse -std=c99
-+    QMAKE_CFLAGS += -O3 -fopenmp -march=native -std=c99
++    QMAKE_CFLAGS += -O3 -fopenmp -std=c99
      QMAKE_CXXFLAGS += -fopenmp
      LIBS += -lgomp
  }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`-march=native` breaks purity, so let's remove it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
