### PR TITLE
kamid: fix cross-compilation

### DIFF
--- a/pkgs/servers/ftp/kamid/default.nix
+++ b/pkgs/servers/ftp/kamid/default.nix
@@ -28,11 +28,13 @@ stdenv.mkDerivation rec {
     libbsd
   ];
 
+  makeFlags = [ "AR:=$(AR)" ];
+
   meta = with lib; {
     description = "A FREE, easy-to-use and portable implementation of a 9p file server daemon for UNIX-like systems";
     homepage = "https://kamid.omarpolo.com";
     license = licenses.isc;
     maintainers = with maintainers; [ heph2 ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes
Fix cross-compilation:
```sh
$ nix build -L .#pkgsCross.aarch64-multiplatform.kamid
...
kamid-aarch64-unknown-linux-gnu> ar cru libopenbsd-compat.a dummy.o getdtablecount.o fmt_scaled.o imsg.o imsg-buffer.o ohash.o
kamid-aarch64-unknown-linux-gnu> /nix/store/dsd5gz46hdbdk2rfdimqddhq6m8m8fqs-bash-5.1-p16/bin/bash: line 1: ar: command not found
kamid-aarch64-unknown-linux-gnu> make[2]: *** [Makefile:347: libopenbsd-compat.a] Error 127
...
```

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
