### PR TITLE
sway: 1.7 -> 1.8

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, substituteAll, swaybg
 , meson, ninja, pkg-config, wayland-scanner, scdoc
-, wayland, libxkbcommon, pcre, json_c, libevdev
+, wayland, libxkbcommon, pcre2, json_c, libevdev
 , pango, cairo, libinput, libcap, pam, gdk-pixbuf, librsvg
-, wlroots, wayland-protocols, libdrm
+, wlroots_0_16, wayland-protocols, libdrm
 , nixosTests
 # Used by the NixOS module:
 , isNixOS ? false
 
-, enableXWayland ? true
+, enableXWayland ? true, xorg
 , systemdSupport ? stdenv.isLinux
 , dbusSupport ? true
 , dbus
@@ -23,13 +23,13 @@ let sd-bus-provider = if systemdSupport then "libsystemd" else "basu"; in
 
 stdenv.mkDerivation rec {
   pname = "sway-unwrapped";
-  version = "1.7";
+  version = "1.8";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
     rev = version;
-    sha256 = "0ss3l258blyf2d0lwd7pi7ga1fxfj8pxhag058k7cmjhs3y30y5l";
+    hash = "sha256-r5qf50YK0Wl0gFiFdSE/J6ZU+D/Cz32u1mKzOqnIuJ0=";
   };
 
   patches = [
@@ -59,12 +59,14 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    wayland libxkbcommon pcre json_c libevdev
+    wayland libxkbcommon pcre2 json_c libevdev
     pango cairo libinput libcap pam gdk-pixbuf librsvg
     wayland-protocols libdrm
-    (wlroots.override { inherit enableXWayland; })
+    (wlroots_0_16.override { inherit enableXWayland; })
   ] ++ lib.optionals dbusSupport [
     dbus
+  ] ++ lib.optionals enableXWayland [
+    xorg.xcbutilwm
   ];
 
   mesonFlags =


### PR DESCRIPTION
https://github.com/swaywm/sway/releases/tag/1.8

https://github.com/swaywm/sway/releases/tag/1.8-rc1
https://github.com/swaywm/sway/releases/tag/1.8-rc2
https://github.com/swaywm/sway/releases/tag/1.8-rc3
https://github.com/swaywm/sway/releases/tag/1.8-rc4

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

TODOs:
- [x] Wait for the final release (obviously)
- [x] Release notes (important changes in the commit message)
- [x] More tests (incl. reverse dependencies)
- [x] `On Linux, CAP_SYS_NICE can be set to improve scheduling: https://github.com/swaywm/sway/pull/6994` -> we might want to support this via the NixOS module -> https://github.com/NixOS/nixpkgs/pull/207842

Notes:
- Original history (before the squash and rebase): https://github.com/primeos/nixpkgs/tree/updates/sway/1.8

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
