### PR TITLE
lispPackages_new.sbclPackages.cl-sat: fix build failure

### DIFF
--- a/pkgs/development/lisp-modules-new/lisp-packages.nix
+++ b/pkgs/development/lisp-modules-new/lisp-packages.nix
@@ -40,6 +40,7 @@ let
     removeSuffix
     hasInfix
     optionalString
+    makeBinPath
     makeLibraryPath
     makeSearchPath
     recurseIntoAttrs
@@ -249,6 +250,12 @@ let
             then pkgs.applyPatches { inherit (args) src patches; }
             else args.src;
       patches = [];
+
+      # make sure that propagated build-inputs from lispLibs are propagated
+      propagatedBuildInputs = lib.unique
+        (builtins.concatLists
+          (lib.catAttrs "propagatedBuildInputs"
+            (builtins.concatLists [[args] lispLibs nativeLibs javaLibs])));
     })));
 
   # Build the set of lisp packages using `lisp`

--- a/pkgs/development/lisp-modules-new/lisp-packages.nix
+++ b/pkgs/development/lisp-modules-new/lisp-packages.nix
@@ -353,7 +353,9 @@ let
           --prefix LD_LIBRARY_PATH : "${o.LD_LIBRARY_PATH}" \
           --prefix LD_LIBRARY_PATH : "${makeLibraryPath o.nativeLibs}" \
           --prefix CLASSPATH : "${o.CLASSPATH}" \
-          --prefix CLASSPATH : "${makeSearchPath "share/java/*" o.javaLibs}"
+          --prefix CLASSPATH : "${makeSearchPath "share/java/*" o.javaLibs}" \
+          --prefix PATH : "${makeBinPath (o.buildInputs or [])}" \
+          --prefix PATH : "${makeBinPath (o.propagatedBuildInputs or [])}"
       '';
     });
 

--- a/pkgs/development/lisp-modules-new/patches/cl-sat.glucose-binary-from-PATH-if-present.patch
+++ b/pkgs/development/lisp-modules-new/patches/cl-sat.glucose-binary-from-PATH-if-present.patch
@@ -1,0 +1,27 @@
+From 2040fcab5a7be2f28add46a1412bef62ac5ccf11 Mon Sep 17 00:00:00 2001
+From: Maximilian Marx <mmarx@wh2.tu-dresden.de>
+Date: Thu, 24 Nov 2022 20:00:33 +0100
+Subject: [PATCH] Use glucose binary from PATH if present
+
+---
+ src/package.lisp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/package.lisp b/src/package.lisp
+index b6e26ac..bdb2581 100644
+--- a/src/package.lisp
++++ b/src/package.lisp
+@@ -13,7 +13,9 @@
+ (defvar *glucose-home* (asdf:system-relative-pathname :cl-sat.glucose "glucose-syrup/"))
+ 
+ (defun glucose-binary (&optional (*glucose-home* *glucose-home*))
+-  (merge-pathnames "simp/glucose_static" *glucose-home*))
++  (if (trivial-package-manager:which "glucose")
++      "glucose"
++      (merge-pathnames "simp/glucose_static" *glucose-home*)))
+ 
+ (defmethod solve ((input pathname) (solver (eql :glucose)) &rest options &key debug &allow-other-keys)
+   (remf options :debug)
+-- 
+2.36.2
+

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -190,6 +190,9 @@ let
       nativeBuildInputs = [ pkgs.zeromq ];
       nativeLibs = [ pkgs.zeromq ];
     };
+    trivial-package-manager = pkg: {
+      propagatedBuildInputs = [ pkgs.which ];
+    };
   };
 
   qlpkgs =

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -198,6 +198,9 @@ let
       patches = [ ./patches/cl-sat.glucose-binary-from-PATH-if-present.patch ];
 
     };
+    "cl-sat.minisat" = pkg: {
+      propagatedBuildInputs = [ pkgs.minisat ];
+    };
   };
 
   qlpkgs =

--- a/pkgs/development/lisp-modules-new/ql.nix
+++ b/pkgs/development/lisp-modules-new/ql.nix
@@ -193,6 +193,11 @@ let
     trivial-package-manager = pkg: {
       propagatedBuildInputs = [ pkgs.which ];
     };
+    "cl-sat.glucose" = pkg: {
+      propagatedBuildInputs = [ pkgs.glucose ];
+      patches = [ ./patches/cl-sat.glucose-binary-from-PATH-if-present.patch ];
+
+    };
   };
 
   qlpkgs =


### PR DESCRIPTION
###### Description of changes

Fix build failures in dependencies of `lispPackages_new.sbclPackages.cl-sat`. These packages need runtime dependencies present when loading the systems, so we need to make sure that these dependencies are actually propagated and taken into account when building a `lispWithPackages`.

This also brings down the number of failing packages below `lispPackages_new` from 400 to 39 (apparently, it's still WIP, so that should be fine, cf. #155851).

Tests for `cl-sat` and its dependencies can be run as follows:
```
nix-shell -p "lispPackages_new.sbclWithPackages (p: [ p.cl-sat_dot_test p.cl-sat_dot_minisat p.cl-sat_dot_minisat_dot_test p.cl-sat_dot_glucose p.cl-sat_dot_glucose_dot_test ])" --run "sbcl --script" <<EOF
(require 'asdf)
(asdf:load-system :cl-sat.minisat)
(asdf:load-system :cl-sat.glucose)
(asdf:test-system :cl-sat)
(asdf:test-system :cl-sat.minisat)
(asdf:test-system :cl-sat.glucose)
EOF
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
