### PR TITLE
build-support: Quote expansions inside `${…}`

### DIFF
--- a/pkgs/build-support/wrapper-common/utils.bash
+++ b/pkgs/build-support/wrapper-common/utils.bash
@@ -104,13 +104,13 @@ badPath() {
     # directory (including the build directory).
     test \
         "$p" != "/dev/null" -a \
-        "${p#${NIX_STORE}}"     = "$p" -a \
-        "${p#${NIX_BUILD_TOP}}" = "$p" -a \
-        "${p#/tmp}"             = "$p" -a \
-        "${p#${TMP:-/tmp}}"     = "$p" -a \
-        "${p#${TMPDIR:-/tmp}}"  = "$p" -a \
-        "${p#${TEMP:-/tmp}}"    = "$p" -a \
-        "${p#${TEMPDIR:-/tmp}}" = "$p"
+        "${p#"${NIX_STORE}"}"     = "$p" -a \
+        "${p#"${NIX_BUILD_TOP}"}" = "$p" -a \
+        "${p#/tmp}"               = "$p" -a \
+        "${p#"${TMP:-/tmp}"}"     = "$p" -a \
+        "${p#"${TMPDIR:-/tmp}"}"  = "$p" -a \
+        "${p#"${TEMP:-/tmp}"}"    = "$p" -a \
+        "${p#"${TEMPDIR:-/tmp}"}" = "$p"
 }
 
 expandResponseParams() {


### PR DESCRIPTION
###### Description of changes

As per ShellCheck:

> SC2295 (info): Expansions inside ${..} need to be quoted separately,
> otherwise they match as patterns.

Motivation: #133088

@happysalada

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).