### PR TITLE
purple-plugin-pack: 2.7.0 -> 2.8.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-plugin-pack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-plugin-pack/default.nix
@@ -1,20 +1,41 @@
-{ lib, stdenv, fetchurl, pidgin, intltool, python2 } :
+{ lib
+, stdenv
+, fetchurl
+, meson
+, ninja
+, pidgin
+}:
 
 stdenv.mkDerivation rec {
   pname = "purple-plugin-pack";
-  version = "2.7.0";
+  version = "2.8.0";
+
   src = fetchurl {
-    url = "https://bitbucket.org/rekkanoryo/purple-plugin-pack/downloads/purple-plugin-pack-${version}.tar.bz2";
-    sha256 = "0g5hmy7fwgjq59j52h9yps28jsjjrfkd4r18gyx6hfd3g3kzbg1b";
+    url = "mirror://sourceforge/pidgin/purple-plugin-pack-2.8.0.tar.xz";
+    hash = "sha256-gszemnJRp1t+A6P5qSkBTY4AjBtvRuWGOPX0dto+JC0=";
   };
 
-  nativeBuildInputs = [ intltool ];
-  buildInputs = [ pidgin python2 ];
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "PURPLE.get_pkgconfig_variable('plugindir')" "'$out/lib/purple-2'" \
+      --replace "PURPLE.get_pkgconfig_variable('datadir')" "'$out/share'" \
+      --replace "PIDGIN.get_pkgconfig_variable('plugindir')" "'$out/lib/pidgin'" \
+      --replace "PIDGIN.get_pkgconfig_variable('datadir')" "'$out/share'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    pidgin
+  ];
 
   meta = with lib; {
-    homepage = "https://bitbucket.org/rekkanoryo/purple-plugin-pack";
-    description = "Plugin pack for Pidgin 2.x";
-    license = licenses.gpl2;
+    homepage = "https://keep.imfreedom.org/pidgin/purple-plugin-pack";
+    description = "Collection of plugins for purple-based clients such as Pidgin";
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ bdimcheff ];
   };


### PR DESCRIPTION
Motivated by https://github.com/NixOS/nixpkgs/pull/201859.

Does someone know a way to install the plugins under `$out`?
```
PermissionError: [Errno 13] Permission denied: '/nix/store/5sym1v97c53vvncj2ps68ycjdjfqaqy4-pidgin-2.14.10/lib/pidgin/album.so'
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
