### PR TITLE
Rename unifi-poller to unpoller

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -76,6 +76,13 @@
           relying on this should provide their own implementation.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>services.prometheus.exporters.unifi-poller</literal>
+          has been renamed to
+          <literal>services.prometheus.exporters.unpoller</literal>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-23.05-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -29,6 +29,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The EC2 image module previously detected and activated swap-formatted instance store devices and partitions in stage-1 (initramfs). This behaviour has been removed. Users relying on this should provide their own implementation.
 
+- `services.prometheus.exporters.unifi-poller` has been renamed to `services.prometheus.exporters.unpoller`.
+
 ## Other Notable Changes {#sec-release-23.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -722,7 +722,7 @@
   ./services/monitoring/thanos.nix
   ./services/monitoring/tremor-rs.nix
   ./services/monitoring/tuptime.nix
-  ./services/monitoring/unifi-poller.nix
+  ./services/monitoring/unpoller.nix
   ./services/monitoring/ups.nix
   ./services/monitoring/uptime.nix
   ./services/monitoring/vmagent.nix

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -72,7 +72,7 @@ let
     "tor"
     "unbound"
     "unifi"
-    "unifi-poller"
+    "unpoller"
     "v2ray"
     "varnish"
     "wireguard"

--- a/nixos/modules/services/monitoring/prometheus/exporters/unpoller.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/unpoller.nix
@@ -3,9 +3,9 @@
 with lib;
 
 let
-  cfg = config.services.prometheus.exporters.unifi-poller;
+  cfg = config.services.prometheus.exporters.unpoller;
 
