### PR TITLE
tts: migrate to torch source builds; torchaudio: init at 0.13.0

### DIFF
--- a/pkgs/development/libraries/openfst/default.nix
+++ b/pkgs/development/libraries/openfst/default.nix
@@ -6,8 +6,13 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.openfst.org/twiki/pub/FST/FstDownload/${pname}-${version}.tar.gz";
-    sha256 = "sha256-3ph782JHIcXVujIa+VdRiY5PS7Qcijbi1k8GJ2Vti0I=";
+    hash = "sha256-3ph782JHIcXVujIa+VdRiY5PS7Qcijbi1k8GJ2Vti0I=";
   };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   configureFlags = [
     "--enable-compact-fsts"

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -1,0 +1,121 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+
+# build
+, cmake
+, ninja
+, pkg-config
+
+# runtime
+, boost
+, lame
+, libogg
+, libvorbis
+, flac
+, kaldi
+, libopus
+, openfst
+, opusfile
+, bzip2
+, opencore-amr
+, sox
+, xz
+, zlib
+
+# kaldi build
+, openblas
+, icu
+
+# propagates
+, torch
+, pybind11
+
+# tests
+}:
+
+let
+  pname = "torchaudio";
+  version = "0.13.0";
+in
+
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "audio";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-66WwbxLGvJ1hEuEUKgpxGIniFAGy7nugrMd5WzIZ5/I=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/use-system-libs.diff?h=python-torchaudio";
+      hash = "sha256-am1Un/y54/pH+JDxedvkHZWy7ThvTlMVsGlVZwWSgL0=";
+    })
+  ];
+
+  postPatch = ''
+    (cd third_party/kaldi/submodule && patch -p1 < ../kaldi.patch)
+
+    for dep in sox bzip2 lzma zlib; do
+      echo "add_library($dep INTERFACE)" > third_party/$dep/CMakeLists.txt
+    done
+
+    sed -i '/_fetch_third_party_libraries()$/d' setup.py
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    pybind11
+  ];
+
+  preConfigure = ''
+    export cmakeBuilDir=$(pwd)
+  '';
+
+  cmakeFlags = [
+    "-DKALDI_INCLUDE_DIRS=${lib.getDev kaldi}/include"
+  ];
+
+
+  buildInputs = [
+    boost
+    bzip2
+    lame
+    libogg
+    flac
+    libvorbis
+    libopus
+    openfst
+    opusfile
+    opencore-amr
+    pybind11
+    torch
+    sox
+    xz
+    zlib
+  ];
+
+  preBuild = ''
+    cd ..
+  '';
+
+  propagatedBuildInputs = [
+    torch
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/pytorch/audio/releases/tag/v${version}";
+    description = "Data manipulation and transformation for audio signal processing, powered by PyTorch";
+    homepage = "https://github.com/pytorch/audio";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/trainer/default.nix
+++ b/pkgs/development/python-modules/trainer/default.nix
@@ -6,13 +6,13 @@
 
 , coqpit
 , fsspec
-, torch-bin
+, soundfile
+, torch
 , tensorboardx
 , protobuf
 
 , pytestCheckHook
-, soundfile
-, torchvision-bin
+, torchvision
 }:
 
 let
@@ -37,18 +37,21 @@ buildPythonPackage {
   propagatedBuildInputs = [
     coqpit
     fsspec
-    torch-bin
+    torch
     soundfile
     tensorboardx
     protobuf
   ];
 
-  # only one test and that requires training data from the internet
-  doCheck = false;
-
   checkInputs = [
     pytestCheckHook
-    torchvision-bin
+    torchvision
+  ];
+
+  disabledTests = [
+    # tries to download training data
+    "test_train_mnist"
+    "test_continue_train"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -88,8 +88,8 @@ python.pkgs.buildPythonApplication rec {
     scipy
     soundfile
     tensorflow
-    torch-bin
-    torchaudio-bin
+    torch
+    torchaudio
     tqdm
     trainer
     umap-learn

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11292,6 +11292,8 @@ self: super: with self; {
 
   torch-tb-profiler = callPackage ../development/python-modules/torch-tb-profiler/default.nix { };
 
+  torchaudio = callPackage ../development/python-modules/torchaudio/default.nix { };
+
   torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix { };
 
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };


### PR DESCRIPTION
###### Description of changes

I'm working on migrating tts and the trainer package away from the binary packages that won't be cached on hydra due to their size.

To that end I'm trying to package up torchaudio.

There are also some other cleanups in there and a cherry-pick of the latest torch bump from #202769 


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
