### PR TITLE
d2-lang: init at 0.0.13

### DIFF
--- a/pkgs/tools/graphics/d2-lang/default.nix
+++ b/pkgs/tools/graphics/d2-lang/default.nix
@@ -1,0 +1,31 @@
+{ fetchFromGitHub
+, buildGoModule
+, git
+, lib
+}:
+buildGoModule rec {
+  pname = "d2-lang";
+  version = "v0.0.13";
+
+  vendorHash = "sha256-/BEl4UqOL4Ux7I2eubNH2YGGl4DxntpI5WN9ggvYu80=";
+  nativeBuildInputs = [ git ];
+  postInstall = "rm $out/bin/{report,d2plugin-dagre}";
+
+  patches = [ ./omit-host-fix.patch ];
+  src = fetchFromGitHub {
+    owner = "terrastruct";
+    repo = "d2";
+    rev = version;
+    hash = "sha256-2abGQmgwqxWFk7NScdgfEjRYZF2rw8kxTKRwcl2LRg0=";
+  };
+
+  meta = {
+    license = lib.licenses.mpl20;
+    homepage = "https://d2lang.com";
+    description = "Declarative diagramming tool";
+    longDescription = ''
+      D2 is a domain-specific language (DSL) that stands for Declarative Diagramming.
+      Declarative, as in, you describe what you want diagrammed, it generates the image.
+      '';
+  };
+}

