### PR TITLE
yabai: 4.0.4 -> 5.0.2

### DIFF
--- a/pkgs/os-specific/darwin/yabai/default.nix
+++ b/pkgs/os-specific/darwin/yabai/default.nix
@@ -9,16 +9,16 @@
 , yabai
 , xxd
 , xcodebuild
+  # These all need to be from SDK 11.0 or later starting with yabai 5.0.0
 , Carbon
 , Cocoa
 , ScriptingBridge
-  # This needs to be from SDK 10.13 or higher, SLS APIs introduced in that version get used
 , SkyLight
 }:
 
 let
   pname = "yabai";
-  version = "4.0.4";
+  version = "5.0.2";
 
   test-version = testers.testVersion {
     package = yabai;
@@ -52,7 +52,7 @@ in
 
     src = fetchzip {
       url = "https://github.com/koekeishiya/yabai/releases/download/v${version}/yabai-v${version}.tar.gz";
-      sha256 = "sha256-NS8tMUgovhWqc6WdkNI4wKee411i/e/OE++JVc86kFE=";
+      sha256 = "sha256-wL6N2+mfFISrOFn4zaCQI+oH6ixwUMRKRi1dAOigBro=";
     };
 
     nativeBuildInputs = [
@@ -81,14 +81,14 @@ in
     };
   };
 
-  x86_64-darwin = stdenv.mkDerivation rec {
+  x86_64-darwin = stdenv.mkDerivation {
     inherit pname version;
 
     src = fetchFromGitHub {
       owner = "koekeishiya";
       repo = "yabai";
       rev = "v${version}";
-      sha256 = "sha256-TeT+8UAV2jR60XvTs4phkp611Gi0nzLmQnezLA0xb44=";
+      sha256 = "sha256-/HS8TDzDA4Zvmm56ZZeMXyCKHRRTcucd7qDHT0qbrQg=";
     };
 
     nativeBuildInputs = [
@@ -128,50 +128,15 @@ in
       mkdir -p $out/{bin,share/icons/hicolor/scalable/apps}
 
       cp ./bin/yabai $out/bin/yabai
-      ln -s ${loadScriptingAddition} $out/bin/yabai-load-sa
       cp ./assets/icon/icon.svg $out/share/icons/hicolor/scalable/apps/yabai.svg
       installManPage ./doc/yabai.1
 
       runHook postInstall
     '';
 
-    # Defining this here exposes it as a passthru attribute, which is useful because it allows us to run `builtins.hashFile` on it in pure-eval mode.
-    # With that we can programmatically generate an `/etc/sudoers.d` entry which disables the password requirement, so that a user-agent can run it at login.
-    loadScriptingAddition = writeShellScript "yabai-load-sa" ''
-      # For whatever reason the regular commands to load the scripting addition do not work, yabai will throw an error.
-      # The installation command mutably installs binaries to '/System', but then fails to start them. Manually running
-      # the bins as root does start the scripting addition, so this serves as a more user-friendly way to do that.
-
-      set -euo pipefail
-
-      if [[ "$EUID" != 0 ]]; then
-          echo "error: the scripting-addition loader must ran as root. try 'sudo $0'"
-          exit 1
-      fi
-
-      loaderPath="/Library/ScriptingAdditions/yabai.osax/Contents/MacOS/mach_loader";
-
-      if ! test -x "$loaderPath"; then
-          echo "could not locate the scripting-addition loader at '$loaderPath', installing it..."
-          echo "note: this may display an error"
-
-          eval "$(dirname "''${BASH_SOURCE[0]}")/yabai --install-sa" || true
-          sleep 1
-      fi
-
-      echo "executing loader..."
-      eval "$loaderPath"
-      echo "scripting-addition started"
-    '';
-
     passthru.tests.version = test-version;
 
     meta = _meta // {
-      longDescription = _meta.longDescription + ''
-        Note that due to a nix-only bug the scripting addition cannot be launched using the regular
-        procedure. Instead, you can use the provided `yabai-load-sa` script.
-      '';
-
       sourceProvenance = with lib.sourceTypes; [
         fromSource
       ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37860,8 +37860,7 @@ with pkgs;
   xzoom = callPackage ../tools/X11/xzoom {};
 
   yabai = darwin.apple_sdk_11_0.callPackage ../os-specific/darwin/yabai {
-    inherit (darwin.apple_sdk.frameworks) Cocoa Carbon ScriptingBridge;
-    inherit (darwin.apple_sdk_11_0.frameworks) SkyLight;
+    inherit (darwin.apple_sdk_11_0.frameworks) SkyLight Cocoa Carbon ScriptingBridge;
   };
 
   yacreader = libsForQt5.callPackage ../applications/graphics/yacreader { };


### PR DESCRIPTION
 This update removes the need for the `yabai-load-sa` script on `x86_64-darwin`. The scripting addition can now simply be installed and launched with `yabai --load-sa`, just like the official installation methods.

I've used this only on `x86_64-darwin` where everything works as expected, testing on `aarch64-darwin` would be appreciated.

Note that the update is required for yabai to work on the new MacOS Ventura, so I suggest that it would be best to backport this PR to 21.11.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
