### PR TITLE
isync: Fix SSL error "unexpected eof while reading"

### DIFF
--- a/pkgs/tools/networking/isync/default.nix
+++ b/pkgs/tools/networking/isync/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
   patches = [
     # Fixes "Fatal: buffer too small" error
     ./0001-Increase-imap_vprintf-buffer-size.patch
+    # Fix #202595: SSL error "Socket error: ... unexpected eof while reading"
+    # Source: https://sourceforge.net/p/isync/isync/ci/b6c36624f04cd388873785c0631df3f2f9ac4bf0/
+    ./work-around-unexpected-EOF-error-messages-at-end-of-SSL-connections.patch
   ];
 
   nativeBuildInputs = [ pkg-config perl ];

--- a/pkgs/tools/networking/isync/work-around-unexpected-EOF-error-messages-at-end-of-SSL-connections.patch
+++ b/pkgs/tools/networking/isync/work-around-unexpected-EOF-error-messages-at-end-of-SSL-connections.patch
@@ -1,0 +1,76 @@
+From b6c36624f04cd388873785c0631df3f2f9ac4bf0 Mon Sep 17 00:00:00 2001
+From: Oswald Buddenhagen <ossi@users.sf.net>
+Date: Mon, 6 Jun 2022 11:55:37 +0200
+Subject: [PATCH] work around "unexpected EOF" error messages at end of SSL
+ connections
+
+gmail apparently doesn't send a close notification (SSL_shutdown())
+before closing the TCP socket.
+---
+ src/drv_imap.c | 7 +++++--
+ src/socket.c   | 9 +++++++++
+ src/socket.h   | 1 +
+ 3 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/src/drv_imap.c b/src/drv_imap.c
+index fb8d165..6286045 100644
+--- a/src/drv_imap.c
++++ b/src/drv_imap.c
+@@ -1620,6 +1620,7 @@ imap_socket_read( void *aux )
+ 					error( "IMAP error: unexpected BYE response: %s\n", cmd );
+ 					/* We just wait for the server to close the connection now. */
+ 					ctx->expectEOF = 1;
++					socket_expect_eof( &ctx->conn );
+ 				} else {
+ 					/* We still need to wait for the LOGOUT's tagged OK. */
+ 				}
+@@ -1882,10 +1883,12 @@ static void
+ imap_cleanup_p2( imap_store_t *ctx,
+                  imap_cmd_t *cmd ATTR_UNUSED, int response )
+ {
+-	if (response == RESP_NO)
++	if (response == RESP_NO) {
+ 		imap_cancel_store( &ctx->gen );
+-	else if (response == RESP_OK)
++	} else if (response == RESP_OK) {
+ 		ctx->expectEOF = 1;
++		socket_expect_eof( &ctx->conn );
++	}
+ }
+ 
+ /******************* imap_open_store *******************/
+diff --git a/src/socket.c b/src/socket.c
+index ac3c847..892cece 100644
+--- a/src/socket.c
++++ b/src/socket.c
+@@ -810,6 +810,15 @@ socket_expect_activity( conn_t *conn, int expect )
+ 		conf_wakeup( &conn->fd_timeout, expect ? conn->conf->timeout : -1 );
+ }
+ 
++void
++socket_expect_eof( conn_t *sock )
++{
++#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF  // implies HAVE_LIBSSL
++	if (sock->ssl)
++		SSL_set_options( sock->ssl, SSL_OP_IGNORE_UNEXPECTED_EOF );
++#endif
++}
++
+ int
+ socket_read( conn_t *conn, char *buf, uint len )
+ {
+diff --git a/src/socket.h b/src/socket.h
+index 5b1edd0..af679aa 100644
+--- a/src/socket.h
++++ b/src/socket.h
+@@ -142,6 +142,7 @@ void socket_start_tls(conn_t *conn, void (*cb)( int ok, void *aux ) );
+ void socket_start_deflate( conn_t *conn );
+ void socket_close( conn_t *sock );
+ void socket_expect_activity( conn_t *sock, int expect );
++void socket_expect_eof( conn_t *sock );
+ int socket_read( conn_t *sock, char *buf, uint len ); /* never waits */
+ char *socket_read_line( conn_t *sock ); /* don't free return value; never waits */
+ typedef enum { KeepOwn = 0, GiveOwn } ownership_t;
+-- 
+2.38.0
+


### PR DESCRIPTION
This seems to be a regression of the switch to OpenSSL3 and affects at least GMail users:
https://sourceforge.net/p/isync/mailman/isync-devel/thread/Y2kZ0YgS2Goayshn%40ugly/#msg37731849

Fix #202595

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
