### PR TITLE
seamly2d: init at 2022-08-15.0339

### DIFF
--- a/pkgs/applications/graphics/seamly2d/default.nix
+++ b/pkgs/applications/graphics/seamly2d/default.nix
@@ -1,0 +1,95 @@
+{ stdenv, lib, qtbase, wrapQtAppsHook, fetchFromGitHub,
+  addOpenGLRunpath, poppler_utils, qtxmlpatterns, qtsvg, mesa, gcc, xvfb-run,
+  fontconfig, freetype, xorg, ccache, qmake, python3, qttools, git
+}:
+with lib;
+let
+  qtPython = python3.withPackages (pkgs: with pkgs; [ pyqt5 ]);
+in
+stdenv.mkDerivation rec {
+  pname = "seamly2d";
+  version = "2022-08-15.0339";
+
+  src = fetchFromGitHub {
+    owner = "FashionFreedom";
+    repo = "Seamly2D";
+    rev = "v${version}";
+    sha256 = "13jxkg84jfz8g52zwhh5jvi23wryzkavwbsfalzr9m04blj5xnik";
+  };
+
+  buildInputs = [
+    git
+    qtPython
+    qtbase
+    addOpenGLRunpath
+    poppler_utils
+    qtxmlpatterns
+    qtsvg
+    mesa
+    gcc
+    xvfb-run
+    fontconfig
+    freetype
+    xorg.libXi
+    xorg.libXrender
+    xorg.libxcb
+    ccache
+  ];
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    qmake
+    qttools
+  ];
+
+  postPatch = ''
+    substituteInPlace common.pri \
+      --replace '$$[QT_INSTALL_HEADERS]/QtXmlPatterns' '${getDev qtxmlpatterns}/include/QtXmlPatterns' \
+      --replace '$$[QT_INSTALL_HEADERS]/QtSvg' '${getDev qtsvg}/include/QtSvg' \
+      --replace '$$[QT_INSTALL_HEADERS]/' '${getDev qtbase}/include/' \
+      --replace '$$[QT_INSTALL_HEADERS]' '${getDev qtbase}'
+    substituteInPlace src/app/translations.pri \
+      --replace '$$[QT_INSTALL_BINS]/$$LRELEASE' '${getDev qttools}/bin/lrelease'
+    substituteInPlace src/app/seamly2d/mainwindowsnogui.cpp \
+      --replace 'define PDFTOPS "pdftops"' 'define PDFTOPS "${getBin poppler_utils}/bin/pdftops"'
+    substituteInPlace src/libs/vwidgets/export_format_combobox.cpp \
+      --replace 'define PDFTOPS "pdftops"' 'define PDFTOPS "${getBin poppler_utils}/bin/pdftops"'
+    substituteInPlace src/app/seamlyme/mapplication.cpp \
+      --replace 'diagrams.rcc' '../share/diagrams.rcc'
+  '';
+
+  qmakeFlags = [
+    "PREFIX=/"
+    "PREFIX_LIB=/lib"
+    "Seamly2D.pro"
+    "-r"
+    "CONFIG+=noDebugSymbols"
+    "CONFIG+=no_ccache"
+  ];
+
+  installFlags = [ "INSTALL_ROOT=$(out)" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    mv $out/usr/share $out/
+    rmdir $out/usr
+
+    mv $out/share/seamly2d/* $out/share/.
+    rmdir $out/share/seamly2d
+
+    mkdir -p $out/share/man/man1
+    gzip -9c dist/debian/seamly2d.1 > $out/share/man/man1/seamly2d.1.gz
+
+    mkdir -p $out/share/mime/packages
+    cp dist/debian/seamly2d.sharedmimeinfo $out/share/mime/packages/seamly2d.xml
+  '';
+
+  meta = {
+    description = "Open source patternmaking software";
+    homepage = "https://seamly.net/";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ WhittlesJr ];
+  };
+}

--- a/pkgs/applications/graphics/seamly2d/default.nix
+++ b/pkgs/applications/graphics/seamly2d/default.nix
@@ -2,7 +2,6 @@
   addOpenGLRunpath, poppler_utils, qtxmlpatterns, qtsvg, mesa, gcc, xvfb-run,
   fontconfig, freetype, xorg, ccache, qmake, python3, qttools, git
 }:
-with lib;
 let
   qtPython = python3.withPackages (pkgs: with pkgs; [ pyqt5 ]);
 in
@@ -21,22 +20,20 @@ stdenv.mkDerivation rec {
     git
     qtPython
     qtbase
-    addOpenGLRunpath
     poppler_utils
     qtxmlpatterns
     qtsvg
     mesa
-    gcc
-    xvfb-run
-    fontconfig
     freetype
     xorg.libXi
     xorg.libXrender
     xorg.libxcb
-    ccache
   ];
 
   nativeBuildInputs = [
+    addOpenGLRunpath
+    xvfb-run
+    fontconfig
     wrapQtAppsHook
     qmake
     qttools
@@ -44,16 +41,16 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace common.pri \
-      --replace '$$[QT_INSTALL_HEADERS]/QtXmlPatterns' '${getDev qtxmlpatterns}/include/QtXmlPatterns' \
-      --replace '$$[QT_INSTALL_HEADERS]/QtSvg' '${getDev qtsvg}/include/QtSvg' \
-      --replace '$$[QT_INSTALL_HEADERS]/' '${getDev qtbase}/include/' \
-      --replace '$$[QT_INSTALL_HEADERS]' '${getDev qtbase}'
+      --replace '$$[QT_INSTALL_HEADERS]/QtXmlPatterns' '${lib.getDev qtxmlpatterns}/include/QtXmlPatterns' \
+      --replace '$$[QT_INSTALL_HEADERS]/QtSvg' '${lib.getDev qtsvg}/include/QtSvg' \
+      --replace '$$[QT_INSTALL_HEADERS]/' '${lib.getDev qtbase}/include/' \
+      --replace '$$[QT_INSTALL_HEADERS]' '${lib.getDev qtbase}'
     substituteInPlace src/app/translations.pri \
-      --replace '$$[QT_INSTALL_BINS]/$$LRELEASE' '${getDev qttools}/bin/lrelease'
+      --replace '$$[QT_INSTALL_BINS]/$$LRELEASE' '${lib.getDev qttools}/bin/lrelease'
     substituteInPlace src/app/seamly2d/mainwindowsnogui.cpp \
-      --replace 'define PDFTOPS "pdftops"' 'define PDFTOPS "${getBin poppler_utils}/bin/pdftops"'
+      --replace 'define PDFTOPS "pdftops"' 'define PDFTOPS "${lib.getBin poppler_utils}/bin/pdftops"'
     substituteInPlace src/libs/vwidgets/export_format_combobox.cpp \
-      --replace 'define PDFTOPS "pdftops"' 'define PDFTOPS "${getBin poppler_utils}/bin/pdftops"'
+      --replace 'define PDFTOPS "pdftops"' 'define PDFTOPS "${lib.getBin poppler_utils}/bin/pdftops"'
     substituteInPlace src/app/seamlyme/mapplication.cpp \
       --replace 'diagrams.rcc' '../share/diagrams.rcc'
   '';
@@ -69,17 +66,12 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     mv $out/usr/share $out/
     rmdir $out/usr
 
     mv $out/share/seamly2d/* $out/share/.
     rmdir $out/share/seamly2d
-
-    mkdir -p $out/share/man/man1
-    gzip -9c dist/debian/seamly2d.1 > $out/share/man/man1/seamly2d.1.gz
 
     mkdir -p $out/share/mime/packages
     cp dist/debian/seamly2d.sharedmimeinfo $out/share/mime/packages/seamly2d.xml
@@ -88,8 +80,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Open source patternmaking software";
     homepage = "https://seamly.net/";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ WhittlesJr ];
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ WhittlesJr ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31578,6 +31578,8 @@ with pkgs;
 
   rofi-vpn = callPackage ../applications/networking/rofi-vpn { };
 
+  seamly2d = libsForQt5.callPackage ../applications/graphics/seamly2d { };
+
   ympd = callPackage ../applications/audio/ympd { };
 
   # a somewhat more maintained fork of ympd


### PR DESCRIPTION
###### Description of changes

Adds Seamly2D and its companion application, SeamlyMe. This is a vector-based fashion pattern drafting application. It is a fork of Valentina, which is already packaged for NixOS by @jfrankenau

This is my second PR. The first one was rebased funny and automatically pulled in a ton of reviewers. It got closed and locked.

https://seamly.net/
https://github.com/FashionFreedom/Seamly2D

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
