### PR TITLE
scala-cli: 0.1.16 -> 0.1.17, set argv0

### DIFF
--- a/pkgs/development/tools/build-managers/scala-cli/default.nix
+++ b/pkgs/development/tools/build-managers/scala-cli/default.nix
@@ -41,7 +41,8 @@ stdenv.mkDerivation {
     runHook preInstall
     install -Dm755 scala-cli $out/bin/.scala-cli-wrapped
     makeWrapper $out/bin/.scala-cli-wrapped $out/bin/scala-cli \
-      --set JAVA_HOME ${jre.home}
+      --set JAVA_HOME ${jre.home} \
+      --argv0 "$out/bin/scala-cli"
     runHook postInstall
   '';
 

--- a/pkgs/development/tools/build-managers/scala-cli/sources.json
+++ b/pkgs/development/tools/build-managers/scala-cli/sources.json
@@ -1,17 +1,17 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "assets": {
     "aarch64-darwin": {
       "asset": "scala-cli-aarch64-apple-darwin.gz",
-      "sha256": "1ryjsf126dsqkpnkc2dmr3p373sb518q2ply0y1ifrx3rhqj0viq"
+      "sha256": "0p3z4wvindcb9wahq2q8ca24zgl05qb3z2asmqi2z54pqfkc21d7"
     },
     "x86_64-darwin": {
       "asset": "scala-cli-x86_64-apple-darwin.gz",
-      "sha256": "1vfx9ccl08mykr579nq9kwbv88d6gaq1vd9xscwyq5rps6lxrz92"
+      "sha256": "17zj3g62b27blbdfa3j4lzvs3v13jyy7428zxalkpdx8ixy0ghyy"
     },
     "x86_64-linux": {
       "asset": "scala-cli-x86_64-pc-linux.gz",
-      "sha256": "1p2lk2hkj149r27p4kwxvwlvjvzv9l0zncqfs3wa972jyn4hhr9g"
+      "sha256": "0dm7jhsvrjb73wyvvds17r779gcm00yvsy31arc8552df5nkq4iz"
     }
   }
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/VirtusLab/scala-cli/releases/tag/v0.1.17

Also sets `argv[0]`, so that the generated `.bsp/scala-cli.json` config in your workspace will take care to use the right Java version. For example:

```json
{
  "name": "scala-cli",
  "argv": [
    "/nix/store/i7ay9wa7m18cvljx1yc0lm77r3xdfb33-scala-cli-0.1.17/bin/scala-cli",
    "bsp",
    "--json-options",
    "/Users/kubukoz/projects/demos/.scala-build/ide-options-v2.json",
    "/Users/kubukoz/projects/demos"
  ],
  "version": "0.1.17",
  "bspVersion": "2.1.0-M3",
  "languages": [
    "scala",
    "java"
  ]
}
```

Before this change, the argv would start with `/nix/store/fa01w8l9jcp90ak08i3dfvvfgda5kf88-scala-cli-0.1.16/bin/.scala-cli-wrapped`, so it might end up without the desired Java version (and, in case of arm64, it might actually use Coursier to fetch and run an x86 JVM, which would be terrible for performance).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
