### PR TITLE
nitter: use nix-update in update script

### DIFF
--- a/pkgs/servers/nitter/update.sh
+++ b/pkgs/servers/nitter/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p common-updater-scripts curl jq nix nix-prefetch-git patchutils
+#!nix-shell -i bash -p curl jq nix nix-update patchutils
 set -euo pipefail
 
 info() {
@@ -11,19 +11,9 @@ info() {
     printf "$@" >&2
 }
 
-nitter_old_version=$(nix-instantiate --eval --strict --json -A nitter.version . | jq -r .)
 nitter_old_rev=$(nix-instantiate --eval --strict --json -A nitter.src.rev . | jq -r .)
-today=$(LANG=C date -u +'%Y-%m-%d')
-
-# use latest commit before today, we should not call the version *today*
-# because there might still be commits coming
-# use the day of the latest commit we picked as version
-commit=$(curl -Sfs "https://api.github.com/repos/zedeus/nitter/compare/$nitter_old_rev~1...master" \
-    | jq '.commits | map(select(.commit.committer.date < $today) | {sha, date: .commit.committer.date}) | .[-1]' --arg today "$today")
-nitter_new_rev=$(jq -r '.sha' <<< "$commit")
-nitter_new_version="unstable-$(jq -r '.date[0:10]' <<< "$commit")"
-info "latest commit before $today: $nitter_new_rev ($(jq -r '.date' <<< "$commit"))"
-
+nix-update --version=branch --commit nitter
+nitter_new_rev=$(nix-instantiate --eval --strict --json -A nitter.src.rev . | jq -r .)
 if [ "$nitter_new_rev" = "$nitter_old_rev" ]; then
     info "nitter is up-to-date."
     exit
@@ -33,8 +23,3 @@ if curl -Sfs "https://github.com/zedeus/nitter/compare/$nitter_old_rev...$nitter
 | lsdiff | grep -Fxe 'a/nitter.nimble' -e 'b/nitter.nimble' > /dev/null; then
     info "nitter.nimble changed, some dependencies probably need updating."
 fi
-
-nitter_new_sha256=$(nix-prefetch-git --rev "$nitter_new_rev" "https://github.com/zedeus/nitter.git" | jq -r .sha256)
-update-source-version nitter "$nitter_new_version" "$nitter_new_sha256" --rev="$nitter_new_rev"
-git commit --all --verbose --message "nitter: $nitter_old_version -> $nitter_new_version"
-info "Updated nitter to $nitter_new_version."


### PR DESCRIPTION
###### Description of changes

Since [updating to unstable packages](https://github.com/Mic92/nix-update/pull/76) made it into nix-update and nix-update [0.10.0](https://github.com/NixOS/nixpkgs/pull/203332) is now in nixpkgs, we can simplify the update script.

See also <https://github.com/NixOS/nixpkgs/pull/203370> and <https://github.com/NixOS/nixpkgs/pull/203371>.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
