### PR TITLE
sane-backends: 1.0.32 -> 1.1.1

### DIFF
--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation {
   pname = "sane-backends";
-  version = "1.0.32";
+  version = "1.1.1";
 
   src = fetchurl {
     # raw checkouts of the repo do not work because, the configure script is
@@ -24,9 +24,9 @@ stdenv.mkDerivation {
     # https://gitlab.com/sane-project/backends/-/issues/440
     # unfortunately this make the url unpredictable on update, to find the link
     # go to https://gitlab.com/sane-project/backends/-/releases and choose
-    # the link with other in the URL.
-    url = "https://gitlab.com/sane-project/backends/uploads/104f09c07d35519cc8e72e604f11643f/sane-backends-1.0.32.tar.gz";
-    sha256 = "055iicihxa6b28iv5fnz13n67frdr5nrydq2c846f9x7q0vw4a1s";
+    # the link under the heading "Other".
+    url = "https://gitlab.com/sane-project/backends/uploads/7d30fab4e115029d91027b6a58d64b43/sane-backends-1.1.1.tar.gz";
+    sha256 = "sha256-3UsEw3pC8UxGGejupqlX9MfGF/5Z4yrihys3OUCotgM=";
   };
 
   patches = [
@@ -137,5 +137,6 @@ stdenv.mkDerivation {
     homepage = "http://www.sane-project.org/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux ++ platforms.darwin;
+    maintainers = [ maintainers.symphorien ];
   };
 }


### PR DESCRIPTION
and add myself as maintainer

changelog: https://gitlab.com/sane-project/backends/-/releases/1.1.1, nothing of note


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
