### PR TITLE
gruvbox-dark-icons: fix icon theme name

### DIFF
--- a/pkgs/data/icons/gruvbox-dark-icons-gtk/default.nix
+++ b/pkgs/data/icons/gruvbox-dark-icons-gtk/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/jmattheis/gruvbox-dark-gtk";
     license = licenses.gpl3Only;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ nomisiv bigshaq9999 ];
+    maintainers = [ maintainers.nomisiv ];
   };
 }

--- a/pkgs/data/icons/gruvbox-dark-icons-gtk/default.nix
+++ b/pkgs/data/icons/gruvbox-dark-icons-gtk/default.nix
@@ -16,10 +16,10 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ breeze-icons gnome-icon-theme hicolor-icon-theme ];
 
   installPhase = ''
-    mkdir -p $out/share/icons/oomox-gruvbox-dark
+    mkdir -p $out/share/icons/Gruvbox-Dark
     rm README.md
-    cp -r * $out/share/icons/oomox-gruvbox-dark
-    gtk-update-icon-cache $out/share/icons/oomox-gruvbox-dark
+    cp -r * $out/share/icons/Gruvbox-Dark
+    gtk-update-icon-cache $out/share/icons/Gruvbox-Dark
   '';
 
   dontDropIconThemeCache = true;
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/jmattheis/gruvbox-dark-gtk";
     license = licenses.gpl3Only;
     platforms = platforms.unix;
-    maintainers = [ maintainers.nomisiv ];
+    maintainers = with maintainers; [ nomisiv bigshaq9999 ];
   };
 }


### PR DESCRIPTION
###### Description of changes
Changed the dir name to 'Gruvbox-Dark' from 'oomox-gruvbox-dark'. 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
