### PR TITLE
rocsolver: init at (WIP)

### DIFF
--- a/pkgs/development/libraries/rocsolver/default.nix
+++ b/pkgs/development/libraries/rocsolver/default.nix
@@ -1,0 +1,104 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, writeScript
+, cmake
+, rocm-cmake
+, rocm-runtime
+, rocm-device-libs
+, rocm-comgr
+, rocblas
+, hip
+, fmt
+, gtest ? null
+, gbenchmark ? null
+, buildTests ? false
+, buildBenchmarks ? false
+, gpuTargets ? null # gpuTargets = [ "gfx803" "gfx900" "gfx906:xnack-" ]
+}:
+
+assert buildTests -> gtest != null;
+assert buildBenchmarks -> gbenchmark != null;
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rocsolver";
+  repoVersion = "3.19.0";
+  rocmVersion = "5.3.3";
+  version = "${finalAttrs.repoVersion}-${finalAttrs.rocmVersion}";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "rocSOLVER";
+    rev = "rocm-${finalAttrs.rocmVersion}";
+    hash = "sha256-X/ec2zDkFOiS0lkCKEQY5WrCaQAC9JD1mGKqjnBK2Qw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+  ];
+
+  buildInputs = [
+    rocm-runtime
+    rocm-device-libs
+    rocm-comgr
+    rocblas
+    fmt
+  ] ++ lib.optionals buildTests [
+    gtest
+  ] ++ lib.optionals buildBenchmarks [
+    gbenchmark
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals (gpuTargets != null) [
+    "-DGPU_TARGETS=${lib.strings.concatStringsSep ";" gpuTargets}"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_TEST=ON"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DBUILD_BENCHMARK=ON"
+  ];
+
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv $out/bin/test_* $test/bin
+  '' + lib.optionalString buildBenchmarks ''
+    mkdir -p $benchmark/bin
+    mv $out/bin/benchmark_* $benchmark/bin
+  '' + lib.optionalString (buildTests || buildBenchmarks) ''
+    rmdir $out/bin
+  '';
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+    json="$(curl -sL "https://api.github.com/repos/ROCmSoftwarePlatform/rocSOLVER/releases?per_page=1")"
+    repoVersion="$(echo "$json" | jq '.[0].name | split(" ") | .[1]' --raw-output)"
+    rocmVersion="$(echo "$json" | jq '.[0].tag_name | split("-") | .[1]' --raw-output)"
+    update-source-version rocsolver "$repoVersion" --ignore-same-hash --version-key=repoVersion
+    update-source-version rocsolver "$rocmVersion" --ignore-same-hash --version-key=rocmVersion
+  '';
+
+  meta = with lib; {
+    description = "ROCm LAPACK implementation";
+    homepage = "https://github.com/ROCmSoftwarePlatform/rocSOLVER";
+    license = with licenses; [ bsd2 ];
+    maintainers = teams.rocm.members;
+    broken = finalAttrs.rocmVersion != hip.version;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14955,6 +14955,8 @@ with pkgs;
 
   rocm-opencl-icd = callPackage ../development/libraries/rocm-opencl-icd { };
 
+  rocsolver = callPackage ../development/libraries/rocsolver { };
+
   rocm-opencl-runtime = callPackage ../development/libraries/rocm-opencl-runtime {
     inherit (llvmPackages_rocm) clang llvm;
   };


### PR DESCRIPTION
###### Description of changes
Tracking: #197885

rocSOLVER seems to suffer from the same problem we're having with rocThrust.
```console
error: no matching function for call to 'norm'
```

cc @Flakebi, I think the problem is ``rocm-llvm``, our include ordering is all messed up.
For reference: https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1277
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
