### PR TITLE
Fix hotpatch: skip tests that assume .so files presence at hardcoded paths

### DIFF
--- a/pkgs/development/libraries/hotpatch/default.nix
+++ b/pkgs/development/libraries/hotpatch/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     LD_LIBRARY_PATH=$(pwd)/src make test
   '';
 
+  patches = [ ./no-loader-test.patch ];
+
   meta = with lib; {
     description = "Hot patching executables on Linux using .so file injection";
     homepage = src.meta.homepage;

--- a/pkgs/development/libraries/hotpatch/no-loader-test.patch
+++ b/pkgs/development/libraries/hotpatch/no-loader-test.patch
@@ -1,0 +1,25 @@
+diff --git a/test/loader.c b/test/loader.c
+index 4e3dfdc..7f98d94 100644
+--- a/test/loader.c
++++ b/test/loader.c
+@@ -54,20 +54,6 @@ int main(int argc, char **argv)
+ 	assert(ret < 0);
+ 	ret = ld_find_library(maps, mapnum, "libc", false, NULL, 6);
+ 	assert(ret >= 0);
+-#if __WORDSIZE == 64
+-	ret = ld_find_library(maps, mapnum, "/lib64/ld-linux-x86-64.so.2",
+-						  true, NULL, 6);
+-	assert(ret >= 0);
+-	ret = ld_find_library(maps, mapnum, "/lib/ld-linux-x86-64.so.2",
+-						  false, NULL, 6);
+-#else
+-	ret = ld_find_library(maps, mapnum, "/lib/ld-linux.so.2",
+-						  true, NULL, 6);
+-	assert(ret >= 0);
+-	ret = ld_find_library(maps, mapnum, "/lib32/ld-linux.so.2",
+-						  false, NULL, 6);
+-#endif
+-	assert(ret < 0);
+ 	ld_free_maps(maps, mapnum);
+     return 0;
+ }


### PR DESCRIPTION
@balsoft 

###### Description of changes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
