### PR TITLE
elasticsearch6: add libxcrypt dependency to fix build

### DIFF
--- a/pkgs/servers/search/elasticsearch/6.x.nix
+++ b/pkgs/servers/search/elasticsearch/6.x.nix
@@ -5,6 +5,7 @@
 , makeWrapper
 , jre_headless
 , util-linux, gnugrep, coreutils
+, libxcrypt
 , autoPatchelfHook
 , zlib
 }:
@@ -37,7 +38,7 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jre_headless util-linux ]
-             ++ optional enableUnfree zlib;
+             ++ optional enableUnfree [ zlib libxcrypt ];
 
   installPhase = ''
     mkdir -p $out


### PR DESCRIPTION
###### Description of changes

glibc's libcrypt is deprecated and since
ff30c899d8bd92d1a1c9f4d4e81455b04cb0868e
is built by default without libcrypt, that's probably the point when `elasticsearch6` started failing with
```
auto-patchelf: 3 dependencies could not be satisfied
error: auto-patchelf could not satisfy dependency libcrypt.so.1 wanted by /nix/store/nd0gn95yfnnmnnw8zk2jnafc9gj2qy91-elasticsearch-6.8.21/modules/x-pack-ml/platform/linux-x86_64/lib/liblog4cxx.so.10
error: auto-patchelf could not satisfy dependency libcrypt.so.1 wanted by /nix/store/nd0gn95yfnnmnnw8zk2jnafc9gj2qy91-elasticsearch-6.8.21/modules/x-pack-ml/platform/linux-x86_64/lib/libaprutil-1.so.0
error: auto-patchelf could not satisfy dependency libcrypt.so.1 wanted by /nix/store/nd0gn95yfnnmnnw8zk2jnafc9gj2qy91-elasticsearch-6.8.21/modules/x-pack-ml/platform/linux-x86_64/lib/libapr-1.so.0
```

Let's add libxcrypt dependency, also note that `elasticsearch6-oss` doesn't seem to need it.

Should resolve https://github.com/NixOS/nixpkgs/issues/203467

Extra note is elk6 may get removed from nixpkgs soon in favor of elk7 https://github.com/NixOS/nixpkgs/pull/194420


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
