### PR TITLE
sbcl: cleanup old versions

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -424,11 +424,11 @@
     "vendorHash": "sha256-uWTY8cFztXFrQQ7GW6/R+x9M6vHmsb934ldq+oeW5vk="
   },
   "github": {
-    "hash": "sha256-o7Sge0rCfP6Yueq+DP7siBsEinawgGe+nEu0/Olu8uQ=",
+    "hash": "sha256-foPj/zLJJx3mI1PpDwcThptT5EprEDfakUWRsjaa0nc=",
     "homepage": "https://registry.terraform.io/providers/integrations/github",
     "owner": "integrations",
     "repo": "terraform-provider-github",
-    "rev": "v5.12.0",
+    "rev": "v5.13.0",
     "spdx": "MIT",
     "vendorHash": null
   },

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -149,11 +149,11 @@
   },
   "baiducloud": {
     "deleteVendor": true,
-    "hash": "sha256-MwpFSUhAZ6TjqWfsy7qazBtd1CrLbsAIDyRLonsDXiM=",
+    "hash": "sha256-g3+n0Q0Hl4yRaYK0snl4um5B5FS54Y6aMM7LeluPik4=",
     "homepage": "https://registry.terraform.io/providers/baidubce/baiducloud",
     "owner": "baidubce",
     "repo": "terraform-provider-baiducloud",
-    "rev": "v1.19.1",
+    "rev": "v1.19.2",
     "spdx": "MPL-2.0",
     "vendorHash": "sha256-3PLBs8LSE5JPtrhmdx+jQsnCrfZQQEUGA7wnf9M72yY="
   },

--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "osinfo-db";
-  version = "20220830";
+  version = "20221130";
 
   src = fetchurl {
     url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.xz";
-    sha256 = "sha256-gRFkPZDeq4ONt/IT8VS+8uBXNQqcg0JF7gHdZEM7qvs=";
+    sha256 = "sha256-opVMrXob7yZ5lJmHxjiI8eCBsJ4R+3JQVDcvA37HcX8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/sbcl/2.x.nix
+++ b/pkgs/development/compilers/sbcl/2.x.nix
@@ -61,6 +61,10 @@ let
     "2.2.11" = {
       sha256 = "sha256-NgfWgBZzGICEXO1dXVXGBUzEnxkSGhUCfmxWB66Elt8=";
     };
+
+    "2.3.0" = {
+      sha256 = "sha256-v3Q5SXEq4Cy3ST87i1fOJBlIv2ETHjaGDdszTaFDnJc=";
+    };
   };
 
 in with versionMap.${version};

--- a/pkgs/development/compilers/sbcl/2.x.nix
+++ b/pkgs/development/compilers/sbcl/2.x.nix
@@ -7,57 +7,13 @@
   # Note that the created binaries still need `patchelf --set-interpreter ...`
   # to get rid of ${glibc} dependency.
 , purgeNixReferences ? false
-, coreCompression ? lib.versionAtLeast version "2.2.6"
+, coreCompression ? true
 , texinfo
 , version
 }:
 
 let
   versionMap = {
-    "2.0.8" = {
-      sha256 = "1xwrwvps7drrpyw3wg5h3g2qajmkwqs9gz0fdw1ns9adp7vld390";
-    };
-
-    "2.0.9" = {
-      sha256 = "17wvrcwgp45z9b6arik31fjnz7908qhr5ackxq1y0gqi1hsh1xy4";
-    };
-
-    "2.1.1" = {
-      sha256 = "15wa66sachhzgvg5n35vihmkpasg100lh561c1d1bdrql0p8kbd9";
-    };
-
-    "2.1.2" = {
-      sha256 = "sha256:02scrqyp2izsd8xjm2k5j5lhn4pdhd202jlcb54ysmcqjd80awdp";
-    };
-
-    "2.1.9" = {
-      sha256 = "189gjqzdz10xh3ybiy4ch1r98bsmkcb4hpnrmggd4y2g5kqnyx4y";
-    };
-
-    "2.1.10" = {
-      sha256 = "0f5ihj486m7ghh3nc0jlnqa656sbqcmhdv32syz2rjx5b47ky67b";
-    };
-
-    "2.1.11" = {
-      sha256 = "1zgypmn19c58pv7j33ga7m1l7lzghj70w3xbybpgmggxwwflihdz";
-    };
-
-    "2.2.4" = {
-      sha256 = "sha256-/N0lHLxl9/gI7QrXckaEjRvhZqppoX90mWABhLelcgI=";
-    };
-
-    "2.2.6" = {
-      sha256 = "sha256-PiMEjI+oJvuRMiC+sqw2l9vFwM3y6J/tjbOe0XEjBKA=";
-    };
-
-    "2.2.9" = {
-      sha256 = "sha256-fr69bSAj//cHewNy+hFx+IBSm97GEE8gmDKXwv63wXI=";
-    };
-
-    "2.2.10" = {
-      sha256 = "sha256-jMPDqHYSI63vFEqIcwsmdQg6Oyb6FV1wz5GruTXpCDM=";
-    };
-
     "2.2.11" = {
       sha256 = "sha256-NgfWgBZzGICEXO1dXVXGBUzEnxkSGhUCfmxWB66Elt8=";
     };
@@ -80,44 +36,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ texinfo ];
   buildInputs = lib.optionals coreCompression [ zstd ];
