### PR TITLE
cryptopp: 8.6.0 -> 8.7.0

### DIFF
--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -11,14 +11,14 @@
 
 stdenv.mkDerivation rec {
   pname = "crypto++";
-  version = "8.6.0";
+  version = "8.7.0";
   underscoredVersion = lib.strings.replaceStrings ["."] ["_"] version;
 
   src = fetchFromGitHub {
     owner = "weidai11";
     repo = "cryptopp";
     rev = "CRYPTOPP_${underscoredVersion}";
-    hash = "sha256-a3TYaK34WvKEXN7LKAfGwQ3ZL6a3k/zMZyyVfnkQqO4=";
+    hash = "sha256-KtZXW7+J9a4uKHnK8sqj5WVaIjG3d6tzBBDxa7Wv4AE=";
   };
 
   outputs = [ "out" "dev" ];
@@ -49,11 +49,6 @@ stdenv.mkDerivation rec {
 
   installTargets = [ "install-lib" ];
   installFlags = [ "LDCONF=true" ];
-  # TODO: remove postInstall hook with v8.7 -> https://github.com/weidai11/cryptopp/commit/230c558a
-  postInstall = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    ln -sr $out/lib/libcryptopp.so.${version} $out/lib/libcryptopp.so.${lib.versions.majorMinor version}
-    ln -sr $out/lib/libcryptopp.so.${version} $out/lib/libcryptopp.so.${lib.versions.major version}
-  '';
 
   meta = with lib; {
     description = "A free C++ class library of cryptographic schemes";


### PR DESCRIPTION
###### Description of changes

https://github.com/weidai11/cryptopp/releases/tag/CRYPTOPP_8_7_0

Note there is a bogus CVE ID assigned to versions <= 8.6.0 (CVE-2021-43398).
See upstream discussion for more information https://github.com/weidai11/cryptopp/issues/1080
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>postgis</li>
    <li>python310Packages.worldengine</li>
    <li>python39Packages.worldengine</li>
    <li>rockbox_utility</li>
  </ul>
</details>
<details>
  <summary>9 packages failed to build:</summary>
  <ul>
    <li>apacheHttpdPackages.mod_tile</li>
    <li>mysql-workbench</li>
    <li>perl534Packages.Tirex</li>
    <li>perl536Packages.Tirex</li>
    <li>python310Packages.cartopy</li>
    <li>python310Packages.rlax</li>
    <li>python39Packages.cartopy</li>
    <li>python39Packages.rlax</li>
    <li>t-rex</li>
  </ul>
</details>
<details>
  <summary>55 packages built:</summary>
  <ul>
    <li>amule</li>
    <li>amule-daemon</li>
    <li>amule-gui</li>
    <li>amule-web</li>
    <li>cie-middleware-linux</li>
    <li>cloudcompare</li>
    <li>cryptopp</li>
    <li>entwine</li>
    <li>gdal (python310Packages.gdal)</li>
    <li>gmt</li>
    <li>gplates</li>
    <li>grass</li>
    <li>libLAS</li>
    <li>mapcache</li>
    <li>mapnik</li>
    <li>mapproxy</li>
    <li>mapserver</li>
    <li>megacmd</li>
    <li>megasync</li>
    <li>merkaartor</li>
    <li>openorienteering-mapper</li>
    <li>paraview</li>
    <li>pdal</li>
    <li>postgresql11Packages.postgis</li>
    <li>postgresql12Packages.postgis</li>
    <li>postgresql13Packages.postgis</li>
    <li>postgresql14Packages.postgis</li>
    <li>postgresql15Packages.postgis</li>
    <li>python310Packages.asf-search</li>
    <li>python310Packages.bsuite</li>
    <li>python310Packages.fiona</li>
    <li>python310Packages.geopandas</li>
    <li>python310Packages.osmnx</li>
    <li>python310Packages.plotnine</li>
    <li>python310Packages.pygmt</li>
    <li>python310Packages.python-mapnik</li>
    <li>python310Packages.rasterio</li>
    <li>python310Packages.wktutils</li>
    <li>python39Packages.asf-search</li>
    <li>python39Packages.bsuite</li>
    <li>python39Packages.fiona</li>
    <li>python39Packages.gdal</li>
    <li>python39Packages.geopandas</li>
    <li>python39Packages.osmnx</li>
    <li>python39Packages.plotnine</li>
    <li>python39Packages.pygmt</li>
    <li>python39Packages.python-mapnik</li>
    <li>python39Packages.rasterio</li>
    <li>python39Packages.wktutils</li>
    <li>pytrainer</li>
    <li>qmapshack</li>
    <li>rockbox-utility</li>
    <li>saga</li>
    <li>sumo</li>
    <li>udig</li>
  </ul>
</details>
It seems there is no new failures.