### PR TITLE
thumbdrives: init at 0.3.1

### DIFF
--- a/pkgs/applications/system/thumbdrives/default.nix
+++ b/pkgs/applications/system/thumbdrives/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, python3
+, fetchFromSourcehut
+, gtk3
+, libhandy_0
+, gobject-introspection
+, meson
+, pkg-config
+, ninja
+, gettext
+, glib
+, desktop-file-utils
+, wrapGAppsHook
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "thumbdrives";
+  version = "0.3.1";
+
+  format = "other";
+
+  src = fetchFromSourcehut {
+    owner = "~martijnbraam";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-CPZKswbvsG61A6J512FOCKAntoJ0sUb2s+MKb0rO+Xw=";
+  };
+
+  postPatch = ''
+    patchShebangs build-aux/meson
+  '';
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+    gettext
+    glib
+    gtk3
+    desktop-file-utils
+    wrapGAppsHook
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk3
+    libhandy_0
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+    pyxdg
+  ];
+
+  meta = with lib; {
+    description = "USB mass storage emulator for Linux handhelds";
+    homepage = "https://sr.ht/~martijnbraam/thumbdrives/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chuangzhu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12040,6 +12040,8 @@ with pkgs;
 
   threema-desktop = callPackage ../applications/networking/instant-messengers/threema-desktop { };
 
+  thumbdrives = callPackage ../applications/system/thumbdrives { };
+
   tidy-viewer = callPackage ../tools/text/tidy-viewer { };
 
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };


### PR DESCRIPTION
###### Description of changes

USB mass storage emulator for Linux handhelds. https://sr.ht/~martijnbraam/thumbdrives/

Tested on my oneplus-enchilada.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