--- a/pkgs/tools/graphics/d2-lang/omit-host-fix.patch
+++ b/pkgs/tools/graphics/d2-lang/omit-host-fix.patch
@@ -1,0 +1,164 @@
+diff --git a/e2etests/testdata/stable/images/dagre/board.exp.json b/e2etests/testdata/stable/images/dagre/board.exp.json
+index e56ad31..7ab6a06 100644
+--- a/e2etests/testdata/stable/images/dagre/board.exp.json
++++ b/e2etests/testdata/stable/images/dagre/board.exp.json
+@@ -29,6 +29,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/004-picture.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+@@ -78,6 +79,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/004-picture.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+diff --git a/e2etests/testdata/stable/images/elk/board.exp.json b/e2etests/testdata/stable/images/elk/board.exp.json
+index 17b1d23..4b04423 100644
+--- a/e2etests/testdata/stable/images/elk/board.exp.json
++++ b/e2etests/testdata/stable/images/elk/board.exp.json
+@@ -29,6 +29,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/004-picture.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+@@ -78,6 +79,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/004-picture.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+diff --git a/e2etests/testdata/stable/investigate/dagre/board.exp.json b/e2etests/testdata/stable/investigate/dagre/board.exp.json
+index 4c21655..6b23797 100644
+--- a/e2etests/testdata/stable/investigate/dagre/board.exp.json
++++ b/e2etests/testdata/stable/investigate/dagre/board.exp.json
+@@ -447,6 +447,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/time.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+@@ -534,6 +535,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/time.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+diff --git a/e2etests/testdata/stable/investigate/elk/board.exp.json b/e2etests/testdata/stable/investigate/elk/board.exp.json
+index 143daff..f7acfe6 100644
+--- a/e2etests/testdata/stable/investigate/elk/board.exp.json
++++ b/e2etests/testdata/stable/investigate/elk/board.exp.json
+@@ -447,6 +447,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/time.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+@@ -534,6 +535,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/time.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+diff --git a/testdata/d2compiler/TestCompile/basic_icon.exp.json b/testdata/d2compiler/TestCompile/basic_icon.exp.json
+index 400adef..5e91150 100644
+--- a/testdata/d2compiler/TestCompile/basic_icon.exp.json
++++ b/testdata/d2compiler/TestCompile/basic_icon.exp.json
+@@ -133,6 +133,7 @@
+             "Host": "icons.terrastruct.com",
+             "Path": "/essentials/004-picture.svg",
+             "RawPath": "",
++            "OmitHost": false,
+             "ForceQuery": false,
+             "RawQuery": "",
+             "Fragment": "",
+diff --git a/testdata/d2compiler/TestCompile/image_dimensions.exp.json b/testdata/d2compiler/TestCompile/image_dimensions.exp.json
+index 941ac98..7b54080 100644
+--- a/testdata/d2compiler/TestCompile/image_dimensions.exp.json
++++ b/testdata/d2compiler/TestCompile/image_dimensions.exp.json
+@@ -230,6 +230,7 @@
+             "Host": "icons.terrastruct.com",
+             "Path": "/essentials/004-picture.svg",
+             "RawPath": "",
++            "OmitHost": false,
+             "ForceQuery": false,
+             "RawQuery": "",
+             "Fragment": "",
+diff --git a/testdata/d2compiler/TestCompile/image_style.exp.json b/testdata/d2compiler/TestCompile/image_style.exp.json
+index 560a8af..61149d1 100644
+--- a/testdata/d2compiler/TestCompile/image_style.exp.json
++++ b/testdata/d2compiler/TestCompile/image_style.exp.json
+@@ -214,6 +214,7 @@
+             "Host": "icons.terrastruct.com",
+             "Path": "/essentials/004-picture.svg",
+             "RawPath": "",
++            "OmitHost": false,
+             "ForceQuery": false,
+             "RawQuery": "",
+             "Fragment": "",
+diff --git a/testdata/d2compiler/TestCompile/reserved_icon_near_style.exp.json b/testdata/d2compiler/TestCompile/reserved_icon_near_style.exp.json
+index f680476..766377c 100644
+--- a/testdata/d2compiler/TestCompile/reserved_icon_near_style.exp.json
++++ b/testdata/d2compiler/TestCompile/reserved_icon_near_style.exp.json
+@@ -364,6 +364,7 @@
+             "Host": "",
+             "Path": "orange",
+             "RawPath": "",
++            "OmitHost": false,
+             "ForceQuery": false,
+             "RawQuery": "",
+             "Fragment": "",
+diff --git a/testdata/d2exporter/TestExport/shape/image_dimensions.exp.json b/testdata/d2exporter/TestExport/shape/image_dimensions.exp.json
+index cc127dd..7b70bf1 100644
+--- a/testdata/d2exporter/TestExport/shape/image_dimensions.exp.json
++++ b/testdata/d2exporter/TestExport/shape/image_dimensions.exp.json
+@@ -29,6 +29,7 @@
+         "Host": "icons.terrastruct.com",
+         "Path": "/essentials/004-picture.svg",
+         "RawPath": "",
++        "OmitHost": false,
+         "ForceQuery": false,
+         "RawQuery": "",
+         "Fragment": "",
+diff --git a/testdata/d2oracle/TestMove/slice_style.exp.json b/testdata/d2oracle/TestMove/slice_style.exp.json
+index ffeedab..0bc79cd 100644
+--- a/testdata/d2oracle/TestMove/slice_style.exp.json
++++ b/testdata/d2oracle/TestMove/slice_style.exp.json
+@@ -227,6 +227,7 @@
+             "Host": "icons.terrastruct.com",
+             "Path": "/essentials/142-target.svg",
+             "RawPath": "",
++            "OmitHost": false,
+             "ForceQuery": false,
+             "RawQuery": "",
+             "Fragment": "",
+diff --git a/testdata/d2oracle/TestSet/icon.exp.json b/testdata/d2oracle/TestSet/icon.exp.json
+index 675c038..c1aa30e 100644
+--- a/testdata/d2oracle/TestSet/icon.exp.json
++++ b/testdata/d2oracle/TestSet/icon.exp.json
+@@ -128,6 +128,7 @@
+             "Host": "icons.terrastruct.com",
+             "Path": "/essentials/087-menu.svg",
+             "RawPath": "",
++            "OmitHost": false,
+             "ForceQuery": false,
+             "RawQuery": "",
+             "Fragment": "",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6349,6 +6349,8 @@ with pkgs;
 
   conform = callPackage ../applications/version-management/git-and-tools/conform { };
 
+  d2-lang = callPackage ../tools/graphics/d2-lang {};
+
   easeprobe = callPackage ../tools/misc/easeprobe { };
 
   emscripten = callPackage ../development/compilers/emscripten {


### PR DESCRIPTION
###### Description of changes

Added [D2](https://d2lang.com).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
