### PR TITLE
nixos/nftables: add option to not drop the whole ruleset

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -427,6 +427,7 @@ in {
   # TODO: Test nfsv3 + Kerberos
   nfs3 = handleTest ./nfs { version = 3; };
   nfs4 = handleTest ./nfs { version = 4; };
+  nftables = handleTest ./nftables.nix {};
   nghttpx = handleTest ./nghttpx.nix {};
   nginx = handleTest ./nginx.nix {};
   nginx-auth = handleTest ./nginx-auth.nix {};

--- a/nixos/tests/nftables.nix
+++ b/nixos/tests/nftables.nix
@@ -1,0 +1,78 @@
+# Test the nftables module.
+
+import ./make-test-python.nix ( { pkgs, ... } : {
+  name = "nftables";
+
+  nodes =
+    {
+      walled = { ... }:
+        {
+          networking.firewall.enable = false;
+          networking.nftables = {
+            enable = true;
+            ruleset = ''
+              table inet nixos_fw {
+                chain input {
+                  type filter hook input priority filter; policy drop;
+                  ct state vmap { invalid : drop, established : accept, related : accept }
+                  tcp dport 80 accept
+                }
+              }
+            '';
+            stopRuleset = ''
+              table inet nixos_fw
+              delete table inet nixos_fw
+            '';
+          };
+          services.httpd.enable = true;
+          services.httpd.adminAddr = "foo@example.org";
+        };
+
+      attacker = { ... }:
+        {
+          networking.firewall.enable = false;
+          networking.nftables.enable = false;
+        };
+    };
+
+  testScript = { nodes, ... }:
+  let
+    customRuleset = pkgs.writeText "custom-ruleset" ''
+      table inet custom {
+        chain custom_input {
+          type filter hook input priority filter; policy accept;
+          tcp dport 80 drop
+        }
+      }
+    '';
+  in ''
+    start_all()
+
+    walled.wait_for_unit("nftables")
+    walled.wait_for_unit("httpd")
+    attacker.wait_for_unit("network.target")
+
+    # Connections should succeed.
+    attacker.succeed("curl -v http://walled/ >&2")
+
+    # Insert a rule. Connections should fail.
+    walled.succeed("nft insert rule inet nixos_fw input tcp dport 80 drop")
+    attacker.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
+
+    # Reload nftables. Connections should succeed.
+    walled.succeed("systemctl reload nftables.service")
+    attacker.succeed("curl -v http://walled/ >&2")
+
+    # Load a custom ruleset. Connections should fail.
+    walled.succeed("nft -f ${customRuleset}")
+    attacker.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
+
+    # Reload nftables. Custom ruleset should exist.
+    walled.succeed("systemctl reload nftables.service")
+    attacker.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
+
+    # Stop nftables. Custom ruleset should still exist.
+    walled.stop_job("nftables")
+    attacker.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
+  '';
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A new option `networking.nftables.stopRuleset` to specify how to clear ruleset/tables/chains on stop and reload.

It can be used to prevent droping the whole ruleset.

See https://github.com/NixOS/nixpkgs/pull/203011#issuecomment-1328236971

@ajs124 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
