### PR TITLE
Update Lapce

### DIFF
--- a/pkgs/applications/editors/lapce/default.nix
+++ b/pkgs/applications/editors/lapce/default.nix
@@ -23,16 +23,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lapce";
-  version = "unstable-2022-09-21";
+  version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "lapce";
     repo = pname;
-    rev = "c5a924ef34250e9117e2b57c19c1f29f6b9b3ea7";
-    sha256 = "sha256-0nAUbtokDgSxPcJCa9xGM8Rpbu282o7OHAQtAfdNmJU=";
+    rev = "v${version}";
+    sha256 = "sha256-A0HeZB022GFrZFkdcSuzUmNBxxZHKCcqtTUh5MbGsEg=";
   };
 
-  cargoSha256 = "sha256-uIFC5x8TzsvTGylQ0AttIRAUWU0k0P7UeF96vUc7cKw=";
+  cargoSha256 = "sha256-XracOWjkFZiv5bc3Xfm8sRta6CdO5rjrYAzRs3JT0rc=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/editors/lapce/default.nix
+++ b/pkgs/applications/editors/lapce/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, gitUpdater
 , rustPlatform
 , cmake
 , pkg-config
@@ -74,6 +75,10 @@ rustPlatform.buildRustPackage rec {
     genericName = "Code Editor";
     categories = [ "Development" "Utility" "TextEditor" ];
   }) ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
 
   meta = with lib; {
     description = "Lightning-fast and Powerful Code Editor written in Rust";


### PR DESCRIPTION
###### Description of changes
Update package `lapce` to latest release, and specify an update script.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes

@Eliot00