### PR TITLE
nixos/ipp-usb: add package and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1008,6 +1008,7 @@
   ./services/networking/zerotierone.nix
   ./services/networking/znc/default.nix
   ./services/printing/cupsd.nix
+  ./services/printing/ipp-usb.nix
   ./services/scheduling/atd.nix
   ./services/scheduling/cron.nix
   ./services/scheduling/fcron.nix

--- a/nixos/modules/services/printing/ipp-usb.nix
+++ b/nixos/modules/services/printing/ipp-usb.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }: {
+  options = {
+    services.ipp-usb = {
+      enable = lib.mkEnableOption (lib.mdDoc "ipp-usb, a daemon to turn an USB printer/scanner supporting IPP everywhere (aka AirPrint, WSD, AirScan) into a locally accessible network printer/scanner");
+    };
+  };
+  config = lib.mkIf config.services.ipp-usb.enable {
+    systemd.services.ipp-usb = {
+      description = "Daemon for IPP over USB printer support";
+      after = [ "cups.service" "avahi-deamon.service" ];
+      wants = [ "avahi-daemon.service" ];
+      serviceConfig = {
+        ExecStart = [ "${pkgs.ipp-usb}/bin/ipp-usb" ];
+        Type = "simple";
+        Restart = "on-failure";
+        StateDirectory = "ipp-usb";
+        LogsDirectory = "ipp-usb";
+
+        # hardening.
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectControlGroups = true;
+        MemoryDenyWriteExecute = true;
+        # breaks the daemon, presumably because it messes with DeviceAllow
+        ProtectClock = false;
+        ProtectKernelTunables = true;
+        ProtectKernelLogs = true;
+        ProtectSystem = "strict";
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        PrivateMounts = true;
+        ProtectHostname = true;
+        ProtectKernelModules = true;
+        RemoveIPC = true;
+        RestrictNamespaces = true;
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_NETLINK" "AF_INET" "AF_INET6" ];
+        ProtectProc = "noaccess";
+      };
+    };
+
+    # starts the systemd service
+    services.udev.packages = [ pkgs.ipp-usb ];
+    services.avahi = {
+      enable = true;
+      publish = {
+        enable = true;
+        userServices = true;
+      };
+    };
+    # enable printing and scanning by default, but not required.
+    services.printing.enable = lib.mkDefault true;
+    hardware.sane.enable = lib.mkDefault true;
+    # so that sane discovers scanners
+    hardware.sane.extraBackends = [ pkgs.sane-airscan ];
+  };
+}
+
+

--- a/pkgs/os-specific/linux/ipp-usb/default.nix
+++ b/pkgs/os-specific/linux/ipp-usb/default.nix
@@ -1,0 +1,42 @@
+{ buildGoModule, avahi, libusb1, pkg-config, lib, fetchFromGitHub, ronn }:
+buildGoModule rec {
+  pname = "ipp-usb";
+  version = "0.9.23";
+
+  src = fetchFromGitHub {
+    owner = "openprinting";
+    repo = "ipp-usb";
+    rev = version;
+    sha256 = "sha256-sbPQWKqkTaD3kLNs0noVIzAN9cwDEaULsqO7SMQH2Jo=";
+  };
+
+  postPatch = ''
+    # rebuild with patched paths
+    rm ipp-usb.8
+    substituteInPlace Makefile --replace "install: all" "install: man"
+    substituteInPlace systemd-udev/ipp-usb.service --replace "/sbin" "$out/bin"
+    for i in Makefile paths.go ipp-usb.8.md; do
+      substituteInPlace $i --replace "/usr" "$out"
+      substituteInPlace $i --replace "/var/ipp-usb" "/var/lib/ipp-usb"
+    done
+  '';
+
+  nativeBuildInputs = [ pkg-config ronn ];
+  buildInputs = [ libusb1 avahi ];
+
+  vendorSha256 = "sha256-KwW6KgopjF4tVo8eB4OtpXF5R8jfrJ9nibNmaN8U4l8=";
+
+  postInstall = ''
+    # to accomodate the makefile
+    cp $out/bin/ipp-usb .
+    make install DESTDIR=$out
+  '';
+
+  meta = {
+    description = "Daemon to use the IPP everywhere protocol with USB printers";
+    homepage = "https://github.com/OpenPrinting/ipp-usb";
+    maintainers = [ lib.maintainers.symphorien ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2806,6 +2806,8 @@ with pkgs;
 
   ipgrep = callPackage ../tools/networking/ipgrep { };
 
+  ipp-usb = callPackage ../os-specific/linux/ipp-usb { };
+
   itch = callPackage ../games/itch {};
 
   itd = callPackage ../applications/misc/itd { };


### PR DESCRIPTION
###### Description of changes

this allow printing and scanning without vendor-specific driver with any AirPrint, WSD, AirScan capable printer, but over USB instead of network.
tested rebased on 22.11 on one (1) printer :)

needs #202874 for scanning

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
