### PR TITLE
jet: 0.1.0 -> 0.3.21

### DIFF
--- a/pkgs/development/tools/jet/default.nix
+++ b/pkgs/development/tools/jet/default.nix
@@ -2,32 +2,22 @@
 
 buildGraalvmNativeImage rec {
   pname = "jet";
-  version = "0.1.0";
+  version = "0.3.21";
 
   src = fetchurl {
     url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
-    sha256 = "sha256-RCEIIZfPmOLW3akjEgaEas4xOtYxL6lQsxDv2szB8K4";
-  };
-
-  reflectionJson = fetchurl {
-    url = "https://raw.githubusercontent.com/borkdude/${pname}/v${version}/reflection.json";
-    sha256 = "sha256-mOUiKEM5tYhtpBpm7KtslyPYFsJ+Wr+4ul6Zi4aS09Q=";
+    sha256 = "sha256-p7jTPnXpDg1bbPMEmznFWNZ4lq/zt2fZUOE6IOc9akY=";
   };
 
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
-    "-J-Dclojure.spec.skip-macros=true"
-    "-J-Dclojure.compiler.direct-linking=true"
-    "-H:IncludeResources=JET_VERSION"
-    "-H:ReflectionConfigurationFiles=${reflectionJson}"
-    "--initialize-at-build-time"
     "-H:Log=registerResource:"
     "--no-fallback"
     "--no-server"
   ];
 
   meta = with lib; {
-    description = "CLI to transform between JSON, EDN and Transit, powered with a minimal query language";
+    description = "CLI to transform between JSON, EDN, YAML and Transit, powered with a minimal query language";
     homepage = "https://github.com/borkdude/jet";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;


### PR DESCRIPTION
###### Description of changes

[Version 0.3.21](https://github.com/borkdude/jet/blob/v0.3.21/CHANGELOG.md) adds support for YAML for input and output. Intermediate versions added support for colored output, integrated specter, migrated to babashika's CLI, and made pretty-printing the default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
