### PR TITLE
s2geometry: 0.9.0 → 0.11.1, enable on darwin

### DIFF
--- a/pkgs/applications/misc/pure-maps/default.nix
+++ b/pkgs/applications/misc/pure-maps/default.nix
@@ -1,6 +1,6 @@
-{ lib, mkDerivation, fetchFromGitHub
+{ lib, mkDerivation, fetchFromGitHub, fetchpatch
 , cmake, qttools, kirigami2, qtquickcontrols2, qtlocation, qtsensors
-, nemo-qml-plugin-dbus, mapbox-gl-qml, s2geometry
+, nemo-qml-plugin-dbus, mapbox-gl-qml, s2geometry, abseil-cpp
 , python3, pyotherside
 }:
 
@@ -16,6 +16,14 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Fix build failure with s2geometry 0.11.1
+    (fetchpatch {
+      url = "https://github.com/rinigus/pure-maps/commit/9f1e3124cf876ca5ab26d717a34e8d925834b044.patch";
+      hash = "sha256-N2FxxJ9qFTRi2cGXl85IySrmc9p6fR3ak9J9QsVzprQ=";
+    })
+  ];
+
   nativeBuildInputs = [
     cmake python3 qttools python3.pkgs.wrapPython
   ];
@@ -23,9 +31,10 @@ mkDerivation rec {
   buildInputs = [
     kirigami2 qtquickcontrols2 qtlocation qtsensors
     nemo-qml-plugin-dbus pyotherside mapbox-gl-qml s2geometry
+    (abseil-cpp.override { cxxStandard = "14"; })
   ];
 
-  cmakeFlags = [ "-DFLAVOR=kirigami" ];
+  cmakeFlags = [ "-DFLAVOR=kirigami" "-DCMAKE_CXX_STANDARD=14" ];
 
   pythonPath = with python3.pkgs; [ gpxpy ];
 

--- a/pkgs/development/libraries/s2geometry/default.nix
+++ b/pkgs/development/libraries/s2geometry/default.nix
@@ -1,38 +1,29 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, pkg-config, openssl, gtest }:
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, openssl, gtest, abseil-cpp }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "s2geometry";
-  version = "0.9.0";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "s2geometry";
-    rev = "v${version}";
-    sha256 = "1mx61bnn2f6bd281qlhn667q6yfg1pxzd2js88l5wpkqlfzzhfaz";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-VjgGcGgQlKmjUq+JU0JpyhOZ9pqwPcBUFEPGV9XoHc0=";
   };
-
-  patches = [
-    # Fix build https://github.com/google/s2geometry/issues/165
-    (fetchpatch {
-      url = "https://github.com/google/s2geometry/commit/a4dddf40647c68cd0104eafc31e9c8fb247a6308.patch";
-      sha256 = "0fp3w4bg7pgf5vv4vacp9g06rbqzhxc2fg6i5appp93q6phiinvi";
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ openssl gtest ];
+  buildInputs = [ openssl gtest (abseil-cpp.override { cxxStandard = "14"; }) ];
 
-  # Default of C++11 is too low for gtest.
-  # In newer versions of s2geometry this can be done with cmakeFlags.
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace "CMAKE_CXX_STANDARD 11" "CMAKE_CXX_STANDARD 14"
-  '';
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeFeature "GOOGLETEST_ROOT" "${gtest.src}")
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "Computational geometry and spatial indexing on the sphere";
     homepage = "http://s2geometry.io/";
-    license = licenses.asl20;
-    maintainers = [ maintainers.Thra11 ];
-    platforms = platforms.linux;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ Thra11 ];
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32704,7 +32704,9 @@ with pkgs;
 
   puremapping = callPackage ../applications/audio/pd-plugins/puremapping { };
 
-  pure-maps = libsForQt5.callPackage ../applications/misc/pure-maps { };
+  pure-maps = libsForQt5.callPackage ../applications/misc/pure-maps {
+    abseil-cpp = abseil-cpp_202401;
+  };
 
   pwdsafety = callPackage ../tools/security/pwdsafety { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23393,7 +23393,9 @@ with pkgs;
 
   rustc-demangle = callPackage ../development/libraries/rustc-demangle { };
 
-  s2geometry = callPackage ../development/libraries/s2geometry { };
+  s2geometry = callPackage ../development/libraries/s2geometry {
+    abseil-cpp = abseil-cpp_202401;
+  };
 
   safefile = callPackage ../development/libraries/safefile { };
 


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/google/s2geometry/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
