### PR TITLE
dockerTools: fixup evaluation without allowed aliases

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -19,7 +19,6 @@
 , pigz
 , rsync
 , runCommand
-, runCommandNoCC
 , runtimeShell
 , shadow
 , skopeo


### PR DESCRIPTION
This is a regression from PR #172736

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
