### PR TITLE
haskellPackages: unbreak selected packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1624,7 +1624,8 @@ self: super: {
 
   # Test suite has a too strict bound on base
   # https://github.com/jswebtools/language-ecmascript/pull/88
-  language-ecmascript = doJailbreak super.language-ecmascript;
+  # Test suite doesn't compile anymore
+  language-ecmascript = dontCheck (doJailbreak super.language-ecmascript);
 
   # Too strict bounds on containers
   # https://github.com/jswebtools/language-ecmascript-analysis/issues/1
@@ -2126,7 +2127,8 @@ self: super: {
   system-fileio = doJailbreak super.system-fileio;
 
   # Bounds too strict on base and ghc-prim: https://github.com/tibbe/ekg-core/pull/43 (merged); waiting on hackage release
-  ekg-core  = assert super.ekg-core.version == "0.1.1.7"; doJailbreak super.ekg-core;
+  ekg-core = assert super.ekg-core.version == "0.1.1.7"; doJailbreak super.ekg-core;
+  hasura-ekg-core = doJailbreak super.hasura-ekg-core;
 
   # https://github.com/Synthetica9/nix-linter/issues/65
   nix-linter = super.nix-linter.overrideScope (self: super: {
@@ -2274,4 +2276,46 @@ self: super: {
   swarm = doJailbreak (super.swarm.override {
     brick = doJailbreak (dontCheck super.brick_1_3);
   });
+
+  # random <1.2
+  unfoldable = doJailbreak super.unfoldable;
+
+  # containers <0.6, semigroupoids <5.3
+  data-lens = doJailbreak super.data-lens;
+
+  # transformers <0.3
+  monads-fd = doJailbreak super.monads-fd;
+
+  # HTF <0.15
+  cases = doJailbreak super.cases;
+
+  # exceptions <0.9
+  eprocess = doJailbreak super.eprocess;
+
+  # hashable <1.4, mmorph <1.2
+  composite-aeson = doJailbreak super.composite-aeson;
+
+  # composite-aeson <0.8, composite-base <0.8
+  compdoc = doJailbreak super.compdoc;
+
+  # composite-aeson <0.8, composite-base <0.8
+  haskell-coffee = doJailbreak super.haskell-coffee;
+
+  # Test suite doesn't compile anymore
+  twitter-types = dontCheck super.twitter-types;
+
+  # base <4.14
+  numbered-semigroups = doJailbreak super.numbered-semigroups;
+
+  # Tests open file "data/test_vectors_aserti3-2d_run01.txt" but it doesn't exist
+  haskoin-core = dontCheck super.haskoin-core;
+
+  # base <4.9, transformers <0.5
+  MonadCatchIO-transformers = doJailbreak super.MonadCatchIO-transformers;
+
+  # unix-compat <0.5
+  hxt-cache = doJailbreak super.hxt-cache;
+
+  # unix-compat <0.5
+  vinyl-utils = doJailbreak super.vinyl-utils;
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -597,7 +597,6 @@ broken-packages:
   - Cascade
   - cascading
   - caseof
-  - cases
   - cas-hashable
   - casr-logbook
   - casr-logbook-types
@@ -781,7 +780,6 @@ broken-packages:
   - compact-string-fix
   - comparse
   - compdata
-  - compdoc
   - compendium-client
   - competition
   - compilation
@@ -993,7 +991,6 @@ broken-packages:
   - DataIndex
   - data-ivar
   - data-kiln
-  - data-lens
   - datalog
   - data-map-multikey
   - data-named
@@ -1324,7 +1321,6 @@ broken-packages:
   - epic
   - epi-sim
   - epoll
-  - eprocess
   - epubname
   - Eq
   - EqualitySolver
@@ -1990,7 +1986,6 @@ broken-packages:
   - haskell-bitmex-rest
   - haskell-brainfuck
   - haskell-cnc
-  - haskell-coffee
   - haskell-compression
   - haskell-conll
   - haskell-course-preludes
@@ -2046,7 +2041,6 @@ broken-packages:
   - haskhol-core
   - haskmon
   - haskoin
-  - haskoin-core
   - haskoin-util
   - haskore
   - haskore-vintage
@@ -2503,7 +2497,6 @@ broken-packages:
   - html-parse
   - html-rules
   - html-tokenizer
-  - htoml
   - htoml-megaparsec
   - htsn
   - htssets
@@ -2567,7 +2560,6 @@ broken-packages:
   - hx
   - hxmppc
   - HXQ
-  - hxt-cache
   - hxt-pickle-utils
   - hyakko
   - hydra-hs
@@ -2718,7 +2710,6 @@ broken-packages:
   - IsNull
   - iso8601-duration
   - isobmff
-  - isomorphism-class
   - isotope
   - itcli
   - itemfield
@@ -2901,7 +2892,6 @@ broken-packages:
   - language-csharp
   - language-dart
   - language-dockerfile
-  - language-ecmascript
   - language-elm
   - language-gcl
   - language-gemini
@@ -3298,7 +3288,6 @@ broken-packages:
   - monad-atom
   - monad-atom-simple
   - monad-branch
-  - MonadCatchIO-transformers
   - monad-choice
   - MonadCompose
   - monad-fork
@@ -3323,7 +3312,6 @@ broken-packages:
   - monadplus
   - monad-ran
   - monad-recorder
-  - monads-fd
   - MonadStack
   - monad-statevar
   - monad-ste
@@ -3560,7 +3548,6 @@ broken-packages:
   - nullary
   - null-canvas
   - nullpipe
-  - numbered-semigroups
   - NumberSieves
   - NumberTheory
   - numerals-base
@@ -5167,7 +5154,6 @@ broken-packages:
   - th-to-exp
   - th-traced
   - thumbnail-plus
-  - thyme
   - tianbar
   - TicTacToe
   - tictactoe3d
@@ -5314,7 +5300,6 @@ broken-packages:
   - twitchapi
   - twitter
   - twitter-feed
-  - twitter-types
   - tx
   - txtblk
   - TYB
@@ -5374,14 +5359,12 @@ broken-packages:
   - uncertain
   - unescaping-print
   - unfix-binders
-  - unfoldable
   - unicode-data-names
   - unicode-data-scripts
   - unicode-data-security
   - unicode-prelude
   - unicode-symbols
   - unicode-tricks
-  - union
   - union-map
   - uniprot-kb
   - uniqueid

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -2406,7 +2406,6 @@ dont-distribute-packages:
  - language-Modula2
  - language-avro
  - language-boogie
- - language-ecmascript-analysis
  - language-eiffel
  - language-kort
  - language-ninja
@@ -3701,7 +3700,6 @@ dont-distribute-packages:
  - twill
  - twitter-conduit
  - twitter-enumerator
- - twitter-types-lens
  - txt
  - type-assertions
  - type-cache


### PR DESCRIPTION
###### Description of changes

I fixed some simple breaks of packages that are causing hydra eval errors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
