### PR TITLE
pythonPackages.kaldi-active-grammar: fix build

### DIFF
--- a/pkgs/development/python-modules/kaldi-active-grammar/fork.nix
+++ b/pkgs/development/python-modules/kaldi-active-grammar/fork.nix
@@ -13,15 +13,19 @@
 }:
 
 let
-  old-openfst = openfst.overrideAttrs (self: {
+  old-openfst = openfst.overrideAttrs (prev: {
+    version = "kag-unstable-2022-05-06";
+
     src = fetchFromGitHub {
       owner = "kkm000";
       repo = "openfst";
+      # required by https://github.com/daanzu/kaldi-fork-active-grammar/blob/e9c7d0ffca401cf312779d25f2c05a34b41ff696/cmake/third_party/openfst.cmake#L7
       rev = "0bca6e76d24647427356dc242b0adbf3b5f1a8d9";
       sha256 = "1802rr14a03zl1wa5a0x1fa412kcvbgprgkadfj5s6s3agnn11rx";
     };
     buildInputs = [ zlib ];
-  }); in
+  });
+in
 
 assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 

--- a/pkgs/development/python-modules/kaldi-active-grammar/fork.nix
+++ b/pkgs/development/python-modules/kaldi-active-grammar/fork.nix
@@ -70,6 +70,20 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # Replace the shebangs for the various build scripts
     patchShebangs src
+    # Compatability with OpenBLAS 0.3.21
+    substituteInPlace src/matrix/cblas-wrappers.h \
+      --replace stptri_ LAPACK_stptri \
+      --replace dtptri_ LAPACK_dtptri \
+      --replace sgetrf_ LAPACK_sgetrf \
+      --replace dgetrf_ LAPACK_dgetrf \
+      --replace sgetri_ LAPACK_sgetri \
+      --replace dgetri_ LAPACK_dgetri \
+      --replace sgesvd_ LAPACK_sgesvd \
+      --replace dgesvd_ LAPACK_dgesvd \
+      --replace ssptri_ LAPACK_ssptri \
+      --replace dsptri_ LAPACK_dsptri \
+      --replace ssptrf_ LAPACK_ssptrf \
+      --replace dsptrf_ LAPACK_dsptrf
   '';
 
   configurePhase = ''


### PR DESCRIPTION
###### Description of changes
Fixes #203089; cc @Lykos153 @mweinelt.

Snuck `backports-zoneinfo` in as it's an indirect dependency and something I ran into because my test shell had `python38`. Can drop.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

ZHF: #199919