### PR TITLE
sapling: set LOCALE_ARCHIVE properly

### DIFF
--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, python3Packages, fetchFromGitHub, fetchurl, sd, curl, pkg-config, openssl, rustPlatform, fetchYarnDeps, yarn, nodejs, fixup_yarn_lock }:
+{ lib, stdenv, python3Packages, fetchFromGitHub, fetchurl, sd, curl, pkg-config, openssl, rustPlatform, fetchYarnDeps, yarn, nodejs, fixup_yarn_lock, glibcLocales }:
 
 let
   inherit (lib.importJSON ./deps.json) links version versionHash;
@@ -85,6 +85,11 @@ let
       sed -i "s|https://files.pythonhosted.org/packages/[[:alnum:]]*/[[:alnum:]]*/[[:alnum:]]*/|file://$NIX_BUILD_TOP/$sourceRoot/hack_pydeps/|g" $sourceRoot/setup.py
     '';
 
+    postFixup = ''
+      wrapProgram $out/bin/sl \
+        --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
+    '';
+
     nativeBuildInputs = [
       curl
       pkg-config
@@ -130,7 +135,7 @@ stdenv.mkDerivation {
     description = "A Scalable, User-Friendly Source Control System";
     homepage = "https://sapling-scm.com";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ pbar ];
+    maintainers = with maintainers; [ pbar thoughtpolice ];
     platforms = platforms.linux;
     mainProgram = "sl";
   };

--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -131,6 +131,15 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  # just a simple check phase, until we have a running test suite. this should
+  # help catch issues like lack of a LOCALE_ARCHIVE setting (see GH PR #202760)
+  doCheck = true;
+  checkPhase = ''
+    echo -n "testing sapling version; should be \"${version}\"... "
+    ${sapling}/bin/sl version | grep -qw "${version}"
+    echo "OK!"
+  '';
+
   meta = with lib; {
     description = "A Scalable, User-Friendly Source Control System";
     homepage = "https://sapling-scm.com";


### PR DESCRIPTION
Without this, `sl` simply fails on any non-NixOS machine with an immediate failure, as it can't set the locale properly.

As usual, this can be fixed by setting LOCALE_ARCHIVE for glibc explicitly. With this, `sl` works out of the box on NixOS and non-NixOS machines.

Also add myself as a maintainer.