### PR TITLE
boinc: Make xss optional

### DIFF
--- a/pkgs/applications/science/misc/boinc/default.nix
+++ b/pkgs/applications/science/misc/boinc/default.nix
@@ -23,6 +23,7 @@
 , libX11
 , libxcb
 , headless ? false
+, xssIdleDetection ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -52,12 +53,11 @@ stdenv.mkDerivation rec {
     libjpeg
     wxGTK32
     gtk3
-    libXScrnSaver
     libnotify
     libX11
     libxcb
     xcbutil
-  ];
+  ] ++ lib.optional xssIdleDetection libXScrnSaver;
 
   NIX_LDFLAGS = lib.optionalString (!headless) "-lX11";
 


### PR DESCRIPTION
###### Description of changes

Relevant: https://github.com/BOINC/boinc/issues/2256

BOINC tries to use libXScrnSaver to check if the system is idle. If not properly set up, this will print a line to the log every second. If you're not intending to use screensaver idle detection anyway, you can work around this log spam by just removing the library dependency, which will be detected by the configure script, dropping the relevant code.

I did not:
- check whether any other dependencies are optional
- look too much into whether the log line spam is only on my system or a general problem with the way this package sets up boinc

I am using this version of the package (via `services.boinc.package = pkgs.callPackage ./boinc { screensaverIdleDetection = false; };`) on my own system, and can confirm it does tasks and doesn't spam the log.

Since I'm already using a local copy of this package, I don't think it affects me much whether it is backported or not, but it seems eligible to me?

I believe this package doesn't have any tests, and no other packages depend on it. Nevertheless I ran the `nixpkgs-review` thing and tried invoking each binary with `--help`. They all seemed able to run, though I don't know how to use `boincscr` or `switcher` so I'm not sure what them working looks like.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).