### PR TITLE
stm32cubemx: add working desktop file

### DIFF
--- a/pkgs/development/embedded/stm32/stm32cubemx/default.nix
+++ b/pkgs/development/embedded/stm32/stm32cubemx/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, makeDesktopItem, copyDesktopItems, icoutils, fdupes, imagemagick, jdk11, fetchzip }:
+{ lib, stdenv, makeDesktopItem, icoutils, fdupes, imagemagick, jdk11, fetchzip }:
 # TODO: JDK16 causes STM32CubeMX to crash right now, so we fixed the version to JDK11
 # This may be fixed in a future version of STM32CubeMX. This issue has been reported to ST:
 # https://community.st.com/s/question/0D53W00000jnOzPSAU/stm32cubemx-crashes-on-launch-with-openjdk16
@@ -17,17 +17,21 @@ stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ icoutils fdupes imagemagick copyDesktopItems ];
-  desktopItems = [
-    (makeDesktopItem {
-      name = "stm32CubeMX";
-      exec = "stm32cubemx";
-      desktopName = "STM32CubeMX";
-      categories = [ "Development" ];
-      comment = "STM32Cube initialization code generator";
-      icon = "stm32cubemx";
-    })
-  ];
+  nativeBuildInputs = [ icoutils fdupes imagemagick ];
+  desktopItem = makeDesktopItem {
+    name = "STM32CubeMX";
+    exec = "stm32cubemx";
+    desktopName = "STM32CubeMX";
+    categories = [ "Development" ];
+    icon = "stm32cubemx";
+    comment = meta.description;
+    terminal = false;
+    startupNotify = false;
+    mimeTypes = [
+      "x-scheme-handler/sgnl"
+      "x-scheme-handler/signalcaptcha"
+    ];
+  };
 
   buildCommand = ''
     mkdir -p $out/{bin,opt/STM32CubeMX,share/applications}
@@ -55,18 +59,7 @@ stdenv.mkDerivation rec {
       fi
     done;
 
-    cat << EOF > $out/share/applications/stm32cubemx.desktop
-    [Desktop Entry]
-    Name=STM32CubeMX
-    Exec=stm32cubemx %F
-    Terminal=false
-    Type=Application
-    Icon=stm32cubemx
-    StartupWMClass=STM32CubeMX
-    Comment=A graphical tool for configuring STM32 microcontrollers and microprocessors
-    MimeType=x-scheme-handler/sgnl;x-scheme-handler/signalcaptcha;
-    Categories=Programming;
-    EOF
+    cp ${desktopItem}/share/applications/*.desktop $out/share/applications
   '';
 
   meta = with lib; {

--- a/pkgs/development/embedded/stm32/stm32cubemx/default.nix
+++ b/pkgs/development/embedded/stm32/stm32cubemx/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
-  nativeBuildInputs = [ icoutils fdupes imagemagick copyDesktopItems];
+  nativeBuildInputs = [ icoutils fdupes imagemagick copyDesktopItems ];
   desktopItems = [
     (makeDesktopItem {
       name = "stm32CubeMX";
@@ -30,9 +30,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildCommand = ''
-    mkdir -p $out/{bin,opt/STM32CubeMX}
+    mkdir -p $out/{bin,opt/STM32CubeMX,share/applications}
+
     cp -r $src/MX/. $out/opt/STM32CubeMX/
     chmod +rx $out/opt/STM32CubeMX/STM32CubeMX
+
     cat << EOF > $out/bin/${pname}
     #!${stdenv.shell}
     ${jdk11}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX
@@ -52,6 +54,19 @@ stdenv.mkDerivation rec {
           $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
       fi
     done;
+
+    cat << EOF > $out/share/applications/stm32cubemx.desktop
+    [Desktop Entry]
+    Name=STM32CubeMX
+    Exec=stm32cubemx %F
+    Terminal=false
+    Type=Application
+    Icon=stm32cubemx
+    StartupWMClass=STM32CubeMX
+    Comment=A graphical tool for configuring STM32 microcontrollers and microprocessors
+    MimeType=x-scheme-handler/sgnl;x-scheme-handler/signalcaptcha;
+    Categories=Programming;
+    EOF
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Added manual desktop file contents as the builtin version does not work (no file created in `$out/share/applications`).
This is probably not a final solution since a (not working implementation of) builtin function could be fixed.

###### Things done

Create `$out/share/applications/stm32cubemx.desktop` file and fill the contents in *buildCommand*. This works on nixos and on non-nixos (Cinnamon 5.2.7, Gnome 42).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).