### PR TITLE
gitAndTools.git-bug: 0.7.2 -> 0.8.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "git-bug";
-  version = "0.7.2"; # the `rev` below pins the version of the source to get
-  rev = "cc4a93c8ce931b1390c61035b888ad17110b7bd6";
+  version = "0.8.0"; # the `rev` below pins the version of the source to get
+  rev = "a3fa445a9c76631c4cd16f93e1c1c68a954adef7";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "MichaelMure";
     repo = "git-bug";
-    sha256 = "0r6wh0y1fj3d3fbbrzq5n9k6z94xvwqww3xfbslkgyrin5bmziiq";
+    sha256 = "sha256-yCb9SXsKJLriMkg+uBD0LACdkvjBqhe1Bp9Xpa1xfok=";
   };
 
-  vendorSha256 = "15hhsrwwjc4krfc2d0r15lys3vr9rb9xk62pan4jr9ycbv0dny90";
+  vendorSha256 = "sha256-32kNDoBE50Jx1Ef9YwhDk7nd3CaTSnHPlu7PgWPUGfE=";
 
   doCheck = false;
 
@@ -23,8 +23,8 @@ buildGoModule rec {
   ];
 
   postInstall = ''
-    install -D -m 0644 misc/bash_completion/git-bug "$out/share/bash-completion/completions/git-bug"
-    install -D -m 0644 misc/zsh_completion/git-bug "$out/share/zsh/site-functions/git-bug"
+    install -D -m 0644 misc/completion/bash/git-bug "$out/share/bash-completion/completions/git-bug"
+    install -D -m 0644 misc/completion/zsh/git-bug "$out/share/zsh/site-functions/git-bug"
     install -D -m 0644 -t "$out/share/man/man1" doc/man/*
   '';
 


### PR DESCRIPTION
###### Description of changes

Simple version bump. According to the [release notes](https://github.com/MichaelMure/git-bug/releases/tag/v0.8.0), a migration using https://github.com/MichaelMure/git-bug-migration is required. I am unsure whether we should package this as well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Cc @royneary (maintainer)