### PR TITLE
python310Packages.cypherpunkpay: fix the package

### DIFF
--- a/pkgs/development/python-modules/cypherpunkpay/default.nix
+++ b/pkgs/development/python-modules/cypherpunkpay/default.nix
@@ -36,7 +36,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'monero = "^0.99"' 'monero = ">=0.99"' \
+      --replace "bitstring = '^3.1.9'" "bitstring = '>=3.1.9'" \
+      --replace 'cffi = "1.15.0"' 'cffi = ">=1.15.0"' \
+      --replace 'ecdsa = "^0.17.0"' 'ecdsa = ">=0.17.0"' \
       --replace 'pypng = "^0.0.20"' 'pypng = ">=0.0.20"' \
       --replace 'tzlocal = "2.1"' 'tzlocal = ">=2.1"'
   '';
@@ -70,22 +72,26 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # performance test
-    "test/unit/tools/pbkdf2_test.py"
+    "tests/unit/tools/pbkdf2_test.py"
     # tests require network connection
-    "test/network/explorers/bitcoin"
-    "test/network/net/http_client"
-    "test/network/prices"
+    "tests/network/explorers/bitcoin"
+    "tests/network/monero/monero_address_transactions_db_test.py"
+    "tests/network/net/http_client"
+    "tests/network/prices"
     # tests require bitcoind running
-    "test/network/full_node_clients"
+    "tests/network/full_node_clients"
     # tests require lnd running
-    "test/network/ln"
+    "tests/network/ln"
     # tests require tor running
-    "test/network/net/tor_client"
+    "tests/network/monero/monero_test.py"
+    "tests/network/net/tor_client"
+    "tests/network/usecases/calc_monero_address_credits_uc_test.py"
+    "tests/network/usecases/fetch_monero_txs_from_open_node_uc_test.py"
     # tests require the full environment running
-    "test/acceptance/views"
-    "test/acceptance/views_admin"
-    "test/acceptance/views_donations"
-    "test/acceptance/views_dummystore"
+    "tests/acceptance/views"
+    "tests/acceptance/views_admin"
+    "tests/acceptance/views_donations"
+    "tests/acceptance/views_dummystore"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
By (1) relaxing dependencies, (2) updating disabled test paths, and (3) adding new tests that must be disabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
