### PR TITLE
vulkan-cts: init at 1.3.4.1

### DIFF
--- a/pkgs/tools/graphics/vulkan-cts/default.nix
+++ b/pkgs/tools/graphics/vulkan-cts/default.nix
@@ -1,0 +1,147 @@
+{ lib, stdenv
+, fetchFromGitHub
+, fetchurl
+, cmake
+, libdrm
+, libglvnd
+, libffi
+, libpng
+, libX11
+, libXau
+, libXdmcp
+, libxcb
+, makeWrapper
+, ninja
+, pkg-config
+, python3
+, vulkan-loader
+, wayland
+, wayland-protocols
+, zlib
+}:
+let
+  renderdoc = fetchurl {
+    url = "https://raw.githubusercontent.com/baldurk/renderdoc/v1.1/renderdoc/api/app/renderdoc_app.h";
+    hash = "sha256-57XwqlsbDq3GOhxiTAyn9a8TOqhX1qQnGw7z0L22ho4=";
+  };
+
+  # The build system expects all these dependencies inside the external folder and
+  # does not search for system-wide installations.
+  # It also expects the version specified in the repository, which can be incompatible
+  # with the version in nixpkgs (e.g. for SPIRV-Headers), so we don't want to patch in our packages.
+  amber = fetchFromGitHub {
+    owner = "google";
+    repo = "amber";
+    rev = "8b145a6c89dcdb4ec28173339dd176fb7b6f43ed";
+    hash = "sha256-+xFYlUs13khT6r475eJJ+XS875h2sb+YbJ8ZN4MOSAA=";
+  };
+  jsoncpp = fetchFromGitHub {
+    owner = "open-source-parsers";
+    repo = "jsoncpp";
+    rev = "9059f5cad030ba11d37818847443a53918c327b1";
+    hash = "sha256-m0tz8w8HbtDitx3Qkn3Rxj/XhASiJVkThdeBxIwv3WI=";
+  };
+  glslang = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "glslang";
+    rev = "22d39cd684d136a81778cc17a0226ffad40d1cee";
+    hash = "sha256-6LplxN7HOMK1NfeD32P5JAMpCBlouttxLEOT/XTVpLw=";
+  };
+  spirv-tools = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "SPIRV-Tools";
+    rev = "b930e734ea198b7aabbbf04ee1562cf6f57962f0";
+    hash = "sha256-NWpFSRoxtYWi+hLUt9gpw0YScM3shcUwv9yUmbivRb0=";
+  };
+  spirv-headers = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "SPIRV-Headers";
+    rev = "36c0c1596225e728bd49abb7ef56a3953e7ed468";
+    hash = "sha256-t1UMJnYONWOtOxc9zUgxr901QFNvqkgurjpFA8UzhYc=";
+  };
+  vulkan-docs = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "Vulkan-Docs";
+    rev = "135da3a538263ef0d194cab25e2bb091119bdc42";
+    hash = "sha256-VZ8JxIuOEG7IjsVcsJOcC+EQeZbd16/+czLcO9t7dY4=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vulkan-cts";
+  version = "1.3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "VK-GL-CTS";
+    rev = "${finalAttrs.pname}-${finalAttrs.version}";
+    hash = "sha256-XUFlYdudyRqa6iupB8N5QkUpumasyLLQEWcr4M4uP1g=";
+  };
+
+  outputs = [ "out" "lib" ];
+
+  prePatch = ''
+    mkdir -p external/renderdoc/src external/spirv-headers external/vulkan-docs
+
+    cp -r ${renderdoc} external/renderdoc/src/renderdoc_app.h
+
+    cp -r ${amber} external/amber/src
+    cp -r ${jsoncpp} external/jsoncpp/src
+    cp -r ${glslang} external/glslang/src
+    cp -r ${spirv-tools} external/spirv-tools/src
+    cp -r ${spirv-headers} external/spirv-headers/src
+    cp -r ${vulkan-docs} external/vulkan-docs/src
+    chmod u+w -R external
+  '';
+
+  buildInputs = [
+    libdrm
+    libffi
+    libglvnd
+    libpng
+    libX11
+    libXau
+    libXdmcp
+    libxcb
+    spirv-headers
+    spirv-tools
+    wayland
+    wayland-protocols
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    glslang
+    makeWrapper
+    ninja
+    pkg-config
+    python3
+  ];
+
+  # Fix cts cmake not coping with absolute install dirs
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  postInstall = ''
+    mv $out $lib
+
+    mkdir -p $out/bin $out/archive-dir
+    cp -a external/vulkancts/modules/vulkan/deqp-vk external/vulkancts/modules/vulkan/deqp-vksc $out/bin/
+    cp -a external/vulkancts/modules/vulkan/vulkan $out/archive-dir/
+    cp -a external/vulkancts/modules/vulkan/vk-default $out/
+
+    wrapProgram $out/bin/deqp-vk \
+      --add-flags '--deqp-vk-library-path=${vulkan-loader}/lib/libvulkan.so' \
+      --add-flags "--deqp-archive-dir=$out/archive-dir"
+  '';
+
+  meta = with lib; {
+    description = "Khronos Vulkan Conformance Tests";
+    homepage = "https://github.com/KhronosGroup/VK-GL-CTS/blob/main/external/vulkancts/README.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Flakebi ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22933,6 +22933,8 @@ with pkgs;
 
   vulkan-caps-viewer = libsForQt5.callPackage ../tools/graphics/vulkan-caps-viewer { };
 
+  vulkan-cts = callPackage ../tools/graphics/vulkan-cts { };
+
   vulkan-extension-layer = callPackage ../tools/graphics/vulkan-extension-layer { };
   vulkan-headers = callPackage ../development/libraries/vulkan-headers { };
   vulkan-loader = callPackage ../development/libraries/vulkan-loader { inherit (darwin) moltenvk; };


### PR DESCRIPTION
###### Description of changes

Vulkan CTS is the conformance test suite for the Vulkan graphics API: https://github.com/KhronosGroup/VK-GL-CTS/blob/main/external/vulkancts/README.md

To run, try e.g. `deqp-vk -n dEQP-VK.api.smoke.triangle`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
