### PR TITLE
loupe: init at unstable-2023-03-14

### DIFF
--- a/pkgs/applications/graphics/loupe/default.nix
+++ b/pkgs/applications/graphics/loupe/default.nix
@@ -16,25 +16,25 @@
 , libgweather
 , librsvg
 , shared-mime-info
+, libheif
+, libxml2
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "loupe";
-  # latest maeson.build requires gtk4 >=4.9.4
-  # and gtk4-sys with feature v4_10 requires gtk4 >= 4.9
-  version = "unstable-2023-03-01";
+  version = "unstable-2023-03-14";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "Incubator";
     repo = "loupe";
-    rev = "01bebfef384610169d020ea31b083af7cc4eb1db";
-    hash = "sha256-FFsE5sXkmPti8hYwKjMo1xwgjep8CzxXZFm32JDYKZc=";
+    rev = "889c818c14179e3f4755fb56f38d1af603e009cf";
+    hash = "sha256-9FNUAypm2GAd8/deEbNhCV+eIEGxOBCzFyytKaK9dnw=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit (finalAttrs) src;
-    hash = "sha256-a9w6WmTEuuKY956RAhmiCo+ty/9dWjfI6JnXKCSa8JM=";
+    hash = "sha256-tUi+y6raAhfG1bvUuSR/MRIax3OhExOBxn8gElLBRfI=";
   };
 
   nativeBuildInputs = [
@@ -57,6 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     libgweather
     librsvg
     shared-mime-info
+    libheif
+    libxml2
   ];
 
   # based on eog

--- a/pkgs/applications/graphics/loupe/default.nix
+++ b/pkgs/applications/graphics/loupe/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, rustPlatform
+, meson
+, pkg-config
+, gtk4
+, itstool
+, desktop-file-utils
+, ninja
+, wrapGAppsHook4
+, libadwaita
+, libgweather
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "loupe";
+  # latest maeson.build requires gtk4 >=4.9.4
+  # and gtk4-sys with feature v4_10 requires gtk4 >= 4.9
+  version = "unstable-2023-03-01";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "Incubator";
+    repo = "loupe";
+    rev = "01bebfef384610169d020ea31b083af7cc4eb1db";
+    hash = "sha256-FFsE5sXkmPti8hYwKjMo1xwgjep8CzxXZFm32JDYKZc=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) src;
+    hash = "sha256-a9w6WmTEuuKY956RAhmiCo+ty/9dWjfI6JnXKCSa8JM=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    gtk4
+    itstool
+    desktop-file-utils # update-desktop-database
+    ninja
+    wrapGAppsHook4
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  buildInputs = [
+    libadwaita
+    libgweather
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://gitlab.gnome.org/Incubator/loupe/";
+    description = "A simple image viewer application written with GTK4 and Rust";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jk ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/applications/graphics/loupe/default.nix
+++ b/pkgs/applications/graphics/loupe/default.nix
@@ -10,7 +10,12 @@
 , ninja
 , wrapGAppsHook4
 , libadwaita
+, gnome
+, webp-pixbuf-loader
+, gdk-pixbuf
 , libgweather
+, librsvg
+, shared-mime-info
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -48,8 +53,32 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libadwaita
+    gdk-pixbuf
     libgweather
+    librsvg
+    shared-mime-info
   ];
+
+  # based on eog
+  postInstall = ''
+    # Pull in WebP support
+    # In postInstall to run before gappsWrapperArgsHook.
+    export GDK_PIXBUF_MODULE_FILE="${gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
+      extraLoaders = [
+        librsvg
+        webp-pixbuf-loader
+      ];
+    }}"
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # Thumbnailers
+      --prefix XDG_DATA_DIRS : "${gdk-pixbuf}/share"
+      --prefix XDG_DATA_DIRS : "${librsvg}/share"
+      --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
+    )
+  '';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -63,7 +63,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gtk4";
-  version = "4.8.3";
+  version = "4.9.4";
 
   outputs = [ "out" "dev" ] ++ lib.optionals x11Support [ "devdoc" ];
   outputBin = "dev";
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
-    sha256 = "s2L5aNCFtNPZNA1NOMcGN33tnVN05pSitrfmKS48unQ=";
+    sha256 = "kaOv1YQB1OXYHjCwjuPxE6R2j/EBQDNqcqMmx3JyvjA=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/libadwaita/default.nix
+++ b/pkgs/development/libraries/libadwaita/default.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libadwaita";
-  version = "1.2.3";
+  version = "1.3.beta";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "devdoc"; # demo app
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "GNOME";
     repo = "libadwaita";
     rev = version;
-    hash = "sha256-m69TpXCs6QpVrN+6auig71ik+HvVprHi0OnlyDwTL7U=";
+    hash = "sha256-SqJrWaGIfqxmd6OxiIWa3QfFUZgnoWKGsu6/+0QPlyI=";
   };
 
   depsBuildBuild = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5181,6 +5181,8 @@ with pkgs;
 
   lowdown = callPackage ../tools/typesetting/lowdown { };
 
+  loupe = callPackage ../applications/graphics/loupe { };
+
   numatop = callPackage ../os-specific/linux/numatop { };
 
   numworks-udev-rules = callPackage ../os-specific/linux/numworks-udev-rules { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package loupe for nixpkgs

Things to think about:

* try build for other platforms and arches?
* wait for a tag?
* does it also want dbus? pretty much everything seemed to work but there was an issue with the GUI "help" feature

>  2023-03-15T12:39:07.066Z ERROR loupe::application > Failed to launch help: The specified location is not supported

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
