### PR TITLE
nixos/nix-daemon: allow registry paths to be... paths

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -414,6 +414,7 @@ in
               str
               int
               bool
+              path
               package
             ]);
           in


### PR DESCRIPTION
Currently paths are handled by [`types.package`](https://github.com/NixOS/nixpkgs/blob/343ea4052c014657981f19b267e16122de4264e6/lib/types.nix#L457-L473), whose semantics are a bit of a mess. In particular, it converts path values to derivations using `toDerivation`, which will lead to problems when flake `outPath`s become paths in https://github.com/NixOS/nix/pull/6530.

This change makes the "incompatible changes" section in the above PR obsolete: `nix.registry.nixpkgs.flake = nixpkgs;` works as expected (the flake is copied to the store).