-
-  patches = lib.optional
-    (lib.versionAtLeast version "2.1.2" && lib.versionOlder version "2.1.8")
-    (fetchpatch {
-      # Fix segfault on ARM when reading large core files
-      url = "https://github.com/sbcl/sbcl/commit/8fa3f76fba2e8572e86ac6fc5754e6b2954fc774.patch";
-      sha256 = "1ic531pjnws1k3xd03a5ixbq8cn10dlh2nfln59k0vbm0253g3lv";
-    })
-  ++ lib.optionals (lib.versionAtLeast version "2.1.10" && lib.versionOlder version "2.2.9") [
-      # Fix included in SBCL trunk since 2.2.9:
-      #   https://bugs.launchpad.net/sbcl/+bug/1980570
-      (fetchpatch {
-        name = "darwin-fno-common.patch";
-        url = "https://bugs.launchpad.net/sbcl/+bug/1980570/+attachment/5600916/+files/0001-src-runtime-fix-fno-common-build-on-darwin.patch";
-        sha256 = "0avpwgjdaxxdpq8pfvv9darfn4ql5dgqq7zaf3nmxnvhh86ngzij";
-      })
-  ] ++ lib.optionals (lib.versionAtLeast version "2.1.10" && lib.versionOlder version "2.2.0") [
-      # Fix -fno-common on arm64
-      (fetchpatch {
-        name = "arm64-fno-common.patch";
-        url = "https://github.com/sbcl/sbcl/commit/ac3739eae36de92feffef5bb9b4b4bd93f6c4942.patch";
-        sha256 = "1kxg0ng7d465rk5v4biikrzaps41x4n1v4ygnb5qh4f5jzkbms8y";
-      })
-  ] ++ lib.optionals (version == "2.2.6") [
-    # Take contrib blocklist into account for doc generation.  This fixes sbcl
-    # build on aarch64, because the docs Makefile tries to require sb-simd,
-    # which is blocked in that platform.
-    (fetchpatch {
-      url = "https://github.com/sbcl/sbcl/commit/f88989694200a5192fb68047d43d0500b2165f7b.patch";
-      sha256 = "sha256-MXEsK46RARPmB2WBPcrmZk6ArliU8DgHw73x9+/QAmk=";
-    })
-  ] ++ lib.optionals (version == "2.2.10") [
-    # hard-coded /bin/cat to just ‘cat’, trusting the PATH
-    (fetchpatch {
-      url = "https://github.com/sbcl/sbcl/commit/8ed662fbfeb5dde35eb265f390b55b01f79f70c1.patch";
-      sha256 = "sha256-2aqb13AFdw9KMf8KQ9yj1HVxgoFWZ9xWmnoDdbRSLy4=";
-    })
-  ];
 
   postPatch = ''
     echo '"${version}.nixos"' > version.lisp-expr
