### PR TITLE
rlaunch: fix build on aarch64-linux

### DIFF
--- a/pkgs/applications/misc/rlaunch/default.nix
+++ b/pkgs/applications/misc/rlaunch/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , rustPlatform
 , xorg
 }:
@@ -17,6 +18,15 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "00lnw48kn97gp45lylv5c6v6pil74flzpsq9k69xgvvjq9yqjzrx";
 
+  patches = [
+    # Fixes "error[E0308]: mismatched types; expected `u8`, found `i8`" on aarch64
+    # Remove with next version update
+    (fetchpatch {
+      url = "https://github.com/PonasKovas/rlaunch/commit/f78f36876bba45fe4e7310f58086ddc63f27a57e.patch";
+      hash = "sha256-rTS1khw1zt3i1AJ11BhAILcmaohAwVc7Qfl6Fc76Kvs=";
+    })
+  ];
+
   # The x11_dl crate dlopen()s these libraries, so we have to inject them into rpath.
   postFixup = ''
     patchelf --set-rpath ${lib.makeLibraryPath (with xorg; [ libX11 libXft libXinerama ])} $out/bin/rlaunch
@@ -26,6 +36,7 @@ rustPlatform.buildRustPackage rec {
     description = "A lightweight application launcher for X11";
     homepage = "https://github.com/PonasKovas/rlaunch";
     license = licenses.mit;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ danc86 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Fixes "error[E0308]: mismatched types; expected `u8`, found `i8`" on aarch64 ([Log](https://hydra.nixos.org/build/199409138/nixlog/2))

ZHF: #199919

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
