### PR TITLE
roc*: remove ? null from inputs

### DIFF
--- a/pkgs/development/libraries/miopen/default.nix
+++ b/pkgs/development/libraries/miopen/default.nix
@@ -21,12 +21,12 @@
 , boost
 , sqlite
 , bzip2
-, texlive ? null
-, doxygen ? null
-, sphinx ? null
-, python3Packages ? null
-, zlib ? null
-, fetchurl ? null
+, texlive
+, doxygen
+, sphinx
+, python3Packages
+, zlib
+, fetchurl
 , buildDocs ? false
 , buildTests ? false
 # LFS isn't working, so we will manually fetch these
@@ -35,13 +35,6 @@
 , fetchKDBs ? true
 , useOpenCL ? false
 }:
-
-assert buildDocs -> texlive != null;
-assert buildDocs -> doxygen != null;
-assert buildDocs -> sphinx != null;
-assert buildDocs -> python3Packages != null;
-assert buildTests -> zlib != null;
-assert fetchKDBs -> fetchurl != null;
 
 let
   latex = lib.optionalAttrs buildDocs (texlive.combine {

--- a/pkgs/development/libraries/rocblas/default.nix
+++ b/pkgs/development/libraries/rocblas/default.nix
@@ -10,13 +10,13 @@
 , rocm-comgr
 , hip
 , python3
-, tensile ? null
-, msgpack ? null
-, libxml2 ? null
-, llvm ? null
-, python3Packages ? null
-, gtest ? null
-, gfortran ? null
+, tensile
+, msgpack
+, libxml2
+, llvm
+, python3Packages
+, gtest
+, gfortran
 , buildTensile ? true
 , buildTests ? false
 , buildBenchmarks ? false
@@ -27,14 +27,6 @@
 , tensileLibFormat ? "msgpack"
 , gpuTargets ? [ "all" ]
 }:
-
-assert buildTensile -> tensile != null;
-assert buildTensile -> msgpack != null;
-assert buildTensile -> libxml2 != null;
-assert buildTensile -> llvm != null;
-assert buildTensile -> python3Packages != null;
-assert buildTests -> gtest != null;
-assert buildTests -> gfortran != null;
 
 # Tests and benchmarks are a can of worms that I will tackle in a different PR
 # It involves completely rewriting the amd-blis derivation

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -10,20 +10,14 @@
 , hip
 , sqlite
 , python3
-, gtest ? null
-, boost ? null
-, fftw ? null
-, fftwFloat ? null
-, llvmPackages ? null
+, gtest
+, boost
+, fftw
+, fftwFloat
+, llvmPackages
 , buildTests ? false
 , buildBenchmarks ? false
 }:
-
-assert buildTests -> gtest != null;
-assert buildBenchmarks -> fftw != null;
-assert buildBenchmarks -> fftwFloat != null;
-assert (buildTests || buildBenchmarks) -> boost != null;
-assert (buildTests || buildBenchmarks) -> llvmPackages != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocfft";

--- a/pkgs/development/libraries/rocprim/default.nix
+++ b/pkgs/development/libraries/rocprim/default.nix
@@ -8,14 +8,11 @@
 , rocm-device-libs
 , rocm-comgr
 , hip
-, gtest ? null
-, gbenchmark ? null
+, gtest
+, gbenchmark
 , buildTests ? false
 , buildBenchmarks ? false
 }:
-
-assert buildTests -> gtest != null;
-assert buildBenchmarks -> gbenchmark != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprim";

--- a/pkgs/development/libraries/rocrand/default.nix
+++ b/pkgs/development/libraries/rocrand/default.nix
@@ -8,14 +8,11 @@
 , rocm-device-libs
 , rocm-comgr
 , hip
-, gtest ? null
-, gbenchmark ? null
+, gtest
+, gbenchmark
 , buildTests ? false
 , buildBenchmarks ? false
 }:
-
-assert buildTests -> gtest != null;
-assert buildBenchmarks -> gbenchmark != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocrand";

--- a/pkgs/development/libraries/rocsparse/default.nix
+++ b/pkgs/development/libraries/rocsparse/default.nix
@@ -12,16 +12,12 @@
 , hip
 , gfortran
 , git
-, gtest ? null
-, boost ? null
-, python3Packages ? null
+, gtest
+, boost
+, python3Packages
 , buildTests ? false
 , buildBenchmarks ? false # Seems to depend on tests
 }:
-
-assert (buildTests || buildBenchmarks) -> gtest != null;
-assert (buildTests || buildBenchmarks) -> boost != null;
-assert (buildTests || buildBenchmarks) -> python3Packages != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocsparse";

--- a/pkgs/development/libraries/rocthrust/default.nix
+++ b/pkgs/development/libraries/rocthrust/default.nix
@@ -9,12 +9,10 @@
 , rocm-comgr
 , rocprim
 , hip
-, gtest ? null
+, gtest
 , buildTests ? false
 , buildBenchmarks ? false
 }:
-
-assert buildTests -> gtest != null;
 
 # Doesn't seem to work, thousands of errors compiling with no clear fix
 # Is this an upstream issue? We don't seem to be missing dependencies

--- a/pkgs/development/libraries/rocwmma/default.nix
+++ b/pkgs/development/libraries/rocwmma/default.nix
@@ -6,24 +6,17 @@
 , rocm-cmake
 , hip
 , openmp
-, gtest ? null
-, rocblas ? null
-, texlive ? null
-, doxygen ? null
-, sphinx ? null
-, python3Packages ? null
+, gtest
+, rocblas
+, texlive
+, doxygen
+, sphinx
+, python3Packages
 , buildTests ? false
 , buildSamples ? false
 , buildDocs ? false
 , gpuTargets ? null # gpuTargets = [ "gfx908:xnack-" "gfx90a:xnack-" "gfx90a:xnack+" ... ]
 }:
-
-assert buildTests -> gtest != null;
-assert buildTests -> rocblas != null;
-assert buildDocs -> texlive != null;
-assert buildDocs -> doxygen != null;
-assert buildDocs -> sphinx != null;
-assert buildDocs -> python3Packages != null;
 
 # Building tests isn't working for now
 # undefined reference to symbol '_ZTIN7testing4TestE'


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
