### PR TITLE
haproxyHTTP3: add http/3 support

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,6 +1,7 @@
 { useLua ? true
 , usePcre ? true
 , withPrometheusExporter ? true
+, http3Support ? false
 , stdenv
 , lib
 , fetchurl
@@ -42,6 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildFlags = [
     "USE_OPENSSL=yes"
     "USE_ZLIB=yes"
+  ] ++ lib.optionals http3Support [
+    "USE_QUIC=yes"
   ] ++ lib.optionals usePcre [
     "USE_PCRE=yes"
     "USE_PCRE_JIT=yes"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9053,6 +9053,11 @@ with pkgs;
 
   haproxy = callPackage ../tools/networking/haproxy { };
 
+  haproxyHTTP3 = haproxy.override {
+    openssl = quictls;
+    http3Support = true;
+  };
+
   hackertyper = callPackage ../tools/misc/hackertyper { };
 
   hackneyed = callPackage ../data/icons/hackneyed { };


### PR DESCRIPTION
###### Description of changes
Analogous to curlHTTP3, default to openssl for haproxy and provide haproxyHTTP3 for quic support.

Add a `package` option to the nixos module.

Running haproxy and fetching a website worked fine with quic:
```python
nix shell nixpkgs#curlHTTP3
curl --http3 -v https://…
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
