### PR TITLE
shells/zsh: add zsh-histdb 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12719,6 +12719,13 @@
     githubId = 4294323;
     name = "Langston Barrett";
   };
+  sielicki = {
+    name = "Nicholas Sielicki";
+    email = "nix@opensource.nslick.com";
+    github = "sielicki";
+    githubId = 4522995;
+    matrix = "@sielicki:matrix.org";
+  };
   siers = {
     email = "veinbahs+nixpkgs@gmail.com";
     github = "siers";

--- a/pkgs/shells/zsh/zsh-histdb-fzf/default.nix
+++ b/pkgs/shells/zsh/zsh-histdb-fzf/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, fzf, zsh-histdb }:
+
+stdenv.mkDerivation rec {
+  pname = "zsh-histdb-fzf";
+  version = src.rev;
+
+  src = fetchFromGitHub {
+    owner = "m42e";
+    repo = pname;
+    rev = "055523a798acf02a67e242b3281d917f5ee4309a";
+    sha256 = "sha256-5R6XImDVswD/vTWQRtL28XHNzqurUeukfLevQeMDpuY=";
+  };
+
+  strictDeps = true;
+  dontBuild = true;
+
+  buildInputs = [ fzf zsh-histdb ];
+
+  installPhase = ''
+    install -D -t $out/share/zsh/plugins/fzf-histdb/ fzf-histdb.zsh
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/m42e/zsh-histdb-fzf";
+    license = licenses.mit;
+    description = "uses fzf for searching the history kept with zsh-histdb.";
+    maintainers = with maintainers; [ sielicki ];
+  };
+}

--- a/pkgs/shells/zsh/zsh-histdb-skim/default.nix
+++ b/pkgs/shells/zsh/zsh-histdb-skim/default.nix
@@ -1,0 +1,31 @@
+{ lib, rustPlatform, fetchFromGitHub, sqlite, pkgconfig, makeWrapper }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "zsh-histdb-skim";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "m42e";
+    repo = pname;
+    rev = "f00f63f13f69c5d05daf9b9a059b55aa521a53fe";
+    sha256 = "sha256-PF8BxFEyNIe8zTO1CyGjNI8T9RyQ1e53ZlK+/LkOkKM=";
+  };
+  cargoSha256 = "sha256-a5a0JdVVkWrMw3F9mpgkj2US3mS9YHzpdkjgMlep9xw=";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ sqlite ];
+
+  postInstall = ''
+    # use the vendored zsh script which doesn't support autoupdating; don't
+    # install the one capable of autoupdates.
+    install -D zsh-histdb-skim-vendored.zsh $out/share/zsh/plugins/zsh-histdb-skim/zsh-histdb-skim.zsh
+    chmod +x $out/share/zsh/plugins/zsh-histdb-skim/zsh-histdb-skim.zsh
+  '';
+
+  meta = with lib; {
+    description = "A zsh histdb browser using skim.";
+    homepage = "https://github.com/m42e/zsh-histdb-skim";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sielicki ];
+  };
+}

--- a/pkgs/shells/zsh/zsh-histdb/default.nix
+++ b/pkgs/shells/zsh/zsh-histdb/default.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, fetchFromGitHub, sqlite, coreutils }:
+
+stdenv.mkDerivation rec {
+  pname = "zsh-histdb";
+  version = src.rev;
+
+  src = fetchFromGitHub {
+    owner = "larkery";
+    repo = pname;
+    rev = "30797f0c50c31c8d8de32386970c5d480e5ab35d";
+    sha256 = "sha256-PQIFF8kz+baqmZWiSr+wc4EleZ/KD8Y+lxW2NT35/bg=";
+  };
+
+  strictDeps = true;
+  dontBuild = true;
+
+  # nativeBuildInputs
+  buildInputs = [ sqlite coreutils ];
+
+  installPhase = ''
+    # core plugin zsh functions
+    install -D -t $out/share/zsh/plugins/histdb/ \
+       zsh-histdb.plugin.zsh \
+       sqlite-history.zsh \
+       histdb-interactive.zsh \
+       histdb-migrate \
+       histdb-merge
+
+    # Migrations -- may grow in the future.
+    install -D -t $out/share/zsh/plugins/histdb/db_migrations/ \
+      db_migrations/0to2.sql
+
+    patchShebangs $out/share/zsh/plugins/histdb/histdb-migrate
+    patchShebangs $out/share/zsh/plugins/histdb/histdb-merge
+    substituteInPlace $out/share/zsh/plugins/histdb/histdb-merge \
+        --replace sqlite3 /bin/sqlite3
+    substituteInPlace $out/share/zsh/plugins/histdb/histdb-migrate \
+        --replace sqlite3 /bin/sqlite3
+
+    mkdir -p $out/bin/
+    ln -s $out/share/zsh/plugins/histdb/histdb-migrate $out/bin/histdb-migrate
+    ln -s $out/share/zsh/plugins/histdb/histdb-merge   $out/bin/histdb-merge
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/larkery/zsh-histdb";
+    license = licenses.mit;
+    description = "a small bit of zsh code that stores your history into a sqlite3 database.";
+    maintainers = with maintainers; [ sielicki ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13260,6 +13260,10 @@ with pkgs;
 
   zsh-git-prompt = callPackage ../shells/zsh/zsh-git-prompt { };
 
+  zsh-histdb = callPackage ../shells/zsh/zsh-histdb { };
+  zsh-histdb-fzf = callPackage ../shells/zsh/zsh-histdb-fzf { };
+  zsh-histdb-skim = callPackage ../shells/zsh/zsh-histdb-skim { };
+
   zsh-history = callPackage ../shells/zsh/zsh-history { };
 
   zsh-history-search-multi-word = callPackage ../shells/zsh/zsh-history-search-multi-word { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).