### PR TITLE
klipper: use python3

### DIFF
--- a/pkgs/servers/klipper/klipper-firmware.nix
+++ b/pkgs/servers/klipper/klipper-firmware.nix
@@ -6,7 +6,6 @@
 , libffi
 , libusb1
 , wxGTK30-gtk3
-, python2
 , python3
 , gcc-arm-embedded
 , klipper
@@ -20,7 +19,6 @@
   src = klipper.src;
 
   nativeBuildInputs = [
-    python2
     python3
     pkgsCross.avr.stdenv.cc
     gcc-arm-embedded

--- a/pkgs/servers/klipper/klipper-flash.nix
+++ b/pkgs/servers/klipper/klipper-flash.nix
@@ -4,7 +4,7 @@
 , pkgsCross
 , klipper
 , klipper-firmware
-, python2
+, python3
 , avrdude
 , stm32flash
 , mcu ? "mcu"
@@ -19,7 +19,7 @@ in
 writeShellApplication {
   name = "klipper-flash-${mcu}";
   runtimeInputs = [
-    python2
+    python3
     pkgsCross.avr.stdenv.cc
     gnumake
   ] ++ lib.optionals (boardArch == "avr") [ avrdude ] ++ lib.optionals (boardArch == "stm32") [ stm32flash ];

--- a/pkgs/servers/klipper/klipper-genconf.nix
+++ b/pkgs/servers/klipper/klipper-genconf.nix
@@ -1,12 +1,12 @@
 { writeShellApplication
 , klipper
-, python2
+, python3
 , gnumake
 , pkgsCross
 }: writeShellApplication {
   name = "klipper-genconf";
   runtimeInputs = [
-    python2
+    python3
     pkgsCross.avr.stdenv.cc
     gnumake
   ];


### PR DESCRIPTION
Motivated by https://github.com/NixOS/nixpkgs/pull/201859.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @vtuan10  