### PR TITLE
klick: 0.12.2 -> 0.14.2

### DIFF
--- a/pkgs/applications/audio/klick/default.nix
+++ b/pkgs/applications/audio/klick/default.nix
@@ -1,19 +1,34 @@
-{ lib, stdenv, fetchurl, sconsPackages, pkg-config
-, libsamplerate, libsndfile, liblo, libjack2, boost }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, sconsPackages
+, rubberband
+, boost
+, libjack2
+, liblo
+, libsamplerate
+, libsndfile
+}:
 
 stdenv.mkDerivation rec {
   pname = "klick";
-  version = "0.12.2";
+  version = "0.14.2";
 
-  src = fetchurl {
-    url = "http://das.nasophon.de/download/${pname}-${version}.tar.gz";
-    sha256 = "1289533c0849b1b66463bf27f7ce5f71736b655cfb7672ef884c7e6eb957ac42";
+  src = fetchFromGitHub {
+    owner = "Allfifthstuning";
+    repo = "klick";
+    rev = version;
+    hash = "sha256-jHyeVCmyy9ipbVaF7GSW19DOVpU9EQJoLcGq9uos+eY=";
   };
 
-  nativeBuildInputs = [ sconsPackages.scons_3_0_1 pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    rubberband
+    sconsPackages.scons_latest
+  ];
   buildInputs = [ libsamplerate libsndfile liblo libjack2 boost ];
   prefixKey = "PREFIX=";
-  NIX_CFLAGS_COMPILE = "-fpermissive";
 
   meta = {
     homepage = "http://das.nasophon.de/klick/";


### PR DESCRIPTION
Motivated by https://github.com/NixOS/nixpkgs/pull/201859.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
