### PR TITLE
Fix filelight

### DIFF
--- a/pkgs/applications/kde/filelight.nix
+++ b/pkgs/applications/kde/filelight.nix
@@ -1,7 +1,17 @@
-{
-  mkDerivation, lib,
-  extra-cmake-modules, kdoctools,
-  kio, kparts, kxmlgui, qtbase, qtscript, solid, qtquickcontrols2, kdeclarative, kirigami2, kquickcharts
+{ mkDerivation
+, lib
+, extra-cmake-modules
+, kdoctools
+, kio
+, kparts
+, kxmlgui
+, qtbase
+, qtscript
+, solid
+, qtquickcontrols2
+, kdeclarative
+, kirigami2
+, kquickcharts
 }:
 
 mkDerivation {
@@ -15,7 +25,15 @@ mkDerivation {
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   propagatedBuildInputs = [
-    kio kparts kxmlgui qtscript solid qtquickcontrols2 kdeclarative kirigami2 kquickcharts
+    kio
+    kparts
+    kxmlgui
+    qtscript
+    solid
+    qtquickcontrols2
+    kdeclarative
+    kirigami2
+    kquickcharts
   ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/applications/kde/filelight.nix
+++ b/pkgs/applications/kde/filelight.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, kdoctools,
-  kio, kparts, kxmlgui, qtbase, qtscript, solid, qtquickcontrols2, kdeclarative
+  kio, kparts, kxmlgui, qtbase, qtscript, solid, qtquickcontrols2, kdeclarative, kirigami2, kquickcharts
 }:
 
 mkDerivation {
@@ -15,7 +15,7 @@ mkDerivation {
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   propagatedBuildInputs = [
-    kio kparts kxmlgui qtscript solid qtquickcontrols2 kdeclarative
+    kio kparts kxmlgui qtscript solid qtquickcontrols2 kdeclarative kirigami2 kquickcharts
   ];
   outputs = [ "out" "dev" ];
 }


### PR DESCRIPTION
###### Description of changes

filelight crashes during startup with the following segfault

```bash
> filelight                  
QQmlComponent: Component is not ready
[1]    1114430 segmentation fault (core dumped)  filelight
```

###### Things done

Add missing dependency on kirigami and kquickcharts. Looks like they are needed for (at least?) v22.07.08+ see [here](https://invent.kde.org/utilities/filelight/-/commit/296d077b4b2f1e6827c5f8c3cdd3467b311520cc) for the commit that makes the dependency visible at build time.


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
