### PR TITLE
lokalize: init at 22.12.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10774,6 +10774,13 @@
     github = "nigelgbanks";
     githubId = 487373;
   };
+  niknetniko = {
+    name = "Niko Strijbol";
+    email = "niko@strijbol.be";
+    matrix = "@niknetniko:matrix.org";
+    github = "niknetniko";
+    githubId = 1756811;
+  };
   NikolaMandic = {
     email = "nikola@mandic.email";
     github = "NikolaMandic";

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -217,6 +217,7 @@ let
       libksane = callPackage ./libksane.nix {};
       libksieve = callPackage ./libksieve.nix {};
       libktorrent = callPackage ./libktorrent.nix {};
+      lokalize = callPackage ./lokalize.nix {};
       mailcommon = callPackage ./mailcommon.nix {};
       mailimporter = callPackage ./mailimporter.nix {};
       marble = callPackage ./marble.nix {};

--- a/pkgs/applications/kde/lokalize.nix
+++ b/pkgs/applications/kde/lokalize.nix
@@ -1,0 +1,35 @@
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, qtbase
+, kactivities
+, kross
+, qtscript
+, hunspell
+, gettext
+}:
+
+mkDerivation rec {
+  pname = "lokalize";
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ extra-cmake-modules ];
+
+  propagatedBuildInputs = [
+    kross
+    qtscript
+    hunspell
+    kactivities
+    qtbase
+    gettext
+  ];
+
+  meta = with lib; {
+    homepage = "https://apps.kde.org/lokalize/";
+    description = "Computer-aided translation system that focuses on productivity and quality assurance";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ niknetniko ];
+    broken = lib.versionOlder qtbase.version "5.15";
+  };
+}


### PR DESCRIPTION
###### Description of changes

Adds Lokalize. Quoting the application website:

> Lokalize is the localization tool for KDE software and other free and open source software. It is also a general computer-aided translation system (CAT) with which you can translate OpenDocument files (*.odt). Translate-Toolkit is used internally to extract text for translation from .odt to .xliff files and to merge translation back into .odt file.

See https://apps.kde.org/en/lokalize/.

Previously attempted at #89743.
Also works towards #62168.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).