### PR TITLE
nvidia-system-monitor-qt: init at 1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5346,6 +5346,12 @@
       fingerprint = "F7D3 7890 228A 9074 40E1  FD48 46B9 228E 814A 2AAC";
     }];
   };
+  hacker1024 = {
+    name = "hacker1024";
+    email = "hacker1024@users.sourceforge.net";
+    github = "hacker1024";
+    githubId = 20849728;
+  };
   hagl = {
     email = "harald@glie.be";
     github = "hagl";

--- a/pkgs/tools/system/nvidia-system-monitor-qt/default.nix
+++ b/pkgs/tools/system/nvidia-system-monitor-qt/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, qtbase
+, wrapQtAppsHook
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+let
+  # Based in desktop files from official packages:
+  # https://github.com/congard/nvidia-system-monitor-qt/tree/master/package
+  desktopItem = makeDesktopItem {
+    name = "nvidia-system-monitor-qt";
+    desktopName = "NVIDIA System Monitor";
+    icon = "qnvsm";
+    exec = "qnvsm";
+    categories = [
+      "System"
+      "Utility"
+      "Qt"
+    ];
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "nvidia-system-monitor-qt";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "congard";
+    repo = "nvidia-system-monitor-qt";
+    rev = "v${version}";
+    sha256 = "sha256-VDw5Wp/QFDV1zKF4yz0aR0Hox9KHXZmeAKzKLSlu8Ck=";
+  };
+
+  buildInputs = [ qtbase ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook copyDesktopItems ];
+
+  cmakeFlags = [
+    "-DIconPath=${placeholder "out"}/share/icons/hicolor/512x512/apps/qnvsm.png"
+    "-DVersionPrefix=(Nixpkgs)"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 qnvsm $out/bin/qnvsm
+    install -Dm644 $src/icon.png $out/share/icons/hicolor/512x512/apps/qnvsm.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  meta = rec {
+    description = "Task Manager for Linux for NVIDIA graphics cards";
+    homepage = "https://github.com/congard/nvidia-system-monitor-qt";
+    downloadPage = "${homepage}/releases";
+    changelog = "${downloadPage}/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hacker1024 ];
+    mainProgram = "qnvsm";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21614,6 +21614,8 @@ with pkgs;
 
   nvidia-optical-flow-sdk = callPackage ../development/libraries/nvidia-optical-flow-sdk { };
 
+  nvidia-system-monitor-qt = libsForQt5.callPackage ../tools/system/nvidia-system-monitor-qt { };
+
   nvitop = callPackage ../tools/system/nvitop { };
 
   nvtop = callPackage ../tools/system/nvtop { };


### PR DESCRIPTION
###### Description of changes

This PR packages [nvidia-system-monitor-qt](https://github.com/congard/nvidia-system-monitor-qt).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
