### PR TITLE
nixos/kexec-boot: various improvements

### DIFF
--- a/nixos/doc/manual/from_md/installation/installing-kexec.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-kexec.section.xml
@@ -25,11 +25,11 @@
     you can run:
   </para>
   <programlisting>
-nix-build -A kexec.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
+nix-build -A kexecTarball.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
 </programlisting>
   <para>
-    This will create a <literal>result</literal> directory containing
-    the following:
+    This will create a <literal>result</literal> tarball containing the
+    following:
   </para>
   <itemizedlist spacing="compact">
     <listitem>
@@ -44,25 +44,20 @@ nix-build -A kexec.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
     </listitem>
     <listitem>
       <para>
-        <literal>kexec-boot</literal> (a shellscript invoking
+        <literal>kexec-boot</literal> (a shell script invoking
         <literal>kexec</literal>)
       </para>
     </listitem>
   </itemizedlist>
   <para>
-    These three files are meant to be copied over to the other already
-    running Linux Distribution.
+    This file is meant to be copied over to the other already running
+    Linux distribution.
   </para>
   <para>
-    Note it’s symlinks pointing elsewhere, so <literal>cd</literal> in,
-    and use <literal>scp * root@$destination</literal> to copy it over,
-    rather than rsync.
-  </para>
-  <para>
-    Once you finished copying, execute <literal>kexec-boot</literal>
-    <emphasis>on the destination</emphasis>, and after some seconds, the
-    machine should be booting into an (ephemeral) NixOS installation
-    medium.
+    Once you finish copying and extracting, execute
+    <literal>kexec-boot</literal> <emphasis>on the
+    destination</emphasis>, and after some seconds, the machine should
+    be booting into an (ephemeral) NixOS installation medium.
   </para>
   <para>
     In case you want to describe your own system closure to kexec into,
@@ -83,8 +78,8 @@ nix-build -A kexec.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
 </programlisting>
   <programlisting>
 nix-build '&lt;nixpkgs/nixos&gt;' \
-  --arg configuration ./configuration.nix
-  --attr config.system.build.kexecTree
+  --arg configuration ./configuration.nix \
+  --attr config.system.build.kexecTarball
 </programlisting>
   <para>
     Make sure your <literal>configuration.nix</literal> does still

--- a/nixos/doc/manual/from_md/installation/installing-kexec.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-kexec.section.xml
@@ -34,7 +34,7 @@ nix-build -A kexecTarball.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
   <itemizedlist spacing="compact">
     <listitem>
       <para>
-        <literal>bzImage</literal> (the Linux kernel)
+        <literal>kernel</literal> (the Linux kernel)
       </para>
     </listitem>
     <listitem>

--- a/nixos/doc/manual/from_md/installation/installing-kexec.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-kexec.section.xml
@@ -44,6 +44,12 @@ nix-build -A kexecTarball.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
     </listitem>
     <listitem>
       <para>
+        <literal>kernel-params</literal> (the kernel command-line
+        parameters)
+      </para>
+    </listitem>
+    <listitem>
+      <para>
         <literal>kexec-boot</literal> (a shell script invoking
         <literal>kexec</literal>)
       </para>

--- a/nixos/doc/manual/from_md/installation/installing-kexec.section.xml
+++ b/nixos/doc/manual/from_md/installation/installing-kexec.section.xml
@@ -21,15 +21,11 @@
     however is rarely the case.
   </para>
   <para>
-    To build the necessary files from your current version of nixpkgs,
-    you can run:
-  </para>
-  <programlisting>
-nix-build -A kexecTarball.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
-</programlisting>
-  <para>
-    This will create a <literal>result</literal> tarball containing the
-    following:
+    You can download a <literal>nixos.kexecTarball</literal> build
+    corresponding to your system from the <literal>nixos-YY.MM</literal>
+    jobsets (or <literal>trunk-combined</literal> for unstable) on
+    <link xlink:href="https://hydra.nixos.org/project/nixos">the NixOS
+    Hydra project</link>. This contains the following:
   </para>
   <itemizedlist spacing="compact">
     <listitem>
@@ -56,6 +52,13 @@ nix-build -A kexecTarball.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
     </listitem>
   </itemizedlist>
   <para>
+    Alternatively, you can get a tarball corresponding to an existing
+    Nix installation’s current version of nixpkgs:
+  </para>
+  <programlisting>
+nix-build -A kexecTarball.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
+</programlisting>
+  <para>
     This file is meant to be copied over to the other already running
     Linux distribution.
   </para>
@@ -66,20 +69,34 @@ nix-build -A kexecTarball.x86_64-linux '&lt;nixpkgs/nixos/release.nix&gt;'
     be booting into an (ephemeral) NixOS installation medium.
   </para>
   <para>
-    In case you want to describe your own system closure to kexec into,
-    instead of the default installer image, you can build your own
-    <literal>configuration.nix</literal>:
+    You can also enable SSH login as the <literal>nixos</literal> user
+    by specifying an authorized keys file, or append additional
+    parameters to the kernel command line:
+  </para>
+  <programlisting>
+./kexec-boot \
+  --ssh-authorized-keys ~/.ssh/authorized_keys \
+  --append 'panic=30 boot.panic_on_fail'
+</programlisting>
+  <para>
+    In case you want to customize things further, you can build your own
+    <literal>configuration.nix</literal> to describe a system closure to
+    kexec into instead of the default installer image:
   </para>
   <programlisting language="bash">
-{ modulesPath, ... }: {
+{ pkgs, modulesPath, ... }: {
   imports = [
     (modulesPath + &quot;/installer/netboot/netboot-minimal.nix&quot;)
   ];
 
-  services.openssh.enable = true;
-  users.users.root.openssh.authorizedKeys.keys = [
-    &quot;my-ssh-pubkey&quot;
-  ];
+  environment.systemPackages = [ pkgs.kakoune ];
+
+  users.users.nixos = {
+    shell = pkgs.fish;
+    openssh.authorizedKeys.keys = [
+      &quot;my-ssh-pubkey&quot;
+    ];
+  };
 }
 </programlisting>
   <programlisting>

--- a/nixos/doc/manual/installation/installing-kexec.section.md
+++ b/nixos/doc/manual/installation/installing-kexec.section.md
@@ -15,18 +15,22 @@ Note that kexec may not work correctly on some hardware, as devices are not
 fully re-initialized in the process. In practice, this however is rarely the
 case.
 
-To build the necessary files from your current version of nixpkgs,
-you can run:
-
-```ShellSession
-nix-build -A kexecTarball.x86_64-linux '<nixpkgs/nixos/release.nix>'
-```
-
-This will create a `result` tarball containing the following:
+You can download a `nixos.kexecTarball` build corresponding
+to your system from the `nixos-YY.MM` jobsets (or
+`trunk-combined` for unstable) on [the NixOS Hydra
+project](https://hydra.nixos.org/project/nixos). This contains the
+following:
  - `kernel` (the Linux kernel)
  - `initrd` (the initrd file)
  - `kernel-params` (the kernel command-line parameters)
  - `kexec-boot` (a shell script invoking `kexec`)
+
+Alternatively, you can get a tarball corresponding to an existing
+Nix installation's current version of nixpkgs:
+
+```ShellSession
+nix-build -A kexecTarball.x86_64-linux '<nixpkgs/nixos/release.nix>'
+```
 
 This file is meant to be copied over to the other already running
 Linux distribution.
@@ -35,19 +39,33 @@ Once you finish copying and extracting, execute `kexec-boot` *on the
 destination*, and after some seconds, the machine should be booting into an
 (ephemeral) NixOS installation medium.
 
-In case you want to describe your own system closure to kexec into, instead of
-the default installer image, you can build your own `configuration.nix`:
+You can also enable SSH login as the `nixos` user by specifying an authorized
+keys file, or append additional parameters to the kernel command line:
+
+```ShellSession
+./kexec-boot \
+  --ssh-authorized-keys ~/.ssh/authorized_keys \
+  --append 'panic=30 boot.panic_on_fail'
+```
+
+In case you want to customize things further, you can build your own
+`configuration.nix` to describe a system closure to kexec into instead of
+the default installer image:
 
 ```nix
-{ modulesPath, ... }: {
+{ pkgs, modulesPath, ... }: {
   imports = [
     (modulesPath + "/installer/netboot/netboot-minimal.nix")
   ];
 
-  services.openssh.enable = true;
-  users.users.root.openssh.authorizedKeys.keys = [
-    "my-ssh-pubkey"
-  ];
+  environment.systemPackages = [ pkgs.kakoune ];
+
+  users.users.nixos = {
+    shell = pkgs.fish;
+    openssh.authorizedKeys.keys = [
+      "my-ssh-pubkey"
+    ];
+  };
 }
 ```
 

--- a/nixos/doc/manual/installation/installing-kexec.section.md
+++ b/nixos/doc/manual/installation/installing-kexec.section.md
@@ -25,6 +25,7 @@ nix-build -A kexecTarball.x86_64-linux '<nixpkgs/nixos/release.nix>'
 This will create a `result` tarball containing the following:
  - `bzImage` (the Linux kernel)
  - `initrd` (the initrd file)
+ - `kernel-params` (the kernel command-line parameters)
  - `kexec-boot` (a shell script invoking `kexec`)
 
 This file is meant to be copied over to the other already running

--- a/nixos/doc/manual/installation/installing-kexec.section.md
+++ b/nixos/doc/manual/installation/installing-kexec.section.md
@@ -19,23 +19,20 @@ To build the necessary files from your current version of nixpkgs,
 you can run:
 
 ```ShellSession
-nix-build -A kexec.x86_64-linux '<nixpkgs/nixos/release.nix>'
+nix-build -A kexecTarball.x86_64-linux '<nixpkgs/nixos/release.nix>'
 ```
 
-This will create a `result` directory containing the following:
+This will create a `result` tarball containing the following:
  - `bzImage` (the Linux kernel)
  - `initrd` (the initrd file)
- - `kexec-boot` (a shellscript invoking `kexec`)
+ - `kexec-boot` (a shell script invoking `kexec`)
 
-These three files are meant to be copied over to the other already running
-Linux Distribution.
+This file is meant to be copied over to the other already running
+Linux distribution.
 
-Note it's symlinks pointing elsewhere, so `cd` in, and use
-`scp * root@$destination` to copy it over, rather than rsync.
-
-Once you finished copying, execute `kexec-boot` *on the destination*, and after
-some seconds, the machine should be booting into an (ephemeral) NixOS
-installation medium.
+Once you finish copying and extracting, execute `kexec-boot` *on the
+destination*, and after some seconds, the machine should be booting into an
+(ephemeral) NixOS installation medium.
 
 In case you want to describe your own system closure to kexec into, instead of
 the default installer image, you can build your own `configuration.nix`:
@@ -53,11 +50,10 @@ the default installer image, you can build your own `configuration.nix`:
 }
 ```
 
-
 ```ShellSession
 nix-build '<nixpkgs/nixos>' \
-  --arg configuration ./configuration.nix
-  --attr config.system.build.kexecTree
+  --arg configuration ./configuration.nix \
+  --attr config.system.build.kexecTarball
 ```
 
 Make sure your `configuration.nix` does still import `netboot-minimal.nix` (or

--- a/nixos/doc/manual/installation/installing-kexec.section.md
+++ b/nixos/doc/manual/installation/installing-kexec.section.md
@@ -23,7 +23,7 @@ nix-build -A kexecTarball.x86_64-linux '<nixpkgs/nixos/release.nix>'
 ```
 
 This will create a `result` tarball containing the following:
- - `bzImage` (the Linux kernel)
+ - `kernel` (the Linux kernel)
  - `initrd` (the initrd file)
  - `kernel-params` (the kernel command-line parameters)
  - `kexec-boot` (a shell script invoking `kexec`)

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 set -e
 
+kexecTree=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+kernelParams=$(<"$kexecTree/kernel-params")
+
+usage() {
+    printf >&2 'usage: %s [%s]\n' "$0" \
+        '--append <cmdline>'
+    exit 2
+}
+
+while (( $# )); do
+    arg=$1; shift 1
+    case "$arg" in
+        --append)
+            (( $# )) || usage
+            kernelParams="$kernelParams $1"; shift 1
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
 if ! kexec --version &>/dev/null; then
     printf >&2 'kexec not found: please install kexec-tools\n'
     exit 1
@@ -11,12 +33,10 @@ if (( EUID != 0 )); then
     exit 1
 fi
 
-kexecTree=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-
 kexec --load \
     --kexec-syscall-auto \
     --initrd="$kexecTree/initrd" \
-    --append="$(<"$kexecTree/kernel-params")" \
+    --append="$kernelParams" \
     -- "$kexecTree/kernel"
 
 if [[ -d /run/systemd/system ]] && command -v systemctl >/dev/null; then

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -18,4 +18,8 @@ kexec --load \
     --command-line="$(<"$kexecTree/kernel-params")" \
     -- "$kexecTree/kernel"
 
-kexec -e
+if [[ -d /run/systemd/system ]] && command -v systemctl >/dev/null; then
+    systemctl kexec
+else
+    kexec -e
+fi

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+if ! kexec -v >/dev/null 2>&1; then
+  echo "kexec not found: please install kexec-tools" 2>&1
+  exit 1
+fi
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+kexec --load ${SCRIPT_DIR}/bzImage \
+  --initrd=${SCRIPT_DIR}/initrd.gz \
+  --command-line="$(< "${SCRIPT_DIR}/kernel-params")"
+kexec -e

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -8,8 +8,8 @@ fi
 kexecTree=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 kexec --load \
-    --initrd="$kexecTree/initrd.gz" \
+    --initrd="$kexecTree/initrd" \
     --command-line="$(<"$kexecTree/kernel-params")" \
-    -- "$kexecTree/bzImage"
+    -- "$kexecTree/kernel"
 
 kexec -e

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -16,7 +16,7 @@ kexecTree=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 kexec --load \
     --kexec-syscall-auto \
     --initrd="$kexecTree/initrd" \
-    --command-line="$(<"$kexecTree/kernel-params")" \
+    --append="$(<"$kexecTree/kernel-params")" \
     -- "$kexecTree/kernel"
 
 if [[ -d /run/systemd/system ]] && command -v systemctl >/dev/null; then

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-if ! kexec -v &>/dev/null; then
-    echo 'kexec not found: please install kexec-tools' 2>&1
+if ! kexec --version &>/dev/null; then
+    printf >&2 'kexec not found: please install kexec-tools\n'
+    exit 1
+fi
+
+if (( EUID != 0 )); then
+    printf >&2 'kexec-boot must be run as root\n'
     exit 1
 fi
 

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -14,6 +14,7 @@ fi
 kexecTree=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 kexec --load \
+    --kexec-syscall-auto \
     --initrd="$kexecTree/initrd" \
     --command-line="$(<"$kexecTree/kernel-params")" \
     -- "$kexecTree/kernel"

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 if ! kexec -v &>/dev/null; then
     echo 'kexec not found: please install kexec-tools' 2>&1

--- a/nixos/modules/installer/netboot/kexec-boot.sh
+++ b/nixos/modules/installer/netboot/kexec-boot.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-if ! kexec -v >/dev/null 2>&1; then
-  echo "kexec not found: please install kexec-tools" 2>&1
-  exit 1
+
+if ! kexec -v &>/dev/null; then
+    echo 'kexec not found: please install kexec-tools' 2>&1
+    exit 1
 fi
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-kexec --load ${SCRIPT_DIR}/bzImage \
-  --initrd=${SCRIPT_DIR}/initrd.gz \
-  --command-line="$(< "${SCRIPT_DIR}/kernel-params")"
+
+kexecTree=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+kexec --load \
+    --initrd="$kexecTree/initrd.gz" \
+    --command-line="$(<"$kexecTree/kernel-params")" \
+    -- "$kexecTree/bzImage"
+
 kexec -e

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -146,6 +146,13 @@ with lib;
 
     boot.loader.timeout = 10;
 
+    boot.initrd.postMountCommands = ''
+      # Copy any overlays from the kexec script.
+      if [[ -d /overlay ]]; then
+        cp -a --target-directory=/mnt-root /overlay/.
+      fi
+    '';
+
     boot.postBootCommands =
       ''
         # After booting, register the contents of the Nix store

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -101,18 +101,18 @@ with lib;
       boot
     '';
 
-    # A script invoking kexec on ./bzImage and ./initrd.gz.
+    # A script invoking kexec to boot into the kernel and initrd.
     # Usually used through system.build.kexecTree, but exposed here for composability.
     system.build.kexecScript = ./kexec-boot.sh;
 
     # A tree containing the kexec-boot script and its dependencies.
     system.build.kexecTree = pkgs.linkFarm "kexec-tree" [
       {
-        name = "initrd.gz";
+        name = "initrd";
         path = "${config.system.build.netbootRamdisk}/initrd";
       }
       {
-        name = "bzImage";
+        name = "kernel";
         path = "${config.system.build.kernel}/${config.system.boot.loader.kernelFile}";
       }
       {

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -146,6 +146,7 @@ with lib;
         ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
       '';
 
+    system.stateVersion = lib.mkDefault lib.trivial.release;
   };
 
 }

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -103,18 +103,7 @@ with lib;
 
     # A script invoking kexec on ./bzImage and ./initrd.gz.
     # Usually used through system.build.kexecTree, but exposed here for composability.
-    system.build.kexecScript = pkgs.writeScript "kexec-boot" ''
-      #!/usr/bin/env bash
-      if ! kexec -v >/dev/null 2>&1; then
-        echo "kexec not found: please install kexec-tools" 2>&1
-        exit 1
-      fi
-      SCRIPT_DIR=$( cd -- "$( dirname -- "''${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-      kexec --load ''${SCRIPT_DIR}/bzImage \
-        --initrd=''${SCRIPT_DIR}/initrd.gz \
-        --command-line="$(< "''${SCRIPT_DIR}/kernel-params")"
-      kexec -e
-    '';
+    system.build.kexecScript = ./kexec-boot.sh;
 
     # A tree containing the kexec-boot script and its dependencies.
     system.build.kexecTree = pkgs.linkFarm "kexec-tree" [

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -112,11 +112,11 @@ with lib;
       SCRIPT_DIR=$( cd -- "$( dirname -- "''${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
       kexec --load ''${SCRIPT_DIR}/bzImage \
         --initrd=''${SCRIPT_DIR}/initrd.gz \
-        --command-line "init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}"
+        --command-line="$(< "''${SCRIPT_DIR}/kernel-params")"
       kexec -e
     '';
 
-    # A tree containing initrd.gz, bzImage and a kexec-boot script.
+    # A tree containing the kexec-boot script and its dependencies.
     system.build.kexecTree = pkgs.linkFarm "kexec-tree" [
       {
         name = "initrd.gz";
@@ -125,6 +125,11 @@ with lib;
       {
         name = "bzImage";
         path = "${config.system.build.kernel}/${config.system.boot.loader.kernelFile}";
+      }
+      {
+        name = "kernel-params";
+        path = pkgs.writeText "kernel-params"
+          "init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}";
       }
       {
         name = "kexec-boot";

--- a/nixos/modules/system/boot/kexec.nix
+++ b/nixos/modules/system/boot/kexec.nix
@@ -25,7 +25,11 @@
               exit 1
             fi
             echo "Loading NixOS system via kexec."
-            exec kexec --load $p/kernel --initrd=$p/initrd --append="$(cat $p/kernel-params) init=$p/init"
+            exec kexec --load \
+              --kexec-syscall-auto \
+              --initrd="$p/initrd" \
+              --append="$(<"$p/kernel-params") init=$p/init" \
+              -- "$p/kernel"
           '';
       };
   };

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -151,12 +151,12 @@ in rec {
   # Build the initial ramdisk so Hydra can keep track of its size over time.
   initialRamdisk = buildFromConfig ({ ... }: { }) (config: config.system.build.initialRamdisk);
 
-  kexec = forMatchingSystems supportedSystems (system: (import lib/eval-config.nix {
+  kexecTarball = forMatchingSystems supportedSystems (system: (import lib/eval-config.nix {
     inherit system;
     modules = [
       ./modules/installer/netboot/netboot-minimal.nix
     ];
-  }).config.system.build.kexecTree);
+  }).config.system.build.kexecTarball);
 
   netboot = forMatchingSystems supportedSystems (system: makeNetboot {
     module = ./modules/installer/netboot/netboot-minimal.nix;

--- a/nixos/tests/kexec.nix
+++ b/nixos/tests/kexec.nix
@@ -40,6 +40,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     node1.succeed('touch /run/foo')
     node1.fail('hello')
     node1.execute('${nodes.node2.config.system.build.kexecTree}/kexec-boot', check_return=False)
+    node1.connected = False
+    node1.connect()
+    node1.wait_for_unit("multi-user.target")
+
     node1.succeed('! test -e /run/foo')
     node1.succeed('hello')
     node1.succeed('[ "$(hostname)" = "node2" ]')

--- a/nixos/tests/kexec.nix
+++ b/nixos/tests/kexec.nix
@@ -37,10 +37,11 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     node2.shutdown()
 
     # Kexec node1 to the toplevel of node2 via the kexec-boot script
-    node1.succeed('touch /run/foo')
+    node1.succeed('printf test-key >/run/foo')
     node1.fail('hello')
     node1.execute(
         '${nodes.node2.config.system.build.kexecTree}/kexec-boot'
+        ' --ssh-authorized-keys /run/foo'
         ' --append nixos.foo=bar',
         check_return=False,
     )
@@ -51,6 +52,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     node1.succeed('! test -e /run/foo')
     node1.succeed('hello')
     node1.succeed('[ "$(hostname)" = "node2" ]')
+    node1.succeed('grep test-key /etc/ssh/authorized_keys.d/nixos')
     node1.succeed('grep nixos.foo=bar /proc/cmdline')
 
     node1.shutdown()

--- a/nixos/tests/kexec.nix
+++ b/nixos/tests/kexec.nix
@@ -39,7 +39,11 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     # Kexec node1 to the toplevel of node2 via the kexec-boot script
     node1.succeed('touch /run/foo')
     node1.fail('hello')
-    node1.execute('${nodes.node2.config.system.build.kexecTree}/kexec-boot', check_return=False)
+    node1.execute(
+        '${nodes.node2.config.system.build.kexecTree}/kexec-boot'
+        ' --append nixos.foo=bar',
+        check_return=False,
+    )
     node1.connected = False
     node1.connect()
     node1.wait_for_unit("multi-user.target")
@@ -47,6 +51,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     node1.succeed('! test -e /run/foo')
     node1.succeed('hello')
     node1.succeed('[ "$(hostname)" = "node2" ]')
+    node1.succeed('grep nixos.foo=bar /proc/cmdline')
 
     node1.shutdown()
   '';


### PR DESCRIPTION
###### Description of changes

Improve the robustness, compatibility, speed and features of the kexec bootstrap machinery. I wanted to install a system with this functionality and made some changes to get it suitable for purpose for that. May be easier to review commit by commit.

Headline changes:

* Improve speed by using the `kexec_load_file(2)` system call when possible; this resulted in a boot speed improvement of over an order of magnitude on my AArch64 test machine, although I imagine the impact is probably more limited on x86-64.

* Use `systemctl kexec` when possible to ensure that disks are unmounted cleanly and services are stopped gracefully.

* Generate a standalone tarball (well, relatively standalone; you need `kexec(8)` and optionally `cpio(1)`, but a more complete bundler could be built on top of this) to allow bootstrapping without an existing Nix installation and save redundant downloads. `system.build.kexecTree` is still there for those who want it.

* Add `--ssh-authorized-keys` and `--append` options to allow using a Hydra-built `kexecTarball` in more circumstances (like the primary use case of bootstrapping remote servers) without writing system configuration and rebuilding a whole netboot image.

Unresolved questions:

* Should there be a way to overlay more into the booted system than just an `authorized_keys` file? I figured that's what most people (including me) will require and if you want other files in the installation environment you can probably mount the existing disk partitions after the fact, but it would be simple to implement. Mostly I couldn't figure out a good interface for it (e.g. where should the files go?) and worried it'd be feature creep; you can always create a custom configuration if you need to get fancier.

* Perhaps instead of building `authorized_keys` injection into this it could be parsed from a kernel command-line parameter, so that the other installer formats could benefit from it too? (But it seems fussy to parse out of there, and you'll likely have at least a serial console if nothing else with most other installer formats.)

* Is setting `system.stateVersion` in `netboot.nix` appropriate? Maybe there's a reason it's in the `.iso` installer and not there that I'm missing, or maybe it should go into `installation-device.nix`?

* Would it be useful to use kernel parameters like `panic=30 boot.panic_on_fail` by default to automatically restore the system to a working configuration in case of boot failure when you have no way of monitoring it?

* Are there backwards compatibility concerns with replacing `kexec` with `kexecTarball` wholesale in `release.nix`? I suppose 23.11 will release with the old form?

* Is linking to Hydra in the documentation okay? The various `nixos.*` image/installer jobs are not very discoverable in general, so I felt a pointer in the manual was warranted, although search doesn't work very well and there's seemingly no good way to link to jobs independent of release versions.

* Does this warrant a release notes entry?

cc @flokli (author of original code)

cc @Mic92 (I only just noticed [nix-community/nixos-images](https://github.com/nix-community/nixos-images) now after finishing these changes; maybe you have comments?)

@ofborg text kexec

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->