### PR TITLE
include-what-you-use: fix shebangs

### DIFF
--- a/pkgs/development/tools/analysis/include-what-you-use/default.nix
+++ b/pkgs/development/tools/analysis/include-what-you-use/default.nix
@@ -10,8 +10,12 @@ stdenv.mkDerivation rec {
     url = "${meta.homepage}/downloads/${pname}-${version}.src.tar.gz";
   };
 
-  nativeBuildInputs = with llvmPackages; [ cmake llvm.dev llvm python3];
-  buildInputs = with llvmPackages; [ libclang clang-unwrapped ];
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  nativeBuildInputs = with llvmPackages; [ cmake llvm.dev llvm python3 ];
+  buildInputs = with llvmPackages; [ libclang clang-unwrapped python3 ];
 
   cmakeFlags = [ "-DIWYU_LLVM_ROOT_PATH=${llvmPackages.clang-unwrapped}" ];
 


### PR DESCRIPTION
###### Description of changes
Before:
```
$ iwyu_tool.py -h
/usr/bin/env: 'python': No such file or directory
```
After:
```
$ iwyu_tool.py -h
usage: iwyu_tool.py [-h] [-v] [-o {iwyu,clang}] [-j JOBS] [-l LOAD] -p <build-path> [source ...] -- [<IWYU args>]

Include-what-you-use compilation database driver.

positional arguments:
  source                Zero or more source files (or directories) to run IWYU on. Defaults to all in compilation database.

options:
  -h, --help            show this help message and exit
  -v, --verbose         Print IWYU commands
  -o {iwyu,clang}, --output-format {iwyu,clang}
                        Output format (default: iwyu)
  -j JOBS, --jobs JOBS  Number of concurrent subprocesses
  -l LOAD, --load LOAD  Do not start new jobs if the 1min load average is greater than the provided value
  -p <build-path>       Compilation database path

Assumes include-what-you-use is available on the PATH.
```

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
