### PR TITLE
appimage-run: export OWD

### DIFF
--- a/pkgs/build-support/appimage/appimage-exec.sh
+++ b/pkgs/build-support/appimage/appimage-exec.sh
@@ -7,6 +7,9 @@ fi
 
 PATH="@path@:$PATH"
 apprun_opt=true
+OWD=$(readlink -f .)
+# can be read by appimages: https://docs.appimage.org/packaging-guide/environment-variables.html
+export OWD
 
 # src : AppImage
 # dest : let's unpack() create the directory

--- a/pkgs/tools/package-management/appimage-run/test.nix
+++ b/pkgs/tools/package-management/appimage-run/test.nix
@@ -5,6 +5,10 @@ let
     url = "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage";
     sha256 =  "04ws94q71bwskmhizhwmaf41ma4wabvfgjgkagr8wf3vakgv866r";
   };
+  owdtest = fetchurl {
+    url = "https://github.com/NixOS/nixpkgs/files/10099048/owdtest.AppImage.gz";
+    sha256 = "sha256-EEp9dxz/+l5XkNaVBFgv5v64sizQILnljRAzwXv/yV8=";
+  };
 in
   runCommand "appimage-run-tests" {
     buildInputs = [ appimage-run glibcLocales file ];
@@ -18,6 +22,9 @@ in
     # regression test for #108426
     cp ${sample-appImage} foo.appImage
     LANG=fr_FR appimage-run ${sample-appImage} --list foo.appImage
+    cp ${owdtest} owdtest.AppImage.gz
+    gunzip owdtest.AppImage.gz
+    appimage-run owdtest.AppImage
     set +x
     touch $out
   ''


### PR DESCRIPTION
documented here: https://docs.appimage.org/packaging-guide/environment-variables.html

Fixes #203330

could you test, @gvegidy ? If you already have installed nix to test your appimage, then it's easy:

```
git clone https://github.com/NixOS/nixpkgs
cd nixpkgs
nix-shell -p nix-review --run "nix-review pr https://github.com/NixOS/nixpkgs/pull/203598 -p appimage-run"
```
inside the shell that opens, you have the fixed appimage-run:
```
appimage-run foo.appImage
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
