### PR TITLE
haskellPackages: unbreak selected packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2315,4 +2315,26 @@ self: super: {
 
   # unix-compat <0.5
   hxt-cache = doJailbreak super.hxt-cache;
+
+  # base <4.16
+  fast-builder = doJailbreak super.fast-builder;
+
+  # QuickCheck <2.14
+  term-rewriting = doJailbreak super.term-rewriting;
+
+  # tests can't find the test binary anymore - parseargs-example
+  parseargs = dontCheck super.parseargs;
+
+  # base <4.14
+  decimal-literals = doJailbreak super.decimal-literals;
+
+  # multiple bounds too strict
+  snaplet-sqlite-simple = doJailbreak super.snaplet-sqlite-simple;
+
+  # doctest <0.19
+  polysemy = doJailbreak super.polysemy;
+
+  # multiple bounds too strict
+  co-log-polysemy = doJailbreak super.co-log-polysemy;
+  co-log-polysemy-formatting = doJailbreak super.co-log-polysemy-formatting;
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -414,7 +414,6 @@ broken-packages:
   - bizzlelude-js
   - bkr
   - blakesum
-  - Blammo
   - blas
   - blaze-html-contrib
   - blaze-html-hexpat
@@ -753,7 +752,6 @@ broken-packages:
   - collections-api
   - co-log-concurrent
   - co-log-json
-  - co-log-polysemy-formatting
   - co-log-sys
   - colonnade
   - colorless
@@ -1044,7 +1042,6 @@ broken-packages:
   - dead-simple-json
   - debug-tracy
   - decepticons
-  - decimal-literals
   - DecisionTree
   - decoder-conduit
   - deepcontrol
@@ -3737,7 +3734,6 @@ broken-packages:
   - PArrows
   - Parry
   - parse
-  - parseargs
   - parsec2
   - parsec3
   - parsec-free
@@ -3943,7 +3939,6 @@ broken-packages:
   - polysemy-keyed-state
   - polysemy-kvstore-jsonfile
   - polysemy-log-co
-  - polysemy-managed
   - polysemy-mocks
   - polysemy-readline
   - polysemy-scoped-fs
@@ -4534,7 +4529,6 @@ broken-packages:
   - servant-namedargs
   - servant-nix
   - servant-pandoc
-  - servant-polysemy
   - servant-pool
   - servant-proto-lens
   - servant-purescript
@@ -4911,7 +4905,6 @@ broken-packages:
   - stripe
   - stripe-core
   - stripe-servant
-  - strongweak
   - structural-traversal
   - structures
   - stt
@@ -5071,7 +5064,6 @@ broken-packages:
   - termbox-tea
   - termination-combinators
   - termplot
-  - term-rewriting
   - terntup
   - tersmu
   - tesla


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
