### PR TITLE
media-types: init at 10.1.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -572,6 +572,7 @@ in {
   nginx-etag = handleTest ./nginx-etag.nix {};
   nginx-globalredirect = handleTest ./nginx-globalredirect.nix {};
   nginx-http3 = handleTest ./nginx-http3.nix {};
+  nginx-media-types = handleTest ./nginx-media-types.nix {};
   nginx-modsecurity = handleTest ./nginx-modsecurity.nix {};
   nginx-njs = handleTest ./nginx-njs.nix {};
   nginx-proxyprotocol = handleTest ./nginx-proxyprotocol {};

--- a/nixos/tests/nginx-media-types.nix
+++ b/nixos/tests/nginx-media-types.nix
@@ -1,0 +1,25 @@
+import ./make-test-python.nix ({lib, pkgs, ...}:
+{
+  name = "nginx-media-types";
+  meta.maintainers = with pkgs.lib.maintainers; [ izorkin ];
+
+  nodes = {
+    machine = { pkgs, ... }: {
+      services.nginx = {
+        enable = true;
+        defaultMimeTypes = "${pkgs.media-types}/etc/nginx/mime.types";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("nginx")
+
+    # Checking for duplicate media.types
+    machine.fail("journalctl --unit nginx --grep 'duplicate extension'")
+
+    machine.shutdown()
+  '';
+})

--- a/pkgs/data/misc/media-types/default.nix
+++ b/pkgs/data/misc/media-types/default.nix
@@ -1,0 +1,117 @@
+{ lib, stdenv, fetchFromGitLab, nixosTests }:
+
+stdenv.mkDerivation rec {
+  pname = "media-types";
+  version = "10.1.0";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = pname;
+    rev = version;
+    hash = "sha256-vLQHjHrYShEBf4Py0vjpugbfY8HHnIIrmnxIDjHu5g8=";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  installPhase = ''
+    # Replace tabs symbols
+    substituteInPlace ./mime.types \
+      --replace "					" "  " \
+      --replace "				" "  " \
+      --replace "			" "  " \
+      --replace "		" "  " \
+      --replace "	" "  " \
+
+    # Compatibility mode
+    # See here for more information:
+    # https://trac.nginx.org/nginx/ticket/1407
+    substituteInPlace mime.types \
+      --replace "text/javascript  es js mjs" "application/javascript  es js mjs" \
+      --replace "application/xml  xml" "text/xml  xml"
+
+    # Replace mime-type with recommended ones.
+    substituteInPlace mime.types \
+      --replace "application/x-rss+xml  rss" "application/rss+xml  rss" \
+      --replace "image/vnd.microsoft.icon  ico" "image/x-icon  ico"
+
+    # Add missing mime-types and extensions
+    # Some of these mime-types are present only in the nginx package
+    substituteInPlace mime.types \
+      --replace "application/java-archive  jar" "application/java-archive  jar war ear" \
+      --replace "application/octet-stream    bin deploy msu msp" "application/octet-stream    bin deploy img msu msp" \
+      --replace "audio/aac  adts aac ass" "audio/aac  adts aac" \
+      --replace "text/plain  txt text pot brf srt" "text/plain  txt text pot brf less"
+    echo "application/x-cocoa  cco" >> ./mime.types
+    echo "application/x-java-archive-diff  jardiff" >> ./mime.types
+    echo "application/x-makeself  run" >> ./mime.types
+    echo "application/x-ssa  ass ssa" >> ./mime.types
+    echo "application/x-subrip  srt" >> ./mime.types
+    echo "application/x-web-app-manifest+json  webapp" >> ./mime.types
+    echo "audio/midi  midi kar" >> ./mime.types
+    echo "text/vnd.rim.location.xloc  xloc" >> ./mime.types
+    echo "video/mp2t  bdmv clpi cpi m2t m2ts mpl mpls" >> ./mime.types
+
+    # Generate nginx mime-types
+    echo "types {" > ./nginx-mime.types
+    cat mime.types | sed -e '/^#.*/d' -e '/^$/d' -e 's/.*/\ \ &;/' -ne '/[^[:space:]][[:space:]]\{1,\}[^[:space:]]/p' >> ./nginx-mime.types
+    echo "}" >> ./nginx-mime.types
+
+    # Remove duplicate mime-types extensions
+    substituteInPlace ./nginx-mime.types \
+      --replace "application/x-maker  frm maker frame fm fb book fbdoc;" \
+                "application/x-maker  maker frame fb book fbdoc;" \
+      --replace "application/x-qgis  qgs shp shx;" \
+                "application/x-qgis  qgs;" \
+      --replace "application/x-scilab  sci sce;" \
+                "application/x-scilab  sci;" \
+      --replace "audio/AMR  amr AMR;" \
+                "audio/AMR  amr;" \
+      --replace "audio/AMR-WB  awb AWB;" \
+                "audio/AMR-WB  awb;" \
+      --replace "audio/EVRC-QCP  qcp QCP;" \
+                "audio/EVRC-QCP  qcp;" \
+      --replace "chemical/x-mdl-sdfile  sd sdf;" \
+                "chemical/x-mdl-sdfile  sd;" \
+      --replace "chemical/x-mopac-input  mop mopcrt mpc zmt;" \
+                "chemical/x-mopac-input  mop mopcrt zmt;" \
+      --replace "chemical/x-ncbi-asn1-binary  val aso;" \
+                "chemical/x-ncbi-asn1-binary  val;"\
+      --replace "image/j2c  j2c J2C j2k J2K;" \
+                "image/j2c  j2c j2k;" \
+      --replace "image/vnd.globalgraphics.pgb  PGB pgb;" \
+                "image/vnd.globalgraphics.pgb  pgb;" \
+      --replace "text/x-tcl  tcl tk;" \
+                "text/x-tcl  tk;"
+
+    sed -i ./nginx-mime.types \
+      -e '/application\/mac-compactpro  .*/d' \
+      -e '/audio\/x-gsm  .*/d' \
+      -e '/chemical\/x-chemdraw  .*/d' \
+      -e '/chemical\/x-cif  .*/d' \
+      -e '/chemical\/x-cml  .*/d' \
+      -e '/chemical\/x-ncbi-asn1-spec  .*/d' \
+      -e '/chemical\/x-pdb  .*/d' \
+      -e '/image\/x-jg  .*/d' \
+      -e '/text\/x-csh  .*/d' \
+      -e '/text\/x-sh  .*/d'
+
+    install -D -m0444 mime.types $out/etc/mime.types
+    install -D -m0444 nginx-mime.types $out/etc/nginx/mime.types
+    install -D -m0444 debian/bug-presubj $doc/share/doc/media-types/presubj
+    install -D -m0444 debian/changelog $doc/share/doc/media-types/changelog
+    install -D -m0444 debian/copyright $doc/share/doc/media-types/copyright
+  '';
+
+  passthru = {
+    tests.nginx-media-types = nixosTests.nginx-media-types;
+  };
+
+  meta = with lib; {
+    description = "List of standard media types and their usual file extension";
+    homepage = "https://salsa.debian.org/debian/media-types";
+    license = licenses.publicDomain;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29641,6 +29641,8 @@ with pkgs;
 
   media-player-info = callPackage ../data/misc/media-player-info { };
 
+  media-types = callPackage ../data/misc/media-types {};
+
   medio = callPackage ../data/fonts/medio { };
 
   melete = callPackage ../data/fonts/melete { };


### PR DESCRIPTION
###### Description of changes
Add package media-types version 10.1.0.
This package includes the latest changes in mime.types.
In nginx mime-types added missing types specified in the recommended nginx settings - https://github.com/h5bp/server-configs-nginx
Also removed duplicate extensions in nginx mime-types.
Example:
```
nginx[130522]: nginx: [warn] duplicate extension "frm", content type: "application/x-maker", previous content type: "application/vnd.ufdl" in /etc/nginx/nginx-mime.types:760
nginx[130522]: nginx: [warn] duplicate extension "fm", content type: "application/x-maker", previous content type: "application/vnd.framemaker" in /etc/nginx/nginx-mime.types:760
nginx[130522]: nginx: [warn] duplicate extension "shp", content type: "application/x-qgis", previous content type: "application/vnd.shp" in /etc/nginx/nginx-mime.types:772
nginx[130522]: nginx: [warn] duplicate extension "shx", content type: "application/x-qgis", previous content type: "application/vnd.shx" in /etc/nginx/nginx-mime.types:772
nginx[130522]: nginx: [warn] duplicate extension "sce", content type: "application/x-scilab", previous content type: "application/vnd.etsi.asic-e+zip" in /etc/nginx/nginx-mime.types:778
nginx[130522]: nginx: [warn] duplicate extension "amr", content type: "audio/AMR", previous content type: "audio/AMR" in /etc/nginx/nginx-mime.types:825
nginx[130522]: nginx: [warn] duplicate extension "awb", content type: "audio/AMR-WB", previous content type: "audio/AMR-WB" in /etc/nginx/nginx-mime.types:826
nginx[130522]: nginx: [warn] duplicate extension "qcp", content type: "audio/EVRC-QCP", previous content type: "audio/EVRC-QCP" in /etc/nginx/nginx-mime.types:836
nginx[130522]: nginx: [warn] duplicate extension "chm", content type: "chemical/x-chemdraw", previous content type: "application/vnd.ms-htmlhelp" in /etc/nginx/nginx-mime.types:884
nginx[130522]: nginx: [warn] duplicate extension "cif", content type: "chemical/x-cif", previous content type: "application/vnd.multiad.creator.cif" in /etc/nginx/nginx-mime.types:885
nginx[130522]: nginx: [warn] duplicate extension "cml", content type: "chemical/x-cml", previous content type: "application/cellml+xml" in /etc/nginx/nginx-mime.types:887
nginx[130522]: nginx: [warn] duplicate extension "sdf", content type: "chemical/x-mdl-sdfile", previous content type: "application/vnd.Kinar" in /etc/nginx/nginx-mime.types:911
nginx[130522]: nginx: [warn] duplicate extension "mpc", content type: "chemical/x-mopac-input", previous content type: "application/vnd.mophun.certificate" in /etc/nginx/nginx-mime.types:917
nginx[130522]: nginx: [warn] duplicate extension "aso", content type: "chemical/x-ncbi-asn1-binary", previous content type: "application/vnd.accpac.simply.aso" in /etc/nginx/nginx-mime.types:922
nginx[130522]: nginx: [warn] duplicate extension "asn", content type: "chemical/x-ncbi-asn1-spec", previous content type: "chemical/x-ncbi-asn1" in /etc/nginx/nginx-mime.types:923
nginx[130522]: nginx: [warn] duplicate extension "pdb", content type: "chemical/x-pdb", previous content type: "application/vnd.palm" in /etc/nginx/nginx-mime.types:924
nginx[130522]: nginx: [warn] duplicate extension "pgb", content type: "image/vnd.globalgraphics.pgb", previous content type: "image/vnd.globalgraphics.pgb" in /etc/nginx/nginx-mime.types:987
nginx[130522]: nginx: [warn] duplicate extension "cpt", content type: "image/x-corelphotopaint", previous content type: "application/mac-compactpro" in /etc/nginx/nginx-mime.types:1008
nginx[130522]: nginx: [warn] duplicate extension "art", content type: "message/rfc822", previous content type: "image/x-jg" in /etc/nginx/nginx-mime.types:1027
nginx[130522]: nginx: [warn] duplicate extension "gsm", content type: "model/vnd.gdl", previous content type: "audio/x-gsm" in /etc/nginx/nginx-mime.types:1043
nginx[130522]: nginx: [warn] duplicate extension "csh", content type: "text/x-csh", previous content type: "application/x-csh" in /etc/nginx/nginx-mime.types:1122
nginx[130522]: nginx: [warn] duplicate extension "sh", content type: "text/x-sh", previous content type: "application/x-sh" in /etc/nginx/nginx-mime.types:1138
nginx[130522]: nginx: [warn] duplicate extension "tcl", content type: "text/x-tcl", previous content type: "application/x-tcl" in /etc/nginx/nginx-mime.types:1139
nginx[130522]: nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx[130522]: nginx: configuration file /etc/nginx/nginx.conf test is successful

```
cc @SuperSandro2000 @pennae @ajs124 @dasJ

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
