### PR TITLE
python311Packages.cchardet: fix for python 3.11

### DIFF
--- a/pkgs/development/python-modules/cchardet/default.nix
+++ b/pkgs/development/python-modules/cchardet/default.nix
@@ -2,18 +2,23 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
-, python
+, cython
 , nose
 }:
 
 buildPythonPackage rec {
   pname = "cchardet";
   version = "2.1.7";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "c428b6336545053c2589f6caf24ea32276c6664cb86db817e03a94c60afa0eaf";
   };
+
+  nativeBuildInputs = [
+    cython # pending https://github.com/PyYoshi/cChardet/pull/78 being released to PyPI
+  ];
 
   pythonImportsCheck = [
     "cchardet"


### PR DESCRIPTION
The .cpp file released with this package to PyPI was built using an older version of Cython that is incompatible with Python 3.11. This package is not actively maintained, so it's unclear when the fix for this will be merged and released.

In the meantime, we can include a newer version of Cython locally, which will be used instead to regenerate the .cpp file.

Related: https://github.com/PyYoshi/cChardet/issues/81, https://github.com/PyYoshi/cChardet/issues/77, and https://github.com/PyYoshi/cChardet/pull/78

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
