### PR TITLE
gfxreconstruct: init at 0.9.15

### DIFF
--- a/pkgs/tools/graphics/gfxreconstruct/default.nix
+++ b/pkgs/tools/graphics/gfxreconstruct/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, cmake
+, makeWrapper
+, pkg-config
+, python3
+, wayland
+, libX11
+, libxcb
+, lz4
+, vulkan-loader
+, xcbutilkeysyms
+, zlib
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gfxreconstruct";
+  version = "0.9.15";
+
+  src = fetchFromGitHub {
+    owner = "LunarG";
+    repo = "gfxreconstruct";
+    rev = "v${version}";
+    hash = "sha256-hIzQ5L0Payj8hlyy5UI7RXgnyhQBPqG7nfbvW2VYvTg=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    libX11
+    libxcb
+    lz4
+    python3
+    wayland
+    xcbutilkeysyms
+    zlib
+    zstd
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  # The python script searches in subfolders, but we want to search in the same bin directory
+  prePatch = ''
+    substituteInPlace tools/gfxrecon/gfxrecon.py \
+      --replace "scriptdir, '..', cmd" 'scriptdir'
+  '';
+
+  # Fix the path to the layer library
+  postInstall = ''
+    substituteInPlace $out/share/vulkan/explicit_layer.d/VkLayer_gfxreconstruct.json \
+      --replace 'libVkLayer_gfxreconstruct.so' "$out/lib/libVkLayer_gfxreconstruct.so"
+    wrapProgram $out/bin/gfxrecon-replay \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+  '';
+
+  meta = with lib; {
+    description = "Graphics API Capture and Replay Tools";
+    homepage = "https://github.com/LunarG/gfxreconstruct/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Flakebi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4172,6 +4172,8 @@ with pkgs;
 
   gdu = callPackage ../tools/system/gdu { };
 
+  gfxreconstruct = callPackage ../tools/graphics/gfxreconstruct { };
+
   go-chromecast = callPackage ../applications/video/go-chromecast { };
 
   go-containerregistry = callPackage ../development/tools/go-containerregistry { };


### PR DESCRIPTION
###### Description of changes
[gfxreconstruct](https://github.com/LunarG/gfxreconstruct) is a Graphics API Capture and Replay Tools for Reconstructing Graphics Application Behavior.

To try it out, install `vulkan-tools` for vkcube and run
```bash
gfxrecon.py capture vkcube # Close window after some frames
gfxrecon.py replay gfxrecon_capture_*.gfxr
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
