### PR TITLE
snabb: fix build

### DIFF
--- a/pkgs/tools/networking/snabb/default.nix
+++ b/pkgs/tools/networking/snabb/default.nix
@@ -1,51 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, bash, makeWrapper, git, mariadb, diffutils, which, coreutils, procps, nettools
-,supportOpenstack ? true
+{ lib
+, stdenv
+, fetchFromGitHub
 }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   pname = "snabb";
-  version = "2019.11";
+  version = "2022.10";
 
   src = fetchFromGitHub {
     owner = "snabbco";
     repo = "snabb";
     rev = "v${version}";
-    sha256 = "1sas9d9kk92mc2wrwgmm0xxz7ycmh388dwvyxf1hy183yvin1nac";
+    sha256 = "GIIW+2/1fuHTmYev/QvuO5Yb2ozbyw/45qQkym36US8=";
   };
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-truncation" ];
-
-  patchPhase = ''
-    patchShebangs .
-
-    # some hardcodeism
-    for f in $(find src/program/snabbnfv/ -type f); do
-      substituteInPlace $f --replace "/bin/bash" "${bash}/bin/bash"
-    done
-  '' + optionalString supportOpenstack ''
-    # We need a way to pass $PATH to the scripts
-    sed -i '2iexport PATH=${git}/bin:${mariadb}/bin:${which}/bin:${procps}/bin:${coreutils}/bin' src/program/snabbnfv/neutron_sync_master/neutron_sync_master.sh.inc
-    sed -i '2iexport PATH=${git}/bin:${coreutils}/bin:${diffutils}/bin:${nettools}/bin' src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.sh.inc
-  '';
-
-  preBuild = ''
-    make clean
-  '';
 
   installPhase = ''
     mkdir -p $out/bin
     cp src/snabb $out/bin
   '';
 
-  # Dependencies are underspecified: "make -C src obj/arch/sse2_c.o" fails with
-  # "Fatal error: can't create obj/arch/sse2_c.o: No such file or directory".
-  enableParallelBuilding = false;
-
-  meta =  {
+  meta = {
     homepage = "https://github.com/SnabbCo/snabbswitch";
     description = "Simple and fast packet networking toolkit";
     longDescription = ''


### PR DESCRIPTION
###### Description of changes

- Fixed the build for ZHF (https://github.com/NixOS/nixpkgs/issues/199919) at #ZurichZHF :)
- Version bump from 2019.11 to 2022.10
- Remove prePatch substitutions as these were causing build failure 
- More cleanups to nix file based on feedback from @lukego @risicle 
  - removed openstack refs
  - removed parallel build content
  - removed pre build `make clean`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
