### PR TITLE
update grafanaPlugins

### DIFF
--- a/pkgs/servers/monitoring/grafana/plugins/doitintl-bigquery-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/doitintl-bigquery-datasource/default.nix
@@ -2,8 +2,8 @@
 
 grafanaPlugin rec {
   pname = "doitintl-bigquery-datasource";
-  version = "2.0.2";
-  zipHash = "sha256-GE6DNuQ5WtS/2VmXbQBeRdVKDbLlLirWXW51i0RF6Cc=";
+  version = "2.0.3";
+  zipHash = "sha256-QxUNRsO1ony+6tVdpwx3P/63XNIdAVIren6hUwChf9E=";
   meta = with lib; {
     description = "BigQuery DataSource for Grafana";
     license = licenses.mit;

--- a/pkgs/servers/monitoring/grafana/plugins/grafadruid-druid-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafadruid-druid-datasource/default.nix
@@ -2,8 +2,8 @@
 
 grafanaPlugin rec {
   pname = "grafadruid-druid-datasource";
-  version = "1.2.0";
-  zipHash = "sha256-DPeyV2jZquSQcSE+HzvxArWEefs9bFNPjZwDFp+dIjg=";
+  version = "1.4.1";
+  zipHash = "sha256-7atxqRqKqop6ABQ+ead6wR/YRpJaV8j/Ri4VB9FXMu8=";
   meta = with lib; {
     description = "Connects Grafana to Druid";
     license = licenses.asl20;

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-clock-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-clock-panel/default.nix
@@ -2,8 +2,8 @@
 
 grafanaPlugin rec {
   pname = "grafana-clock-panel";
-  version = "1.1.3";
-  zipHash = "sha256-80JaMhY/EduSWvFrScfua99DGhT/FJUqY/kl0CafKCs=";
+  version = "2.1.2";
+  zipHash = "sha256-LRlyK0mv5gFNknjc9mDr84NDTIXDzlKV9spQVhZSv+I=";
   meta = with lib; {
     description = "Clock panel for Grafana";
     license = licenses.mit;

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-piechart-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-piechart-panel/default.nix
@@ -2,8 +2,8 @@
 
 grafanaPlugin rec {
   pname = "grafana-piechart-panel";
-  version = "1.6.2";
-  zipHash = "sha256-xKyVT092Ffgzl0BewQw5iZ14I/q6CviUR5t9BVM0bf0=";
+  version = "1.6.4";
+  zipHash = "sha256-bdAl3OmZgSNB+IxxlCb81abR+4dykKkRY3MpQUQyLks=";
   meta = with lib; {
     description = "Pie chart panel for Grafana";
     license = licenses.mit;

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-polystat-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-polystat-panel/default.nix
@@ -2,8 +2,8 @@
 
 grafanaPlugin rec {
   pname = "grafana-polystat-panel";
-  version = "1.2.6";
-  zipHash = "sha256-gbMD2o8A2YYZzkpYiXNkv8Oj958RP47fL6DXj1SBYF0=";
+  version = "2.0.4";
+  zipHash = "sha256-wkf/LK+kcjTbMJzlAg6zRWgEO5LjdDR/oy7/SrNuCXM=";
   meta = with lib; {
     description = "Hexagonal multi-stat panel for Grafana";
     license = licenses.asl20;

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-worldmap-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-worldmap-panel/default.nix
@@ -2,8 +2,8 @@
 
 grafanaPlugin rec {
   pname = "grafana-worldmap-panel";
-  version = "0.3.3";
-  zipHash = "sha256-3n1p3SvcBQMmnbnHimLBP7hauVV1IS3SMwttUWTNvb8=";
+  version = "1.0.3";
+  zipHash = "sha256-xpcQTymxA4d8jRnHm4cHAFOzPT1BseOaX0Qeq5vDvac=";
   meta = with lib; {
     description = "World Map panel for Grafana";
     license = licenses.mit;


### PR DESCRIPTION
###### Description of changes

updates all grafana plugins to their latest version.
The previous versions of the clock-panel and the polystat-panel were broken with grafana 9, and the new versions appear to work fine. The worldmap plugin and the piechart-plugin also work.

I have not nested the grafadruid-druid-datasource or the doitintl-bigquery-datasource plugin.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
