### PR TITLE
libvirt, perlPackages.SysVirt: 8.8.0 -> 8.9.0

### DIFF
--- a/pkgs/development/libraries/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+++ b/pkgs/development/libraries/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
@@ -230,7 +230,7 @@ diff --git a/src/network/meson.build b/src/network/meson.build
 index b5eff0c3ab..a0f26d624e 100644
 --- a/src/network/meson.build
 +++ b/src/network/meson.build
-@@ -73,11 +73,11 @@ if conf.has('WITH_NETWORK')
+@@ -73,11 +73,11 @@ 'in_file': files('virtnetworkd.init.in'),
    }
  
    virt_install_dirs += [
@@ -247,7 +247,7 @@ index b5eff0c3ab..a0f26d624e 100644
    ]
  
    configure_file(
-@@ -85,12 +85,12 @@ if conf.has('WITH_NETWORK')
+@@ -85,12 +85,12 @@ input: 'default.xml.in',
      output: '@BASENAME@',
      copy: true,
      install: true,
@@ -256,7 +256,7 @@ index b5eff0c3ab..a0f26d624e 100644
    )
  
    meson.add_install_script(
-     meson_python_prog.path(), python3_prog.path(), meson_install_symlink_prog.path(),
+     meson_python_prog.full_path(), python3_prog.full_path(), meson_install_symlink_prog.full_path(),
 -    confdir / 'qemu' / 'networks' / 'autostart',
 +    install_prefix + confdir / 'qemu' / 'networks' / 'autostart',
      '../default.xml', 'default.xml',

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -114,13 +114,13 @@ stdenv.mkDerivation rec {
   # NOTE: You must also bump:
   # <nixpkgs/pkgs/development/python-modules/libvirt/default.nix>
   # SysVirt in <nixpkgs/pkgs/top-level/perl-packages.nix>
-  version = "8.8.0";
+  version = "8.9.0";
 
   src = fetchFromGitLab {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-p7z+paiSeIm2cWnc6n9Hrd++BDmccGj+EOhqHNsJiXw=";
+    sha256 = "sha256-79frEYItbf1weOkrcyI/Z/TjTg6kLMQbteaTi9LAt0g=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "8.8.0";
+  version = "8.9.0";
 
   src = fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt-python";
     rev = "v${version}";
-    sha256 = "sha256-UguqUsIfrql1UZeBoHLKXvLYuWicbJWamglkvqS++FI=";
+    sha256 = "sha256-vquchyGJlpg0R0R6Wh2MWB5RUZ3jzOQYzUoLwiLxIy8=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22634,12 +22634,12 @@ let
 
   SysVirt = buildPerlModule rec {
     pname = "Sys-Virt";
-    version = "8.8.0";
+    version = "8.9.0";
     src = fetchFromGitLab {
       owner = "libvirt";
       repo = "libvirt-perl";
       rev = "v${version}";
-      hash = "sha256-8maLIW4hBbMbq+rnwEfaHsUgpppaU5K4aQTwTgUjdcI=";
+      hash = "sha256-s3N4KU0JnIXHKOme+2Vxapd6o8QeT6lUAb+r5i9Ogv0=";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [ pkgs.libvirt CPANChanges TestPod TestPodCoverage XMLXPath ];


### PR DESCRIPTION
###### Description of changes

Updating libvirt and associated libraries from 8.8.0 to 8.9.0. One of the patches had to be updated to work with 8.9.0. Should be fine to backport to 22.11.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
