### PR TITLE
dataexplorer: 3.6.2 -> 3.7.3

### DIFF
--- a/pkgs/applications/science/electronics/dataexplorer/default.nix
+++ b/pkgs/applications/science/electronics/dataexplorer/default.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "dataexplorer";
-  version = "3.6.2";
+  version = "3.7.3";
 
   src = fetchurl {
     url = "mirror://savannah/dataexplorer/dataexplorer-${version}-src.tar.gz";
-    sha256 = "sha256-2e8qeoJh7z/RIowMtAd8PGcMPck5H8iHqel6bW7EQ0E=";
+    sha256 = "sha256-cqvlPV4i9m0x3hbruC5y2APsyjfI5y9RT8XVzsDaT/Q=";
   };
 
   nativeBuildInputs = [ ant makeWrapper ];
@@ -38,11 +38,11 @@ stdenv.mkDerivation rec {
     # So we create our own wrapper, using similar cmdline args as upstream.
     mkdir -p $out/bin
     makeWrapper ${jre}/bin/java $out/bin/DataExplorer \
-      --add-flags "-Dfile.encoding=UTF-8 -Xms64m -Xmx3092m -jar $out/share/DataExplorer/DataExplorer.jar" \
+      --add-flags "-Xms64m -Xmx3092m -jar $out/share/DataExplorer/DataExplorer.jar" \
       --set SWT_GTK3 0
 
     makeWrapper ${jre}/bin/java $out/bin/DevicePropertiesEditor \
-      --add-flags "-Dfile.encoding=UTF-8 -Xms32m -Xmx512m -classpath $out/share/DataExplorer/DataExplorer.jar gde.ui.dialog.edit.DevicePropertiesEditor" \
+      --add-flags "-Xms32m -Xmx512m -classpath $out/share/DataExplorer/DataExplorer.jar gde.ui.dialog.edit.DevicePropertiesEditor" \
       --set SWT_GTK3 0 \
       --set LIBOVERLAY_SCROLLBAR 0
 
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.nongnu.org/dataexplorer/index.html";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ panicgh ];
-    platforms = jdk.meta.platforms;
+    platforms = [ "x86_64-linux" ];
     sourceProvenance = with sourceTypes; [
       fromSource
       binaryNativeCode  # contains RXTXcomm (JNI library with *.so files)


### PR DESCRIPTION
###### Description of changes

Package update with bug fixes and a few improvements.

In v3.7.1, the `file.encoding=UTF-8` setting has been moved into the application itself. It is not needed any more to pass it via the `java` command line.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>dataexplorer</li>
  </ul>
</details>

- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I'm not sure how to correctly test building for systems != `x86_64-linux`:
* `nix-build default.nix -A pkgsCross.x86_64-darwin.dataexplorer`:
   error: infinite recursion encountered
  *  same for `aarch64-dawin`
* `nix-build default.nix -A pkgsCross.aarch64-multiplatform.dataexplorer`:
    meson fails in `glib`, "Program 'xsltproc' not found or not executable"
* `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD --system x86_64-darwin"`:
   error: a 'x86_64-darwin' with features {} is required to build '/nix/store/...-dataexplorer-3.7.3.drv', but I am a 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test}
* `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 NIXPKGS_ALLOW_INSECURE=1 nix-build default.nix -A pkgsi686Linux.dataexplorer`:
     configure error for openjdk-headless-12.0.2-ga