### PR TITLE
mautrix-signal: fix v11 migration for SQLite

### DIFF
--- a/pkgs/servers/mautrix-signal/default.nix
+++ b/pkgs/servers/mautrix-signal/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3, fetchFromGitHub }:
+{ lib, python3, fetchFromGitHub, fetchpatch }:
 
 python3.pkgs.buildPythonPackage rec {
   pname = "mautrix-signal";
@@ -36,6 +36,14 @@ python3.pkgs.buildPythonPackage rec {
       --replace "asyncpg>=0.20,<0.26" "asyncpg>=0.20" \
       --replace "mautrix>=0.16.0,<0.17" "mautrix>=0.16.0"
   '';
+
+  patches = [
+    (fetchpatch {
+      name = "fix-v11-upgrade.patch";
+      url = "https://github.com/mautrix/signal/commit/4839e2afbef6179f4e0b494298086ac802ff912c.patch";
+      sha256 = "sha256-rnIFRCegNGbE383hodOdXc92PXhzbcaSN4PN5zK46Ds=";
+    })
+  ];
 
   postInstall = ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Description of changes

When trying to upgrade from v0.3.0 to v0.4.1, the following error occurs:

    sqlite3.OperationalError: unrecognized token: ":"

This is because the migration script was not written in ANSI SQL and made use of the double-colon syntax for type casting (supported by PostgreSQL and CockroachDB, but not SQLite).

This patch comes from the upstream repository and should be included in the next release of mautrix-signal, so it seems likely that this can be reverted when the package version is bumped.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
