### PR TITLE
aesmd: allow to customize quote provider library, init sgx-azure-dcap-client at 1.11.2

### DIFF
--- a/nixos/modules/services/security/aesmd.nix
+++ b/nixos/modules/services/security/aesmd.nix
@@ -25,6 +25,16 @@ in
       default = false;
       description = lib.mdDoc "Whether to build the PSW package in debug mode.";
     };
+    environment = mkOption {
+      type = with types; attrsOf str;
+      default = { };
+      description = mdDoc "Additional environment variables to pass to the AESM service.";
+      # Example environment variable for `sgx-azure-dcap-client` provider library
+      example = {
+        AZDCAP_COLLATERAL_VERSION = "v2";
+        AZDCAP_DEBUG_LOG_LEVEL = "INFO";
+      };
+    };
     quoteProviderLibrary = mkOption {
       type = with types; nullOr path;
       default = null;
@@ -104,7 +114,7 @@ in
           NAME = "aesm_service";
           AESM_PATH = storeAesmFolder;
           LD_LIBRARY_PATH = makeLibraryPath [ cfg.quoteProviderLibrary ];
-        };
+        } // cfg.environment;
 
         # Make sure any of the SGX application enclave devices is available
         unitConfig.AssertPathExists = [

--- a/nixos/modules/services/security/aesmd.nix
+++ b/nixos/modules/services/security/aesmd.nix
@@ -25,6 +25,12 @@ in
       default = false;
       description = lib.mdDoc "Whether to build the PSW package in debug mode.";
     };
