### PR TITLE
ocamlPackages.js_of_ocaml: 4.0.0 → 4.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/gen_js_api/default.nix
+++ b/pkgs/development/ocaml-modules/gen_js_api/default.nix
@@ -10,6 +10,7 @@
 buildDunePackage rec {
   pname = "gen_js_api";
   version = "1.1.1";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "LexiFi";

--- a/pkgs/development/ocaml-modules/gen_js_api/ojs.nix
+++ b/pkgs/development/ocaml-modules/gen_js_api/ojs.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   pname = "ojs";
 
   inherit (gen_js_api) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ js_of_ocaml-compiler ];
 

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -84,6 +84,7 @@ with self;
 
   async_js = janePackage {
     pname = "async_js";
+    duneVersion = "3";
     hash = "0rld8792lfwbinn9rhrgacivz49vppgy29smpqnvpga89wchjv0v";
     meta.description = "A small library that provide Async support for JavaScript platforms";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -190,6 +191,7 @@ with self;
 
   bonsai = janePackage {
     pname = "bonsai";
+    duneVersion = "3";
     hash = "0k4grabwqc9sy4shzp77bgfvyajvvc0l8qq89ia7cvlwvly7gv6a";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ ppx_pattern_bind ];
@@ -309,6 +311,7 @@ with self;
 
   incr_dom = janePackage {
     pname = "incr_dom";
+    duneVersion = "3";
     hash = "0mi98cwi4npdh5vvcz0pb4sbb9j9dydl52s51rswwc3kn8mipxfx";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -877,6 +880,7 @@ with self;
 
   virtual_dom = janePackage {
     pname = "virtual_dom";
+    duneVersion = "3";
     hash = "0vcydxx0jhbd5hbriahgp947mc7n3xymyrsfny1c4adk6aaq3c5w";
     meta.description = "OCaml bindings for the virtual-dom library";
     buildInputs = [ js_of_ocaml-ppx ];

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -87,6 +87,7 @@ with self;
 
   async_js = janePackage {
     pname = "async_js";
+    duneVersion = "3";
     hash = "184j077bz686k5lrqswircnrdqldb316ngpzq7xri1pcsl39sy3q";
     meta.description = "A small library that provide Async support for JavaScript platforms";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -207,6 +208,7 @@ with self;
 
   bonsai = janePackage {
     pname = "bonsai";
+    duneVersion = "3";
     hash = "150zx2g1dmhyrxwqq8j7f2m3hjpmk5bk182ihx2gdbarhw1ainpm";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ ppx_pattern_bind ];
@@ -382,6 +384,7 @@ with self;
 
   incr_dom = janePackage {
     pname = "incr_dom";
+    duneVersion = "3";
     hash = "1sija9w2im8vdp61h387w0mww9hh7jgkgsjcccps4lbv936ac7c1";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ js_of_ocaml-ppx ];
@@ -570,6 +573,7 @@ with self;
 
   ppx_css = janePackage {
     pname = "ppx_css";
+    duneVersion = "3";
     hash = "09dpmj3f3m3z1ji9hq775iqr3cfmv5gh7q9zlblizj4wx4y0ibyi";
     meta.description = "A ppx that takes in css strings and produces a module for accessing the unique names defined within";
     propagatedBuildInputs = [ core_kernel ppxlib js_of_ocaml js_of_ocaml-ppx sedlex ];
@@ -1045,6 +1049,7 @@ with self;
     hash = "15xia9v4ighzm0gv3vbqk9nvg47cvzqmfnl2zr67yxv4b98kyzv3";
     meta.description = "OCaml bindings for the virtual-dom library";
     buildInputs = [ js_of_ocaml-ppx ];
+    duneVersion = "3";
     propagatedBuildInputs = [ core_kernel gen_js_api js_of_ocaml lambdasoup tyxml ];
   };
 

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
  propagatedBuildInputs = [ calendar js_of_ocaml-ppx_deriving_json eliom ];
  nativeBuildInputs = [ ocaml findlib opaline eliom ];
 
+ # Remove widgets not compatible with jsoo 4.1.0
+ # https://github.com/ocsigen/ocsigen-toolkit/issues/221
+ preConfigure = ''
+   rm src/widgets/ot_{carousel,drawer,swipe,tongue}.eliom{,i}
+ '';
+
   strictDeps = true;
 
  installPhase = ''

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -5,12 +5,12 @@
 
 buildDunePackage rec {
   pname = "js_of_ocaml-compiler";
-  version = "4.0.0";
-  useDune2 = true;
+  version = "4.1.0";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-    sha256 = "sha256:0pj9jjrmi0xxrzmygv4b5whsibw1jxy3wgibmws85x5jwlczh0nz";
+    sha256 = "sha256-kXk/KaWvPeq6P301zqsR5znP4KXMMFVvYgFGGm1CNu8=";
   };
 
   nativeBuildInputs = [ menhir ];

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -5,7 +5,8 @@
 buildDunePackage {
   pname = "js_of_ocaml";
 
-  inherit (js_of_ocaml-compiler) version src useDune2;
+  inherit (js_of_ocaml-compiler) version src;
+  duneVersion = "3";
 
   buildInputs = [ ppxlib ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -5,7 +5,8 @@
 buildDunePackage {
   pname = "js_of_ocaml-lwt";
 
-  inherit (js_of_ocaml-compiler) version src useDune2;
+  inherit (js_of_ocaml-compiler) version src;
+  duneVersion = "3";
 
   buildInputs = [ js_of_ocaml-ppx ];
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
@@ -6,7 +6,8 @@
 buildDunePackage {
   pname = "js_of_ocaml-ppx";
 
-  inherit (js_of_ocaml-compiler) version src useDune2;
+  inherit (js_of_ocaml-compiler) version src;
+  duneVersion = "3";
 
   buildInputs = [ js_of_ocaml ];
   propagatedBuildInputs = [ ppxlib ];

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
@@ -5,7 +5,8 @@
 buildDunePackage {
   pname = "js_of_ocaml-ppx_deriving_json";
 
-  inherit (js_of_ocaml-compiler) version src useDune2;
+  inherit (js_of_ocaml-compiler) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ js_of_ocaml ppxlib ];
 


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
