### PR TITLE
libsForQt5.bonsai: init at 2.2.0

### DIFF
--- a/pkgs/applications/maui/bonsai.nix
+++ b/pkgs/applications/maui/bonsai.nix
@@ -1,0 +1,42 @@
+{ lib
+, mkDerivation
+, cmake
+, extra-cmake-modules
+, kcoreaddons
+, ki18n
+, kirigami2
+, mauikit
+, mauikit-filebrowsing
+, qtquickcontrols2
+, libgit2
+, mauikit-texteditor
+, sonnet
+}:
+
+mkDerivation {
+  pname = "bonsai";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kcoreaddons
+    ki18n
+    kirigami2
+    libgit2
+    mauikit
+    mauikit-filebrowsing
+    mauikit-texteditor
+    qtquickcontrols2
+    sonnet
+  ];
+
+  meta = with lib; {
+    description = "Mobile Git repository manager";
+    homepage = "https://invent.kde.org/maui/bonsai";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/applications/maui/default.nix
+++ b/pkgs/applications/maui/default.nix
@@ -70,6 +70,7 @@ let
       mauiman = callPackage ./mauiman.nix { };
 
       # applications
+      bonsai = callPackage ./bonsai.nix { };
       booth = callPackage ./booth.nix { };
       buho = callPackage ./buho.nix { };
       clip = callPackage ./clip.nix { };


### PR DESCRIPTION
###### Description of changes

add missing maui application [bonsai](https://invent.kde.org/maui/bonsai), mobile git repository manager

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
