### PR TITLE
vortex: init at 1.6.14

### DIFF
--- a/pkgs/games/vortex/default.nix
+++ b/pkgs/games/vortex/default.nix
@@ -1,0 +1,33 @@
+{pkgs}:
+let
+  version = "1.6.14";
+in
+pkgs.mkYarnPackage {
+  name = "vortex";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "Nexus-Mods";
+    repo = "Vortex";
+    rev = "v${version}";
+    sha256 = "sha256-X18lyVUMPlP+dkBXcqDimQlwUWVBg6PmoDbBPoO5LUs=";
+    fetchSubmodules = true;
+  };
+
+  yarnPreBuild = ''
+    yarn config set msvs_version 2022
+  '';
+
+  extraBuildInputs = [
+    pkgs.python3
+  ];
+
+  meta = {
+    description = "Mod manager";
+    homepage = "https://www.nexusmods.com/site/mods/1";
+    changelog = "https://github.com/Nexus-Mods/Vortex/releases/tag/v${version}";
+    license = pkgs.lib.licenses.gpl3Only;
+    maintainers = [
+      pkgs.lib.maintainers.l0b0
+    ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

GPLv3 [Mod manager by Nexus Mods](https://www.nexusmods.com/site/mods/1).

Closes #147228. Depends on [upstream issue](https://github.com/Nexus-Mods/Vortex/issues/2862).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).