### PR TITLE
npmHooks.npmConfigHook: make diagnostic match prefetch-npm-deps

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
@@ -20,7 +20,7 @@ npmBuildHook() {
         echo
         echo "Here are a few things you can try, depending on the error:"
         echo "1. Make sure your build script ($npmBuildScript) exists"
-        echo "  If there is none, set `dontNpmBuild = true`."
+        echo '  If there is none, set `dontNpmBuild = true`.'
         echo '2. If the error being thrown is something similar to "error:0308010C:digital envelope routines::unsupported", add `NODE_OPTIONS = "--openssl-legacy-provider"` to your derivation'
         echo "  See https://github.com/webpack/webpack/issues/14532 for more information."
         echo

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -28,7 +28,7 @@ npmConfigHook() {
       if ! [ -e "$srcLockfile" ]; then
         echo
         echo "ERROR: Missing package-lock.json from src. Expected to find it at: $srcLockfile"
-        echo "Hint: You can use the patches attribute to add a package-lock.json manually to the build."
+        echo "Hint: You can copy a vendored package-lock.json file via postPatch."
         echo
 
         exit 1


### PR DESCRIPTION
###### Description of changes

It looks like another diagnostic message indicating how to manually add a package-lock.json was missed. This PR adjusts it to use the same wording as #201731

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).