### PR TITLE
nixos/lxd: disable systemd-oomd to avoid degraded system state

### DIFF
--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -112,6 +112,10 @@ in {
     # TODO: remove once LXD gets proper support for cgroupsv2
     # (currently most of the e.g. CPU accounting stuff doesn't work)
     systemd.enableUnifiedCgroupHierarchy = false;
+    # systemd-oomd is marked as failed unless we have cgroupsv2
+    # ("Userspace Out-Of-Memory (OOM) Killer was skipped because of a failed condition check (ConditionControlGroupController=v2)"),
+    # so disable.
+    systemd.services.systemd-oomd.enable = false;
 
     systemd.sockets.lxd = {
       description = "LXD UNIX socket";


### PR DESCRIPTION
###### Description of changes

`virtualisation.lxd.enable = true` sets
`systemd.enableUnifiedCgroupHierarchy = false`, and that breaks
systemd-oomd:

```
  $ systemctl status systemd-oomd
  ○ systemd-oomd.service - Userspace Out-Of-Memory (OOM) Killer
       Loaded: loaded (/etc/systemd/system/systemd-oomd.service; enabled; preset: enabled)
      Drop-In: /nix/store/f2sd4r00203m8qli3pb3dr7hh4l7a30i-system-units/systemd-oomd.service.d
               └─overrides.conf
       Active: inactive (dead)
  TriggeredBy: × systemd-oomd.socket
    Condition: start condition failed at Tue 2022-11-29 12:28:21 UTC; 3s ago
               └─ ConditionControlGroupController=v2 was not met
         Docs: man:systemd-oomd.service(8)

  Nov 29 12:28:21 machine systemd[1]: Userspace Out-Of-Memory (OOM) Killer was skipped because of a failed condition check (ConditionControlGroupController=v2).
  Nov 29 12:28:21 machine systemd[1]: Userspace Out-Of-Memory (OOM) Killer was skipped because of a failed condition check (ConditionControlGroupController=v2).
  Nov 29 12:28:21 machine systemd[1]: Userspace Out-Of-Memory (OOM) Killer was skipped because of a failed condition check (ConditionControlGroupController=v2).
  [...snip repeated lines...]
```

This leaves the system in a degraded state and `systemd is-system-running`
fails. Better disable systemd-oomd to begin with.

Ref https://github.com/NixOS/nixpkgs/issues/195085

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
