### PR TITLE
ngrok: 3.0.4 -> 3.1.0

### DIFF
--- a/pkgs/tools/networking/ngrok/versions.json
+++ b/pkgs/tools/networking/ngrok/versions.json
@@ -1,38 +1,38 @@
 {
   "linux-386": {
     "sys": "linux-386",
-    "url": "https://bin.equinox.io/a/fZXabEBxqTt/ngrok-v3-3.0.4-linux-386",
-    "sha256": "94c106392171a537d45ff5db749ce064d721b7c2204c7c951b9e9bfd96fd41f5",
-    "version": "3.0.4"
+    "url": "https://bin.equinox.io/a/26QHEgwoE5Z/ngrok-v3-3.1.0-linux-386",
+    "sha256": "85f1da543cd77021862c757186220c414b849bb25a31c9e8cc280bc843bb3ba6",
+    "version": "3.1.0"
   },
   "linux-amd64": {
     "sys": "linux-amd64",
-    "url": "https://bin.equinox.io/a/fydLsfbG16K/ngrok-v3-3.0.4-linux-amd64",
-    "sha256": "1d93dfcbcf8f1be3a21460022b5644228f9dcc2e71012bd61fcfb39ddf2a7a89",
-    "version": "3.0.4"
+    "url": "https://bin.equinox.io/a/7UAdGDeyg6i/ngrok-v3-3.1.0-linux-amd64",
+    "sha256": "2f6d941d421987daa37fbf3c726d875c9e3ef1c2e26bbf452223d64c0d2b2adb",
+    "version": "3.1.0"
   },
   "linux-arm": {
     "sys": "linux-arm",
-    "url": "https://bin.equinox.io/a/8Fzm6mvbW6H/ngrok-v3-3.0.4-linux-arm",
-    "sha256": "d9bf182808f254bea7f177f7dc814dbfa0f3a5ee2aea18cfabac7975a9c6397e",
-    "version": "3.0.4"
+    "url": "https://bin.equinox.io/a/hAZN7QUBMxw/ngrok-v3-3.1.0-linux-arm",
+    "sha256": "27ace158cadd1e5e5c6e9b2f0652bdf7ab0d4cf39e3d9454fbefcc6c6ec03d56",
+    "version": "3.1.0"
   },
   "linux-arm64": {
     "sys": "linux-arm64",
-    "url": "https://bin.equinox.io/a/NGErr1qsBJ/ngrok-v3-3.0.4-linux-arm64",
-    "sha256": "26174fa2a0c22cf44fff118658348d6e4bfa8d60e4cfc092dedc4a0223427916",
-    "version": "3.0.4"
+    "url": "https://bin.equinox.io/a/5skoQje3DKb/ngrok-v3-3.1.0-linux-arm64",
+    "sha256": "668cc681c4d5bd6b4d205b8332091f8236575ebebd900b5ef9d273116471d820",
+    "version": "3.1.0"
   },
   "darwin-amd64": {
     "sys": "darwin-amd64",
-    "url": "https://bin.equinox.io/a/RZEPEGHd2t/ngrok-v3-3.0.4-darwin-amd64",
-    "sha256": "a7eca7635e6174174880a79d51e2d9c4ec32e15752751d5427f70ecf59f9f8e2",
-    "version": "3.0.4"
+    "url": "https://bin.equinox.io/a/h7mizaTkyfP/ngrok-v3-3.1.0-darwin-amd64",
+    "sha256": "5f607e9f3aa699ae4e85ceeb25c275d9e720614f457423bc4657b3f48168cfad",
+    "version": "3.1.0"
   },
   "darwin-arm64": {
     "sys": "darwin-arm64",
-    "url": "https://bin.equinox.io/a/dxEFAXR7WZr/ngrok-v3-3.0.4-darwin-arm64",
-    "sha256": "6db91466407e9538a4f598cc362e8be292d4621f8b331e0d0818e1c672decc66",
-    "version": "3.0.4"
+    "url": "https://bin.equinox.io/a/46gUrn19J7F/ngrok-v3-3.1.0-darwin-arm64",
+    "sha256": "0a2119d6ef9dcc0b6203d38b536483c417a59c355d505e92a4b6c7c96810ef4b",
+    "version": "3.1.0"
   }
 }


### PR DESCRIPTION

###### Description of changes

See: https://ngrok.com/docs/ngrok-agent/changelog#ngrok-agent-310---2022-09-14 

In summary, updates agent root CA, some header inspect UI formatting issues, tunnel start API parameters, and ngrok diagnose bugs. Nothing is breaking to existing users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