+    quoteProviderLibrary = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      example = literalExpression "pkgs.sgx-azure-dcap-client";
+      description = lib.mdDoc "Custom quote provider library to use.";
+    };
     settings = mkOption {
       description = lib.mdDoc "AESM configuration";
       default = { };
@@ -83,7 +89,6 @@ in
         storeAesmFolder = "${sgx-psw}/aesm";
         # Hardcoded path AESM_DATA_FOLDER in psw/ae/aesm_service/source/oal/linux/aesm_util.cpp
         aesmDataFolder = "/var/opt/aesmd/data";
-        aesmStateDirSystemd = "%S/aesmd";
       in
       {
         description = "Intel Architectural Enclave Service Manager";
@@ -98,7 +103,7 @@ in
         environment = {
           NAME = "aesm_service";
           AESM_PATH = storeAesmFolder;
-          LD_LIBRARY_PATH = storeAesmFolder;
+          LD_LIBRARY_PATH = makeLibraryPath [ cfg.quoteProviderLibrary ];
         };
 
         # Make sure any of the SGX application enclave devices is available

--- a/nixos/tests/aesmd.nix
+++ b/nixos/tests/aesmd.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, ... }: {
   name = "aesmd";
   meta = {
-    maintainers = with lib.maintainers; [ veehaitch ];
+    maintainers = with lib.maintainers; [ trundle veehaitch ];
   };
 
   nodes.machine = { lib, ... }: {
@@ -25,38 +25,69 @@
 
     # We don't have a real SGX machine in NixOS tests
     systemd.services.aesmd.unitConfig.AssertPathExists = lib.mkForce [ ];
+
+    specialisation = {
+      withQuoteProvider.configuration = { ... }: {
+        services.aesmd.quoteProviderLibrary = pkgs.sgx-azure-dcap-client;
+      };
+    };
   };
 
-  testScript = ''
-    with subtest("aesmd.service starts"):
-      machine.wait_for_unit("aesmd.service")
-      status, main_pid = machine.systemctl("show --property MainPID --value aesmd.service")
-      assert status == 0, "Could not get MainPID of aesmd.service"
-      main_pid = main_pid.strip()
+  testScript = { nodes, ... }:
+    let
+      specialisations = "${nodes.machine.system.build.toplevel}/specialisation";
+    in
+    ''
+      def get_aesmd_pid():
+        status, main_pid = machine.systemctl("show --property MainPID --value aesmd.service")
+        assert status == 0, "Could not get MainPID of aesmd.service"
+        return main_pid.strip()
 
-    with subtest("aesmd.service runtime directory permissions"):
-      runtime_dir = "/run/aesmd";
-      res = machine.succeed(f"stat -c '%a %U %G' {runtime_dir}").strip()
-      assert "750 aesmd sgx" == res, f"{runtime_dir} does not have the expected permissions: {res}"
+      with subtest("aesmd.service starts"):
+        machine.wait_for_unit("aesmd.service")
 
-    with subtest("aesm.socket available on host"):
-      socket_path = "/var/run/aesmd/aesm.socket"
-      machine.wait_until_succeeds(f"test -S {socket_path}")
-      machine.succeed(f"test 777 -eq $(stat -c '%a' {socket_path})")
-      for op in [ "-r", "-w", "-x" ]:
-        machine.succeed(f"sudo -u sgxtest test {op} {socket_path}")
-        machine.fail(f"sudo -u nosgxtest test {op} {socket_path}")
+      main_pid = get_aesmd_pid()
 
-    with subtest("Copies white_list_cert_to_be_verify.bin"):
-      whitelist_path = "/var/opt/aesmd/data/white_list_cert_to_be_verify.bin"
-      whitelist_perms = machine.succeed(
-        f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/stat -c '%a' {whitelist_path}"
-      ).strip()
-      assert "644" == whitelist_perms, f"white_list_cert_to_be_verify.bin has permissions {whitelist_perms}"
+      with subtest("aesmd.service runtime directory permissions"):
+        runtime_dir = "/run/aesmd";
+        res = machine.succeed(f"stat -c '%a %U %G' {runtime_dir}").strip()
+        assert "750 aesmd sgx" == res, f"{runtime_dir} does not have the expected permissions: {res}"
 
-    with subtest("Writes and binds aesm.conf in service namespace"):
-      aesmd_config = machine.succeed(f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/cat /etc/aesmd.conf")
+      with subtest("aesm.socket available on host"):
+        socket_path = "/var/run/aesmd/aesm.socket"
+        machine.wait_until_succeeds(f"test -S {socket_path}")
+        machine.succeed(f"test 777 -eq $(stat -c '%a' {socket_path})")
+        for op in [ "-r", "-w", "-x" ]:
+          machine.succeed(f"sudo -u sgxtest test {op} {socket_path}")
+          machine.fail(f"sudo -u nosgxtest test {op} {socket_path}")
 
-      assert aesmd_config == "whitelist url = http://nixos.org\nproxy type = direct\ndefault quoting type = ecdsa_256\n", "aesmd.conf differs"
-  '';
+      with subtest("Copies white_list_cert_to_be_verify.bin"):
+        whitelist_path = "/var/opt/aesmd/data/white_list_cert_to_be_verify.bin"
+        whitelist_perms = machine.succeed(
+          f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/stat -c '%a' {whitelist_path}"
+        ).strip()
+        assert "644" == whitelist_perms, f"white_list_cert_to_be_verify.bin has permissions {whitelist_perms}"
+
+      with subtest("Writes and binds aesm.conf in service namespace"):
+        aesmd_config = machine.succeed(f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/cat /etc/aesmd.conf")
+
+        assert aesmd_config == "whitelist url = http://nixos.org\nproxy type = direct\ndefault quoting type = ecdsa_256\n", "aesmd.conf differs"
+
+      with subtest("aesmd.service without quote provider library has correct LD_LIBRARY_PATH"):
+        status, environment = machine.systemctl("show --property Environment --value aesmd.service")
+        assert status == 0, "Could not get Environment of aesmd.service"
+        env_by_name = dict(entry.split("=", 1) for entry in environment.split())
+        assert not env_by_name["LD_LIBRARY_PATH"], "LD_LIBRARY_PATH is not empty"
+
+      with subtest("aesmd.service with quote provider library starts"):
+        machine.succeed('${specialisations}/withQuoteProvider/bin/switch-to-configuration test')
+        machine.wait_for_unit("aesmd.service")
+
+      main_pid = get_aesmd_pid()
+
+      with subtest("aesmd.service with quote provider library has correct LD_LIBRARY_PATH"):
+        ld_library_path = machine.succeed(f"xargs -0 -L1 -a /proc/{main_pid}/environ | grep LD_LIBRARY_PATH")
+        assert ld_library_path.startswith("LD_LIBRARY_PATH=${pkgs.sgx-azure-dcap-client}/lib:"), \
+          "LD_LIBRARY_PATH is not set to the configured quote provider library"
+    '';
 }

--- a/nixos/tests/aesmd.nix
+++ b/nixos/tests/aesmd.nix
@@ -28,7 +28,12 @@
 
     specialisation = {
       withQuoteProvider.configuration = { ... }: {
-        services.aesmd.quoteProviderLibrary = pkgs.sgx-azure-dcap-client;
+        services.aesmd = {
+          quoteProviderLibrary = pkgs.sgx-azure-dcap-client;
+          environment = {
+            AZDCAP_DEBUG_LOG_LEVEL = "INFO";
+          };
+        };
       };
     };
   };
@@ -89,5 +94,9 @@
         ld_library_path = machine.succeed(f"xargs -0 -L1 -a /proc/{main_pid}/environ | grep LD_LIBRARY_PATH")
         assert ld_library_path.startswith("LD_LIBRARY_PATH=${pkgs.sgx-azure-dcap-client}/lib:"), \
           "LD_LIBRARY_PATH is not set to the configured quote provider library"
+
+      with subtest("aesmd.service with quote provider library has set AZDCAP_DEBUG_LOG_LEVEL"):
+        azdcp_debug_log_level = machine.succeed(f"xargs -0 -L1 -a /proc/{main_pid}/environ | grep AZDCAP_DEBUG_LOG_LEVEL")
+        assert azdcp_debug_log_level == "AZDCAP_DEBUG_LOG_LEVEL=INFO\n", "AZDCAP_DEBUG_LOG_LEVEL is not set to INFO"
     '';
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -69,7 +69,7 @@ in {
   _3proxy = runTest ./3proxy.nix;
   acme = runTest ./acme.nix;
   adguardhome = runTest ./adguardhome.nix;
-  aesmd = runTest ./aesmd.nix;
+  aesmd = runTestOn ["x86_64-linux"] ./aesmd.nix;
   agate = runTest ./web-servers/agate.nix;
   agda = handleTest ./agda.nix {};
   airsonic = handleTest ./airsonic.nix {};

--- a/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
+++ b/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, fetchFromGitHub
+, fetchurl
+, lib
+, curl
+, nlohmann_json
+, openssl
+, pkg-config
+, linkFarmFromDrvs
+}:
+
+let
+  # Although those headers are also included in the source of `sgx-psw`, the `azure-dcap-client` build needs specific versions
+  filterSparse = list: ''
+    cp -r "$out"/. .
+    find "$out" -mindepth 1 -delete
+    cp ${lib.concatStringsSep " " list} "$out/"
+  '';
+  headers = linkFarmFromDrvs "azure-dcpa-client-intel-headers" [
+    (fetchFromGitHub rec {
+      name = "${repo}-headers";
+      owner = "intel";
+      repo = "SGXDataCenterAttestationPrimitives";
+      rev = "0436284f12f1bd5da7e7a06f6274d36b4c8d39f9";
+      sparseCheckout = [ "QuoteGeneration/quote_wrapper/common/inc/sgx_ql_lib_common.h" ];
+      hash = "sha256-ipKpYHbiwjCUXF/pCArJZy5ko1YX2wqMMdSnMUzhkgY=";
+      postFetch = filterSparse sparseCheckout;
+    })
+    (fetchFromGitHub rec {
+      name = "${repo}-headers";
+      owner = "intel";
+      repo = "linux-sgx";
+      rev = "1ccf25b64abd1c2eff05ead9d14b410b3c9ae7be";
+      hash = "sha256-WJRoS6+NBVJrFmHABEEDpDhW+zbWFUl65AycCkRavfs=";
+      sparseCheckout = [
+        "common/inc/sgx_report.h"
+        "common/inc/sgx_key.h"
+        "common/inc/sgx_attributes.h"
+      ];
+      postFetch = filterSparse sparseCheckout;
+    })
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "azure-dcap-client";
+  version = "1.11.2";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = pname;
+    rev = version;
+    hash = "sha256-EYj3jnzTyJRl6N7avNf9VrB8r9U6zIE6wBNeVsMtWCA=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    nlohmann_json
+    openssl
+  ];
+
+  postPatch = ''
+    mkdir -p src/Linux/ext/intel
+    find -L '${headers}' -type f -exec ln -s {} src/Linux/ext/intel \;
+
+    substitute src/Linux/Makefile{.in,} \
+      --replace '##CURLINC##' '${curl.dev}/include/curl/' \
+      --replace '$(TEST_SUITE): $(PROVIDER_LIB) $(TEST_SUITE_OBJ)' '$(TEST_SUITE): $(TEST_SUITE_OBJ)'
+  '';
+
+  NIX_CFLAGS_COMPILE = "-Wno-deprecated-declarations";
+
+  makeFlags = [
+    "-C src/Linux"
+    "prefix=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "Interfaces between SGX SDKs and the Azure Attestation SGX Certification Cache";
+    homepage = "https://github.com/microsoft/azure-dcap-client";
+    maintainers = with maintainers; [ trundle veehaitch ];
+    platforms = [ "x86_64-linux" ];
+    license = [ licenses.mit ];
+  };
+}

--- a/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
+++ b/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
@@ -7,6 +7,7 @@
 , openssl
 , pkg-config
 , linkFarmFromDrvs
+, callPackage
 }:
 
 let
