### PR TITLE
linx-server: init at unstable-2021-12-24

### DIFF
--- a/pkgs/servers/web-apps/linx-server/default.nix
+++ b/pkgs/servers/web-apps/linx-server/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule
+, fetchFromGitHub
+, go-rice
+, lib
+}:
+
+buildGoModule rec {
+  pname = "linx-server";
+  version = "unstable-2021-12-24";
+
+  src = fetchFromGitHub {
+    owner = "zizzydizzymc";
+    repo = pname;
+    rev = "3f503442f10fca68a3212975b23cf74d92c9988c";
+    hash = "sha256-tTHw/rIb2Gs5i5vZKsSgbUePIY7Np6HofBXu4TTjKbw=";
+  };
+
+  # upstream tests are broken, see zizzydizzymc/linx-server#34
+  patches = [ ./test.patch ];
+
+  vendorHash = "sha256-/N3AXrPyENp3li4X86LNXsfBYbjJulk+0EAyogPNIpc=";
+
+  nativeBuildInputs = [ go-rice ];
+
+  preBuild = "rice embed-go";
+
+  meta = with lib; {
+    description = "Self-hosted file/code/media sharing website.";
+    homepage = "https://put.icu";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/servers/web-apps/linx-server/test.patch
+++ b/pkgs/servers/web-apps/linx-server/test.patch
@@ -1,0 +1,74 @@
+diff --git a/server_test.go b/server_test.go
+index fc225ce..2df3608 100644
+--- a/server_test.go
++++ b/server_test.go
+@@ -446,63 +446,6 @@ func TestPostJSONUpload(t *testing.T) {
+ 	}
+ }
+ 
+-func TestPostJSONUploadMaxExpiry(t *testing.T) {
+-	mux := setup()
+-	Config.maxExpiry = 300
+-
+-	// include 0 to test edge case
+-	// https://github.com/andreimarcu/linx-server/issues/111
+-	testExpiries := []string{"86400", "-150", "0"}
+-	for _, expiry := range testExpiries {
+-		w := httptest.NewRecorder()
+-
+-		filename := generateBarename() + ".txt"
+-
+-		var b bytes.Buffer
+-		mw := multipart.NewWriter(&b)
+-		fw, err := mw.CreateFormFile("file", filename)
+-		if err != nil {
+-			t.Fatal(err)
+-		}
+-
+-		fw.Write([]byte("File content"))
+-		mw.Close()
+-
+-		req, err := http.NewRequest("POST", "/upload/", &b)
+-		req.Header.Set("Content-Type", mw.FormDataContentType())
+-		req.Header.Set("Accept", "application/json")
+-		req.Header.Set("Linx-Expiry", expiry)
+-		if err != nil {
+-			t.Fatal(err)
+-		}
+-
+-		mux.ServeHTTP(w, req)
+-
+-		if w.Code != 200 {
+-			t.Log(w.Body.String())
+-			t.Fatalf("Status code is not 200, but %d", w.Code)
+-		}
+-
+-		var myjson RespOkJSON
+-		err = json.Unmarshal([]byte(w.Body.String()), &myjson)
+-		if err != nil {
+-			t.Fatal(err)
+-		}
+-
+-		myExp, err := strconv.ParseInt(myjson.Expiry, 10, 64)
+-		if err != nil {
+-			t.Fatal(err)
+-		}
+-
+-		expected := time.Now().Add(time.Duration(Config.maxExpiry) * time.Second).Unix()
+-		if myExp != expected {
+-			t.Fatalf("File expiry is not %d but %s", expected, myjson.Expiry)
+-		}
+-	}
+-
+-	Config.maxExpiry = 0
+-}
+-
+ func TestPostExpiresJSONUpload(t *testing.T) {
+ 	mux := setup()
+ 	w := httptest.NewRecorder()
+@@ -1301,5 +1244,4 @@ func TestPutAndGetCLI(t *testing.T) {
+ 	if !strings.HasPrefix(contentType, "text/plain") {
+ 		t.Fatalf("Didn't receive file directly but %s", contentType)
+ 	}
+-
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23844,6 +23844,8 @@ with pkgs;
 
   listmonk = callPackage ../servers/mail/listmonk { };
 
+  linx-server = callPackage ../servers/web-apps/linx-server {};
+
   livepeer = callPackage ../servers/livepeer { };
 
   lwan = callPackage ../servers/http/lwan { };


### PR DESCRIPTION
###### Description of changes

Fixes #188667

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
