### PR TITLE
sapling: fix on macOS

### DIFF
--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -1,7 +1,41 @@
-{ lib, stdenv, python3Packages, fetchFromGitHub, fetchurl, sd, curl, pkg-config, openssl, rustPlatform, fetchYarnDeps, yarn, nodejs, fixup_yarn_lock, glibcLocales }:
+{ lib
+, stdenv
+, python38Packages
+, fetchFromGitHub
+, fetchurl
+, sd
+, curl
+, pkg-config
+, openssl
+, rustPlatform
+, fetchYarnDeps
+, yarn
+, nodejs
+, fixup_yarn_lock
+, glibcLocales
+, libiconv
+, CoreFoundation
+, CoreServices
+, Security
+}:
 
 let
   inherit (lib.importJSON ./deps.json) links version versionHash;
+  # Sapling sets a Cargo config containing lines like so:
+  # [target.aarch64-apple-darwin]
+  # rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]
+  #
+  # The default cargo config that's set by the build hook will set
+  # unstable.host-config and unstable.target-applies-to-host which seems to
+  # result in the link arguments above being ignored and thus link failures.
+  # All it is there to do anyway is just to do stuff with musl and cross
+  # compilation, which doesn't work on macOS anyway so we can just stub it
+  # on macOS.
+  #
+  # See https://github.com/NixOS/nixpkgs/pull/198311#issuecomment-1326894295
+  myCargoSetupHook = rustPlatform.cargoSetupHook.overrideAttrs (old: {
+    cargoConfig = if stdenv.isDarwin then "" else old.cargoConfig;
+  });
 
   src = fetchFromGitHub {
     owner = "facebook";
@@ -54,7 +88,11 @@ let
   };
 
   # Builds the main `sl` binary and its Python extensions
-  sapling = python3Packages.buildPythonPackage {
+  #
+  # FIXME(lf-): when next updating this package, delete the python 3.8 override
+  # here, since the fix for https://github.com/facebook/sapling/issues/279 that
+  # required it will be in the next release.
+  sapling = python38Packages.buildPythonPackage {
     pname = "sapling-main";
     inherit src version;
 
@@ -85,7 +123,7 @@ let
       sed -i "s|https://files.pythonhosted.org/packages/[[:alnum:]]*/[[:alnum:]]*/[[:alnum:]]*/|file://$NIX_BUILD_TOP/$sourceRoot/hack_pydeps/|g" $sourceRoot/setup.py
     '';
 
-    postFixup = ''
+    postFixup = lib.optionalString stdenv.isLinux ''
       wrapProgram $out/bin/sl \
         --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
     '';
@@ -94,13 +132,19 @@ let
       curl
       pkg-config
     ] ++ (with rustPlatform; [
-      cargoSetupHook
+      myCargoSetupHook
       rust.cargo
       rust.rustc
     ]);
 
     buildInputs = [
+      curl
       openssl
+    ] ++ lib.optionals stdenv.isDarwin [
+      libiconv
+      CoreFoundation
+      CoreServices
+      Security
     ];
 
     doCheck = false;
@@ -124,7 +168,7 @@ stdenv.mkDerivation {
 
     cp -r ${sapling}/* $out
 
-    sitepackages=$out/lib/${python3Packages.python.libPrefix}/site-packages
+    sitepackages=$out/lib/${python38Packages.python.libPrefix}/site-packages
     chmod +w $sitepackages
     cp -r ${isl} $sitepackages/edenscm-isl
 
@@ -145,7 +189,7 @@ stdenv.mkDerivation {
     homepage = "https://sapling-scm.com";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ pbar thoughtpolice ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     mainProgram = "sl";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30351,7 +30351,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
-  sapling = callPackage ../applications/version-management/sapling { };
+  sapling = callPackage ../applications/version-management/sapling {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices Security;
+  };
 
   mercurialFull = mercurial.override { fullBuild = true; };
 


### PR DESCRIPTION
###### Description of changes

Fixed compilation of Sapling on Darwin. One small problem is that it doesn't actually work at all: when I run `sl clone https://github.com/nixos/nixpkgs` it completes instantly (it shouldn't be *that* fast) and has no working tree or history. However, I think that this is a useful starting point for people to debug further, so I'm posting this as-is.

Fixes #202703 

Here's what it does:
```
~/dev » ~/dev/nixpkgs/result/bin/sl clone https://github.com/lf-/dotfiles 
~/dev » cd dotfiles
dev/dotfiles » ls
dev/dotfiles » tree .sl
.sl
├── 00changelog.i
├── config
├── reponame
├── requires
├── store
│   ├── metalog
│   │   ├── blobs
│   │   │   ├── index2-id
│   │   │   ├── log
│   │   │   ├── meta
│   │   │   └── rlock
│   │   └── roots
│   │       ├── index2-reverse
│   │       ├── log
│   │       ├── meta
│   │       └── rlock
│   └── requires
└── treestate

5 directories, 13 files
dev/dotfiles » ~/dev/nixpkgs/result/bin/sl log                                   
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
