### PR TITLE
emacs: change substituteInPlace invocation to an aligning patch

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -7,7 +7,7 @@
   , patches ? _: [ ]
   , macportVersion ? null
 }:
-{ stdenv, llvmPackages_6, lib, fetchurl, fetchpatch, ncurses, xlibsWrapper, libXaw, libXpm
+{ stdenv, llvmPackages_6, lib, fetchurl, fetchpatch, substituteAll, ncurses, xlibsWrapper, libXaw, libXpm
 , Xaw3d, libXcursor,  pkg-config, gettext, libXft, dbus, libpng, libjpeg, giflib
 , libtiff, librsvg, libwebp, gconf, libxml2, imagemagick, gnutls, libselinux
 , alsa-lib, cairo, acl, gpm, m17n_lib, libotf
@@ -67,7 +67,29 @@ let emacs = (if withMacport then llvmPackages_6.stdenv else stdenv).mkDerivation
   pname = pname + lib.optionalString ( !withX && !withNS && !withMacport && !withGTK2 && !withGTK3 ) "-nox";
   inherit version;
 
-  patches = patches fetchpatch;
+  patches = patches fetchpatch ++
+            lib.optionals nativeComp
+              [
+                (substituteAll {
+                  src = let majorVersionStr = lib.versions.major version;
+                        in
+                          if lib.versionOlder version "29" || (lib.stringLength majorVersionStr == 8 && lib.versionOlder version "20221003")
+                          then ./native-comp-driver-options-28.patch
+                          else ./native-comp-driver-options.patch;
+                  backendPath = (lib.concatStringsSep " "
+                    (builtins.map (x: ''"-B${x}"'') [
+                      # Paths necessary so the JIT compiler finds its libraries:
+                      "${lib.getLib libgccjit}/lib"
+                      "${lib.getLib libgccjit}/lib/gcc"
+                      "${lib.getLib stdenv.cc.libc}/lib"
+
+                      # Executable paths necessary for compilation (ld, as):
+                      "${lib.getBin stdenv.cc.cc}/bin"
+                      "${lib.getBin stdenv.cc.bintools}/bin"
+                      "${lib.getBin stdenv.cc.bintools.bintools}/bin"
+                    ]));
+                })
+              ];
 
   src = if macportVersion != null then fetchFromBitbucket {
     owner = "mituharu";
@@ -112,25 +134,6 @@ let emacs = (if withMacport then llvmPackages_6.stdenv else stdenv).mkDerivation
     done
     ''
 
-    # Make native compilation work both inside and outside of nix build
-    (lib.optionalString nativeComp (let
-      backendPath = (lib.concatStringsSep " "
-        (builtins.map (x: ''\"-B${x}\"'') [
-          # Paths necessary so the JIT compiler finds its libraries:
-          "${lib.getLib libgccjit}/lib"
-          "${lib.getLib libgccjit}/lib/gcc"
-          "${lib.getLib stdenv.cc.libc}/lib"
-
-          # Executable paths necessary for compilation (ld, as):
-          "${lib.getBin stdenv.cc.cc}/bin"
-          "${lib.getBin stdenv.cc.bintools}/bin"
-          "${lib.getBin stdenv.cc.bintools.bintools}/bin"
-        ]));
-    in ''
-      substituteInPlace lisp/emacs-lisp/comp.el --replace \
-        "(defcustom native-comp-driver-options nil" \
-        "(defcustom native-comp-driver-options '(${backendPath})"
-    ''))
     ""
   ];
 

--- a/pkgs/applications/editors/emacs/native-comp-driver-options-28.patch
+++ b/pkgs/applications/editors/emacs/native-comp-driver-options-28.patch
@@ -1,0 +1,16 @@
+diff --git a/lisp/emacs-lisp/comp.el b/lisp/emacs-lisp/comp.el
+index a5ab12ae38..e33e71cb55 100644
+--- a/lisp/emacs-lisp/comp.el
++++ b/lisp/emacs-lisp/comp.el
+@@ -178,7 +178,7 @@ native-comp-compiler-options
+   :type '(repeat string)
+   :version "28.1")
+ 
+-(defcustom native-comp-driver-options nil
++(defcustom native-comp-driver-options '(@backendPath@)
+   "Options passed verbatim to the native compiler's back-end driver.
+ Note that not all options are meaningful; typically only the options
+ affecting the assembler and linker are likely to be useful.
+-- 
+2.37.3
+

--- a/pkgs/applications/editors/emacs/native-comp-driver-options.patch
+++ b/pkgs/applications/editors/emacs/native-comp-driver-options.patch
@@ -1,0 +1,19 @@
+diff --git a/lisp/emacs-lisp/comp.el b/lisp/emacs-lisp/comp.el
+index 2c9b79334b..50c6b5ac85 100644
+--- a/lisp/emacs-lisp/comp.el
++++ b/lisp/emacs-lisp/comp.el
+@@ -178,8 +178,9 @@ native-comp-compiler-options
+   :type '(repeat string)
+   :version "28.1")
+ 
+-(defcustom native-comp-driver-options (when (eq system-type 'darwin)
+-                                        '("-Wl,-w"))
++(defcustom native-comp-driver-options (append (when (eq system-type 'darwin)
++                                                '("-Wl,-w"))
++                                              '(@backendPath@))
+   "Options passed verbatim to the native compiler's back-end driver.
+ Note that not all options are meaningful; typically only the options
+ affecting the assembler and linker are likely to be useful.
+-- 
+2.37.3
+


### PR DESCRIPTION
Re-submission of #193621. I interpreted a message as suggesting I target the `staging` branch instead, but after rebasing, I forgot to change the target branch on GitHub, which resulted in a lot of people getting spurious review requests.

This patch isn't very urgent, so `staging` should be an OK place anyway.

---

Commit 97b928ce09d6034ebcb541fb548e5d4862302add in Emacs messed up the substituteInPlace. Use a patch instead to prevent silent failures.

https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=97b928ce09d6034ebcb541fb548e5d4862302add

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
