### PR TITLE
Enrich PostgreSQL ensure users and databases support

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -446,7 +446,7 @@ in
             addS = n: p: optional (p != null) "${n} '${p}'";
             addL = n: p: optional (p != null) "${n} ${toString p}";
           in
-            escapeShellArg (concatStringsSep " " (
+            concatStringsSep " " (
               [ "CREATE DATABASE \"${ps.name}\"" ]
               ++ addS "OWNER" ps.owner
               ++ addS "TEMPLATE" ps.template
@@ -455,7 +455,34 @@ in
               ++ addS "LC_CTYPE" ps.lcCtype
               ++ addL "ALLOW_CONNECTIONS" ps.allowConnections
               ++ addL "CONNECTION LIMIT" ps.connectionLimit
-              ++ addL "IS_TEMPLATE" ps.isTemplate));
+              ++ addL "IS_TEMPLATE" ps.isTemplate);
+
+          # Run a single SQL command.
+          psqlCmd = cmd: "$PSQL -tA <<< ${escapeShellArg cmd}";
+
+          ensureDatabases = map (database: ''
+              ${psqlCmd "SELECT 1 FROM pg_database WHERE datname = '${database.name}'"} \
+                | grep -q 1 \
+                || ${psqlCmd (createDatabase database)}
+            '') cfg.ensureDatabases;
+
+          ensureUsers = map (user: ''
+              ${psqlCmd "SELECT 1 FROM pg_roles WHERE rolname='${user.name}'"} \
+                | grep -q 1 \
+                || ${psqlCmd "CREATE USER \"${user.name}\""}
+            '') cfg.ensureUsers;
+
+          ensureUserGrant = user: mapAttrsToList (database: permission: ''
+              ${psqlCmd "GRANT ${permission} ON ${database} TO \"${user.name}\""}
+            '') user.ensurePermissions;
+
+          ensureUserGrants = concatMap ensureUserGrant cfg.ensureUsers;
+
+          # Makes sure the specified users and databases are available. Note, we
+          # first create the users then the databases to be able to set the
+          # database owner to the newly created user. Finally we set user grants
+          # so that we can refer to both newly created users and databases.
+          ensures = concatStrings (ensureUsers ++ ensureDatabases ++ ensureUserGrants);
         in
           ''
             PSQL="psql --port=${toString cfg.port}"
@@ -471,18 +498,7 @@ in
               ''}
               rm -f "${cfg.dataDir}/.first_startup"
             fi
-          '' + optionalString (cfg.ensureDatabases != []) ''
-            ${concatMapStrings (database: ''
-              $PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = '${database.name}'" | grep -q 1 || $PSQL -tAc ${createDatabase database}
-            '') cfg.ensureDatabases}
-          '' + ''
-            ${concatMapStrings (user: ''
-              $PSQL -tAc "SELECT 1 FROM pg_roles WHERE rolname='${user.name}'" | grep -q 1 || $PSQL -tAc 'CREATE USER "${user.name}"'
-              ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
-                $PSQL -tAc 'GRANT ${permission} ON ${database} TO "${user.name}"'
-              '') user.ensurePermissions)}
-            '') cfg.ensureUsers}
-          '';
+          '' + ensures;
 
         serviceConfig = mkMerge [
           { ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";

--- a/nixos/tests/matrix/synapse.nix
+++ b/nixos/tests/matrix/synapse.nix
@@ -98,13 +98,22 @@ in {
         #   - services.matrix-synapse.database_user
         #
         # The values used here represent the default values of the module.
-        initialScript = pkgs.writeText "synapse-init.sql" ''
-          CREATE ROLE "matrix-synapse" WITH LOGIN PASSWORD 'synapse';
-          CREATE DATABASE "matrix-synapse" WITH OWNER "matrix-synapse"
-            TEMPLATE template0
-            LC_COLLATE = "C"
-            LC_CTYPE = "C";
-        '';
+        ensureUsers = [
+          {
+            name = "matrix-synapse";
+            passwordFile = builtins.toFile "pwd" "synapse";
+          }
+        ];
+
+        ensureDatabases = [
+          {
+            name = "matrix-synapse";
+            owner = "matrix-synapse";
+            template = "template0";
+            lcCollate = "C";
+            lcCtype = "C";
+          }
+        ];
       };
 
       networking.extraHosts = ''


### PR DESCRIPTION
###### Description of changes

This PR includes a general cleanup of the generation of the "ensure users and databases" script.

It also makes it possible to create users with password.

Finally, it also makes it possible to create databases with additional parameters such as DB owner and encoding.

The matrix-synapse test is updated to use the new capabilities.

The changes should be backwards compatible.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).