### PR TITLE
sdrplay: add support for aarch64

### DIFF
--- a/pkgs/applications/radio/sdrplay/default.nix
+++ b/pkgs/applications/radio/sdrplay/default.nix
@@ -1,20 +1,36 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook, udev }:
+{ stdenv, lib, fetchurl, autoPatchelfHook, udev, libusb }:
 let
-  arch = if stdenv.isx86_64  then "x86_64"
-    else if stdenv.isi686    then "i686"
+  arch =
+    if stdenv.isx86_64 then "x86_64"
+    else if stdenv.isi686 then "i686"
+    else if stdenv.isAarch64 then "aarch64"
     else throw "unsupported architecture";
-in stdenv.mkDerivation rec {
-  pname = "sdrplay";
+
   version = "3.07.1";
 
-  src = fetchurl {
-    url = "https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-${version}.run";
-    sha256 = "1a25c7rsdkcjxr7ffvx2lwj7fxdbslg9qhr8ghaq1r53rcrqgzmf";
+  srcs = rec {
+    aarch64 = {
+      url = "https://www.sdrplay.com/software/SDRplay_RSP_API-ARM64-${version}.run";
+      hash = "sha256-GJPFW6W8Ke4mnczcSLFYfioOMGCfFn2/EIA07VnmVGY=";
+    };
+
+    x86_64 = {
+      url = "https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-${version}.run";
+      sha256 = "1a25c7rsdkcjxr7ffvx2lwj7fxdbslg9qhr8ghaq1r53rcrqgzmf";
+    };
+
+    i686 = x86_64;
   };
+in
+stdenv.mkDerivation rec {
+  pname = "sdrplay";
+  inherit version;
+
+  src = fetchurl srcs."${arch}";
 
   nativeBuildInputs = [ autoPatchelfHook ];
 
-  buildInputs = [ udev stdenv.cc.cc.lib ];
+  buildInputs = [ libusb udev stdenv.cc.cc.lib ];
 
   unpackPhase = ''
     sh "$src" --noexec --target source
@@ -46,7 +62,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://www.sdrplay.com/downloads/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = [ maintainers.pmenke ];
+    maintainers = with maintainers; [ pmenke zaninime ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `sdrplay` is a binary-only service that also distribute aarch64-compatible binaries. This work is for pulling the appropriate binary given the current architecture.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

/cc @pmenke-de 