### PR TITLE
python310Packages.aioquic: fix build

### DIFF
--- a/pkgs/development/python-modules/aioquic/default.nix
+++ b/pkgs/development/python-modules/aioquic/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchPypi
+, fetchpatch
 , buildPythonPackage
 , openssl
 , pylsqpack
@@ -16,6 +17,19 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-7ENqqs6Ze4RrAeUgDtv34+VrkYJqFE77l0j9jd0zK74=";
   };
+
+  patches = [
+    # This patch is here because it's required by the next patch.
+    (fetchpatch {
+      url = "https://github.com/aiortc/aioquic/commit/3930580b50831a034d21ee4689362188b21a4d6a.patch";
+      hash = "sha256-XjhyajDawN/G1nPtkMbNe66iJCo76UpdA7PqwtxO5ag=";
+    })
+    # https://github.com/aiortc/aioquic/pull/349, fixes test failure due pyopenssl==22
+    (assert lib.versions.major pyopenssl.version == "22"; fetchpatch {
+      url = "https://github.com/aiortc/aioquic/commit/c3b72be85868d67ee32d49ab9bd98a4357cbcde9.patch";
+      hash = "sha256-AjW+U9DpNXgA5yqKkWnx0OYpY2sZR9KIdQ3pSzxU+uY=";
+    })
+  ];
 
   propagatedBuildInputs = [
     certifi


### PR DESCRIPTION
###### Description of changes

Fixes python310Packages.aioquic.

Some tests broke due to an update in a command output parsed by pyopenssl 22.
This patches fix the parsing of the command output.

#ZurichZHF

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->