### PR TITLE
qt6.qtwebengine: add aarch64-darwin support

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -137,6 +137,9 @@ let
           GameController ImageCaptureCore LocalAuthentication
           MediaAccessibility MediaPlayer MetalKit Network OpenDirectory Quartz
           ReplayKit SecurityInterface Vision;
+        xcbuild = buildPackages.xcbuild.override {
+          productBuildVer = "20A2408";
+        };
       };
       qtwebsockets = callPackage ./modules/qtwebsockets.nix { };
       qtwebview = callPackage ./modules/qtwebview.nix {

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -127,6 +127,12 @@ qtModule {
   # which cannot be set at the same time as -Wformat-security
   hardeningDisable = [ "format" ];
 
+  # removes macOS 12+ dependencies
+  patches = [
+    ../patches/qtwebengine-darwin-no-low-latency-flag.patch
+    ../patches/qtwebengine-darwin-no-copy-certificate-chain.patch
+  ];
+
   postPatch = ''
     # Patch Chromium build tools
     (
@@ -301,7 +307,8 @@ qtModule {
 
   meta = with lib; {
     description = "A web engine based on the Chromium web browser";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin && stdenv.isx86_64;
     # This build takes a long time; particularly on slow architectures
     # 1 hour on 32x3.6GHz -> maybe 12 hours on 4x2.4GHz
     timeout = 24 * 3600;

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-copy-certificate-chain.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-copy-certificate-chain.patch
@@ -1,0 +1,16 @@
+diff --git a/src/3rdparty/chromium/net/cert/x509_util_apple.cc b/src/3rdparty/chromium/net/cert/x509_util_apple.cc
+index ae69948dfca..7062a9a9b97 100644
+--- a/src/3rdparty/chromium/net/cert/x509_util_apple.cc
++++ b/src/3rdparty/chromium/net/cert/x509_util_apple.cc
+@@ -139,11 +139,6 @@ SHA256HashValue CalculateFingerprint256(SecCertificateRef cert) {
+ 
+ base::ScopedCFTypeRef<CFArrayRef> CertificateChainFromSecTrust(
+     SecTrustRef trust) {
+-  if (__builtin_available(macOS 12.0, iOS 15.0, *)) {
+-    return base::ScopedCFTypeRef<CFArrayRef>(
+-        SecTrustCopyCertificateChain(trust));
+-  }
+-
+   base::ScopedCFTypeRef<CFMutableArrayRef> chain(
+       CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks));
+   const CFIndex chain_length = SecTrustGetCertificateCount(trust);

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-low-latency-flag.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-low-latency-flag.patch
@@ -1,0 +1,60 @@
+diff --git a/src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc b/src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc
+index 6a3a777..249d4cc 100644
+--- a/src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc
++++ b/src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc
+@@ -20,12 +20,6 @@
+ #include "media/base/media_log.h"
+ #include "media/base/video_frame.h"
+ 
+-// This is a min version of macOS where we want to support SVC encoding via
+-// EnableLowLatencyRateControl flag. The flag is actually supported since 11.3,
+-// but there we see frame drops even with ample bitrate budget. Excessive frame
+-// drops were fixed in 12.0.1.
+-#define LOW_LATENCY_FLAG_AVAILABLE_VER 12.0.1
+-
+ namespace media {
+ 
+ namespace {
+@@ -150,8 +144,6 @@ VTVideoEncodeAccelerator::GetSupportedProfiles() {
+   profile.max_framerate_numerator = kMaxFrameRateNumerator;
+   profile.max_framerate_denominator = kMaxFrameRateDenominator;
+   profile.max_resolution = gfx::Size(kMaxResolutionWidth, kMaxResolutionHeight);
+-  if (__builtin_available(macOS LOW_LATENCY_FLAG_AVAILABLE_VER, *))
+-    profile.scalability_modes.push_back(SVCScalabilityMode::kL1T2);
+   for (const auto& supported_profile : kSupportedProfiles) {
+     profile.profile = supported_profile;
+     profiles.push_back(profile);
+@@ -595,13 +587,6 @@ bool VTVideoEncodeAccelerator::CreateCompressionSession(
+       kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder};
+   std::vector<CFTypeRef> encoder_values{kCFBooleanTrue};
+ 
+-  if (__builtin_available(macOS LOW_LATENCY_FLAG_AVAILABLE_VER, *)) {
+-    if (require_low_delay_) {
+-      encoder_keys.push_back(
+-          kVTVideoEncoderSpecification_EnableLowLatencyRateControl);
+-      encoder_values.push_back(kCFBooleanTrue);
+-    }
+-  }
+   base::ScopedCFTypeRef<CFDictionaryRef> encoder_spec =
+       video_toolbox::DictionaryWithKeysAndValues(
+           encoder_keys.data(), encoder_values.data(), encoder_keys.size());
+@@ -669,19 +654,8 @@ bool VTVideoEncodeAccelerator::ConfigureCompressionSession() {
+   }
+ 
+   if (num_temporal_layers_ == 2) {
+-    if (__builtin_available(macOS LOW_LATENCY_FLAG_AVAILABLE_VER, *)) {
+-      if (!session_property_setter.IsSupported(
+-              kVTCompressionPropertyKey_BaseLayerFrameRateFraction)) {
+-        DLOG(ERROR) << "BaseLayerFrameRateFraction is not supported";
+-        return false;
+-      }
+-      rv &= session_property_setter.Set(
+-          kVTCompressionPropertyKey_BaseLayerFrameRateFraction, 0.5);
+-      DLOG_IF(ERROR, !rv) << " Setting BaseLayerFrameRate property failed.";
+-    } else {
+       DLOG(ERROR) << "SVC encoding is not supported on this OS version.";
+       rv = false;
+-    }
+   }
+ 
+   return rv;


### PR DESCRIPTION
###### Description of changes

This PR allows building Qt WebEngine 6.4.x / 6.5.0 on aarch64-darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
