### PR TITLE
nyan: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5269,6 +5269,12 @@
     githubId = 31556469;
     name = "Prem Netsuwan";
   };
+  Grubben = {
+    email = "antoniomsprc@gmail.com";
+    github = "Grubben";
+    githubId = 63401009;
+    name = "Antonio Maria Ribeiro da Cunha";
+  };
   gruve-p = {
     email = "groestlcoin@gmail.com";
     github = "gruve-p";

--- a/pkgs/development/libraries/nyan/default.nix
+++ b/pkgs/development/libraries/nyan/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, clang_14
+, cmake
+, flex
+}:
+
+stdenv.mkDerivation {
+  pname = "nyan";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "SFTtech";
+    repo = "nyan";
+    rev = "7b5517f8c3c17b1fb2483f6dec882ccb84b70bbb";
+    sha256 = "sha256-9pTWXgbGNrvA6o90TDbouUJx9Q6xpSN+aGbnwXKm0V4=";
+  };
+
+  nativeBuildInputs = [
+    clang_14 # Just clang doesn't work on MACOS
+    cmake
+  ];
+
+  buildInputs = [
+    flex
+  ];
+
+  meta = with lib; {
+    description = "A data description language";
+    longDescription = ''
+      Nyan stores hierarchical objects with key-value pairs in a database with the key idea that changes in a parent affect all children. We created nyan because there existed no suitable language to properly represent the enormous complexity of storing the data for openage.
+    '';
+    homepage = "https://openage.sft.mx";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ Grubben ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/development/libraries/nyan/default.nix
+++ b/pkgs/development/libraries/nyan/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation {
   pname = "nyan";
-  version = "0.2.0";
+  version = "0.2";
 
   src = fetchFromGitHub {
     owner = "SFTtech";

--- a/pkgs/development/libraries/nyan/default.nix
+++ b/pkgs/development/libraries/nyan/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
       Nyan stores hierarchical objects with key-value pairs in a database with the key idea that changes in a parent affect all children. We created nyan because there existed no suitable language to properly represent the enormous complexity of storing the data for openage.
     '';
     homepage = "https://openage.sft.mx";
-    license = licenses.lgpl3;
+    license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ Grubben ];
     platforms = platforms.unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37724,6 +37724,8 @@ with pkgs;
 
   zxing-cpp = callPackage ../development/libraries/zxing-cpp { };
 
+  nyan = callPackage ../development/libraries/nyan { };
+
   bullet = callPackage ../development/libraries/bullet {
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->This is nyan a a data description language for the FOSS engine openage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [*] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
I am a noob! Please correct me if I made any mistakes