### PR TITLE
beetsPackages.originquery: init at 1.0.2

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -94,4 +94,5 @@ lib.makeExtensible (self: {
   alternatives = callPackage ./plugins/alternatives.nix { beets = self.beets-minimal; };
   copyartifacts = callPackage ./plugins/copyartifacts.nix { beets = self.beets-minimal; };
   extrafiles = callPackage ./plugins/extrafiles.nix { beets = self.beets-minimal; };
+  originquery = callPackage ./plugins/originquery.nix { beets = self.beets-minimal; };
 })

--- a/pkgs/tools/audio/beets/plugins/originquery.nix
+++ b/pkgs/tools/audio/beets/plugins/originquery.nix
@@ -1,0 +1,29 @@
+{ lib, fetchFromGitHub, beets, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "beets-originquery";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "x1ppy";
+    rev = version;
+    hash = "sha256-32S8Ik6rzw6kx69o9G/v7rVsVzGA1qv5pHegYDmTW68=";
+  };
+
+  nativeBuildInputs = [ beets ];
+
+  propagatedBuildInputs = with python3Packages; [
+    confuse
+    jsonpath_rw
+    pyyaml
+  ];
+
+  meta = with lib; {
+    description = "Integrate origin metadata (origin.txt) into beets' MusicBrainz queries";
+    homepage = "https://github.com/x1ppy/beets-originquery";
+    maintainers = with maintainers; [ somasis ];
+    license = licenses.unfree; # <https://github.com/x1ppy/beets-originquery/issues/3>
+    inherit (beets.meta) platforms;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Depends on #203542

https://github.com/x1ppy/beets-originquery

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
