### PR TITLE
J: fixing init script

### DIFF
--- a/pkgs/development/interpreters/j/default.nix
+++ b/pkgs/development/interpreters/j/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     bc
   ];
 
+  patches = [
+    ./fix-install-path.patch
+  ];
+
   dontConfigure = true;
 
   # emulating build_all.sh configuration variables

--- a/pkgs/development/interpreters/j/fix-install-path.patch
+++ b/pkgs/development/interpreters/j/fix-install-path.patch
@@ -1,0 +1,10 @@
+--- a/jlibrary/bin/profile.ijs	2022-11-23 18:45:50.049675025 +0100
++++ b/jlibrary/bin/profile.ijs	2022-11-23 18:47:43.798532581 +0100
+@@ -13,6 +13,7 @@
+ fhs=. (FHS"_)^:(0=4!:0<'FHS')(5=systype)*.0=#1!:0<BINPATH,'/../system/util/boot.ijs'
+ install=. (0&~:fhs){::install;install,'/share/j/',omitversion{::'9.03';'0'
+ install=. (INSTALLROOT"_)^:(0=4!:0<'INSTALLROOT') install
++install=. bin,'/../share/j'
+ addons=. install,'/addons'
+ system=. install,'/system'
+ tools=. install,'/tools'


### PR DESCRIPTION
The startup script used by jconsole (/bin/profile.ijs) doesn't try very hard to understand the file hierarchy it lives in, and just did not work with NixOS. For reasons unknown, it Just Worked for some time, but finally broke with an actual error message every time you launch jconsole in recent versions of nixpkgs. This commit just overwrites all the heuristics J uses to find out where its installation files are, to point where they actually are put by the installer.

###### Description of changes

A patch of the above mentioned init script has been added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
