### PR TITLE
ngn-k: unstable-2021-12-17 -> 2022-11-27

### DIFF
--- a/pkgs/development/interpreters/ngn-k/default.nix
+++ b/pkgs/development/interpreters/ngn-k/default.nix
@@ -3,12 +3,14 @@
 , stdenvNoLibs
 , fetchFromGitea
 , runtimeShell
-, doCheck ? stdenv.hostPlatform == stdenv.buildPlatform
+, doCheck ? withLibc && stdenv.hostPlatform == stdenv.buildPlatform
+, withLibc ? true
 }:
 
 let
-  # k itself is compiled with -ffreestanding, but tests require a libc
-  useStdenv = if doCheck then stdenv else stdenvNoLibs;
+  # k itself can be compiled with -ffreestanding, but tests require a libc;
+  # if we want to build k-libc we need a libc obviously
+  useStdenv = if withLibc || doCheck then stdenv else stdenvNoLibs;
 in
 
 useStdenv.mkDerivation {
@@ -37,7 +39,10 @@ useStdenv.mkDerivation {
   '';
 
   makeFlags = [ "-e" ];
-  buildFlags = [ "k" "libk.so" ];
+  buildFlags = [
+    (if withLibc then "k-libc" else "k")
+    "libk.so"
+  ];
   checkTarget = "t";
   inherit doCheck;
 

--- a/pkgs/development/interpreters/ngn-k/default.nix
+++ b/pkgs/development/interpreters/ngn-k/default.nix
@@ -15,14 +15,14 @@ in
 
 useStdenv.mkDerivation {
   pname = "ngn-k";
-  version = "unstable-2022-11-27";
+  version = "unstable-2022-11-28";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "ngn";
     repo = "k";
-    rev = "79834b6b9be2a23eec8027d0a2ce11e29f01959c";
-    sha256 = "0dczfyqf33mwxfly39xsgwwgjqqm6pjyrlr6gx04zg8n4ch11zhl";
+    rev = "e5138f182a8ced07dd240e3fe58274130842a85d";
+    sha256 = "1pn416znrdndb8iccprzx4zicmsx8c6i9dm3wq5z3jg8nan53p69";
   };
 
   patches = [
@@ -65,6 +65,6 @@ useStdenv.mkDerivation {
     homepage = "https://codeberg.org/ngn/k";
     license = lib.licenses.agpl3Only;
     maintainers = [ lib.maintainers.sternenseemann ];
-    platforms = [ "x86_64-linux" "x86_64-freebsd" ];
+    platforms = [ "x86_64-linux" "x86_64-freebsd13" ];
   };
 }

--- a/pkgs/development/interpreters/ngn-k/default.nix
+++ b/pkgs/development/interpreters/ngn-k/default.nix
@@ -13,14 +13,14 @@ in
 
 useStdenv.mkDerivation {
   pname = "ngn-k";
-  version = "unstable-2021-12-17";
+  version = "unstable-2022-11-27";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "ngn";
     repo = "k";
-    rev = "26f83645e9ed4798b43390fb9dcdfa0ab8245a8f";
-    sha256 = "sha256-VcJcLcL1C8yQH6xvpKR0R0gMrhSfsU4tW+Yy0rGdSSw=";
+    rev = "79834b6b9be2a23eec8027d0a2ce11e29f01959c";
+    sha256 = "0dczfyqf33mwxfly39xsgwwgjqqm6pjyrlr6gx04zg8n4ch11zhl";
   };
 
   patches = [
@@ -28,10 +28,10 @@ useStdenv.mkDerivation {
   ];
 
   postPatch = ''
-    patchShebangs a19/a.sh a20/a.sh a21/a.sh dy/a.sh e/a.sh
+    patchShebangs --build a19/a.sh a20/a.sh a21/a.sh dy/a.sh e/a.sh
 
     # don't use hardcoded /bin/sh
-    for f in repl.k m.c;do
+    for f in repl.k repl-bg.k m.c;do
       substituteInPlace "$f" --replace "/bin/sh" "${runtimeShell}"
     done
   '';
@@ -43,6 +43,7 @@ useStdenv.mkDerivation {
 
   outputs = [ "out" "dev" "lib" ];
 
+  # TODO(@sternenseemann): package bulgarian translation
   installPhase = ''
     runHook preInstall
     install -Dm755 k "$out/bin/k"

--- a/pkgs/development/interpreters/ngn-k/repl-license-path.patch
+++ b/pkgs/development/interpreters/ngn-k/repl-license-path.patch
@@ -1,10 +1,13 @@
+diff --git a/repl.k b/repl.k
+index 4c023467..10414162 100755
 --- a/repl.k
 +++ b/repl.k
-@@ -1,6 +1,6 @@
- #!k
- `1:"ngn/k, (c) 2019-2021 ngn, GNU AGPLv3. type \\ for more info\n",repl.prompt:," "
--repl.cmds:(,"a")!{`1:1:repl.joinpath[repl.dirname`argv 0]"LICENSE";}
-+repl.cmds:(,"a")!{`1:1:repl.joinpath[repl.dirname`argv 0]"../share/ngn-k/LICENSE";}
- repl.dirname:{$[#x:"/"/-1_"/"\x;x;,"."]}
- repl.joinpath:{$[x~,".";y;"/"~*|x;x,y;x,"/",y]}
- repl.fmt:{$[x~(::);"";(`A~@x)&1<#x;"(",("\n "/`k'x),")\n";`k[x],"\n"]}
+@@ -2,7 +2,7 @@
+ `1:"ngn/k, (c) 2019-2022 ngn, GNU AGPLv3. type \\ for more info\n"
+ \d repl
+ `1:prompt:," " /use 0x0720 for emacs integration
+-cmds:(,"a")!{`1:1:joinpath[dirname`argv 0]"LICENSE";}
++cmds:(,"a")!{`1:1:joinpath[dirname`argv 0]"../share/ngn-k/LICENSE";}
+ dirname:{$[#x:"/"/-1_"/"\x;x;,"."]}
+ joinpath:{$[x~,".";y;"/"~*|x;x,y;x,"/",y]}
+ fmt:{$[x~(::);"";(`A~@x)&1<#x;"(",("\n "/`k'x),")\n";`k[x],"\n"]}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
