### PR TITLE
asc: 2.6.0.0 -> 2.6.3.0

### DIFF
--- a/pkgs/games/asc/default.nix
+++ b/pkgs/games/asc/default.nix
@@ -1,27 +1,69 @@
-{ fetchurl, lib, stdenv, SDL, SDL_image, SDL_mixer, SDL_sound, libsigcxx, physfs
-, boost, expat, freetype, libjpeg, wxGTK32, lua, perl, pkg-config, zlib, zip, bzip2
-, libpng, libtiff, fluidsynth, libmikmod, libvorbis, flac, libogg }:
+{ fetchFromGitHub
+, lib
+, stdenv
+, SDL
+, SDL_image
+, SDL_mixer
+, SDL_sound
+, libsigcxx
+, physfs
+, boost
+, expat
+, freetype
+, libjpeg
+, wxGTK32
+, lua
+, perl
+, pkg-config
+, zlib
+, zip
+, bzip2
+, libpng
+, libtiff
+, fluidsynth
+, libmikmod
+, libvorbis
+, flac
+, libogg
+}:
 
 stdenv.mkDerivation rec {
   pname = "asc";
-  version = "2.6.0.0";
+  version = "2.6.3.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/asc-hq/asc-${version}.tar.bz2";
-    sha256 = "1fybasb6srqfg6pqbvh0s0vvzjq9r0n6aq0z44hs7n68kmaam775";
+  src = fetchFromGitHub {
+    owner = "ValHaris";
+    repo = "asc-hq";
+    rev = "fa3bca082a5cea2b35812349f99b877f0113aef0";
+    sha256 = "atamYCN2mOqxV6auToTeWdpKuFfC+GLfLdRsfT0ouwQ=";
   };
-
-  configureFlags = [ "--disable-paragui" "--disable-paraguitest" ];
-
-  NIX_CFLAGS_COMPILE = "-fpermissive -Wno-error=narrowing -std=c++11"; # I'm too lazy to catch all gcc47-related problems
-  hardeningDisable = [ "format" ];
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
-    SDL SDL_image SDL_mixer SDL_sound libsigcxx physfs boost expat
-    freetype libjpeg wxGTK32 lua perl zlib zip bzip2 libpng
-    libtiff fluidsynth libmikmod flac libvorbis libogg
+    SDL
+    SDL_image
+    SDL_mixer
+    SDL_sound
+    physfs
+    boost
+    expat
+    freetype
+    libjpeg
+    wxGTK32
+    lua
+    perl
+    zlib
+    zip
+    bzip2
+    libpng
+    libtiff
+    fluidsynth
+    libmikmod
+    flac
+    libvorbis
+    libogg
+    libsigcxx
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33961,7 +33961,6 @@ with pkgs;
 
   asc = callPackage ../games/asc {
     lua = lua5_1;
-    libsigcxx = libsigcxx12;
     physfs = physfs_2;
   };
 


### PR DESCRIPTION
- Fixed the build for ZHF (https://github.com/NixOS/nixpkgs/issues/199919) at #ZurichZHF :)
- Updated to new source repository which users newer libraries

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
