### PR TITLE
telepathy-logger: build using python3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv, fetchurl, pkg-config, libxslt, telepathy-glib, python2, libxml2, dbus-glib, dbus
-, sqlite, libsoup, libnice, gnutls}:
+{ lib, stdenv, fetchurl, pkg-config, libxslt, telepathy-glib, python3, libxml2, dbus-glib, dbus
+, sqlite, libsoup, libnice, gnutls
+, fetchpatch
+}:
 
 stdenv.mkDerivation rec {
   pname = "telepathy-gabble";
@@ -10,8 +12,15 @@ stdenv.mkDerivation rec {
     sha256 = "174nlkqm055vrhv11gy73m20jbsggcb0ddi51c7s9m3j5ibr2p0i";
   };
 
-  nativeBuildInputs = [ pkg-config libxslt ];
-  buildInputs = [ libxml2 dbus-glib sqlite libsoup libnice telepathy-glib gnutls python2 ];
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/archlinux/svntogit-packages/raw/edcf78c831894000f2fbfd3e5818e363911c746a/trunk/telepathy-gabble-0.18.4-python3.patch";
+      hash = "sha256-bvcZW6gbCNogqwPDaXHTbohe7c2GAYjXeHGyBEDVsB4=";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config libxslt python3 ];
+  buildInputs = [ libxml2 dbus-glib sqlite libsoup libnice telepathy-glib gnutls ];
 
   checkInputs = [ dbus.daemon ];
 

--- a/pkgs/applications/networking/instant-messengers/telepathy/haze/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/haze/default.nix
@@ -1,26 +1,17 @@
-{ lib, stdenv, fetchurl, fetchpatch, pidgin, telepathy-glib, python2, glib, dbus-glib, pkg-config, libxslt }:
+{ lib, stdenv, fetchurl, fetchpatch, pidgin, telepathy-glib, python3, glib, dbus-glib, pkg-config, libxslt }:
 
 stdenv.mkDerivation rec {
   pname = "telepathy-haze";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchurl {
-    url = "https://telepathy.freedesktop.org/releases/telepathy-haze/telepathy-haze${version}.tar.gz";
-    sha256 = "1jgrp32p6rllj089ynbsk3n9xrvsvzmwzhf0ql05kkgj0nf08xiy";
+    url = "https://telepathy.freedesktop.org/releases/telepathy-haze/telepathy-haze-${version}.tar.gz";
+    hash = "sha256-cEvvpC7sIXPspLrAH/0AQBRmXyutRtyJSOVCM2TN4wo=";
   };
 
-  buildInputs = [ glib telepathy-glib dbus-glib pidgin python2 ];
+  buildInputs = [ glib telepathy-glib dbus-glib pidgin ];
 
-  nativeBuildInputs = [ pkg-config libxslt ];
-
-  patches = [
-    # Patch from Gentoo that helps telepathy-haze build with more
-    # recent versions of pidgin.
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/gentoo/master/net-voip/telepathy-haze/files/telepathy-haze-0.8.0-pidgin-2.10.12-compat.patch";
-      sha256 = "0fa1p4n1559qd096w7ya4kvfnc1c98ykarkxzlpkwvzbczwzng3c";
-    })
-  ];
+  nativeBuildInputs = [ pkg-config libxslt python3 ];
 
   meta = {
     description = "A Telepathy connection manager based on libpurple";

--- a/pkgs/applications/networking/instant-messengers/telepathy/idle/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/idle/default.nix
@@ -1,16 +1,16 @@
-{ lib, stdenv, fetchurl, glib, dconf, pkg-config, dbus-glib, telepathy-glib, python2, libxslt, makeWrapper }:
+{ lib, stdenv, fetchurl, glib, dconf, pkg-config, dbus-glib, telepathy-glib, python3, libxslt, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "telepathy-idle";
-  version = "0.2.0";
+  version = "0.2.2";
 
   src = fetchurl {
     url = "http://telepathy.freedesktop.org/releases/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "1argdzbif1vdmwp5vqbgkadq9ancjmgdm2ncp0qfckni715ss4rh";
+    hash = "sha256-g4fiXl+wtMvnAeXcCS1mbWUQuDP9Pn5GLpFw027DwV8=";
   };
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
-  buildInputs = [ glib telepathy-glib dbus-glib libxslt python2 (lib.getLib dconf) ];
+  nativeBuildInputs = [ pkg-config python3 makeWrapper ];
+  buildInputs = [ glib telepathy-glib dbus-glib libxslt (lib.getLib dconf) ];
 
   preFixup = ''
     wrapProgram "$out/libexec/telepathy-idle" \

--- a/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv, fetchurl, dbus-glib, libxml2, sqlite, telepathy-glib, python2, pkg-config
-, dconf, makeWrapper, intltool, libxslt, gobject-introspection, dbus }:
+{ lib, stdenv, fetchurl, dbus-glib, libxml2, sqlite, telepathy-glib, python3, pkg-config
+, dconf, makeWrapper, intltool, libxslt, gobject-introspection, dbus
+, fetchpatch
+}:
 
 stdenv.mkDerivation rec {
   pname = "telepathy-logger";
@@ -10,12 +12,20 @@ stdenv.mkDerivation rec {
     sha256 = "1bjx85k7jyfi5pvl765fzc7q2iz9va51anrc2djv7caksqsdbjlg";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/archlinux/svntogit-packages/raw/2b5bdbb4739d3517f5e7300edc8dab775743b96d/trunk/0001-tools-Fix-the-build-with-Python-3.patch";
+      hash = "sha256-o1lfdZIIqaxn7ntQZnoOMqquc6efTHgSIxB5dpFWRgg=";
+    })
+  ];
+
   nativeBuildInputs = [
     makeWrapper pkg-config intltool libxslt gobject-introspection
+    python3
   ];
   buildInputs = [
     dbus-glib libxml2 sqlite telepathy-glib
-    dbus python2
+    dbus
   ];
 
   configureFlags = [ "--enable-call" ];


### PR DESCRIPTION
Motivated by https://github.com/NixOS/nixpkgs/pull/201859.

###### Description of changes
Move Python to `nativeBuildInputs` because it's only used at build time according to Arch's PKGBUILD and Alpine's APKBUILD.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
