### PR TITLE
qemu-vm: remove bootDisk, refactor using make-disk-image with better EFI support

### DIFF
--- a/doc/builders/images.xml
+++ b/doc/builders/images.xml
@@ -10,4 +10,5 @@
  <xi:include href="images/ocitools.section.xml" />
  <xi:include href="images/snaptools.section.xml" />
  <xi:include href="images/portableservice.section.xml" />
+ <xi:include href="images/makediskimage.section.xml" />
 </chapter>

--- a/doc/builders/images/makediskimage.section.md
+++ b/doc/builders/images/makediskimage.section.md
@@ -1,0 +1,181 @@
+# `<nixpkgs/nixos/lib/make-disk-image.nix>` {#sec-make-disk-image}
+
+`<nixpkgs/nixos/lib/make-disk-image.nix>` is a function to create _disk image_ in multiple formats: raw, QCOW2 (QEMU image format), QCOW2-Compressed (compressed version), VDI (Virtual Box native format), VPC (VirtualPC).
+
+There are two operations mode for this function:
+
+- either, you want only a Nix store disk image, it can be done using `cptofs` without any virtual machine involved ;
+- or, you want a full NixOS install on the disk, it will start a virtual machine to perform various tasks such as partitionning, installation and bootloader installation.
+
+When NixOS tests are running, this function gets called to generate potentially two kinds of disk images:
+
+- a Nix-store only disk image: useful when the test _do not need_ bootloader
+- a full-fledged NixOS installation disk image: useful when the test _do need_ to test the bootloader
+
+## Features
+
+- whether to produce a Nix-store only image or not, **this can be incompatible with other options**
+- arbitrary NixOS configuration
+- multiple partition table layouts: EFI, legacy, legacy + GPT, hybrid, none through `partitionTableType` parameter
+- automatic or bound disk size: `diskSize` parameter, `additionalSpace` can be set when `diskSize` is `auto` to add a constant of disk space 
+- boot partition size when partition table is `efi` or `hybrid`
+- arbitrary contents with permissions can be placed in the target filesystem using `contents`, incompatible with Nix-store only image
+- bootloaders are supported, incompatible with Nix-store only image
+- EFI variables can be mutated during image production and the result is exposed in `$out`
+- system management mode (SMM) can enabled during virtual machine operations
+- OVMF or EFI firmwares and variables templates can be customized
+- root filesystem `fsType` can be customized to whatever `mkfs.${fsType}` exist during operations
+- root filesystem label can be customized, defaults to `nix-store` if it's a nix store image, otherwise `nixpkgs/nixos`
+- a `/etc/nixpkgs/nixos/configuration.nix` can be provided through `configFile`, incompatible with a Nix-store only image
+- arbitrary code can be executed after the VM has finished its operations with `postVM`
+- the current nixpkgs can be realized as a channel in the disk image, which will change the hash of the image when the sources are updated
+- additional store paths can be provided through `additionalPaths`
+
+Images are **NOT** deterministic, please do not hesitate to try to fix this, source of determinisms are (not exhaustive) :
+
+- bootloader installation have timestamps ;
+- SQLite Nix store database contain registration times ;
+- `/etc/shadow` is in a non-deterministic order
+
+For more, read the function signature source code for documentation on arguments: <https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/make-disk-image.nix>.
+
+## Usage
+
+To produce a Nix-store only image:
+```nix
+let
+  pkgs = import <nixpkgs> {};
+  lib = pkgs.lib;
+  make-disk-image = import <nixpkgs/nixos/lib/make-disk-image.nix>;
+in
+  make-disk-image {
+    inherit pkgs lib;
+    config = {};
+    additionalPaths = [ ];
+    format = "qcow2";
+    onlyNixStore = true;
+    partitionTableType = "none";
+    installBootLoader = false;
+    touchEFIVars = false;
+    diskSize = "auto";
+    additionalSpace = "0M"; # Defaults to 512M.
+    copyChannel = false;
+  }
+```
+
+Some arguments can be left out, they are shown explicitly for the sake of the example.
+
+Building this derivation will provide a QCOW2 disk image containing only the Nix store and its registration information.
+
+To produce a NixOS installation image disk with UEFI and bootloader installed:
+```nix
+let
+  pkgs = import <nixpkgs> {};
+  lib = pkgs.lib;
+  make-disk-image = import <nixpkgs/nixos/lib/make-disk-image.nix>;
+  evalConfig = import <nixpkgs/nixos/lib/eval-config.nix>;
+in
+  make-disk-image {
+    inherit pkgs lib;
+    config = evalConfig {
+      modules = [
+        {
+          fileSystems."/" = { device = "/dev/vda"; fsType = "ext4"; autoFormat = true; };
+          boot.grub.device = "/dev/vda";
+        }
+      ];
+    };
+    format = "qcow2";
+    onlyNixStore = false;
+    partitionTableType = "legacy+gpt";
+    installBootLoader = true;
+    touchEFIVars = true;
+    diskSize = "auto";
+    additionalSpace = "0M"; # Defaults to 512M.
+    copyChannel = false;
+  }
+```
+
+## Technical details
+
+`make-disk-image` has a bit of magic to minimize the amount of work to do in a virtual machine.
+
+It relies on the [LKL (Linux Kernel Library) project](https://github.com/lkl/linux) which provides Linux kernel as userspace library.
+
+::: {.note}
+The Nix-store only image only need to run LKL tools to produce an image and will never spawn a virtual machine, whereas full images will always require a virtual machine, but also use LKL.
+:::
+
+### Image preparation phase
+
+Image preparation phase will produce the initial image layout in a folder:
+
+- devise a root folder based on `$PWD`
+- preparing the contents by copying and restoring ACLs in this root folder
+- load in the Nix store database all additional paths computed by `pkgs.closureInfo` in a temporary Nix store
+- run `nixos-install` in a temporary folder
+- transfer from the temporary store the additional paths registered to the installed NixOS
+- do fancy computations for the size of the disk image based on the apparent size of the root folder
+- partition the disk image using the corresponding script according to the partition table type
+- format the partitions if needed
+- use `cptofs` (LKL tool) to copy the root folder inside the disk image
+
+At this step, the disk image contains already the Nix store, it only needs to be converted to the desired format to be used.
+
+### Image conversion phase
+
+Using `qemu-img`, the disk image is converted from a raw format to the desired format: qcow2(-compressed), vdi, vpc.
+
+### Partitionning script based on layouts
+
+#### `none`
+
+No partition table layout is written.
+
+#### `legacy`
+
+This partition table type is composed of a MBR and one primary ext4 partition starting at 1MiB extending to the full disk image.
+
+It is unsuitable for UEFI.
+
+#### `legacy+gpt`
+
+This partition table type uses GPT and:
+
+- create a "no filesystem" partition from 1MiB to 2MiB ;
+- set `bios_grub` flag on this "no filesystem" partition, which marks it as a [GRUB BIOS partition](https://www.gnu.org/software/parted/manual/html_node/set.html) ;
+- create a primary ext4 partition starting at 2MiB and extending to the full disk image ;
+- perform optimal alignments checks on each partition
+
+This partition has no ESP partition, it is unsuitable for EFI boot which requires an ESP partition, but it can work with CSM (Compatibility Support Module) which emulates BIOS for UEFI.
+
+#### `efi`
+
+This partition table type uses GPT and:
+
+- creates an FAT32 ESP partition from 8MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
+- create a primary ext4 partition starting after the boot one and extending to the full disk image
+
+#### `hybrid`
+
+This partition table type uses GPT and:
+
+- creates a "no filesystem" partition from 0 to 1MiB, set `bios_grub` flag on it ;
+- creates an FAT32 ESP partition from 8MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
+- creates a primary ext4 partition starting after the boot one and extending to the full disk image
+
+This partition could be booted by a BIOS able to understand GPT layouts and recognizing the MBR at the start.
+
+### How to run determinism analysis on results?
+
+Run your derivation with `--check` to rebuild it and verify it is the same.
+
+Once it fails, you will be left with two folders with one having `.check`.
+
+`diffoscope` is not able at the moment to diff two QCOW2 filesystems, it is advised to use raw format.
+
+But even with raw formats, `diffoscope` cannot diff the partition table and partitions recursively.
+
+For this, you can run `fdisk -l $image` and generate `dd if=$image of=$image-p$i.raw skip=$start count=$sectors` for each `(start, sectors)` listed in the `fdisk` output.
+
+With this, you will have each partition as a separate file and you can diffoscope pairs of them to use `diffoscope` ability to read filesystems.

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -275,6 +275,26 @@
       </listitem>
       <listitem>
         <para>
+          Disk layout in NixOS tests has changed when using bootloaders:
+          instead of two disks <literal>/dev/vda</literal> and
+          <literal>/dev/vdb</literal>, there is only a unified
+          <literal>/dev/vda</literal> with multiple partitions.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>hardware.nvidia</literal> has a new option
+          <literal>open</literal> that can be used to opt in the
+          opensource version of NVIDIA kernel driver. Note that the
+          driver’s support for GeForce and Workstation GPUs is still
+          alpha quality, see
+          <link xlink:href="https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/">NVIDIA
+          Releases Open-Source GPU Kernel Modules</link> for the
+          official announcement.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           Cinnamon has been updated to 5.4, and the Cinnamon module now
           defaults to Blueman as the Bluetooth manager and slick-greeter
           as the LightDM greeter, to match upstream.
@@ -359,6 +379,21 @@
           Please convert any uses to
           <link linkend="opt-services.logrotate.settings">services.logrotate.settings</link>
           instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Disk layout in NixOS tests has changed when using bootloaders:
+          instead of two disks <literal>/dev/vda</literal> and
+          <literal>/dev/vdb</literal>, there is only a unified
+          <literal>/dev/vda</literal> with multiple partitions. This
+          require you to change <literal>/dev/vdc</literal> to
+          <literal>/dev/vdb</literal> and so on if you were using
+          <literal>emptyDiskImages</literal> which creates disks in
+          order, as <literal>/dev/vdb</literal> has disappeared, every
+          disk has to start over from <literal>/dev/vdb</literal> rather
+          than <literal>/dev/vdc</literal>, see the #191665 PR in
+          nixpkgs to learn about examples for your migration.
         </para>
       </listitem>
       <listitem>
@@ -1052,7 +1087,24 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
-          Synapse’s systemd unit has been hardened.
+          <literal>pkgs.OVMF.fd</literal> exposes
+          <literal>firmware</literal> and <literal>variables</literal>
+          which points to your host architecture binaries for the
+          correspoding UEFI artifacts.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>nixos/lib/make-disk-image.nix</literal> can now
+          mutate EFI variables, run user-provided EFI firmware or
+          variable templates. As a result, NixOS tests have better
+          support of UEFI platforms tests such as SecureBoot tests.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>services.matrix-synapse</literal> systemd unit
+          has been hardened.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1095,6 +1095,14 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
+          QEMU test architecture supports running System Management
+          Enforcement (SMM), useful to lock down UEFI authenticated
+          variables. At the moment, it seems to prevent any change to
+          UEFI platform, breaking disk production and tests, if enabled.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>nixos/lib/make-disk-image.nix</literal> can now
           mutate EFI variables, run user-provided EFI firmware or
           variable templates. As a result, NixOS tests have better

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -275,14 +275,6 @@
       </listitem>
       <listitem>
         <para>
-          Disk layout in NixOS tests has changed when using bootloaders:
-          instead of two disks <literal>/dev/vda</literal> and
-          <literal>/dev/vdb</literal>, there is only a unified
-          <literal>/dev/vda</literal> with multiple partitions.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
           <literal>hardware.nvidia</literal> has a new option
           <literal>open</literal> that can be used to opt in the
           opensource version of NVIDIA kernel driver. Note that the
@@ -379,21 +371,6 @@
           Please convert any uses to
           <link linkend="opt-services.logrotate.settings">services.logrotate.settings</link>
           instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Disk layout in NixOS tests has changed when using bootloaders:
-          instead of two disks <literal>/dev/vda</literal> and
-          <literal>/dev/vdb</literal>, there is only a unified
-          <literal>/dev/vda</literal> with multiple partitions. This
-          require you to change <literal>/dev/vdc</literal> to
-          <literal>/dev/vdb</literal> and so on if you were using
-          <literal>emptyDiskImages</literal> which creates disks in
-          order, as <literal>/dev/vdb</literal> has disappeared, every
-          disk has to start over from <literal>/dev/vdb</literal> rather
-          than <literal>/dev/vdc</literal>, see the #191665 PR in
-          nixpkgs to learn about examples for your migration.
         </para>
       </listitem>
       <listitem>
@@ -1091,22 +1068,6 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
           <literal>firmware</literal> and <literal>variables</literal>
           which points to your host architecture binaries for the
           correspoding UEFI artifacts.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          QEMU test architecture supports running System Management
-          Enforcement (SMM), useful to lock down UEFI authenticated
-          variables. At the moment, it seems to prevent any change to
-          UEFI platform, breaking disk production and tests, if enabled.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>nixos/lib/make-disk-image.nix</literal> can now
-          mutate EFI variables, run user-provided EFI firmware or
-          variable templates. As a result, NixOS tests have better
-          support of UEFI platforms tests such as SecureBoot tests.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -172,6 +172,26 @@
       </listitem>
       <listitem>
         <para>
+          Disk layout in NixOS tests has changed when using bootloaders:
+          instead of two disks <literal>/dev/vda</literal> and
+          <literal>/dev/vdb</literal>, there is only a unified
+          <literal>/dev/vda</literal> with multiple partitions. This
+          require you to change <literal>/dev/vdc</literal> to
+          <literal>/dev/vdb</literal> and so on if you were using
+          <literal>emptyDiskImages</literal> which creates disks in
+          order, as <literal>/dev/vdb</literal> has disappeared, every
+          disk has to start over from <literal>/dev/vdb</literal> rather
+          than <literal>/dev/vdc</literal>, see the
+          <link xlink:href="https://github.com/NixOS/nixpkgs/pull/203641">#203641
+          PR in nixpkgs</link> to learn about examples for your
+          migration. In addition,
+          <literal>virtualisation.rootDevice</literal> option was
+          introduced and should be used instead of
+          <literal>virtualisation.bootDevice</literal> in many cases.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>nix.readOnlyStore</literal> option has been
           renamed to <literal>boot.readOnlyNixStore</literal> to clarify
           that it configures the NixOS boot process, not the Nix daemon.
@@ -238,6 +258,22 @@
         <para>
           <literal>mastodon</literal> now supports connection to a
           remote <literal>PostgreSQL</literal> database.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          QEMU test architecture supports running System Management
+          Enforcement (SMM), useful to lock down UEFI authenticated
+          variables. At the moment, it seems to prevent any change to
+          UEFI platform, breaking disk production and tests, if enabled.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>nixos/lib/make-disk-image.nix</literal> can now
+          mutate EFI variables, run user-provided EFI firmware or
+          variable templates. As a result, NixOS tests have better
+          support of UEFI platforms tests such as SecureBoot tests.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -74,6 +74,10 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - KDE Plasma has been upgraded from v5.24 to v5.26. Please see the release notes for [v5.25](https://kde.org/announcements/plasma/5/5.25.0/) and [v5.26](https://kde.org/announcements/plasma/5/5.26.0/) for more details on the included changes.
 
+- Disk layout in NixOS tests has changed when using bootloaders: instead of two disks `/dev/vda` and `/dev/vdb`, there is only a unified `/dev/vda` with multiple partitions.
+
+- `hardware.nvidia` has a new option `open` that can be used to opt in the opensource version of NVIDIA kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [NVIDIA Releases Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for the official announcement.
+
 - Cinnamon has been updated to 5.4, and the Cinnamon module now defaults to
   Blueman as the Bluetooth manager and slick-greeter as the LightDM greeter, to match upstream.
 
@@ -105,6 +109,10 @@ In addition to numerous new and upgraded packages, this release includes the fol
 - Deprecated settings `logrotate.paths` and `logrotate.extraConfig` have
   been removed. Please convert any uses to
   [services.logrotate.settings](#opt-services.logrotate.settings) instead.
+
+- Disk layout in NixOS tests has changed when using bootloaders: instead of two disks `/dev/vda` and `/dev/vdb`, there is only a unified `/dev/vda` with multiple partitions.
+  This require you to change `/dev/vdc` to `/dev/vdb` and so on if you were using `emptyDiskImages` which creates disks in order, as `/dev/vdb` has disappeared, every disk
+  has to start over from `/dev/vdb` rather than `/dev/vdc`, see the #191665 PR in nixpkgs to learn about examples for your migration.
 
 - The `isPowerPC` predicate, found on `platform` attrsets (`hostPlatform`, `buildPlatform`, `targetPlatform`, etc) has been removed in order to reduce confusion.  The predicate was was defined such that it matches only the 32-bit big-endian members of the POWER/PowerPC family, despite having a name which would imply a broader set of systems.  If you were using this predicate, you can replace `foo.isPowerPC` with `(with foo; isPower && is32bit && isBigEndian)`.
 
@@ -305,7 +313,12 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - The `bloat` package has been updated from unstable-2022-03-31 to unstable-2022-10-25, which brings a breaking change. See [this upstream commit message](https://git.freesoftwareextremist.com/bloat/commit/?id=887ed241d64ba5db3fd3d87194fb5595e5ad7d73) for details.
 
-- Synapse's systemd unit has been hardened.
+- `pkgs.OVMF.fd` exposes `firmware` and `variables` which points to your host architecture binaries for the correspoding UEFI artifacts.
+
+- `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates.
+  As a result, NixOS tests have better support of UEFI platforms tests such as SecureBoot tests.
+
+- The `services.matrix-synapse` systemd unit has been hardened.
 
 - The module `services.grafana` was refactored to be compliant with [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md). To be precise, this means that the following things have changed:
   - The newly introduced option [](#opt-services.grafana.settings) is an attribute-set that

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -315,6 +315,9 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - `pkgs.OVMF.fd` exposes `firmware` and `variables` which points to your host architecture binaries for the correspoding UEFI artifacts.
 
+- QEMU test architecture supports running System Management Enforcement (SMM), useful to lock down UEFI authenticated variables.
+  At the moment, it seems to prevent any change to UEFI platform, breaking disk production and tests, if enabled.
+
 - `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates.
   As a result, NixOS tests have better support of UEFI platforms tests such as SecureBoot tests.
 

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -74,8 +74,6 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - KDE Plasma has been upgraded from v5.24 to v5.26. Please see the release notes for [v5.25](https://kde.org/announcements/plasma/5/5.25.0/) and [v5.26](https://kde.org/announcements/plasma/5/5.26.0/) for more details on the included changes.
 
-- Disk layout in NixOS tests has changed when using bootloaders: instead of two disks `/dev/vda` and `/dev/vdb`, there is only a unified `/dev/vda` with multiple partitions.
-
 - `hardware.nvidia` has a new option `open` that can be used to opt in the opensource version of NVIDIA kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [NVIDIA Releases Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for the official announcement.
 
 - Cinnamon has been updated to 5.4, and the Cinnamon module now defaults to
@@ -109,10 +107,6 @@ In addition to numerous new and upgraded packages, this release includes the fol
 - Deprecated settings `logrotate.paths` and `logrotate.extraConfig` have
   been removed. Please convert any uses to
   [services.logrotate.settings](#opt-services.logrotate.settings) instead.
-
-- Disk layout in NixOS tests has changed when using bootloaders: instead of two disks `/dev/vda` and `/dev/vdb`, there is only a unified `/dev/vda` with multiple partitions.
-  This require you to change `/dev/vdc` to `/dev/vdb` and so on if you were using `emptyDiskImages` which creates disks in order, as `/dev/vdb` has disappeared, every disk
-  has to start over from `/dev/vdb` rather than `/dev/vdc`, see the #191665 PR in nixpkgs to learn about examples for your migration.
 
 - The `isPowerPC` predicate, found on `platform` attrsets (`hostPlatform`, `buildPlatform`, `targetPlatform`, etc) has been removed in order to reduce confusion.  The predicate was was defined such that it matches only the 32-bit big-endian members of the POWER/PowerPC family, despite having a name which would imply a broader set of systems.  If you were using this predicate, you can replace `foo.isPowerPC` with `(with foo; isPower && is32bit && isBigEndian)`.
 
@@ -314,12 +308,6 @@ In addition to numerous new and upgraded packages, this release includes the fol
 - The `bloat` package has been updated from unstable-2022-03-31 to unstable-2022-10-25, which brings a breaking change. See [this upstream commit message](https://git.freesoftwareextremist.com/bloat/commit/?id=887ed241d64ba5db3fd3d87194fb5595e5ad7d73) for details.
 
 - `pkgs.OVMF.fd` exposes `firmware` and `variables` which points to your host architecture binaries for the correspoding UEFI artifacts.
-
-- QEMU test architecture supports running System Management Enforcement (SMM), useful to lock down UEFI authenticated variables.
-  At the moment, it seems to prevent any change to UEFI platform, breaking disk production and tests, if enabled.
-
-- `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates.
-  As a result, NixOS tests have better support of UEFI platforms tests such as SecureBoot tests.
 
 - The `services.matrix-synapse` systemd unit has been hardened.
 

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -49,6 +49,11 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - In `mastodon` it is now necessary to specify location of file with `PostgreSQL` database password. In `services.mastodon.database.passwordFile` parameter default value `/var/lib/mastodon/secrets/db-password` has been changed to `null`.
 
+- Disk layout in NixOS tests has changed when using bootloaders: instead of two disks `/dev/vda` and `/dev/vdb`, there is only a unified `/dev/vda` with multiple partitions.
+  This require you to change `/dev/vdc` to `/dev/vdb` and so on if you were using `emptyDiskImages` which creates disks in order, as `/dev/vdb` has disappeared, every disk
+  has to start over from `/dev/vdb` rather than `/dev/vdc`, see the [#203641 PR in nixpkgs](https://github.com/NixOS/nixpkgs/pull/203641) to learn about examples for your migration.
+  In addition, `virtualisation.rootDevice` option was introduced and should be used instead of `virtualisation.bootDevice` in many cases.
+
 - The `nix.readOnlyStore` option has been renamed to `boot.readOnlyNixStore` to clarify that it configures the NixOS boot process, not the Nix daemon.
 
 ## Other Notable Changes {#sec-release-23.05-notable-changes}
@@ -71,6 +76,12 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The minimal ISO image now uses the `nixos/modules/profiles/minimal.nix` profile.
 
 - `mastodon` now supports connection to a remote `PostgreSQL` database.
+
+- QEMU test architecture supports running System Management Enforcement (SMM), useful to lock down UEFI authenticated variables.
+  At the moment, it seems to prevent any change to UEFI platform, breaking disk production and tests, if enabled.
+
+- `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates.
+  As a result, NixOS tests have better support of UEFI platforms tests such as SecureBoot tests.
 
 - A new `virtualisation.rosetta` module was added to allow running `x86_64` binaries through [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) inside virtualised NixOS guests on Apple silicon. This feature works by default with the [UTM](https://docs.getutm.app/) virtualisation [package](https://search.nixos.org/packages?channel=unstable&show=utm&from=0&size=1&sort=relevance&type=packages&query=utm).
 

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -17,7 +17,7 @@
   # either "efi" or "hybrid"
   # This will be undersized slightly, as this is actually the offset of
   # the end of the partition. Generally it will be 1MiB smaller.
-  bootSize ? "256MiB"
+  bootSize ? "256M"
 
 , # The files and directories to be placed in the target file system.
   # This is a list of attribute sets {source, target, mode, user, group} where

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -462,6 +462,7 @@ let format' = format; in let
       ${optionalString (fsType == "ext4" && deterministic) ''
         tune2fs -T now ${optionalString deterministic "-U ${rootFSUID}"} -c 0 -i 0 $rootDisk
       ''}
+
       # make systemd-boot find ESP without udev
       mkdir /dev/block
       ln -s /dev/vda1 /dev/block/254:1
@@ -492,10 +493,6 @@ let format' = format; in let
         ${optionalString (config.boot.loader.grub.device != "/dev/vda") ''
             ln -s /dev/vda ${config.boot.loader.grub.device}
         ''}
-        # TODO: needed?
-        # For GRUB 0.97 compatibility
-        mkdir -p /mnt/boot/grub
-        echo '(hd0) /dev/vda' > /mnt/boot/grub/device.map
 
         # Set up core system link, bootloader (sd-boot, GRUB, uboot, etc.), etc.
         NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -43,7 +43,7 @@ in {
 
     sizeMB = mkOption {
       type = with types; either (enum [ "auto" ]) int;
-      default = 2048;
+      default = 2252;
       example = 8192;
       description = lib.mdDoc "The size in MB of the image";
     };

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -55,6 +55,11 @@ let
 
   };
 
+  selectPartitionTableLayout = { useEFIBoot, useDefaultFilesystems }:
+  if useDefaultFilesystems then
+    if useEFIBoot then "efi" else "legacy"
+  else "none";
+
   driveCmdline = idx: { file, driveExtraOpts, deviceExtraOpts, ... }:
     let
       drvId = "drive${toString idx}";
@@ -98,7 +103,6 @@ let
   addDeviceNames =
     imap1 (idx: drive: drive // { device = driveDeviceName idx; });
 
-
   # Shell script to start the VM.
   startVM =
     ''
@@ -111,8 +115,23 @@ let
       NIX_DISK_IMAGE=$(readlink -f "''${NIX_DISK_IMAGE:-${config.virtualisation.diskImage}}")
 
       if ! test -e "$NIX_DISK_IMAGE"; then
-          ${qemu}/bin/qemu-img create -f qcow2 "$NIX_DISK_IMAGE" \
-            ${toString config.virtualisation.diskSize}M
+          echo "Disk image do not exist, creating the virtualisation disk image..."
+          # If we are using a bootloader and default filesystems layout.
+          # We have to reuse the system image layout as a backing image format (CoW)
+          # So we can write on the top of it.
+
+          # If we are not using the default FS layout, potentially, we are interested into
+          # performing operations in postDeviceCommands or at early boot on the raw device.
+          # We can still boot through QEMU direct kernel boot feature.
+
+          # CoW prevent size to be attributed to an image.
+          # FIXME: raise this issue to upstream.
+          ${qemu}/bin/qemu-img create \
+          ${concatStringsSep " \\\n" ([ "-f qcow2" ]
+          ++ optional (cfg.useBootLoader && cfg.useDefaultFilesystems) "-F qcow2 -b ${systemImage}/nixos.qcow2"
+          ++ optional (!(cfg.useBootLoader && cfg.useDefaultFilesystems)) "-o size=${toString config.virtualisation.diskSize}M"
+          ++ [ "$NIX_DISK_IMAGE" ])}
+          echo "Virtualisation disk image created."
       fi
 
       # Create a directory for storing temporary data of the running VM.
@@ -152,17 +171,13 @@ let
 
       ${lib.optionalString cfg.useBootLoader
       ''
-        # Create a writable copy/snapshot of the boot disk.
-        # A writable boot disk can be booted from automatically.
-        ${qemu}/bin/qemu-img create -f qcow2 -F qcow2 -b ${bootDisk}/disk.img "$TMPDIR/disk.img"
-
-        NIX_EFI_VARS=$(readlink -f "''${NIX_EFI_VARS:-${cfg.efiVars}}")
+        NIX_EFI_VARS=$(readlink -f "''${NIX_EFI_VARS:-${config.system.name}-efi-vars.fd}")
 
         ${lib.optionalString cfg.useEFIBoot
         ''
           # VM needs writable EFI vars
           if ! test -e "$NIX_EFI_VARS"; then
-            cp ${bootDisk}/efi-vars.fd "$NIX_EFI_VARS"
+            cp ${systemImage}/efi-vars.fd "$NIX_EFI_VARS"
             chmod 0644 "$NIX_EFI_VARS"
           fi
         ''}
@@ -198,96 +213,23 @@ let
 
   regInfo = pkgs.closureInfo { rootPaths = config.virtualisation.additionalPaths; };
 
+  # System image is akin to a complete NixOS install with
+  # a boot partition and root partition.
+  systemImage = import ../../lib/make-disk-image.nix {
+    inherit pkgs config lib;
+    additionalPaths = [ regInfo ];
+    format = "qcow2";
+    onlyNixStore = false;
+    partitionTableType = selectPartitionTableLayout { inherit (cfg) useDefaultFilesystems useEFIBoot; };
+    installBootLoader = cfg.useBootLoader && cfg.useDefaultFilesystems;
+    touchEFIVars = cfg.useEFIBoot;
+    diskSize = "auto";
+    additionalSpace = "0M";
+    copyChannel = false;
+  };
 
-  # Generate a hard disk image containing a /boot partition and GRUB
-  # in the MBR.  Used when the `useBootLoader' option is set.
-  # Uses `runInLinuxVM` to create the image in a throwaway VM.
-  # See note [Disk layout with `useBootLoader`].
-  # FIXME: use nixos/lib/make-disk-image.nix.
-  bootDisk =
-    pkgs.vmTools.runInLinuxVM (
-      pkgs.runCommand "nixos-boot-disk"
-        { preVM =
-            ''
-              mkdir $out
-              diskImage=$out/disk.img
-              ${qemu}/bin/qemu-img create -f qcow2 $diskImage "60M"
-              ${if cfg.useEFIBoot then ''
-                efiVars=$out/efi-vars.fd
-                cp ${cfg.efi.variables} $efiVars
-                chmod 0644 $efiVars
-              '' else ""}
-            '';
-          buildInputs = [ pkgs.util-linux ];
-          QEMU_OPTS = "-nographic -serial stdio -monitor none"
-                      + lib.optionalString cfg.useEFIBoot (
-                        " -drive if=pflash,format=raw,unit=0,readonly=on,file=${cfg.efi.firmware}"
-                      + " -drive if=pflash,format=raw,unit=1,file=$efiVars");
-        }
-        ''
-          # Create a /boot EFI partition with 60M and arbitrary but fixed GUIDs for reproducibility
-          ${pkgs.gptfdisk}/bin/sgdisk \
-            --set-alignment=1 --new=1:34:2047 --change-name=1:BIOSBootPartition --typecode=1:ef02 \
-            --set-alignment=512 --largest-new=2 --change-name=2:EFISystem --typecode=2:ef00 \
-            --attributes=1:set:1 \
-            --attributes=2:set:2 \
-            --disk-guid=97FD5997-D90B-4AA3-8D16-C1723AEA73C1 \
-            --partition-guid=1:1C06F03B-704E-4657-B9CD-681A087A2FDC \
-            --partition-guid=2:970C694F-AFD0-4B99-B750-CDB7A329AB6F \
-            --hybrid 2 \
-            --recompute-chs /dev/vda
-
-          ${optionalString (config.boot.loader.grub.device != "/dev/vda")
-            # In this throwaway VM, we only have the /dev/vda disk, but the
-            # actual VM described by `config` (used by `switch-to-configuration`
-            # below) may set `boot.loader.grub.device` to a different device
-            # that's nonexistent in the throwaway VM.
-            # Create a symlink for that device, so that the `grub-install`
-            # by `switch-to-configuration` will hit /dev/vda anyway.
-            ''
-              ln -s /dev/vda ${config.boot.loader.grub.device}
-            ''
-          }
-
-          ${pkgs.dosfstools}/bin/mkfs.fat -F16 /dev/vda2
-          export MTOOLS_SKIP_CHECK=1
-          ${pkgs.mtools}/bin/mlabel -i /dev/vda2 ::boot
-
-          # Mount /boot; load necessary modules first.
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_cp437.ko.xz || true
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_iso8859-1.ko.xz || true
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/fat.ko.xz || true
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/vfat.ko.xz || true
-          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/efivarfs/efivarfs.ko.xz || true
-          mkdir /boot
-          mount /dev/vda2 /boot
-
-          ${optionalString config.boot.loader.efi.canTouchEfiVariables ''
-            mount -t efivarfs efivarfs /sys/firmware/efi/efivars
-          ''}
-
-          # This is needed for GRUB 0.97, which doesn't know about virtio devices.
-          mkdir /boot/grub
-          echo '(hd0) /dev/vda' > /boot/grub/device.map
-
-          # This is needed for systemd-boot to find ESP, and udev is not available here to create this
-          mkdir -p /dev/block
-          ln -s /dev/vda2 /dev/block/254:2
-
-          # Set up system profile (normally done by nixos-rebuild / nix-env --set)
-          mkdir -p /nix/var/nix/profiles
-          ln -s ${config.system.build.toplevel} /nix/var/nix/profiles/system-1-link
-          ln -s /nix/var/nix/profiles/system-1-link /nix/var/nix/profiles/system
-
-          # Install bootloader
-          touch /etc/NIXOS
-          export NIXOS_INSTALL_BOOTLOADER=1
-          ${config.system.build.toplevel}/bin/switch-to-configuration boot
-
-          umount /boot
-        '' # */
-    );
-
+  # This image is supposed to have no side-effects on the system image.
+  # It should be used when you do not need the bootloader.
   storeImage = import ../../lib/make-disk-image.nix {
     inherit pkgs config lib;
     additionalPaths = [ regInfo ];
@@ -295,10 +237,15 @@ let
     onlyNixStore = true;
     partitionTableType = "none";
     installBootLoader = false;
+    touchEFIVars = false;
     diskSize = "auto";
     additionalSpace = "0M";
     copyChannel = false;
   };
+
+  OVMF_fd = (pkgs.OVMF.override {
+    secureBoot = cfg.useSecureBoot;
+  }).fd;
 
 in
 
@@ -306,6 +253,7 @@ in
   imports = [
     ../profiles/qemu-guest.nix
     (mkRenamedOptionModule [ "virtualisation" "pathsInNixDB" ] [ "virtualisation" "additionalPaths" ])
+    (mkRemovedOptionModule [ "virtualisation" "efiVars" ] "This option was removed, it is possible to provide a template UEFI variable with `virtualisation.efi.variables` ; if this option is important to you, open an issue")
   ];
 
   options = {
@@ -360,10 +308,35 @@ in
     virtualisation.bootDevice =
       mkOption {
         type = types.path;
+        default = lookupDriveDeviceName "root" cfg.qemu.drives;
+        defaultText = literalExpression ''lookupDriveDeviceName "root" cfg.qemu.drives'';
         example = "/dev/vda";
         description =
           lib.mdDoc ''
-            The disk to be used for the root filesystem.
+            The disk to be used for the boot filesystem.
+            By default, it is the same disk as the root filesystem.
+          '';
+        };
+
+    virtualisation.rootDevice =
+      mkOption {
+        type = types.path;
+        default =
+          if (cfg.useBootLoader && cfg.bootDevice == options.virtualisation.bootDevice.default)
+          then "${cfg.bootDevice}2"
+          else
+            if !cfg.useBootLoader then cfg.bootDevice else null;
+        defaultText = ''if (cfg.useBootLoader && !hasPrefix "/dev/mapper/" ''${cfg.bootDevice}) then "''${cfg.bootDevice}2" else cfg.bootDevice;'';
+        example = "/dev/vda2";
+        description =
+          lib.mdDoc ''
+            The disk or partition to be used for the root filesystem.
+            By default :
+
+            - the boot disk in case you're **NOT** using a bootloader (`useBootLoader == false`)
+            - the second partition of the boot disk in case you're using a bootloader (`useBootLoader == true` && boot device is the default one).
+
+            In case you are not using a default boot device, you have to set explicitly your root device.
           '';
       };
 
@@ -756,17 +729,16 @@ in
           '';
       };
 
-    virtualisation.efiVars =
+    virtualisation.useSecureBoot =
       mkOption {
-        type = types.str;
-        default = "./${config.system.name}-efi-vars.fd";
-        defaultText = literalExpression ''"./''${config.system.name}-efi-vars.fd"'';
+        type = types.bool;
+        default = false;
         description =
           lib.mdDoc ''
-            Path to nvram image containing UEFI variables.  The will be created
-            on startup if it does not exist.
+            Enable Secure Boot support in the EFI firmware.
           '';
       };
+
 
     virtualisation.bios =
       mkOption {
@@ -823,27 +795,7 @@ in
             ${opt.writableStore} = false;
         '';
 
-    # Note [Disk layout with `useBootLoader`]
-    #
-    # If `useBootLoader = true`, we configure 2 drives:
-    # `/dev/?da` for the root disk, and `/dev/?db` for the boot disk
-    # which has the `/boot` partition and the boot loader.
-    # Concretely:
-    #
-    # * The second drive's image `disk.img` is created in `bootDisk = ...`
-    #   using a throwaway VM. Note that there the disk is always `/dev/vda`,
-    #   even though in the final VM it will be at `/dev/*b`.
-    # * The disks are attached in `virtualisation.qemu.drives`.
-    #   Their order makes them appear as devices `a`, `b`, etc.
-    # * `fileSystems."/boot"` is adjusted to be on device `b`.
-
-    # If `useBootLoader`, GRUB goes to the second disk, see
-    # note [Disk layout with `useBootLoader`].
-    boot.loader.grub.device = mkVMOverride (
-      if cfg.useBootLoader
-        then driveDeviceName 2 # second disk
-        else cfg.bootDevice
-    );
+    boot.loader.grub.device = mkVMOverride cfg.bootDevice;
     boot.loader.grub.gfxmodeBios = with cfg.resolution; "${toString x}x${toString y}";
 
     boot.initrd.kernelModules = optionals (cfg.useNixStoreImage && !cfg.writableStore) [ "erofs" ];
@@ -858,10 +810,10 @@ in
       ''
         # If the disk image appears to be empty, run mke2fs to
         # initialise.
-        FSTYPE=$(blkid -o value -s TYPE ${cfg.bootDevice} || true)
-        PARTTYPE=$(blkid -o value -s PTTYPE ${cfg.bootDevice} || true)
+        FSTYPE=$(blkid -o value -s TYPE ${cfg.rootDevice} || true)
+        PARTTYPE=$(blkid -o value -s PTTYPE ${cfg.rootDevice} || true)
         if test -z "$FSTYPE" -a -z "$PARTTYPE"; then
-            mke2fs -t ext4 ${cfg.bootDevice}
+            mke2fs -t ext4 ${cfg.rootDevice}
         fi
       '';
 
@@ -907,7 +859,7 @@ in
       optional cfg.writableStore "overlay"
       ++ optional (cfg.qemu.diskInterface == "scsi") "sym53c8xx";
 
-    virtualisation.bootDevice = mkDefault (driveDeviceName 1);
+    # TODO: needed? virtualisation.bootDevice = mkDefault (driveDeviceName 1);
 
     virtualisation.additionalPaths = [ config.system.build.toplevel ];
 
@@ -980,23 +932,14 @@ in
         file = ''"$NIX_DISK_IMAGE"'';
         driveExtraOpts.cache = "writeback";
         driveExtraOpts.werror = "report";
+        deviceExtraOpts.bootindex = "1";
       }]
       (mkIf cfg.useNixStoreImage [{
         name = "nix-store";
         file = ''"$TMPDIR"/store.img'';
-        deviceExtraOpts.bootindex = if cfg.useBootLoader then "3" else "2";
+        deviceExtraOpts.bootindex = "2";
         driveExtraOpts.format = if cfg.writableStore then "qcow2" else "raw";
       }])
-      (mkIf cfg.useBootLoader [
-        # The order of this list determines the device names, see
-        # note [Disk layout with `useBootLoader`].
-        {
-          name = "boot";
-          file = ''"$TMPDIR"/disk.img'';
-          driveExtraOpts.media = "disk";
-          deviceExtraOpts.bootindex = "1";
-        }
-      ])
       (imap0 (idx: _: {
         file = "$(pwd)/empty${toString idx}.qcow2";
         driveExtraOpts.werror = "report";
@@ -1027,7 +970,8 @@ in
     in
       mkVMOverride (cfg.fileSystems //
       optionalAttrs cfg.useDefaultFilesystems {
-        "/".device = cfg.bootDevice;
+        # cfg.useBootLoader -> [ boot partition ; root partition ] layout on *root* disk
+        "/".device = cfg.rootDevice;
         "/".fsType = "ext4";
         "/".autoFormat = true;
       } //
@@ -1057,7 +1001,7 @@ in
       optionalAttrs cfg.useBootLoader {
         # see note [Disk layout with `useBootLoader`]
         "/boot" = {
-          device = "${lookupDriveDeviceName "boot" cfg.qemu.drives}2"; # 2 for e.g. `vdb2`, as created in `bootDisk`
+          device = "${lookupDriveDeviceName "root" cfg.qemu.drives}1"; # 1 for e.g. `vda1`, as created in `systemImage`
           fsType = "vfat";
           noCheck = true; # fsck fails on a r/o filesystem
         };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -571,6 +571,7 @@ in {
   sddm = handleTest ./sddm.nix {};
   seafile = handleTest ./seafile.nix {};
   searx = handleTest ./searx.nix {};
+  secureboot = handleTest ./secureboot.nix {};
   service-runner = handleTest ./service-runner.nix {};
   sfxr-qt = handleTest ./sfxr-qt.nix {};
   shadow = handleTest ./shadow.nix {};

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -63,7 +63,7 @@ in makeTest {
         # Small root disk for installer
         512
       ];
-      virtualisation.bootDevice = "/dev/vdb";
+      virtualisation.rootDevice = "/dev/vdb";
     };
   };
 

--- a/nixos/tests/lvm2/systemd-stage-1.nix
+++ b/nixos/tests/lvm2/systemd-stage-1.nix
@@ -1,18 +1,18 @@
 { kernelPackages ? null, flavour }: let
   preparationCode = {
     raid = ''
-      machine.succeed("vgcreate test_vg /dev/vdc /dev/vdd")
+      machine.succeed("vgcreate test_vg /dev/vdb /dev/vdc")
       machine.succeed("lvcreate -L 512M --type raid0 test_vg -n test_lv")
     '';
 
     thinpool = ''
-      machine.succeed("vgcreate test_vg /dev/vdc")
+      machine.succeed("vgcreate test_vg /dev/vdb")
       machine.succeed("lvcreate -L 512M -T test_vg/test_thin_pool")
       machine.succeed("lvcreate -n test_lv -V 16G --thinpool test_thin_pool test_vg")
     '';
 
     vdo = ''
-      machine.succeed("vgcreate test_vg /dev/vdc")
+      machine.succeed("vgcreate test_vg /dev/vdb")
       machine.succeed("lvcreate --type vdo -n test_lv -L 6G -V 12G test_vg/vdo_pool_lv")
     '';
   }.${flavour};

--- a/nixos/tests/lvm2/systemd-stage-1.nix
+++ b/nixos/tests/lvm2/systemd-stage-1.nix
@@ -79,7 +79,7 @@ in import ../make-test-python.nix ({ pkgs, ... }: {
       kernelPackages = lib.mkIf (kernelPackages != null) kernelPackages;
     };
 
-    specialisation.boot-lvm.configuration.virtualisation.bootDevice = "/dev/test_vg/test_lv";
+    specialisation.boot-lvm.configuration.virtualisation.rootDevice = "/dev/test_vg/test_lv";
   };
 
   testScript = ''

--- a/nixos/tests/secureboot.nix
+++ b/nixos/tests/secureboot.nix
@@ -1,0 +1,39 @@
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+
+let
+  common = {
+    virtualisation.useBootLoader = true;
+    virtualisation.useEFIBoot = true;
+    virtualisation.useSecureBoot = true;
+    boot.loader.systemd-boot.enable = true;
+    boot.loader.efi.canTouchEfiVariables = true;
+    environment.systemPackages = [ pkgs.efibootmgr pkgs.sbsigntool pkgs.sbctl ];
+  };
+in
+{
+  basic = makeTest {
+    name = "secureboot-installation-prevent-reboot";
+    meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+
+    nodes.machine = common;
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed("sbctl create-keys")
+      machine.succeed("sbctl enroll-keys --yes-this-might-brick-my-machine")
+      machine.shutdown()
+      # Now we cannot reboot because we did not sign our boot files!
+      # machine.sleep(1)
+      # Test for Linux Boot Manager
+      # assert ('Not Found' in machine.get_screen_text())
+    '';
+  };
+}

--- a/nixos/tests/secureboot.nix
+++ b/nixos/tests/secureboot.nix
@@ -8,16 +8,19 @@ with pkgs.lib;
 
 let
   common = {
-    virtualisation.useBootLoader = true;
-    virtualisation.useEFIBoot = true;
-    virtualisation.useSecureBoot = true;
+    virtualisation = {
+      useBootLoader = true;
+      useEFIBoot = true;
+      useSecureBoot = true;
+      efi.systemManagementModeEnforcement = false; # Investigate why it breaks everything.
+    };
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;
     environment.systemPackages = [ pkgs.efibootmgr pkgs.sbsigntool pkgs.sbctl ];
   };
 in
 {
-  basic = makeTest {
+  prevent-reboot = makeTest {
     name = "secureboot-installation-prevent-reboot";
     meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
 

--- a/nixos/tests/secureboot.nix
+++ b/nixos/tests/secureboot.nix
@@ -16,7 +16,7 @@ let
     };
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;
-    environment.systemPackages = [ pkgs.efibootmgr pkgs.sbsigntool pkgs.sbctl ];
+    environment.systemPackages = with pkgs; [ efibootmgr sbsigntool sbctl ];
   };
 in
 {

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -107,7 +107,7 @@ in
       )
 
       output = machine.succeed("/run/current-system/bin/switch-to-configuration boot")
-      assert "updating systemd-boot from (000.0-1-notnixos) to " in output
+      assert "updating systemd-boot from 000.0-1-notnixos to " in output
     '';
   };
 

--- a/nixos/tests/systemd-initrd-btrfs-raid.nix
+++ b/nixos/tests/systemd-initrd-btrfs-raid.nix
@@ -21,14 +21,14 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
       fileSystems = lib.mkVMOverride {
         "/".fsType = lib.mkForce "btrfs";
       };
-      virtualisation.bootDevice = "/dev/vdc";
+      virtualisation.rootDevice = "/dev/vdb";
     };
   };
 
   testScript = ''
     # Create RAID
-    machine.succeed("mkfs.btrfs -d raid0 /dev/vdc /dev/vdd")
-    machine.succeed("mkdir -p /mnt && mount /dev/vdc /mnt && echo hello > /mnt/test && umount /mnt")
+    machine.succeed("mkfs.btrfs -d raid0 /dev/vdb /dev/vdc")
+    machine.succeed("mkdir -p /mnt && mount /dev/vdb /mnt && echo hello > /mnt/test && umount /mnt")
 
     # Boot from the RAID
     machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-btrfs-raid.conf")
@@ -38,7 +38,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
 
     # Ensure we have successfully booted from the RAID
     assert "(initrd)" in machine.succeed("systemd-analyze")  # booted with systemd in stage 1
-    assert "/dev/vdc on / type btrfs" in machine.succeed("mount")
+    assert "/dev/vdb on / type btrfs" in machine.succeed("mount")
     assert "hello" in machine.succeed("cat /test")
     assert "Total devices 2" in machine.succeed("btrfs filesystem show")
   '';

--- a/nixos/tests/systemd-initrd-luks-fido2.nix
+++ b/nixos/tests/systemd-initrd-luks-fido2.nix
@@ -19,19 +19,19 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     specialisation.boot-luks.configuration = {
       boot.initrd.luks.devices = lib.mkVMOverride {
         cryptroot = {
-          device = "/dev/vdc";
+          device = "/dev/vdb";
           crypttabExtraOpts = [ "fido2-device=auto" ];
         };
       };
-      virtualisation.bootDevice = "/dev/mapper/cryptroot";
+      virtualisation.rootDevice = "/dev/mapper/cryptroot";
     };
   };
 
   testScript = ''
     # Create encrypted volume
     machine.wait_for_unit("multi-user.target")
-    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdc -")
-    machine.succeed("PASSWORD=supersecret SYSTEMD_LOG_LEVEL=debug systemd-cryptenroll --fido2-device=auto /dev/vdc |& systemd-cat")
+    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdb -")
+    machine.succeed("PASSWORD=supersecret SYSTEMD_LOG_LEVEL=debug systemd-cryptenroll --fido2-device=auto /dev/vdb |& systemd-cat")
 
     # Boot from the encrypted disk
     machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-luks.conf")

--- a/nixos/tests/systemd-initrd-luks-keyfile.nix
+++ b/nixos/tests/systemd-initrd-luks-keyfile.nix
@@ -27,11 +27,11 @@ in {
     specialisation.boot-luks.configuration = {
       boot.initrd.luks.devices = lib.mkVMOverride {
         cryptroot = {
-          device = "/dev/vdc";
+          device = "/dev/vdb";
           keyFile = "/etc/cryptroot.key";
         };
       };
-      virtualisation.bootDevice = "/dev/mapper/cryptroot";
+      virtualisation.rootDevice = "/dev/mapper/cryptroot";
       boot.initrd.secrets."/etc/cryptroot.key" = keyfile;
     };
   };
@@ -39,7 +39,7 @@ in {
   testScript = ''
     # Create encrypted volume
     machine.wait_for_unit("multi-user.target")
-    machine.succeed("cryptsetup luksFormat -q --iter-time=1 -d ${keyfile} /dev/vdc")
+    machine.succeed("cryptsetup luksFormat -q --iter-time=1 -d ${keyfile} /dev/vdb")
 
     # Boot from the encrypted disk
     machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-luks.conf")

--- a/nixos/tests/systemd-initrd-luks-password.nix
+++ b/nixos/tests/systemd-initrd-luks-password.nix
@@ -19,10 +19,10 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     specialisation.boot-luks.configuration = {
       boot.initrd.luks.devices = lib.mkVMOverride {
         # We have two disks and only type one password - key reuse is in place
-        cryptroot.device = "/dev/vdc";
-        cryptroot2.device = "/dev/vdd";
+        cryptroot.device = "/dev/vdb";
+        cryptroot2.device = "/dev/vdc";
       };
-      virtualisation.bootDevice = "/dev/mapper/cryptroot";
+      virtualisation.rootDevice = "/dev/mapper/cryptroot";
       # test mounting device unlocked in initrd after switching root
       virtualisation.fileSystems."/cryptroot2".device = "/dev/mapper/cryptroot2";
     };
@@ -31,9 +31,9 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
   testScript = ''
     # Create encrypted volume
     machine.wait_for_unit("multi-user.target")
+    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdb -")
     machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdc -")
-    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdd -")
-    machine.succeed("echo -n supersecret | cryptsetup luksOpen   -q               /dev/vdd cryptroot2")
+    machine.succeed("echo -n supersecret | cryptsetup luksOpen   -q               /dev/vdc cryptroot2")
     machine.succeed("mkfs.ext4 /dev/mapper/cryptroot2")
 
     # Boot from the encrypted disk
@@ -47,7 +47,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     machine.send_console("supersecret\n")
     machine.wait_for_unit("multi-user.target")
 
-    assert "/dev/mapper/cryptroot on / type ext4" in machine.succeed("mount")
+    assert "/dev/mapper/cryptroot on / type ext4" in machine.succeed("mount"), "/dev/mapper/cryptroot do not appear in mountpoints list"
     assert "/dev/mapper/cryptroot2 on /cryptroot2 type ext4" in machine.succeed("mount")
   '';
 })

--- a/nixos/tests/systemd-initrd-luks-tpm2.nix
+++ b/nixos/tests/systemd-initrd-luks-tpm2.nix
@@ -21,11 +21,11 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     specialisation.boot-luks.configuration = {
       boot.initrd.luks.devices = lib.mkVMOverride {
         cryptroot = {
-          device = "/dev/vdc";
+          device = "/dev/vdb";
           crypttabExtraOpts = [ "tpm2-device=auto" ];
         };
       };
-      virtualisation.bootDevice = "/dev/mapper/cryptroot";
+      virtualisation.rootDevice = "/dev/mapper/cryptroot";
     };
   };
 
@@ -55,8 +55,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
 
     # Create encrypted volume
     machine.wait_for_unit("multi-user.target")
-    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdc -")
-    machine.succeed("PASSWORD=supersecret SYSTEMD_LOG_LEVEL=debug systemd-cryptenroll --tpm2-pcrs= --tpm2-device=auto /dev/vdc |& systemd-cat")
+    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdb -")
+    machine.succeed("PASSWORD=supersecret SYSTEMD_LOG_LEVEL=debug systemd-cryptenroll --tpm2-pcrs= --tpm2-device=auto /dev/vdb |& systemd-cat")
 
     # Boot from the encrypted disk
     machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-luks.conf")

--- a/nixos/tests/systemd-initrd-swraid.nix
+++ b/nixos/tests/systemd-initrd-swraid.nix
@@ -20,18 +20,18 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
       services.swraid = {
         enable = true;
         mdadmConf = ''
-          ARRAY /dev/md0 devices=/dev/vdc,/dev/vdd
+          ARRAY /dev/md0 devices=/dev/vdb,/dev/vdc
         '';
       };
       kernelModules = [ "raid0" ];
     };
 
-    specialisation.boot-swraid.configuration.virtualisation.bootDevice = "/dev/disk/by-label/testraid";
+    specialisation.boot-swraid.configuration.virtualisation.rootDevice = "/dev/disk/by-label/testraid";
   };
 
   testScript = ''
     # Create RAID
-    machine.succeed("mdadm --create --force /dev/md0 -n 2 --level=raid0 /dev/vdc /dev/vdd")
+    machine.succeed("mdadm --create --force /dev/md0 -n 2 --level=raid0 /dev/vdb /dev/vdc")
     machine.succeed("mkfs.ext4 -L testraid /dev/md0")
     machine.succeed("mkdir -p /mnt && mount /dev/md0 /mnt && echo hello > /mnt/test && umount /mnt")
 

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -3,6 +3,7 @@
 , secureBoot ? false
 , httpSupport ? false
 , tpmSupport ? false
+, systemManagementModeSupport ? false
 }:
 
 assert csmSupport -> seabios != null;
@@ -41,6 +42,7 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
 
   buildFlags =
     lib.optionals secureBoot [ "-D SECURE_BOOT_ENABLE=TRUE" ]
+    ++ lib.optionals systemManagementModeSupport [ "-D SMM_REQUIRE" ]
     ++ lib.optionals csmSupport [ "-D CSM_ENABLE" "-D FD_SIZE_2MB" ]
     ++ lib.optionals httpSupport [ "-D NETWORK_HTTP_ENABLE=TRUE" "-D NETWORK_HTTP_BOOT_ENABLE=TRUE" ]
     ++ lib.optionals tpmSupport [ "-D TPM_ENABLE" "-D TPM2_ENABLE" "-D TPM2_CONFIG_ENABLE"];


### PR DESCRIPTION
### Description of changes

This PR does multiple things :

###### make-disk-image refactoring in QEMU test infrastructure

As per https://github.com/NixOS/nixpkgs/issues/23052 — QEMU test infrastructure do not use ad-hoc code to build the boot disk image but reuse make-disk-image which was improved to support use-cases.

Doing this consolidates make-disk-image as one place to do these changes, it seems like the boot disk production code was doing old stuff with GRUB 0.97, I'm uncertain whether that should be cleaned up.

###### UEFI firmware infrastructure

As part of https://github.com/NixOS/nixpkgs/pull/187887 ; this uses consolidated UEFI firmware and variables and expose their variables to end users.

It also adds SecureBoot and System Management Mode enforcement support in the test infrastructure and the make-disk-image function.

EFIVARS can be modified as part of the disk image build process, enabling people to build a disk image with specific authenticated UEFI variables, e.g. SecureBoot keys.

###### Documentation

This PR adds documentation on what are the breaking changes in regard to the disk layout (storeImage is used only if needed at all.)

TODO/notes:

- [x] Cleanup UEFI firmware infrastructure: done in
- [x] Cleanup the /dev/vdb2 stuff in QEMU code.
- [x] Some tests such as installer depends on bootDevice being vdb or second drive.
- [x] GRUB version 1 may have some subtleties.
- [x] Assert touchEFIVars only if partition table type is hybrid or efi.
- [x] Use a better error message for assert.
- [x] Refactor in make-disk-image the EFI firmware infrastructure using https://github.com/NixOS/nixpkgs/pull/187887.
- [x] Simple tests:
- [x] Legacy boot without any EFI stuff should still work.
- [x] EFI/Hybrid boot without touching EFI vars should still work.
- [x] EFI/Hybrid boot with touching EFI vars should still work AND we should be able to write/read in EFIVARS.
- [x] Reproducibility of system image, wrt to fixed GUIDs in partition table.
- [x] Documentation:
    - [x] How to test this kind of changes? What to look for?
    - [x] Where are the breaking changes? Everything that relies on /dev/vdb2 is now incorrect.
    - [x] Compatibility layer? Deprecation notice?
    - [x] Prevent users to shoot their foot: increase the number of assertions & warnings accordingly in the module
- [ ] For a future PR
    - [ ] Over {systemd-boot, GRUB1, GRUB2} cartesian product for SecureBoot test.
    - [ ] makeEc2Test is useful to initialize using an image, it would be good to extract it as a lower level primitive to start test off an already existing disk image, maybe put it directly into makeTest machinery or makeTestFromImage
