### PR TITLE
mysql_jdbc: 5.1.59 -> 8.0.31

### DIFF
--- a/pkgs/servers/sql/mysql/jdbc/default.nix
+++ b/pkgs/servers/sql/mysql/jdbc/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "mysql-connector-java";
-  version = "5.1.49";
+  version = "8.0.31";
 
   src = fetchurl {
-    url = "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${version}.zip";
-    sha256 = "1bm4mm4xka4pq2rwxx3k8xlcpa1vjcglr3pf4ls2i4hamww047yk";
+    url = "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-${version}.zip";
+    sha256 = "sha256-Wo86n/4mono7YAagI/5Efm/X+2jjpOPaFSCMNAB6btI=";
   };
 
   installPhase = ''
     mkdir -p $out/share/java
-    cp mysql-connector-java-*-bin.jar $out/share/java/mysql-connector-java.jar
+    cp mysql-connector-j-*.jar $out/share/java/mysql-connector-j.jar
   '';
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2019-2692.

https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-whats-new.html
https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages built:</summary>
  <ul>
    <li>atlassian-bamboo</li>
    <li>atlassian-confluence</li>
    <li>jboss_mysql_jdbc</li>
    <li>liquibase</li>
    <li>mysql_jdbc</li>
    <li>squirrel-sql</li>
    <li>tomcat_mysql_jdbc</li>
  </ul>
</details>

I tested to connect to MySQL DB using Squirrel SQL, I did not encounter any issues.