### PR TITLE
php8*: disable PCRE2 JIT SEAlloc to avoid crashes when forking

### DIFF
--- a/nixos/tests/php/pcre.nix
+++ b/nixos/tests/php/pcre.nix
@@ -1,7 +1,7 @@
 let
   testString = "can-use-subgroups";
 in
-import ../make-test-python.nix ({ lib, php, ... }: {
+import ../make-test-python.nix ({ pkgs, lib, php, ... }: {
   name = "php-${php.version}-httpd-pcre-jit-test";
   meta.maintainers = lib.teams.php.members;
 
@@ -31,12 +31,22 @@ import ../make-test-python.nix ({ lib, php, ... }: {
         '';
     };
   };
-  testScript = { ... }:
-    ''
+  testScript = let
+    # PCRE JIT SEAlloc feature does not play well with fork()
+    # The feature needs to either be disabled or PHP configured correctly
+    # More information in https://bugs.php.net/bug.php?id=78927 and https://bugs.php.net/bug.php?id=78630
+    pcreJitSeallocForkIssue = pkgs.writeText "pcre-jit-sealloc-issue.php" ''
+      <?php
+      preg_match('/nixos/', 'nixos');
+      $pid = pcntl_fork();
+      pcntl_wait($pid);
+    '';
+  in ''
       machine.wait_for_unit("httpd.service")
       # Ensure php evaluation by matching on the var_dump syntax
       response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/index.php")
       expected = 'string(${toString (builtins.stringLength testString)}) "${testString}"'
       assert expected in response, "Does not appear to be able to use subgroups."
+      machine.succeed("${php}/bin/php -f ${pcreJitSeallocForkIssue}")
     '';
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15834,7 +15834,7 @@ with pkgs;
   php82 = callPackage ../development/interpreters/php/8.2.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
     pcre2 = pcre2.override {
-      withJitSealloc = !stdenv.isDarwin;
+      withJitSealloc = false; # See https://bugs.php.net/bug.php?id=78927 and https://bugs.php.net/bug.php?id=78630
     };
   };
   php82Extensions = recurseIntoAttrs php82.extensions;
@@ -15844,7 +15844,7 @@ with pkgs;
   php81 = callPackage ../development/interpreters/php/8.1.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
     pcre2 = pcre2.override {
-      withJitSealloc = !stdenv.isDarwin;
+      withJitSealloc = false; # See https://bugs.php.net/bug.php?id=78927 and https://bugs.php.net/bug.php?id=78630
     };
   };
   php81Extensions = recurseIntoAttrs php81.extensions;
@@ -15854,7 +15854,7 @@ with pkgs;
   php80 = callPackage ../development/interpreters/php/8.0.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
     pcre2 = pcre2.override {
-      withJitSealloc = !stdenv.isDarwin;
+      withJitSealloc = false; # See https://bugs.php.net/bug.php?id=78927 and https://bugs.php.net/bug.php?id=78630
     };
   };
   php80Extensions = recurseIntoAttrs php80.extensions;


### PR DESCRIPTION
###### Description of changes

This is a follow up to #200815 and #184634.
    
The PCRE2 JIT SEAlloc does not support the `fork()` as announced in [their README](https://www.pcre.org/readme.txt
):
> If you are enabling JIT under SELinux environment you may also want to add
>  --enable-jit-sealloc, which enables the use of an executable memory allocator
>  that is compatible with SELinux. Warning: this allocator is experimental!
>  It does not support fork() operation and may crash when no disk space is
>  available. This option has no effect if JIT is disabled.
    
As a result using it in PHP can break apps and tools, it can only be enabled under very specific context where you have a full picture of what the PHP code is doing.
    
This contribution disables again the PCRE2 JIT SEAlloc and extends the existing PHP/PCRE2 tests to make sure we do not enable it again by mistake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages marked as broken and skipped:</summary>
  <ul>
    <li>kcachegrind</li>
    <li>libsForQt512.kcachegrind</li>
    <li>libsForQt514.kcachegrind</li>
    <li>php80Extensions.datadog_trace</li>
    <li>php80Extensions.gnupg</li>
    <li>php80Packages.php-parallel-lint</li>
    <li>pulseeffects-pw</li>
  </ul>
</details>
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>php82Extensions.datadog_trace</li>
    <li>php82Extensions.gnupg</li>
    <li>php82Extensions.pdo_oci</li>
  </ul>
</details>
<details>
  <summary>333 packages built:</summary>
  <ul>
    <li>adminer</li>
    <li>php (apacheHttpdPackages.php)</li>
    <li>arcanist</li>
    <li>bookstack</li>
    <li>drush</li>
    <li>easyeffects</li>
    <li>engelsystem</li>
    <li>freshrss</li>
    <li>icingaweb2</li>
    <li>libsForQt5.kcachegrind</li>
    <li>lsp-plugins</li>
    <li>matomo</li>
    <li>matomo-beta</li>
    <li>nagios</li>
    <li>nextcloud-news-updater</li>
    <li>nominatim</li>
    <li>pdepend</li>
    <li>phoronix-test-suite</li>
    <li>php80</li>
    <li>php80Extensions.amqp</li>
    <li>php80Extensions.apcu</li>
    <li>php80Extensions.ast</li>
    <li>php80Extensions.bcmath</li>
    <li>php80Extensions.bz2</li>
    <li>php80Extensions.calendar</li>
    <li>php80Extensions.couchbase</li>
    <li>php80Extensions.ctype</li>
    <li>php80Extensions.curl</li>
    <li>php80Extensions.dba</li>
    <li>php80Extensions.dom</li>
    <li>php80Extensions.ds</li>
    <li>php80Extensions.enchant</li>
    <li>php80Extensions.event</li>
    <li>php80Extensions.exif</li>
    <li>php80Extensions.ffi</li>
    <li>php80Extensions.fileinfo</li>
    <li>php80Extensions.filter</li>
    <li>php80Extensions.ftp</li>
    <li>php80Extensions.gd</li>
    <li>php80Extensions.gettext</li>
    <li>php80Extensions.gmp</li>
    <li>php80Extensions.grpc</li>
    <li>php80Extensions.iconv</li>
    <li>php80Extensions.igbinary</li>
    <li>php80Extensions.imagick</li>
    <li>php80Extensions.imap</li>
    <li>php80Extensions.inotify</li>
    <li>php80Extensions.intl</li>
    <li>php80Extensions.ldap</li>
    <li>php80Extensions.mailparse</li>
    <li>php80Extensions.maxminddb</li>
    <li>php80Extensions.mbstring</li>
    <li>php80Extensions.memcached</li>
    <li>php80Extensions.mongodb</li>
    <li>php80Extensions.mysqli</li>
    <li>php80Extensions.mysqlnd</li>
    <li>php80Extensions.oci8</li>
    <li>php80Extensions.opcache</li>
    <li>php80Extensions.openssl</li>
    <li>php80Extensions.openssl-legacy</li>
    <li>php80Extensions.openswoole</li>
    <li>php80Extensions.pcntl</li>
    <li>php80Extensions.pcov</li>
    <li>php80Extensions.pdlib</li>
    <li>php80Extensions.pdo</li>
    <li>php80Extensions.pdo_dblib</li>
    <li>php80Extensions.pdo_mysql</li>
    <li>php80Extensions.pdo_oci</li>
    <li>php80Extensions.pdo_odbc</li>
    <li>php80Extensions.pdo_pgsql</li>
    <li>php80Extensions.pdo_sqlite</li>
    <li>php80Extensions.pdo_sqlsrv</li>
    <li>php80Extensions.pgsql</li>
    <li>php80Extensions.pinba</li>
    <li>php80Extensions.posix</li>
    <li>php80Extensions.protobuf</li>
    <li>php80Extensions.pspell</li>
    <li>php80Extensions.rdkafka</li>
    <li>php80Extensions.readline</li>
    <li>php80Extensions.redis</li>
    <li>php80Extensions.session</li>
    <li>php80Extensions.shmop</li>
    <li>php80Extensions.simplexml</li>
    <li>php80Extensions.smbclient</li>
    <li>php80Extensions.snmp</li>
    <li>php80Extensions.snuffleupagus</li>
    <li>php80Extensions.soap</li>
    <li>php80Extensions.sockets</li>
    <li>php80Extensions.sodium</li>
    <li>php80Extensions.sqlite3</li>
    <li>php80Extensions.sqlsrv</li>
    <li>php80Extensions.swoole</li>
    <li>php80Extensions.sysvmsg</li>
    <li>php80Extensions.sysvsem</li>
    <li>php80Extensions.sysvshm</li>
    <li>php80Extensions.tidy</li>
    <li>php80Extensions.tokenizer</li>
    <li>php80Extensions.xdebug</li>
    <li>php80Extensions.xml</li>
    <li>php80Extensions.xmlreader</li>
    <li>php80Extensions.xmlwriter</li>
    <li>php80Extensions.xsl</li>
    <li>php80Extensions.yaml</li>
    <li>php80Extensions.zend_test</li>
    <li>php80Extensions.zip</li>
    <li>php80Extensions.zlib</li>
    <li>php80Packages.box</li>
    <li>php80Packages.composer</li>
    <li>php80Packages.deployer</li>
    <li>php80Packages.grumphp</li>
    <li>php80Packages.phing</li>
    <li>php80Packages.phive</li>
    <li>php80Packages.php-cs-fixer</li>
    <li>php80Packages.phpcbf</li>
    <li>php80Packages.phpcs</li>
    <li>php80Packages.phpmd</li>
    <li>php80Packages.phpstan</li>
    <li>php80Packages.psalm</li>
    <li>php80Packages.psysh</li>
    <li>php81Extensions.amqp</li>
    <li>php81Extensions.apcu</li>
    <li>php81Extensions.ast</li>
    <li>php81Extensions.bcmath</li>
    <li>php81Extensions.bz2</li>
    <li>php81Extensions.calendar</li>
    <li>php81Extensions.couchbase</li>
    <li>php81Extensions.ctype</li>
    <li>php81Extensions.curl</li>
    <li>php81Extensions.datadog_trace</li>
    <li>php81Extensions.dba</li>
    <li>php81Extensions.dom</li>
    <li>php81Extensions.ds</li>
    <li>php81Extensions.enchant</li>
    <li>php81Extensions.event</li>
    <li>php81Extensions.exif</li>
    <li>php81Extensions.ffi</li>
    <li>php81Extensions.fileinfo</li>
    <li>php81Extensions.filter</li>
    <li>php81Extensions.ftp</li>
    <li>php81Extensions.gd</li>
    <li>php81Extensions.gettext</li>
    <li>php81Extensions.gmp</li>
    <li>php81Extensions.gnupg</li>
    <li>php81Extensions.grpc</li>
    <li>php81Extensions.iconv</li>
    <li>php81Extensions.igbinary</li>
    <li>php81Extensions.imagick</li>
    <li>php81Extensions.imap</li>
    <li>php81Extensions.inotify</li>
    <li>php81Extensions.intl</li>
    <li>php81Extensions.ldap</li>
    <li>php81Extensions.mailparse</li>
    <li>php81Extensions.maxminddb</li>
    <li>php81Extensions.mbstring</li>
    <li>php81Extensions.memcached</li>
    <li>php81Extensions.mongodb</li>
    <li>php81Extensions.mysqli</li>
    <li>php81Extensions.mysqlnd</li>
    <li>php81Extensions.oci8</li>
    <li>php81Extensions.opcache</li>
    <li>php81Extensions.openssl</li>
    <li>php81Extensions.openssl-legacy</li>
    <li>php81Extensions.openswoole</li>
    <li>php81Extensions.pcntl</li>
    <li>php81Extensions.pcov</li>
    <li>php81Extensions.pdlib</li>
    <li>php81Extensions.pdo</li>
    <li>php81Extensions.pdo_dblib</li>
    <li>php81Extensions.pdo_mysql</li>
    <li>php81Extensions.pdo_oci</li>
    <li>php81Extensions.pdo_odbc</li>
    <li>php81Extensions.pdo_pgsql</li>
    <li>php81Extensions.pdo_sqlite</li>
    <li>php81Extensions.pdo_sqlsrv</li>
    <li>php81Extensions.pgsql</li>
    <li>php81Extensions.pinba</li>
    <li>php81Extensions.posix</li>
    <li>php81Extensions.protobuf</li>
    <li>php81Extensions.pspell</li>
    <li>php81Extensions.rdkafka</li>
    <li>php81Extensions.readline</li>
    <li>php81Extensions.redis</li>
    <li>php81Extensions.session</li>
    <li>php81Extensions.shmop</li>
    <li>php81Extensions.simplexml</li>
    <li>php81Extensions.smbclient</li>
    <li>php81Extensions.snmp</li>
    <li>php81Extensions.snuffleupagus</li>
    <li>php81Extensions.soap</li>
    <li>php81Extensions.sockets</li>
    <li>php81Extensions.sodium</li>
    <li>php81Extensions.sqlite3</li>
    <li>php81Extensions.sqlsrv</li>
    <li>php81Extensions.swoole</li>
    <li>php81Extensions.sysvmsg</li>
    <li>php81Extensions.sysvsem</li>
    <li>php81Extensions.sysvshm</li>
    <li>php81Extensions.tidy</li>
    <li>php81Extensions.tokenizer</li>
    <li>php81Extensions.xdebug</li>
    <li>php81Extensions.xml</li>
    <li>php81Extensions.xmlreader</li>
    <li>php81Extensions.xmlwriter</li>
    <li>php81Extensions.xsl</li>
    <li>php81Extensions.yaml</li>
    <li>php81Extensions.zend_test</li>
    <li>php81Extensions.zip</li>
    <li>php81Extensions.zlib</li>
    <li>php81Packages.box</li>
    <li>php81Packages.composer</li>
    <li>php81Packages.deployer</li>
    <li>php81Packages.grumphp</li>
    <li>php81Packages.phing</li>
    <li>php81Packages.phive</li>
    <li>php81Packages.php-cs-fixer</li>
    <li>php81Packages.php-parallel-lint</li>
    <li>php81Packages.phpcbf</li>
    <li>php81Packages.phpcs</li>
    <li>php81Packages.phpmd</li>
    <li>php81Packages.phpstan</li>
    <li>php81Packages.psalm</li>
    <li>php81Packages.psysh</li>
    <li>php82</li>
    <li>php82Extensions.amqp</li>
    <li>php82Extensions.apcu</li>
    <li>php82Extensions.ast</li>
    <li>php82Extensions.bcmath</li>
    <li>php82Extensions.bz2</li>
    <li>php82Extensions.calendar</li>
    <li>php82Extensions.couchbase</li>
    <li>php82Extensions.ctype</li>
    <li>php82Extensions.curl</li>
    <li>php82Extensions.dba</li>
    <li>php82Extensions.dom</li>
    <li>php82Extensions.ds</li>
    <li>php82Extensions.enchant</li>
    <li>php82Extensions.event</li>
    <li>php82Extensions.exif</li>
    <li>php82Extensions.ffi</li>
    <li>php82Extensions.fileinfo</li>
    <li>php82Extensions.filter</li>
    <li>php82Extensions.ftp</li>
    <li>php82Extensions.gd</li>
    <li>php82Extensions.gettext</li>
    <li>php82Extensions.gmp</li>
    <li>php82Extensions.grpc</li>
    <li>php82Extensions.iconv</li>
    <li>php82Extensions.igbinary</li>
    <li>php82Extensions.imagick</li>
    <li>php82Extensions.imap</li>
    <li>php82Extensions.inotify</li>
    <li>php82Extensions.intl</li>
    <li>php82Extensions.ldap</li>
    <li>php82Extensions.mailparse</li>
    <li>php82Extensions.maxminddb</li>
    <li>php82Extensions.mbstring</li>
    <li>php82Extensions.memcached</li>
    <li>php82Extensions.mongodb</li>
    <li>php82Extensions.mysqli</li>
    <li>php82Extensions.mysqlnd</li>
    <li>php82Extensions.oci8</li>
    <li>php82Extensions.opcache</li>
    <li>php82Extensions.openssl</li>
    <li>php82Extensions.openssl-legacy</li>
    <li>php82Extensions.openswoole</li>
    <li>php82Extensions.pcntl</li>
    <li>php82Extensions.pcov</li>
    <li>php82Extensions.pdlib</li>
    <li>php82Extensions.pdo</li>
    <li>php82Extensions.pdo_dblib</li>
    <li>php82Extensions.pdo_mysql</li>
    <li>php82Extensions.pdo_odbc</li>
    <li>php82Extensions.pdo_pgsql</li>
    <li>php82Extensions.pdo_sqlite</li>
    <li>php82Extensions.pdo_sqlsrv</li>
    <li>php82Extensions.pgsql</li>
    <li>php82Extensions.pinba</li>
    <li>php82Extensions.posix</li>
    <li>php82Extensions.protobuf</li>
    <li>php82Extensions.pspell</li>
    <li>php82Extensions.rdkafka</li>
    <li>php82Extensions.readline</li>
    <li>php82Extensions.redis</li>
    <li>php82Extensions.session</li>
    <li>php82Extensions.shmop</li>
    <li>php82Extensions.simplexml</li>
    <li>php82Extensions.smbclient</li>
    <li>php82Extensions.snmp</li>
    <li>php82Extensions.snuffleupagus</li>
    <li>php82Extensions.soap</li>
    <li>php82Extensions.sockets</li>
    <li>php82Extensions.sodium</li>
    <li>php82Extensions.sqlite3</li>
    <li>php82Extensions.sqlsrv</li>
    <li>php82Extensions.swoole</li>
    <li>php82Extensions.sysvmsg</li>
    <li>php82Extensions.sysvsem</li>
    <li>php82Extensions.sysvshm</li>
    <li>php82Extensions.tidy</li>
    <li>php82Extensions.tokenizer</li>
    <li>php82Extensions.xdebug</li>
    <li>php82Extensions.xml</li>
    <li>php82Extensions.xmlreader</li>
    <li>php82Extensions.xmlwriter</li>
    <li>php82Extensions.xsl</li>
    <li>php82Extensions.yaml</li>
    <li>php82Extensions.zend_test</li>
    <li>php82Extensions.zip</li>
    <li>php82Extensions.zlib</li>
    <li>php82Packages.box</li>
    <li>php82Packages.composer</li>
    <li>php82Packages.deployer</li>
    <li>php82Packages.grumphp</li>
    <li>php82Packages.phing</li>
    <li>php82Packages.phive</li>
    <li>php82Packages.php-cs-fixer</li>
    <li>php82Packages.php-parallel-lint</li>
    <li>php82Packages.phpcbf</li>
    <li>php82Packages.phpcs</li>
    <li>php82Packages.phpmd</li>
    <li>php82Packages.phpstan</li>
    <li>php82Packages.psalm</li>
    <li>php82Packages.psysh</li>
    <li>platformsh</li>
    <li>pulseeffects-legacy</li>
    <li>qcachegrind</li>
    <li>rss-bridge-cli</li>
    <li>snipe-it</li>
    <li>unit</li>
    <li>weechat</li>
    <li>weechat-unwrapped</li>
    <li>wp-cli</li>
    <li>yle-dl</li>
  </ul>
</details>