### PR TITLE
python310Packages.google-reauth: init at 0.1.1, python310Packages.google-apitools: init at 0.5.32, python310Packages.gcs-oauth2-boto-plugin: init at 3.0

### DIFF
--- a/pkgs/development/python-modules/gcs-oauth2-boto-plugin/default.nix
+++ b/pkgs/development/python-modules/gcs-oauth2-boto-plugin/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, boto
+, buildPythonPackage
+, fasteners
+, fetchFromGitHub
+, freezegun
+, google-reauth
+, httplib2
+, oauth2client
+, pyopenssl
+, pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+, retry_decorator
+, rsa
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "gcs-oauth2-boto-plugin";
+  version = "3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "GoogleCloudPlatform";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-slTxh2j9VhLiSyiTmJIFFakzpzH/+mgilDRxx0VqqKQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "rsa==4.7.2" "rsa" \
+      --replace "version='2.7'" "version='${version}'"
+  '';
+
+  propagatedBuildInputs = [
+    boto
+    freezegun
+    google-reauth
+    httplib2
+    oauth2client
+    pyopenssl
+    retry_decorator
+    rsa
+    six
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "gcs_oauth2_boto_plugin"
+  ];
+
+  meta = with lib; {
+    description = "Auth plugin allowing use the use of OAuth 2.0 credentials for Google Cloud Storage";
+    homepage = "https://github.com/GoogleCloudPlatform/gcs-oauth2-boto-plugin";
+    changelog = "https://github.com/GoogleCloudPlatform/gcs-oauth2-boto-plugin/releases/tag/v${version}";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/google-apitools/default.nix
+++ b/pkgs/development/python-modules/google-apitools/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fasteners
+, fetchFromGitHub
+, gflags
+, httplib2
+, mock
+, oauth2client
+, pytestCheckHook
+, pythonOlder
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "google-apitools";
+  version = "0.5.32";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "apitools";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Z9BTDU6KKCcjspVLi5mJqVZMYEapnMXLPL5BXsIKZAw=";
+  };
+
+  propagatedBuildInputs = [
+    fasteners
+    httplib2
+    oauth2client
+    six
+  ];
+
+  passthru.optional-dependencies = {
+    cli = [
+      gflags
+    ];
+  };
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "apitools"
+  ];
+
+  disabledTests = [
+    # AttributeError: 'FieldList' object has no attribute '_FieldList__field'
+    "testPickle"
+    "testDecodeBadBase64BytesField"
+    "testConvertIdThatNeedsEscaping"
+    "testGeneration"
+  ];
+
+  disabledTestPaths = [
+    # Samples are partially postfixed with test
+    "samples"
+  ];
+
+  meta = with lib; {
+    description = "Collection of utilities to make it easier to build client-side tools";
+    homepage = "https://github.com/google/apitools";
+    changelog = "https://github.com/google/apitools/releases/tag/v${version}";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/google-reauth/default.nix
+++ b/pkgs/development/python-modules/google-reauth/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, oauth2client
+, pytestCheckHook
+, pythonOlder
+, pyu2f
+}:
+
+buildPythonPackage rec {
+  pname = "google-reauth";
+  version = "0.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Google";
+    repo = "google-reauth-python";
+    rev = "refs/tags/${version}";
+    hash = "sha256-J7GVh+iY+69rFzf4hN/KLFZMZ1/S3CL5TZ7SsP5Oy3g=";
+  };
+
+  propagatedBuildInputs = [
+    oauth2client
+    pyu2f
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "google_reauth"
+  ];
+
+  meta = with lib; {
+    description = "Auth plugin allowing use the use of OAuth 2.0 credentials for Google Cloud Storage";
+    homepage = "https://github.com/Google/google-reauth-python";
+    changelog = "https://github.com/google/google-reauth-python/releases/tag/${version}";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/retry_decorator/default.nix
+++ b/pkgs/development/python-modules/retry_decorator/default.nix
@@ -1,21 +1,36 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  pname = "retry_decorator";
+  pname = "retry-decorator";
   version = "1.1.1";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e1e8ad02e518fe11073f2ea7d80b6b8be19daa27a60a1838aff7c731ddcf2ebe";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pnpnpn";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-0dZq4YbPcH4ItyMnpF7B20YYLtzwniJClBK9gRndU1M=";
   };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "retry_decorator"
+  ];
 
   meta = with lib; {
+    description = "Decorator for retrying when exceptions occur";
     homepage = "https://github.com/pnpnpn/retry-decorator";
-    description = "Retry Decorator for python functions";
-    license = licenses.mit;
+    changelog = "https://github.com/pnpnpn/retry-decorator/releases/tag/v${version}";
+    license = with licenses; [ asl20 ];
   };
-
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3601,6 +3601,8 @@ self: super: with self; {
 
   gcovr = callPackage ../development/python-modules/gcovr { };
 
+  gcs-oauth2-boto-plugin = callPackage ../development/python-modules/gcs-oauth2-boto-plugin { };
+
   gcsfs = callPackage ../development/python-modules/gcsfs { };
 
   gdal = toPythonModule (pkgs.gdal.override { python3 = python; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3785,6 +3785,8 @@ self: super: with self; {
 
   google-api-python-client = callPackage ../development/python-modules/google-api-python-client { };
 
+  google-apitools = callPackage ../development/python-modules/google-apitools { };
+
   googleapis-common-protos = callPackage ../development/python-modules/googleapis-common-protos { };
 
   google-auth = callPackage ../development/python-modules/google-auth { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3901,6 +3901,8 @@ self: super: with self; {
 
   google-re2 = callPackage ../development/python-modules/google-re2 { };
 
+  google-reauth = callPackage ../development/python-modules/google-reauth { };
+
   google-resumable-media = callPackage ../development/python-modules/google-resumable-media { };
 
   googletrans = callPackage ../development/python-modules/googletrans { };


### PR DESCRIPTION
###### Description of changes
Auth plugin allowing use the use of OAuth 2.0 credentials for Google Cloud Storage

https://github.com/Google/google-reauth-python
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