@@ -171,15 +89,10 @@ stdenv.mkDerivation rec {
     optional (!threadSupport) "sb-thread" ++
     optionals disableImmobileSpace [ "immobile-space" "immobile-code" "compact-instance-header" ];
 
-  NIX_CFLAGS_COMPILE = lib.optionals (lib.versionOlder version "2.1.10") [
-    # Workaround build failure on -fno-common toolchains like upstream
-    # clang-13. Without the change build fails as:
-    #   duplicate symbol '_static_code_space_free_pointer' in: alloc.o traceroot.o
-    # Should be fixed past 2.1.10 release.
-    "-fcommon"
-  ]
+  NIX_CFLAGS_COMPILE = [
     # Fails to find `O_LARGEFILE` otherwise.
-    ++ [ "-D_GNU_SOURCE" ];
+    "-D_GNU_SOURCE"
+  ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/ocaml-modules/fileutils/default.nix
+++ b/pkgs/development/ocaml-modules/fileutils/default.nix
@@ -1,25 +1,25 @@
-{ lib, fetchurl, buildDunePackage, stdlib-shims, ounit }:
+{ lib, fetchurl, ocaml, buildDunePackage, seq, stdlib-shims, ounit2 }:
 
 buildDunePackage rec {
   pname = "fileutils";
-  version = "0.6.3";
+  version = "0.6.4";
 
   src = fetchurl {
-    url = "https://github.com/gildor478/ocaml-fileutils/releases/download/v${version}/fileutils-v${version}.tbz";
-    sha256 = "0qhlhc7fzcq0yfg1wyszsi0gyc4w9hyzmfv84aq9wc79i3283xgg";
+    url = "https://github.com/gildor478/ocaml-fileutils/releases/download/v${version}/fileutils-${version}.tbz";
+    hash = "sha256-enu2vGo2tuvawrTkap6bENNmxaLUQXpfHWih+7oKRF8=";
   };
 
-  minimumOCamlVersion = "4.03";
-  useDune2 = true;
+  minimalOCamlVersion = "4.03";
 
   propagatedBuildInputs = [
+    seq
     stdlib-shims
   ];
 
   checkInputs = [
-    ounit
+    ounit2
   ];
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.04";
 
   meta = with lib; {
     description = "OCaml API to manipulate real files (POSIX like) and filenames";

--- a/pkgs/development/python-modules/ailment/default.nix
+++ b/pkgs/development/python-modules/ailment/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "ailment";
-  version = "9.2.31";
+  version = "9.2.32";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-jG7lZet15mp1ltbdcv1ZMHHa+ydFXQiNS+dl70tmluE=";
+    hash = "sha256-JHKF1uTzAzYrVx1iOtOjJYFbnvFeTzUjTmm24leHIMs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/angr/default.nix
+++ b/pkgs/development/python-modules/angr/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "angr";
-  version = "9.2.31";
+  version = "9.2.32";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-i7kIHDg1iCtEeigS2+4MTS2fmUYYEbruL7q0s1skR9k=";
+    hash = "sha256-nyFEyOo4qtkyjAmkOV0JEOKAKWJKwjRrywKqP2yoJ54=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/archinfo/default.nix
+++ b/pkgs/development/python-modules/archinfo/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "archinfo";
-  version = "9.2.31";
+  version = "9.2.32";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-mrsEdVUp13XqVwrbLYbR8vAsu5wPHQcIOBBSmSPJQYY=";
+    hash = "sha256-LChk65iM238jB1jwgEis5Wfz8YGmb9UCOdmQcU+3bFA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/claripy/default.nix
+++ b/pkgs/development/python-modules/claripy/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "claripy";
-  version = "9.2.31";
+  version = "9.2.32";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-hIzB6E1z3ufbHFoe2IfBTuF4uuJibaFTqDjTf5ubHDU=";
+    hash = "sha256-Cf56Q2ZqBq3uoCGqG5pYxA6ANP8VLC6pAMZIL5ubq30=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/cle/default.nix
+++ b/pkgs/development/python-modules/cle/default.nix
@@ -16,7 +16,7 @@
 
 let
   # The binaries are following the argr projects release cycle
-  version = "9.2.31";
+  version = "9.2.32";
 
   # Binary files from https://github.com/angr/binaries (only used for testing and only here)
   binaries = fetchFromGitHub {
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ZgM1GEsmp6LOoFf33l6cZY6cyCoitPDEpFbAVuAd0p8=";
+    hash = "sha256-KYWhwL3DAa/2Hb4I1NfYWA5gXrwEeMpDpAWCWGLqFeE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/geniushub-client/default.nix
+++ b/pkgs/development/python-modules/geniushub-client/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Module to interact with Genius Hub systems";
-    homepage = "https://github.com/zxdavb/geniushub-client";
+    homepage = "https://github.com/manzanotti/geniushub-client";
     changelog = "https://github.com/manzanotti/geniushub-client/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];

--- a/pkgs/development/python-modules/geniushub-client/default.nix
+++ b/pkgs/development/python-modules/geniushub-client/default.nix
@@ -1,31 +1,45 @@
 { lib
-, buildPythonPackage
-, fetchPypi
 , aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "geniushub-client";
-  version = "0.6.30";
+  version = "0.7.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "390932b6e5051e221d104b2683d9deb6e352172c4ec4eeede0954bf2f9680211";
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "manzanotti";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-amsMZjCsPI8CUfSct4uumn8nVZDESlQFh19LXu3yb7o=";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'VERSION = os.environ["GITHUB_REF_NAME"]' "" \
+      --replace "version=VERSION," 'version="${version}",'
+  '';
 
   propagatedBuildInputs = [
     aiohttp
   ];
 
-  # tests only implemented after 0.6.30
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [
     "geniushubclient"
   ];
 
   meta = with lib; {
-    description = "Aiohttp-based client for Genius Hub systems";
+    description = "Module to interact with Genius Hub systems";
     homepage = "https://github.com/zxdavb/geniushub-client";
     changelog = "https://github.com/manzanotti/geniushub-client/releases/tag/v${version}";
     license = licenses.mit;

--- a/pkgs/development/python-modules/geniushub-client/default.nix
+++ b/pkgs/development/python-modules/geniushub-client/default.nix
@@ -20,11 +20,14 @@ buildPythonPackage rec {
   # tests only implemented after 0.6.30
   doCheck = false;
 
-  pythonImportsCheck = [ "geniushubclient" ];
+  pythonImportsCheck = [
+    "geniushubclient"
+  ];
 
   meta = with lib; {
     description = "Aiohttp-based client for Genius Hub systems";
     homepage = "https://github.com/zxdavb/geniushub-client";
+    changelog = "https://github.com/manzanotti/geniushub-client/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
   };

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -47,8 +47,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mitmproxy";
     repo = "mitmproxy";
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-nW/WfiY6uF67qNa95tvNvSv/alP2WmzTk34LEBma/04=";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-CINKvRnBspciS+wefJB8gzBE13L8CjbYCkmLmTTeYlA=";
   };
 
   propagatedBuildInputs = [
@@ -110,6 +110,10 @@ buildPythonPackage rec {
     "test_flowview"
     # ValueError: Exceeds the limit (4300) for integer string conversion
     "test_roundtrip_big_integer"
+
+    "test_wireguard"
+    "test_commands_exist"
+    "test_statusbar"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/pyatmo/default.nix
+++ b/pkgs/development/python-modules/pyatmo/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "jabesq";
     repo = "pyatmo";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-0AgmH0cxXPUBzC30HyX68WsSyYsDcPaVQHLOIsZbHzI=";
+    hash = "sha256-0AgmH0cxXPUBzC30HyX68WsSyYsDcPaVQHLOIsZbHzI=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -62,6 +62,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Simple API to access Netatmo weather station data";
     homepage = "https://github.com/jabesq/pyatmo";
+    changelog = "https://github.com/jabesq/pyatmo/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ delroth ];
   };

--- a/pkgs/development/python-modules/pyatmo/default.nix
+++ b/pkgs/development/python-modules/pyatmo/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "pyatmo";
-  version = "7.4.0";
+  version = "7.5.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "jabesq";
     repo = "pyatmo";
     rev = "refs/tags/v${version}";
-    hash = "sha256-0AgmH0cxXPUBzC30HyX68WsSyYsDcPaVQHLOIsZbHzI=";
+    hash = "sha256-GucatimZTg0Fggrz4bG1x6YSa3wE/uLGB4ufil/km3w=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "pyvex";
-  version = "9.2.31";
+  version = "9.2.32";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Te0wFz+3/HVKlMXW5WJ6mRGh8wWiMXR6Ypi/4hvnz/8=";
+    hash = "sha256-5ZCFAEHcM+3yH9pFyrduG8Uo1Ofr4JkvcXjJEi5KRMc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/qtawesome/default.nix
+++ b/pkgs/development/python-modules/qtawesome/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "qtawesome";
-  version = "1.2.1";
+  version = "1.2.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "spyder-ide";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-KcYCXrTP8ED5j/VTLTw7a8zotDSqIu9ultmwp8Ip5nM=";
+    hash = "sha256-zXwIwYG76aCKPTE8mGiAOK8kQUCzJbqnjJszmIqByaA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/qtawesome/default.nix
+++ b/pkgs/development/python-modules/qtawesome/default.nix
@@ -40,6 +40,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Iconic fonts in PyQt and PySide applications";
     homepage = "https://github.com/spyder-ide/qtawesome";
+    changelog = "https://github.com/spyder-ide/qtawesome/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux; # fails on Darwin

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.89";
+  version = "0.0.90";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha-device-handlers";
     rev = "refs/tags/${version}";
-    hash = "sha256-5qSznGO3Cke+lGPLHjzh/db5O0/Ypmd6D5MTHuiox6Q=";
+    hash = "sha256-SfzwS7M821uGfbOLR37iiw+gEebKDgu1H7f0fs3J9kw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/tools/pgloader/default.nix
+++ b/pkgs/development/tools/pgloader/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeWrapper, sbcl_2_2_6, sqlite, freetds, libzip, curl, git, cacert, openssl }:
+{ lib, stdenv, fetchurl, makeWrapper, sbcl, sqlite, freetds, libzip, curl, git, cacert, openssl }:
 stdenv.mkDerivation rec {
   pname = "pgloader";
   version = "3.6.9";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ git makeWrapper ];
-  buildInputs = [ sbcl_2_2_6 cacert sqlite freetds libzip curl openssl ];
+  buildInputs = [ sbcl cacert sqlite freetds libzip curl openssl ];
 
   LD_LIBRARY_PATH = lib.makeLibraryPath [ sqlite libzip curl git openssl freetds ];
 

--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "wordpress";
-  version = "6.0.3";
+  version = "6.1.1";
 
   src = fetchurl {
     url = "https://wordpress.org/${pname}-${version}.tar.gz";
-    sha256 = "sha256-eSi0qwzXoJ1wYUzi34s7QbBbwRm2hfXoyGFivhPBq5o=";
+    sha256 = "sha256-IR6FSmm3Pd8cCHNQTH1oIaLYsEP1obVjr0bDJkD7H60=";
   };
 
   installPhase = ''

--- a/pkgs/servers/web-apps/wordpress/packages/default.nix
+++ b/pkgs/servers/web-apps/wordpress/packages/default.nix
@@ -2,7 +2,7 @@
 # Licensed under: MIT
 # Slightly modified
 
-{ lib, newScope, plugins, themes, languages }:
+{ lib, newScope, plugins, themes, languages, callPackage }:
 
 let packages = self:
   let
@@ -82,4 +82,4 @@ let packages = self:
   } // lib.mapAttrs (type: pkgs: lib.makeExtensible (_: lib.mapAttrs (pname: data: self.mkOfficialWordpressDerivation { type = lib.removeSuffix "s" type; inherit pname data; }) pkgs)) generatedJson;
 
 # This creates an extensible scope.
-in (lib.makeExtensible (_: (lib.makeScope newScope packages))).extend (selfWP: superWP: {})
+in lib.recursiveUpdate ((lib.makeExtensible (_: (lib.makeScope newScope packages))).extend (selfWP: superWP: {})) (callPackage ./thirdparty.nix {})

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -160,5 +160,11 @@
     "rev": "2540784",
     "sha256": "1g21nl6xs9zyq0ainjwa06wl90975l8f9rj0fa20zkmw17w2mdgl",
     "version": "1.4.1"
+  },
+  "wpforms-lite": {
+    "path": "wpforms-lite/tags/1.7.8",
+    "rev": "2815943",
+    "sha256": "0xqnjxlj2m6zpcasj3gksg9qzjm8pynjr8sar8xbgfz8ichs5m6m",
+    "version": "1.7.8"
   }
 }

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -150,10 +150,10 @@
     "version": "3.7.0"
   },
   "wp-statistics": {
-    "path": "wp-statistics/tags/13.2.10",
-    "rev": "2838980",
-    "sha256": "02wg8y4zfx0h87k38dy21gfys1g99r4dswwv6g308vflcml68ma1",
-    "version": "13.2.10"
+    "path": "wp-statistics/tags/13.2.11",
+    "rev": "2841966",
+    "sha256": "0bdg63q9wq82rpj7lxiwsvbpxa03r2v1pngs2pxifd4632b7ikni",
+    "version": "13.2.11"
   },
   "wp-user-avatars": {
     "path": "wp-user-avatars/trunk",

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -72,10 +72,10 @@
     "version": "5.0.18"
   },
   "mailpoet": {
-    "path": "mailpoet/tags/4.3.0",
-    "rev": "2836720",
-    "sha256": "0igaq34gq5ysk5ai39b641kx7rqsj052m6r55zl6z7xjpxhf37aw",
-    "version": "4.3.0"
+    "path": "mailpoet/tags/4.3.1",
+    "rev": "2843001",
+    "sha256": "0nnmfk1rxhf31makfc0v7mlh30799saxpf8agqdlavrmqpvypvzb",
+    "version": "4.3.1"
   },
   "merge-minify-refresh": {
     "path": "merge-minify-refresh/trunk",

--- a/pkgs/servers/web-apps/wordpress/packages/thirdparty.nix
+++ b/pkgs/servers/web-apps/wordpress/packages/thirdparty.nix
@@ -1,0 +1,8 @@
+{fetchzip}: {
+  plugins.civicrm = fetchzip rec {
+    name = "civicrm";
+    version = "5.56.0";
+    url = "https://storage.googleapis.com/${name}/${name}-stable/${version}/${name}-${version}-wordpress.zip";
+    hash = "sha256-XsNFxVL0LF+OHlsqjjTV41x9ERLwMDq9BnKKP3Px2aI=";
+  };
+}

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -26,4 +26,5 @@
 , "wp-mail-smtp"
 , "wp-statistics"
 , "wp-user-avatars"
+, "wpforms-lite"
 ]

--- a/pkgs/tools/misc/debian-devscripts/default.nix
+++ b/pkgs/tools/misc/debian-devscripts/default.nix
@@ -67,6 +67,9 @@ in stdenv.mkDerivation rec {
         --prefix PYTHONPATH : "$out/${python.sitePackages}" \
         --prefix PATH : "${dpkg}/bin"
     done
+    ln -s cvs-debi $out/bin/cvs-debc
+    ln -s debchange $out/bin/dch
+    ln -s pts-subscribe $out/bin/pts-unsubscribe
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/debian-devscripts/default.nix
+++ b/pkgs/tools/misc/debian-devscripts/default.nix
@@ -34,13 +34,14 @@ in stdenv.mkDerivation rec {
     tgtpy="$out/lib/${python.libPrefix}/site-packages"
     mkdir -p "$tgtpy"
     export PYTHONPATH="$PYTHONPATH''${PYTHONPATH:+:}$tgtpy"
-    find po4a scripts -type f -exec sed -r \
+    find lib po4a scripts -type f -exec sed -r \
       -e "s@/usr/bin/gpg(2|)@${gnupg}/bin/gpg@g" \
       -e "s@/usr/(s|)bin/sendmail@${sendmailPath}@g" \
       -e "s@/usr/bin/diff@${diffutils}/bin/diff@g" \
       -e "s@/usr/bin/gpgv(2|)@${gnupg}/bin/gpgv@g" \
       -e "s@(command -v|/usr/bin/)curl@${curl.bin}/bin/curl@g" \
       -e "s@sensible-editor@${sensible-editor}@g" \
+      -e "s@(^|\W)/bin/bash@\1${stdenv.shell}@g" \
       -i {} +
     sed -e "s@/usr/share/sgml/[^ ]*/manpages/docbook.xsl@${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl@" -i scripts/Makefile
     sed -r \

--- a/pkgs/tools/networking/smokeping/default.nix
+++ b/pkgs/tools/networking/smokeping/default.nix
@@ -1,15 +1,25 @@
-{ lib, stdenv, fetchurl, fping, rrdtool, perlPackages, nixosTests }:
+{ lib, stdenv, fetchurl, fetchpatch, fping, rrdtool, perlPackages, autoreconfHook, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "smokeping";
-  version = "2.6.11";
+  version = "2.8.2";
   src = fetchurl {
     url = "https://oss.oetiker.ch/smokeping/pub/smokeping-${version}.tar.gz";
-    sha256 = "1p9hpa2zs33p7hzrds80kwrm5255s0869v3s3qmsyx2sx63c7czj";
+    sha256 = "sha256-KeYRGLRV4juWmtpfjiq0MtPi74fUr+LIbeSgPXGItuo=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/smokeping/raw/4ebf1921706a5a29c758fdce2f59cc35652c944a/f/smokeping-2.8.2-no-3rd-party.patch";
+      hash = "sha256-97rQ4m9HHl3lIpQyjZvu+gZSrNIB2pckxmopCQAQPp0=";
+    })
+  ];
+
   propagatedBuildInputs = [ rrdtool ] ++
     (with perlPackages; [ perl FCGI CGI CGIFast ConfigGrammar DigestHMAC NetTelnet
       NetOpenSSH NetSNMP LWP IOTty fping NetDNS perlldap ]);
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   postInstall = ''
     mv $out/htdocs/smokeping.fcgi.dist $out/htdocs/smokeping.fcgi
@@ -19,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Network latency collector";
-    homepage = "http://oss.oetiker.ch/smokeping";
+    homepage = "https://oss.oetiker.ch/smokeping";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.erictapen ];

--- a/pkgs/tools/security/pass/extensions/checkup.nix
+++ b/pkgs/tools/security/pass/extensions/checkup.nix
@@ -3,7 +3,7 @@
 
 let
   pname = "pass-checkup";
-  version = "0.2.1";
+  version = "0.2.2";
 in stdenv.mkDerivation {
   inherit pname version;
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation {
     owner = "etu";
     repo = pname;
     rev = version;
-    sha256 = "18b6rx59r7g0hvqs2affvw0g0jyifyzhanwgz2q2b8nhjgqgnar2";
+    sha256 = "1p65yxr00k35g4bnagszp8i03pmhnrcmipgrdsawps2ba8faqp6r";
   };
 
   nativeBuildInputs = [ shellcheck ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15580,7 +15580,8 @@ with pkgs;
   sbcl_2_2_9 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.9"; };
   sbcl_2_2_10 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.10"; };
   sbcl_2_2_11 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.11"; };
-  sbcl = sbcl_2_2_11;
+  sbcl_2_3_0 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.3.0"; };
+  sbcl = sbcl_2_3_0;
 
   roswell = callPackage ../development/tools/roswell { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16283,6 +16283,8 @@ with pkgs;
 
   pipenv = callPackage ../development/tools/pipenv {};
 
+  pipx = with python3.pkgs; toPythonApplication pipx;
+
   pipewire = callPackage ../development/libraries/pipewire {
     # ffmpeg depends on SDL2 which depends on pipewire by default.
     # Break the cycle by depending on ffmpeg-headless.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15568,17 +15568,6 @@ with pkgs;
   sagittarius-scheme = callPackage ../development/compilers/sagittarius-scheme {};
 
   sbclBootstrap = callPackage ../development/compilers/sbcl/bootstrap.nix {};
-  sbcl_2_0_8 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.0.8"; };
-  sbcl_2_0_9 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.0.9"; };
-  sbcl_2_1_1 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.1"; };
-  sbcl_2_1_2 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.2"; };
-  sbcl_2_1_9 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.9"; };
-  sbcl_2_1_10 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.10"; };
-  sbcl_2_1_11 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.1.11"; };
-  sbcl_2_2_4 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.4"; };
-  sbcl_2_2_6 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.6"; };
-  sbcl_2_2_9 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.9"; };
-  sbcl_2_2_10 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.10"; };
   sbcl_2_2_11 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.2.11"; };
   sbcl_2_3_0 = callPackage ../development/compilers/sbcl/2.x.nix { version = "2.3.0"; };
   sbcl = sbcl_2_3_0;


### PR DESCRIPTION
###### Description of changes


Trying to get the ball rolling on cleaning up SBCL versions. This is just an initial RFC, please if anyone has good ideas / comments / critique, by all means share :)

~I kept the last SBCL version of every minor version. Also totally up for debate of course.~ as suggested in a previous discussion, I only kept the last two versions.

Last discussion on this: #200994 . Mentioned package : StumpWM. I can't test that here--is one of the current SBCLs compatible with it?

Depends on #208876 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
