### PR TITLE
ocamlPackages.gen: 0.5 → 1.0

### DIFF
--- a/pkgs/development/ocaml-modules/gen/default.nix
+++ b/pkgs/development/ocaml-modules/gen/default.nix
@@ -1,31 +1,30 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, ounit }:
+{ lib, buildDunePackage, fetchFromGitHub, ocaml
+, dune-configurator
+, seq
+, qcheck, ounit2
+}:
 
-stdenv.mkDerivation rec {
-  version = "0.5";
-  pname = "ocaml${ocaml.version}-gen";
+buildDunePackage rec {
+  version = "1.0";
+  pname = "gen";
+  minimalOCamlVersion = "4.03";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "gen";
-    rev = version;
-    sha256 = "14b8vg914nb0yp1hgxzm29bg692m0gqncjj43b599s98s1cwl92h";
+    rev = "v${version}";
+    hash = "sha256-YWoVcl2TQoMIgU1LoKL16ia31zJjwAMwuphtSXnhtvw=";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = lib.optionals doCheck [ qtest ounit ];
-  strictDeps = true;
-
-  configureFlags = lib.optional doCheck "--enable-tests";
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ seq ];
+  checkInputs = [ qcheck ounit2 ];
 
   doCheck = lib.versionAtLeast ocaml.version "4.08";
-  checkTarget = "test";
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = "https://github.com/c-cube/gen";
     description = "Simple, efficient iterators for OCaml";
     license = lib.licenses.bsd3;
-    inherit (ocaml.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.0.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
