### PR TITLE
intel-media-driver: use upstream patch for 32bit, remove inactive mai…

### DIFF
--- a/pkgs/development/libraries/intel-media-driver/32bit.patch
+++ b/pkgs/development/libraries/intel-media-driver/32bit.patch
@@ -1,19 +1,46 @@
-diff --git a/media_softlet/linux/common/ddi/media_libva_util_next.cpp b/media_softlet/linux/common/ddi/media_libva_util_next.cpp
-index 66fab63de..a2cdf79d7 100644
---- a/media_softlet/linux/common/ddi/media_libva_util_next.cpp
-+++ b/media_softlet/linux/common/ddi/media_libva_util_next.cpp
-@@ -2195,8 +2195,8 @@ void MediaLibvaUtilNext::MediaPrintFps()
+diff --git a/media_driver/linux/common/ddi/media_libva_util.cpp b/media_driver/linux/common/ddi/media_libva_util.cpp
+index 25b4cb0b5..49254c2f0 100755
+--- a/media_driver/linux/common/ddi/media_libva_util.cpp
++++ b/media_driver/linux/common/ddi/media_libva_util.cpp
+@@ -34,6 +34,7 @@
+ #include <fcntl.h>
+ #include <dlfcn.h>
+ #include <errno.h>
++#include "inttypes.h"
  
-         int64_t diff  = (tv2.tv_sec - m_tv1.tv_sec)*1000000 + tv2.tv_usec - m_tv1.tv_usec;
-         float fps     = m_frameCountFps / (diff / 1000000.0);
--        DDI_NORMALMESSAGE("FPS:%6.4f, Interval:%11lu.", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
+ #include "media_libva_util.h"
+ #include "mos_utilities.h"
+@@ -91,7 +92,7 @@ void DdiMediaUtil_MediaPrintFps()
+         int64_t diff  = (tv2.tv_sec - tv1.tv_sec)*1000000 + tv2.tv_usec - tv1.tv_usec;
+         float fps     = frameCountFps / (diff / 1000000.0);
+         DDI_NORMALMESSAGE("FPS:%6.4f, Interval:%11lu.", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
 -        sprintf(temp,"FPS:%6.4f, Interval:%11lu\n", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
-+        DDI_NORMALMESSAGE("FPS:%6.4f, Interval:%11llu.", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
-+        sprintf(temp,"FPS:%6.4f, Interval:%11llu\n", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
++        sprintf(temp,"FPS:%6.4f, Interval:%" PRIu64"\n", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
  
          MOS_ZeroMemory(fpsFileName,LENGTH_OF_FPS_FILE_NAME);
          sprintf(fpsFileName, FPS_FILE_NAME);
-@@ -2213,4 +2213,4 @@ void MediaLibvaUtilNext::MediaPrintFps()
+diff --git a/media_softlet/linux/common/ddi/media_libva_util_next.cpp b/media_softlet/linux/common/ddi/media_libva_util_next.cpp
+index 66fab63de..38b1fae28 100644
+--- a/media_softlet/linux/common/ddi/media_libva_util_next.cpp
++++ b/media_softlet/linux/common/ddi/media_libva_util_next.cpp
+@@ -24,6 +24,7 @@
+ //! \brief    libva util next implementaion.
+ //!
+ #include <sys/time.h>
++#include "inttypes.h"
+ #include "media_libva_util_next.h"
+ #include "mos_utilities.h"
+ #include "mos_os.h"
+@@ -2196,7 +2197,7 @@ void MediaLibvaUtilNext::MediaPrintFps()
+         int64_t diff  = (tv2.tv_sec - m_tv1.tv_sec)*1000000 + tv2.tv_usec - m_tv1.tv_usec;
+         float fps     = m_frameCountFps / (diff / 1000000.0);
+         DDI_NORMALMESSAGE("FPS:%6.4f, Interval:%11lu.", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
+-        sprintf(temp,"FPS:%6.4f, Interval:%11lu\n", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
++        sprintf(temp,"FPS:%6.4f, Interval:%" PRIu64"\n", fps,((uint64_t)tv2.tv_sec)*1000 + (tv2.tv_usec/1000));
+ 
+         MOS_ZeroMemory(fpsFileName,LENGTH_OF_FPS_FILE_NAME);
+         sprintf(fpsFileName, FPS_FILE_NAME);
+@@ -2213,4 +2214,4 @@ void MediaLibvaUtilNext::MediaPrintFps()
      pthread_mutex_unlock(&m_fpsMutex);
      return;
  }

--- a/pkgs/development/libraries/intel-media-driver/default.nix
+++ b/pkgs/development/libraries/intel-media-driver/default.nix
@@ -33,9 +33,8 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/multimedia-team/intel-media-driver-non-free/-/raw/master/debian/patches/0002-Remove-settings-based-on-ARCH.patch";
       sha256 = "sha256-f4M0CPtAVf5l2ZwfgTaoPw7sPuAP/Uxhm5JSHEGhKT0=";
     })
-  ] ++ lib.optional stdenv.is32bit [
-    # fix compilation on i686-linux but also breaks x86_64
-    # a similar issue got fixed in https://github.com/intel/media-driver/pull/1493 but thats to much C magic for me
+    # fix compilation on 32bit
+    # https://github.com/intel/media-driver/pull/1557
     ./32bit.patch
   ];
 
@@ -73,6 +72,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/intel/media-driver/releases/tag/intel-media-${version}";
     license = with licenses; [ bsd3 mit ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ jfrankenau SuperSandro2000 ];
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
…ntainer

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
