### PR TITLE
butt: init at 0.1.36

### DIFF
--- a/pkgs/applications/audio/butt/default.nix
+++ b/pkgs/applications/audio/butt/default.nix
@@ -1,0 +1,57 @@
+{ curl
+, dbus
+, fdk_aac
+, fetchurl
+, flac
+, fltk
+, lame
+, lib
+, libopus
+, libsamplerate
+, libshout
+, pkg-config
+, portaudio
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "butt";
+  version = "0.1.36";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/butt/${pname}-${version}.tar.gz";
+    sha256 = "1jg7662v88k432cb5dsn0hmbrn517whqw4dv113zp24q1c2kksmm";
+  };
+
+  buildInputs = [
+    curl
+    dbus
+    fdk_aac
+    flac
+    fltk
+    lame
+    libopus
+    libsamplerate
+    libshout
+    portaudio
+  ];
+  nativeBuildInputs = [ pkg-config ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Source client for icecast";
+    longDescription = ''
+      butt (broadcast using this tool) is an easy to use, multi OS streaming
+      tool. It supports ShoutCast and IceCast and runs on Linux, MacOS and
+      Windows. The main purpose of butt is to stream live audio data from your
+      computer's mic or line input to a Shoutcast or Icecast server. Recording
+      is also possible. It is NOT intended to be a server by itself or
+      automatically stream a set of audio files.
+    '';
+    homepage = "https://danielnoethen.de/butt/";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.ddelabru ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2436,6 +2436,8 @@ with pkgs;
 
   bunyan-rs = callPackage ../development/tools/bunyan-rs { };
 
+  butt = callPackage ../applications/audio/butt { };
+
   callaudiod = callPackage ../applications/audio/callaudiod { };
 
   calls = callPackage ../applications/networking/calls { };


### PR DESCRIPTION
###### Description of changes

butt (broadcast using this tool) is a graphical source client application for Icecast. This should techincally compile for darwin as well, but I haven't tested compilation on darwin and the application author provides Mac OS binaries, so for now I've marked the platforms as Linux only.

Tested by compiling on NixOS 22.05 and running the binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