@@ -77,6 +78,10 @@ stdenv.mkDerivation rec {
     "-C src/Linux"
     "prefix=$(out)"
   ];
+
+  # Online test suite; run with
+  # $(nix-build -A sgx-azure-dcap-client.tests.suite)/bin/tests
+  passthru.tests.suite = callPackage ./test-suite.nix { };
 
   meta = with lib; {
     description = "Interfaces between SGX SDKs and the Azure Attestation SGX Certification Cache";

--- a/pkgs/os-specific/linux/sgx/azure-dcap-client/test-suite.nix
+++ b/pkgs/os-specific/linux/sgx/azure-dcap-client/test-suite.nix
@@ -1,0 +1,27 @@
+{ lib
+, sgx-azure-dcap-client
+, gtest
+, makeWrapper
+}:
+sgx-azure-dcap-client.overrideAttrs (oldAttrs: {
+  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
+    makeWrapper
+    gtest
+  ];
+
+  buildFlags = [
+    "tests"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ./src/Linux/tests "$out/bin/tests"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/tests" --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ sgx-azure-dcap-client ]}"
+  '';
+})

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
 
     mkdir $out/bin
     makeWrapper $out/aesm/aesm_service $out/bin/aesm_service \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ protobuf ]}:$out/aesm \
+      --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ protobuf ]}:$out/aesm \
       --chdir "$out/aesm"
 
     # Make sure we didn't forget to handle any files

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25808,6 +25808,8 @@ with pkgs;
 
   seturgent = callPackage ../os-specific/linux/seturgent { };
 
+  sgx-azure-dcap-client = callPackage ../os-specific/linux/sgx/azure-dcap-client { };
+
   sgx-sdk = callPackage ../os-specific/linux/sgx/sdk { };
 
   sgx-ssl = callPackage ../os-specific/linux/sgx/ssl { };


### PR DESCRIPTION
###### Description of changes

* aesmd: allow to customize quote provider library
* [sgx-azure-dcap-client](https://github.com/microsoft/azure-dcap-client): init at 1.11.2

Tested in an Azure VM (with Enarx)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