-  configFile = pkgs.writeText "prometheus-unifi-poller-exporter.json" (generators.toJSON {} {
+  configFile = pkgs.writeText "prometheus-unpoller-exporter.json" (generators.toJSON {} {
     poller = { inherit (cfg.log) debug quiet; };
     unifi = { inherit (cfg) controllers; };
     influxdb.disable = true;
@@ -21,8 +21,8 @@ in {
   port = 9130;
 
   extraOpts = {
-    inherit (options.services.unifi-poller.unifi) controllers;
-    inherit (options.services.unifi-poller) loki;
+    inherit (options.services.unpoller.unifi) controllers;
+    inherit (options.services.unpoller) loki;
     log = {
       debug = mkEnableOption (lib.mdDoc "debug logging including line numbers, high resolution timestamps, per-device logs.");
       quiet = mkEnableOption (lib.mdDoc "startup and error logs only.");
@@ -31,7 +31,7 @@ in {
   };
 
   serviceOpts.serviceConfig = {
-    ExecStart = "${pkgs.unifi-poller}/bin/unpoller --config ${configFile}";
+    ExecStart = "${pkgs.unpoller}/bin/unpoller --config ${configFile}";
     DynamicUser = false;
   };
 }

--- a/nixos/modules/services/monitoring/unpoller.nix
+++ b/nixos/modules/services/monitoring/unpoller.nix
@@ -3,15 +3,15 @@
 with lib;
 
 let
-  cfg = config.services.unifi-poller;
+  cfg = config.services.unpoller;
 
-  configFile = pkgs.writeText "unifi-poller.json" (generators.toJSON {} {
+  configFile = pkgs.writeText "unpoller.json" (generators.toJSON {} {
     inherit (cfg) poller influxdb loki prometheus unifi;
   });
 
 in {
-  options.services.unifi-poller = {
-    enable = mkEnableOption (lib.mdDoc "unifi-poller");
+  options.services.unpoller = {
+    enable = mkEnableOption (lib.mdDoc "unpoller");
 
     poller = {
       debug = mkOption {
@@ -86,11 +86,11 @@ in {
       };
       pass = mkOption {
         type = types.path;
-        default = pkgs.writeText "unifi-poller-influxdb-default.password" "unifipoller";
-        defaultText = literalExpression "unifi-poller-influxdb-default.password";
+        default = pkgs.writeText "unpoller-influxdb-default.password" "unifipoller";
+        defaultText = literalExpression "unpoller-influxdb-default.password";
         description = lib.mdDoc ''
           Path of a file containing the password for influxdb.
-          This file needs to be readable by the unifi-poller user.
+          This file needs to be readable by the unpoller user.
         '';
         apply = v: "file://${v}";
       };
@@ -135,11 +135,11 @@ in {
       };
       pass = mkOption {
         type = types.path;
-        default = pkgs.writeText "unifi-poller-loki-default.password" "";
-        defaultText = "unifi-poller-influxdb-default.password";
+        default = pkgs.writeText "unpoller-loki-default.password" "";
+        defaultText = "unpoller-influxdb-default.password";
         description = lib.mdDoc ''
           Path of a file containing the password for Loki.
-          This file needs to be readable by the unifi-poller user.
+          This file needs to be readable by the unpoller user.
         '';
         apply = v: "file://${v}";
       };
@@ -184,11 +184,11 @@ in {
         };
         pass = mkOption {
           type = types.path;
-          default = pkgs.writeText "unifi-poller-unifi-default.password" "unifi";
-          defaultText = literalExpression "unifi-poller-unifi-default.password";
+          default = pkgs.writeText "unpoller-unifi-default.password" "unifi";
+          defaultText = literalExpression "unpoller-unifi-default.password";
           description = lib.mdDoc ''
             Path of a file containing the password for the unifi service user.
-            This file needs to be readable by the unifi-poller user.
+            This file needs to be readable by the unpoller user.
           '';
           apply = v: "file://${v}";
         };
@@ -274,7 +274,7 @@ in {
         default = false;
         description = lib.mdDoc ''
           Let prometheus select which controller to poll when scraping.
-          Use with default credentials. See unifi-poller wiki for more.
+          Use with default credentials. See unpoller wiki for more.
         '';
       };
 
@@ -292,25 +292,25 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.groups.unifi-poller = { };
-    users.users.unifi-poller = {
-      description = "unifi-poller Service User";
-      group = "unifi-poller";
+    users.groups.unpoller = { };
+    users.users.unpoller = {
+      description = "unpoller Service User";
+      group = "unpoller";
       isSystemUser = true;
     };
 
-    systemd.services.unifi-poller = {
+    systemd.services.unpoller = {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.unifi-poller}/bin/unifi-poller --config ${configFile}";
+        ExecStart = "${pkgs.unpoller}/bin/unpoller --config ${configFile}";
         Restart = "always";
         PrivateTmp = true;
         ProtectHome = true;
         ProtectSystem = "full";
         DevicePolicy = "closed";
         NoNewPrivileges = true;
-        User = "unifi-poller";
+        User = "unpoller";
         WorkingDirectory = "/tmp";
       };
     };

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1244,15 +1244,15 @@ let
       '';
     };
 
-    unifi-poller = {
-      nodeName = "unifi_poller";
+    unpoller = {
+      nodeName = "unpoller";
       exporterConfig.enable = true;
       exporterConfig.controllers = [{ }];
       exporterTest = ''
-        wait_for_unit("prometheus-unifi-poller-exporter.service")
+        wait_for_unit("prometheus-unpoller-exporter.service")
         wait_for_open_port(9130)
         succeed(
-            "curl -sSf localhost:9130/metrics | grep 'unifipoller_build_info{.\\+} 1'"
+            "curl -sSf localhost:9130/metrics | grep 'unpoller_build_info{.\\+} 1'"
         )
       '';
     };

--- a/pkgs/servers/monitoring/unpoller/default.nix
+++ b/pkgs/servers/monitoring/unpoller/default.nix
@@ -4,12 +4,12 @@
 }:
 
 buildGoModule rec {
-  pname = "unifi-poller";
+  pname = "unpoller";
   version = "2.2.0";
 
   src = fetchFromGitHub {
-    owner = "unifi-poller";
-    repo = "unifi-poller";
+    owner = "unpoller";
+    repo = "unpoller";
     rev = "v${version}";
     hash = "sha256-jPatTo+5nQ73AETXI88x/bma0wlY333DNvuyaYQTgz0=";
   };
@@ -26,7 +26,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Collect ALL UniFi Controller, Site, Device & Client Data - Export to InfluxDB or Prometheus";
-    homepage = "https://github.com/unifi-poller/unifi-poller";
+    homepage = "https://github.com/unpoller/unpoller";
     changelog = "https://github.com/unpoller/unpoller/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1216,7 +1216,7 @@ mapAliases ({
   prometheus-cups-exporter = throw "outdated and broken by design; removed by developer"; # Added 2021-03-16
   prometheus-dmarc-exporter = dmarc-metrics-exporter; # added 2022-05-31
   prometheus-mesos-exporter = throw "prometheus-mesos-exporter is deprecated and archived by upstream"; # Added 2022-04-05
-  prometheus-unifi-exporter = throw "prometheus-unifi-exporter is deprecated and archived by upstream, use unifi-poller instead"; # Added 2022-06-03
+  prometheus-unifi-exporter = throw "prometheus-unifi-exporter is deprecated and archived by upstream, use unpoller instead"; # Added 2022-06-03
   protobuf3_7 = throw "protobuf3_7 does not receive updates anymore and has been removed"; # Added 2022-10-03
   protobuf3_11 = throw "protobuf3_11 does not receive updates anymore and has been removed"; # Added 2022-09-28
   protonup = protonup-ng; # Added 2022-11-06
@@ -1515,6 +1515,7 @@ mapAliases ({
   ufraw = throw "ufraw is unmaintained and has been removed from nixpkgs. Its successor, nufraw, doesn't seem to be stable enough. Consider using Darktable for now"; # Added 2020-01-11
   ultrastardx-beta = throw "'ultrastardx-beta' has been renamed to/replaced by 'ultrastardx'"; # Converted to throw 2022-02-22
   unicorn-emu = unicorn; # Added 2020-10-29
+  unifi-poller = unpoller; # Added 2022-11-24
   unifiStable = unifi6; # Added 2020-12-28
   unity3d = throw "'unity3d' is unmaintained, has seen no updates in years and depends on deprecated GTK2"; # Added 2022-06-16
   untrunc = untrunc-anthwlock; # Added 2021-02-01

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38073,7 +38073,7 @@ with pkgs;
     texlive = texlive.combined.scheme-medium;
   };
 
-  unifi-poller = callPackage ../servers/monitoring/unifi-poller {};
+  unpoller = callPackage ../servers/monitoring/unpoller {};
 
   fac-build = callPackage ../development/tools/build-managers/fac {
     inherit (darwin.apple_sdk.frameworks) CoreServices;


### PR DESCRIPTION
###### Description of changes

Rename unifi-poller to unpoller to match upstream change.

Follow-up to #202563, in which @lukegb highlighted that the package name should be updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

NixOS tests executed:
```
$ nix-build ./prometheus-exporters.nix
...snip...
(finished: waiting for the VM to power off, in 1.13 seconds)
(finished: run the VM test script, in 10.15 seconds)
test script finished in 10.15s
cleanup
(finished: cleanup, in 0.00 seconds)
kill vlan (pid 7)
/nix/store/g180g9as5p9vblwm8x5a93dqabsn5d4l-vm-test-run-prometheus-unpoller-exporter
```

**Note**: Seem to be other unrelated broken tests in prometheus-exporters.nix... I disabled all other exporters in `exporterTests` to get this clean test run, otherwise I would have failures like:
```
nix-build ./prometheus-exporters.nix
error:
       Failed assertions:
       - Database dc=example has `olcDbDirectory` (/var/db/openldap) that is not a subdirectory of
       `/var/lib/openldap/`.
(use '--show-trace' to show detailed location information)
```

**Note**: This has a breaking change in the rename of the NixOS exporter module; eg. `services.prometheus.exporters.unifi-poller` has become `services.prometheus.exporters.unpoller`.  I wasn't sure how to resolve this breaking change given the abstraction in exporters.nix; I added it into the 23.05 release notes though.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
