### PR TITLE
lttoolbox: init at 3.7.1

### DIFF
--- a/pkgs/applications/misc/lttoolbox/default.nix
+++ b/pkgs/applications/misc/lttoolbox/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoconf
+, automake
+, pkg-config
+, utf8cpp
+, libtool
+, libxml2
+, icu
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lttoolbox";
+  version = "3.7.1";
+
+  src = fetchFromGitHub {
+    owner = "apertium";
+    repo = "lttoolbox";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-3lHXKtwQSrMGQEGOGr27e3kB2qKkTFZcEzeAnIm89Rg=";
+  };
+
+  patches = [
+    # can be removed once the version goes past this commit
+    # https://github.com/apertium/lttoolbox/commit/e682fe18a96d5a865cfbd3e5661dbc7b3ace1821
+    (fetchpatch {
+      url = "https://github.com/apertium/lttoolbox/commit/e682fe18a96d5a865cfbd3e5661dbc7b3ace1821.patch";
+      hash = "sha256-VeP8Mv2KYxX+eVjIRw/jHbURaWN665+fiFaoT3VxAno=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    pkg-config
+    utf8cpp
+    libtool
+  ];
+  buildInputs = [
+    libxml2
+    icu
+  ];
+  buildFlags = [
+    "CPPFLAGS=-I${utf8cpp}/include/utf8cpp"
+  ];
+  configurePhase = ''
+    ./autogen.sh --prefix $out
+  '';
+  doCheck = true;
+  checkPhase = ''
+    ${python3}/bin/python3 tests/run_tests.py
+  '';
+
+  meta = with lib; {
+    description = "Finite state compiler, processor and helper tools used by apertium";
+    homepage = "https://github.com/apertium/lttoolbox";
+    maintainers = with maintainers; [ onthestairs ];
+    changelog = "https://github.com/apertium/lttoolbox/releases/tag/v${version}";
+    license = licenses.gpl2;
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10049,6 +10049,8 @@ with pkgs;
     lua = lua5_2_compat;
   };
 
+  lttoolbox = callPackage ../applications/misc/lttoolbox { };
+
   ltwheelconf = callPackage ../applications/misc/ltwheelconf { };
 
   lunatask = callPackage ../applications/misc/lunatask { };


### PR DESCRIPTION
###### Description of changes

Add `lttoolbox`, which is contains helper tools for the [apertium](https://wiki.apertium.org/wiki/Main_Page) ecosystem.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

