### PR TITLE
xterm: 375 -> 377

### DIFF
--- a/pkgs/applications/terminal-emulators/xterm/default.nix
+++ b/pkgs/applications/terminal-emulators/xterm/default.nix
@@ -1,17 +1,17 @@
 { lib, stdenv, fetchurl, fetchpatch, xorg, ncurses, freetype, fontconfig
-, pkg-config, makeWrapper, nixosTests, writeScript, common-updater-scripts, git
+, pkg-config, makeWrapper, nixosTests, gitUpdater
 , nixfmt, nix, gnused, coreutils, enableDecLocator ? true }:
 
 stdenv.mkDerivation rec {
   pname = "xterm";
-  version = "375";
+  version = "377";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.invisible-island.net/xterm/${pname}-${version}.tgz"
       "https://invisible-mirror.net/archives/xterm/${pname}-${version}.tgz"
     ];
-    sha256 = "sha256-MCxZor+B55xqcBUl13gWGiGNEjnyFWjYnivdMcAVIX8=";
+    hash = "sha256-2xCP56Rdjtl+YEchtYRDtHNknmHiY2Mb+HWfhhipkLI=";
   };
 
   strictDeps = true;
@@ -81,37 +81,13 @@ stdenv.mkDerivation rec {
       standardTest = nixosTests.terminal-emulators.xterm;
     };
 
-    updateScript = let
-      # Tags that end in letters are unstable
-      suffixes = lib.concatStringsSep " "
-        (map (c: "-c versionsort.suffix='${c}'")
-          (lib.stringToCharacters "abcdefghijklmnopqrstuvwxyz"));
-    in writeScript "update.sh" ''
-      #!${stdenv.shell}
-      set -o errexit
-      PATH=${
-        lib.makeBinPath [
-          common-updater-scripts
-          git
-          nixfmt
-          nix
-          coreutils
-          gnused
-        ]
-      }
-
-      oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"')"
-      latestTag="$(git ${suffixes} ls-remote --exit-code --refs --sort='version:refname' --tags git@github.com:ThomasDickey/xterm-snapshots.git 'xterm-*' | tail --lines=1 | cut --delimiter='/' --fields=3 | sed 's|^xterm-||g')"
-
-      if [ ! "$oldVersion" = "$latestTag" ]; then
-        update-source-version ${pname} "$latestTag" --version-key=version --print-changes
-        nixpkgs="$(git rev-parse --show-toplevel)"
-        default_nix="$nixpkgs/pkgs/applications/terminal-emulators/xterm/default.nix"
-        nixfmt "$default_nix"
-      else
-        echo "${pname} is already up-to-date"
-      fi
-    '';
+    updateScript = gitUpdater {
+      # No nicer place to find latest release.
+      url = "https://github.com/ThomasDickey/xterm-snapshots.git";
+      rev-prefix = "xterm-";
+      # # Tags that end in letters are unstable
+      ignoredVersions = "[a-z]$";
+    };
   };
 
   meta = {


### PR DESCRIPTION
While at it simplified the updater. Current one fails to update xterm.

Changes: https://invisible-island.net/xterm/xterm.log.html#xterm_377

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
