### PR TITLE
haskellPackages.hnix: 0.14.0.8 -> 0.16

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -914,7 +914,12 @@ self: super: {
       '';
     }) super.dhall-nix);
   dhall-yaml = self.generateOptparseApplicativeCompletions ["dhall-to-yaml-ng" "yaml-to-dhall"] super.dhall-yaml;
-  dhall-nixpkgs = self.generateOptparseApplicativeCompletions [ "dhall-to-nixpkgs" ] super.dhall-nixpkgs;
+  dhall-nixpkgs = self.generateOptparseApplicativeCompletions [ "dhall-to-nixpkgs" ]
+    (overrideCabal (drv: {
+      # Allow hnix 0.16, needs unreleased bounds change
+      # https://github.com/dhall-lang/dhall-haskell/pull/2474
+      jailbreak = assert drv.version == "1.0.9" && drv.revision == "1"; true;
+    }) super.dhall-nixpkgs);
 
   stack = self.generateOptparseApplicativeCompletions [ "stack" ] super.stack;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -249,16 +249,11 @@ self: super: {
   }));
 
   # 2020-06-05: HACK: does not pass own build suite - `dontCheck`
-  # 2022-06-17: Use hnix-store 0.5 until hnix 0.17
-  hnix = self.generateOptparseApplicativeCompletions [ "hnix" ] (dontCheck (
-    super.hnix.overrideScope (hself: hsuper: {
-      hnix-store-core = hself.hnix-store-core_0_5_0_0;
-      hnix-store-remote = hself.hnix-store-remote_0_5_0_0;
-    })
-  ));
-  # Too strict bounds on algebraic-graphs
+  # 2022-11-24: jailbreak as it has too strict bounds on a bunch of things
+  hnix = self.generateOptparseApplicativeCompletions [ "hnix" ] (dontCheck (doJailbreak super.hnix));
+  # Too strict bounds on algebraic-graphs and bytestring
   # https://github.com/haskell-nix/hnix-store/issues/180
-  hnix-store-core_0_5_0_0 = doJailbreak super.hnix-store-core_0_5_0_0;
+  hnix-store-core = doJailbreak super.hnix-store-core;
 
   # Too strict upper bound on bytestring
   # https://github.com/wangbj/hashing/issues/3

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -896,7 +896,23 @@ self: super: {
   # https://github.com/commercialhaskell/stackage/issues/5795
   # This issue can be mitigated with 'dontCheck' which skips the tests and their compilation.
   dhall-json = self.generateOptparseApplicativeCompletions ["dhall-to-json" "dhall-to-yaml"] (dontCheck super.dhall-json);
-  dhall-nix = self.generateOptparseApplicativeCompletions [ "dhall-to-nix" ] super.dhall-nix;
+  dhall-nix = self.generateOptparseApplicativeCompletions [ "dhall-to-nix" ]
+    (overrideCabal (drv: {
+      patches = [
+        # Compatibility with hnix 0.16, waiting for release
+        # https://github.com/dhall-lang/dhall-haskell/pull/2474
+        (pkgs.fetchpatch {
+          name = "dhall-nix-hnix-0.16.patch";
+          url = "https://github.com/dhall-lang/dhall-haskell/commit/49b9b3e3ce1718a89773c2b1bfa3c2af1a6e8752.patch";
+          sha256 = "12sh5md81nlhyzzkmf7jrll3w1rvg2j48m57hfyvjn8has9c4gw6";
+          stripLen = 1;
+          includes = [ "dhall-nix.cabal" "src/Dhall/Nix.hs" ];
+        })
+      ] ++ drv.patches or [];
+      prePatch = drv.prePatch or "" + ''
+        ${pkgs.buildPackages.dos2unix}/bin/dos2unix *.cabal
+      '';
+    }) super.dhall-nix);
   dhall-yaml = self.generateOptparseApplicativeCompletions ["dhall-to-yaml-ng" "yaml-to-dhall"] super.dhall-yaml;
   dhall-nixpkgs = self.generateOptparseApplicativeCompletions [ "dhall-to-nixpkgs" ] super.dhall-nixpkgs;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -78,9 +78,6 @@ default-package-overrides:
   - ghc-bignum == 1.0
   # 1.2.0.0: “Dropped support for GHC <9.2 (might readd it later)”
   - retrie < 1.2.0.0
-  # On the recommendation of hnix author:
-  # https://github.com/NixOS/nixpkgs/pull/154461#issuecomment-1015511883
-  - hnix < 0.15
   # needs http-client >= 0.7.11 which isn't part of Stackage LTS 18
   - http-client-restricted < 0.0.5
   # patch is primarily used by reflex packages not all of which are patch 0.0.7 compatible yet
@@ -92,6 +89,9 @@ default-package-overrides:
   # Its dependency brick >= 1.0 is not yet in stackage
   - brick-skylighting < 1.0
   - rope-utf16-splay < 0.4.0.0
+  # hnix < 0.17 (unreleased) needs hnix-store-* 0.5.*
+  - hnix-store-core == 0.5.0.0            # 2022-06-17: Until hnix 0.17
+  - hnix-store-remote == 0.5.0.0        # 2022-06-17: Until hnix 0.17
 
 extra-packages:
   - Cabal == 2.2.*                      # required for jailbreak-cabal etc.
@@ -134,8 +134,6 @@ extra-packages:
   - hinotify == 0.3.9                   # for xmonad-0.26: https://github.com/kolmodin/hinotify/issues/29
   - hlint == 3.2.8                      # 2022-09-21: needed for hls on ghc 8.8
   - hlint == 3.4.1                      # 2022-09-21: needed for hls with ghc-lib-parser 9.2
-  - hnix-store-core == 0.5.0.0          # 2022-06-17: Until hnix 0.17
-  - hnix-store-remote == 0.5.0.0        # 2022-06-17: Until hnix 0.17
   - hpack == 0.35.0                     # 2022-09-29: Needed for stack-2.9.1
   - hspec < 2.8                         # 2022-04-07: Needed for tasty-hspec 1.1.6
   - hspec-core < 2.8                    # 2022-04-07: Needed for tasty-hspec 1.1.6


### PR DESCRIPTION
0.14 doesn't seem to be buildable with LTS 20 / GHC 9.2, so we'll have to try and upgrade. I've also downgraded hnix-store* globally mostly because it was kind of silly to have them on latest before – those packages are not really used independently of hnix.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
