### PR TITLE
swaylock: 1.6 -> 1.7

### DIFF
--- a/pkgs/applications/window-managers/sway/lock.nix
+++ b/pkgs/applications/window-managers/sway/lock.nix
@@ -5,23 +5,14 @@
 
 stdenv.mkDerivation rec {
   pname = "swaylock";
-  version = "1.6";
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "swaylock";
     rev = version;
-    sha256 = "sha256-VVGgidmSQWKxZNx9Cd6z52apxpxVfmX3Ut/G9kzfDcY=";
+    hash = "sha256-xbcVsnE0DecC+g49NOBNpqPl5JTtuxUUc7KinKhi5TE=";
   };
-
-  patches = [
-    # remove once when updating to 1.7
-    # https://github.com/swaywm/swaylock/pull/235
-    (fetchpatch {
-      url = "https://github.com/swaywm/swaylock/commit/5a1e6ad79aa7d79b32d36cda39400f3e889b8f8f.diff";
-      sha256 = "sha256-ZcZVImUzvng7sluC6q2B5UL8sVunLe4PIfc+tyw48RQ=";
-    })
-  ];
 
   strictDeps = true;
   depsBuildBuild = [ pkg-config ];


### PR DESCRIPTION
###### Description of changes

Changelog and release: https://github.com/swaywm/swaylock/releases/tag/1.7

###### Things done

Tested running it.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
