### PR TITLE
patsh: init at 0.1.3

### DIFF
--- a/pkgs/development/tools/misc/patsh/default.nix
+++ b/pkgs/development/tools/misc/patsh/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, runCommand
+, tree-sitter
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "patsh";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-KmQVZwZC7KHlzNnL2IKQ76wHUDNUZKz/aFaY4ujvBo4=";
+  };
+
+  cargoSha256 = "sha256-vozQKBxAVELdqTnqBpgHX0Wyk18EZAtpiRsKjwz8xKE=";
+
+  # tests fail on darwin due to rpath issues
+  doCheck = !stdenv.isDarwin;
+
+  TREE_SITTER_BASH = runCommand "tree-sitter-bash" { } ''
+    mkdir $out
+    ln -s ${tree-sitter.builtGrammars.tree-sitter-bash}/parser $out/libtree-sitter-bash.a
+  '';
+
+  meta = with lib; {
+    description = "A command-line tool for patching shell scripts inspired by resholve";
+    homepage = "https://github.com/nix-community/patsh";
+    changelog = "https://github.com/nix-community/patsh/blob/v${version}/CHANGELOG.md";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/tools/X11/sx/default.nix
+++ b/pkgs/tools/X11/sx/default.nix
@@ -1,12 +1,11 @@
 { lib
-, bash
-, coreutils
+, stdenvNoCC
 , fetchFromGitHub
-, resholve
+, patsh
 , xorg
 }:
 
-resholve.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "sx";
   version = "2.1.7";
 
@@ -19,20 +18,16 @@ resholve.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  solutions = {
-    sx = {
-      scripts = [ "bin/sx" ];
-      interpreter = "${bash}/bin/sh";
-      inputs = [
-        coreutils
-        xorg.xauth
-        xorg.xorgserver
-      ];
-      execer = [
-        "cannot:${xorg.xorgserver}/bin/Xorg"
-      ];
-    };
-  };
+  nativeBuildInputs = [ patsh ];
+
+  buildInputs = [
+    xorg.xauth
+    xorg.xorgserver
+  ];
+
+  postInstall = ''
+    patsh -f $out/bin/sx -s ${builtins.storeDir}
+  '';
 
   meta = with lib; {
     description = "Simple alternative to both xinit and startx for starting a Xorg server";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17550,6 +17550,8 @@ with pkgs;
 
   patchelfUnstable = lowPrio (callPackage ../development/tools/misc/patchelf/unstable.nix { });
 
+  patsh = callPackage ../development/tools/misc/patsh { };
+
   pax-rs = callPackage ../development/tools/pax-rs { };
 
   perfect-hash = callPackage ../development/tools/misc/perfect-hash { };


### PR DESCRIPTION
###### Description of changes

`patsh` is a command-line tool for patching shell scripts inspired by resholve
https://github.com/nix-community/patsh

also see #201859

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
