### PR TITLE
nix-zsh-completions: remove broken _nix completion function

### DIFF
--- a/pkgs/shells/zsh/nix-zsh-completions/default.nix
+++ b/pkgs/shells/zsh/nix-zsh-completions/default.nix
@@ -11,6 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "1n9whlys95k4wc57cnz3n07p7zpkv796qkmn68a50ygkx6h3afqf";
   };
 
+  # https://github.com/spwhitt/nix-zsh-completions/issues/42
+  #
+  # _nix completion is broken. Remove it; _nix provided by the nix
+  # package will be used instead. It is not sufficient to set low
+  # meta.priority below if nix is installed in the system profile and
+  # nix-zsh-completions in an user profile. In that case, the broken
+  # version takes precedence over the good one.
+  postPatch = ''
+    rm _nix
+  '';
+
   strictDeps = true;
   installPhase = ''
     mkdir -p $out/share/zsh/{site-functions,plugins/nix}


### PR DESCRIPTION
###### Description of changes

That completion function works only with nix 2.3 (and older). The newer versions use ANSI escape sequences in the --help output, and this seems to confuse the function.

Nix 2.4+ has zsh completion built in so removing it from nix-zsh-completions should not harm most users.

- [Upstream bug report](https://github.com/spwhitt/nix-zsh-completions/issues/42). The project seems abandoned, so I'm proposing the patch here.
- [Related home-manager issue](https://github.com/nix-community/home-manager/issues/3361)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
