### PR TITLE
fail2ban: 0.11.2 -> 1.0.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -95,6 +95,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The EC2 image module previously detected and activated swap-formatted instance store devices and partitions in stage-1 (initramfs). This behaviour has been removed. Users relying on this should provide their own implementation.
 
+- `fail2ban` has been updated to 1.0.2, which has a few breaking changes compared to 0.11.2 ([changelog for 1.0.1](https://github.com/fail2ban/fail2ban/blob/1.0.1/ChangeLog), [changelog for 1.0.2](https://github.com/fail2ban/fail2ban/blob/1.0.2/ChangeLog))
+
 - Calling `makeSetupHook` without passing a `name` argument is deprecated.
 
 - Qt 5.12 and 5.14 have been removed, as the corresponding branches have been EOL upstream for a long time. This affected under 10 packages in nixpkgs, largely unmaintained upstream as well, however, out-of-tree package expressions may need to be updated manually.

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -273,26 +273,16 @@ in
       "fail2ban/filter.d".source = "${cfg.package}/etc/fail2ban/filter.d/*.conf";
     };
 
+    systemd.packages = [ cfg.package ];
     systemd.services.fail2ban = {
-      description = "Fail2ban Intrusion Prevention System";
-
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
       partOf = optional config.networking.firewall.enable "firewall.service";
 
       restartTriggers = [ fail2banConf jailConf pathsConf ];
 
       path = [ cfg.package cfg.packageFirewall pkgs.iproute2 ] ++ cfg.extraPackages;
 
-      unitConfig.Documentation = "man:fail2ban(1)";
-
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/fail2ban-server -xf start";
-        ExecStop = "${cfg.package}/bin/fail2ban-server stop";
-        ExecReload = "${cfg.package}/bin/fail2ban-server reload";
-        Type = "simple";
-        Restart = "on-failure";
-        PIDFile = "/run/fail2ban/fail2ban.pid";
         # Capabilities
         CapabilityBoundingSet = [ "CAP_AUDIT_READ" "CAP_DAC_READ_SEARCH" "CAP_NET_ADMIN" "CAP_NET_RAW" ];
         # Security

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,18 +1,17 @@
 { lib, stdenv, fetchFromGitHub
 , python3
-, fetchpatch
 , installShellFiles
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "fail2ban";
-  version = "0.11.2";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "fail2ban";
     repo = "fail2ban";
     rev = version;
-    sha256 = "q4U9iWCa1zg8sA+6pPNejt6v/41WGIKN5wITJCrCqQE=";
+    hash = "sha256-Zd8zLkFlvXTbeInEkNFyHgcAiOsX4WwF6hf5juSQvbY=";
   };
 
   outputs = [ "out" "man" ];
@@ -25,31 +24,13 @@ python3.pkgs.buildPythonApplication rec {
       pyinotify
     ];
 
-  patches = [
-    # remove references to use_2to3, for setuptools>=58
-    # has been merged into master, remove next release
-    (fetchpatch {
-      url = "https://github.com/fail2ban/fail2ban/commit/5ac303df8a171f748330d4c645ccbf1c2c7f3497.patch";
-      sha256 = "sha256-aozQJHwPcJTe/D/PLQzBk1YH3OAP6Qm7wO7cai5CVYI=";
-    })
-    # fix use of MutableMapping with Python >= 3.10
-    # https://github.com/fail2ban/fail2ban/issues/3142
-    (fetchpatch {
-      url = "https://github.com/fail2ban/fail2ban/commit/294ec73f629d0e29cece3a1eb5dd60b6fccea41f.patch";
-      sha256 = "sha256-Eimm4xjBDYNn5QdTyMqGgT5EXsZdd/txxcWJojXlsFE=";
-    })
-  ];
-
   preConfigure = ''
-    # workaround for setuptools 58+
-    # https://github.com/fail2ban/fail2ban/issues/3098
     patchShebangs fail2ban-2to3
     ./fail2ban-2to3
 
     for i in config/action.d/sendmail*.conf; do
       substituteInPlace $i \
-        --replace /usr/sbin/sendmail sendmail \
-        --replace /usr/bin/whois whois
+        --replace /usr/sbin/sendmail sendmail
     done
 
     substituteInPlace config/filter.d/dovecot.conf \
@@ -65,15 +46,17 @@ python3.pkgs.buildPythonApplication rec {
     ${python3.interpreter} setup.py install_data --install-dir=$out --root=$out
   '';
 
-  postPatch = ''
-    ${stdenv.shell} ./fail2ban-2to3
-  '';
-
   postInstall =
     let
       sitePackages = "$out/${python3.sitePackages}";
     in
     ''
+      install -m 644 -D -t "$out/lib/systemd/system" build/fail2ban.service
+      # Replace binary paths
+      sed -i "s#build/bdist.*/wheel/fail2ban.*/scripts/#$out/bin/#g" $out/lib/systemd/system/fail2ban.service
+      # Delete creating the runtime directory, systemd does that
+      sed -i "/ExecStartPre/d" $out/lib/systemd/system/fail2ban.service
+
       # see https://github.com/NixOS/nixpkgs/issues/4968
       rm -r "${sitePackages}/etc"
 
@@ -88,6 +71,5 @@ python3.pkgs.buildPythonApplication rec {
     description = "A program that scans log files for repeated failing login attempts and bans IP addresses";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ eelco lovek323 ];
-    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

Update to 1.0.2: https://github.com/fail2ban/fail2ban/blob/1.0.2/ChangeLog#ver-102-20221109---finally-war-game-test-tape-not-a-nuclear-alarm 1.0.1 contained a few breaking changes, but I think they have little impact.

I changed the module to use the systemd service shipping with fail2ban (now added to the package).


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
