### PR TITLE
libsForQt514.qt5.qtwebengine: fix build on GCC with a kludge

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -1,6 +1,7 @@
 { qtModule
 , qtdeclarative, qtquickcontrols, qtlocation, qtwebchannel
 
+, gcc-unwrapped
 , bison, flex, git, gperf, ninja, pkg-config, python, which
 , nodejs, qtbase, perl
 
@@ -203,25 +204,30 @@ qtModule {
     libunwind
   ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [
-    cups
-    sandbox
+  buildInputs =
+    # FIXME: requires gcc-unwrapped in buildInputs, otherwise fails to link QtWebEngineProcess:
+    # /nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/6l2f5avj9fcgmfx45q4zg5dnbxd44nbr-x265-3.5/lib/libx265.so.199: undefined reference to `std::__throw_bad_array_new_length()@GLIBCXX_3.4.29'
+    # FIXME: needs proper fixing, but not in time for 22.11
+    lib.optional stdenv.cc.isGNU gcc-unwrapped
+    ++ lib.optionals stdenv.isDarwin [
+      cups
+      sandbox
 
-    # `sw_vers` is used by `src/3rdparty/chromium/build/config/mac/sdk_info.py`
-    # to get some information about the host platform.
-    (writeScriptBin "sw_vers" ''
-      #!${stdenv.shell}
+      # `sw_vers` is used by `src/3rdparty/chromium/build/config/mac/sdk_info.py`
+      # to get some information about the host platform.
+      (writeScriptBin "sw_vers" ''
+        #!${stdenv.shell}
 
-      while [ $# -gt 0 ]; do
-        case "$1" in
-          -buildVersion) echo "17E199";;
-        *) break ;;
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            -buildVersion) echo "17E199";;
+          *) break ;;
 
-        esac
-        shift
-      done
-    '')
-  ];
+          esac
+          shift
+        done
+      '')
+    ];
 
   dontUseNinjaBuild = true;
   dontUseNinjaInstall = true;


### PR DESCRIPTION
Pass gcc-unwrapped to buildInputs to fix a QtWebEngineProcess link failure where the compiler is unable to link libx265 to libstdc++.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->