### PR TITLE
[22.05] ntfs3g: Patch arbitrary code execution

### DIFF
--- a/pkgs/tools/filesystems/ntfs-3g/default.nix
+++ b/pkgs/tools/filesystems/ntfs-3g/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config
 , gettext, mount, libuuid, kmod, macfuse-stubs, DiskArbitration
 , crypto ? false, libgcrypt, gnutls
 }:
@@ -28,6 +28,16 @@ stdenv.mkDerivation rec {
     # https://github.com/tuxera/ntfs-3g/pull/39
     ./autoconf-sbin-helpers.patch
     ./consistent-sbindir-usage.patch
+    (fetchpatch {
+      name = "CVE-2022-40284-1.patch";
+      url = "https://github.com/tuxera/ntfs-3g/commit/18bfc676119a1188e8135287b8327b0760ba44a1.patch";
+      hash = "sha256-CxM1kHYqQ1Dbwj0VEUtqEnWrB9aQy/O65FHWtcznwDQ=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-40284-2.patch";
+      url = "https://github.com/tuxera/ntfs-3g/commit/76c3a799a97fbcedeeeca57f598be508ae2a1656.patch";
+      hash = "sha256-riGev/z++VQdFkwdMYfBwJa3F8WR6yGDUf2SIsb1kD4=";
+    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
Fixes: CVE-2022-40284

https://www.openwall.com/lists/oss-security/2022/10/31/2

cc #198862 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
