### PR TITLE
{php80,php81,php82}: November bumps

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -141,7 +141,7 @@
       </listitem>
       <listitem>
         <para>
-          PHP 8.2.0 RC 6 is available.
+          PHP 8.2.0 RC 7 is available.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -57,7 +57,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   `mod_php` usage we still enable `ZTS` (Zend Thread Safe). This has been a
   common practice for a long time in other distributions.
 
-- PHP 8.2.0 RC 6 is available.
+- PHP 8.2.0 RC 7 is available.
 
 - `protonup` has been aliased to and replaced by `protonup-ng` due to upstream not maintaining it.
 
@@ -482,12 +482,12 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - Add udev rules for the Teensy family of microcontrollers.
 
-- The Qt QML disk cache is now disabled by default. This fixes a 
-  long-standing issue where updating Qt/KDE apps would sometimes cause 
-  them to crash or behave strangely without explanation. Those concerned 
-  about the small (~10%) performance hit to application startup can 
-  re-enable the cache (and expose themselves to gremlins) by setting the 
-  envrionment variable `QML_FORCE_DISK_CACHE` to `1` using e.g. the 
+- The Qt QML disk cache is now disabled by default. This fixes a
+  long-standing issue where updating Qt/KDE apps would sometimes cause
+  them to crash or behave strangely without explanation. Those concerned
+  about the small (~10%) performance hit to application startup can
+  re-enable the cache (and expose themselves to gremlins) by setting the
+  envrionment variable `QML_FORCE_DISK_CACHE` to `1` using e.g. the
   `environment.sessionVariables` NixOS option.
 
 - systemd-oomd is enabled by default. Depending on which systemd units have

--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -2,8 +2,8 @@
 
 let
   base = callPackage ./generic.nix (_args // {
-    version = "8.0.25";
-    hash = "sha256-CdcWvOtbPbdtkCOxDBaB674EDlH0wY39Nfn/i3O7z4w=";
+    version = "8.0.26";
+    hash = "sha256-bfh6+W8nWnWIns5uP+ShOr2Tp2epmShjvcDpDx6Ifuc=";
   });
 
 in

--- a/pkgs/development/interpreters/php/8.1.nix
+++ b/pkgs/development/interpreters/php/8.1.nix
@@ -2,8 +2,8 @@
 
 let
   base = callPackage ./generic.nix (_args // {
-    version = "8.1.12";
-    hash = "sha256-+H1z6Rf6z3jee83lP8L6pNTb4Eh6lAbhq2jIro8z6wM=";
+    version = "8.1.13";
+    hash = "sha256-k/z9+qo9CUoP2xjOCNIPINUm7j8HoUaoqOyCzgCyN8o=";
   });
 
 in

--- a/pkgs/development/interpreters/php/8.2.nix
+++ b/pkgs/development/interpreters/php/8.2.nix
@@ -1,13 +1,13 @@
 { callPackage, lib, stdenv, fetchurl, ... }@_args:
 
 let
-  hash = "sha256-sbT8sIwle3OugXxqLZO3jKXlrOQsX1iH7WRH8G+nv8Y=";
+  hash = "sha256-MSBENMUl+F5k9manZvYjRDY3YWsYToZSQU9hmhJ8Xvc=";
 
   base = callPackage ./generic.nix (_args // {
     version = "8.2.0";
     phpAttrsOverrides = attrs: attrs // {
       src = fetchurl {
-        url = "https://downloads.php.net/~sergey/php-8.2.0RC6.tar.xz";
+        url = "https://downloads.php.net/~pierrick/php-8.2.0RC7.tar.xz";
         inherit hash;
       };
     };


### PR DESCRIPTION
This PR:

- Update PHP 8.0 from 8.0.25 to 8.0.26 ([changelog](https://www.php.net/ChangeLog-8.php#8.0.26))
- Update PHP 8.1 from 8.1.12 to 8.1.13 ([changelog](https://www.php.net/ChangeLog-8.php#8.1.13))
- Update PHP 8.2 from 8.2.0rc6 to 8.2.0rc7 ([NEWS](https://github.com/php/php-src/blob/php-8.2.0RC7/NEWS))

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
