### PR TITLE
[22.11] hypnotix: Fix launching with mpv 0.35.0

### DIFF
--- a/pkgs/applications/video/hypnotix/default.nix
+++ b/pkgs/applications/video/hypnotix/default.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
       src = ./libmpv-path.patch;
       libmpv = "${lib.getLib mpv}/lib/libmpv${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
+
+    # Fix launching with mpv 0.35.0 (ubuntu 22.04 doesn't have libmpv.so.2)
+    # https://github.com/linuxmint/hypnotix/issues/254
+    ./fix-deprecated-mpv-detach-destroy.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/video/hypnotix/fix-deprecated-mpv-detach-destroy.patch
+++ b/pkgs/applications/video/hypnotix/fix-deprecated-mpv-detach-destroy.patch
@@ -1,0 +1,22 @@
+diff --git a/usr/lib/hypnotix/mpv.py b/usr/lib/hypnotix/mpv.py
+index f42a3be..db94bf6 100644
+--- a/usr/lib/hypnotix/mpv.py
++++ b/usr/lib/hypnotix/mpv.py
+@@ -528,7 +528,7 @@ _mpv_create = backend.mpv_create
+ _handle_func('mpv_create_client',           [c_char_p],                                 MpvHandle, notnull_errcheck)
+ _handle_func('mpv_client_name',             [],                                         c_char_p, errcheck=None)
+ _handle_func('mpv_initialize',              [],                                         c_int, ec_errcheck)
+-_handle_func('mpv_detach_destroy',          [],                                         None, errcheck=None)
++_handle_func('mpv_destroy',                 [],                                         None, errcheck=None)
+ _handle_func('mpv_terminate_destroy',       [],                                         None, errcheck=None)
+ _handle_func('mpv_load_config_file',        [c_char_p],                                 c_int, ec_errcheck)
+ _handle_func('mpv_get_time_us',             [],                                         c_ulonglong, errcheck=None)
+@@ -881,7 +881,7 @@ class MPV(object):
+                         self._message_handlers[target](*args)
+ 
+                 if eid == MpvEventID.SHUTDOWN:
+-                    _mpv_detach_destroy(self._event_handle)
++                    _mpv_destroy(self._event_handle)
+                     return
+ 
+             except Exception as e:


### PR DESCRIPTION
Picked from #201328 commit f0c5278e99749866c47a78cdb1c695d55fdabc89.

Fix launching with mpv 0.35.0 (ubuntu 22.04 doesn't have libmpv.so.2)

###### Description of changes

```
Traceback (most recent call last):
  File "/nix/store/dlv4a0gbgc7vbcg5jxpy6hkgm97xx7l0-hypnotix-2.9/lib/hypnotix/hypnotix.py", line 25, in <module>
    import mpv
  File "/nix/store/dlv4a0gbgc7vbcg5jxpy6hkgm97xx7l0-hypnotix-2.9/lib/hypnotix/mpv.py", line 526, in <module>
    _handle_func('mpv_detach_destroy',          [],                                         None, errcheck=None)
  File "/nix/store/dlv4a0gbgc7vbcg5jxpy6hkgm97xx7l0-hypnotix-2.9/lib/hypnotix/mpv.py", line 473, in _handle_func
    func = getattr(backend, name)
  File "/nix/store/zdba9frlxj2ba8ca095win3nphsiiqhb-python3-3.10.8/lib/python3.10/ctypes/__init__.py", line 387, in __getattr__
    func = self.__getitem__(name)
  File "/nix/store/zdba9frlxj2ba8ca095win3nphsiiqhb-python3-3.10.8/lib/python3.10/ctypes/__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: /nix/store/6wb0c9kkb758j10nakwhnb4k59l0aqsj-mpv-with-scripts-0.35.0/lib/libmpv.so: undefined symbol: mpv_detach_destroy
```

###### Things done

![](https://user-images.githubusercontent.com/20080233/204460131-1c22b477-8001-4b7f-bcd9-149f19431f1c.png)


- [x] Launches and TY plays.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
