### PR TITLE
mujs: 1.2.0 -> 1.3.2

### DIFF
--- a/pkgs/development/interpreters/mujs/default.nix
+++ b/pkgs/development/interpreters/mujs/default.nix
@@ -1,13 +1,23 @@
-{ lib, stdenv, fetchurl, readline }:
+{ lib, stdenv, fetchurl, fetchpatch, readline }:
 
 stdenv.mkDerivation rec {
   pname = "mujs";
-  version = "1.2.0";
+  version = "1.3.2";
 
   src = fetchurl {
     url = "https://mujs.com/downloads/mujs-${version}.tar.xz";
-    sha256 = "sha256-ZpdtHgajUnVKI0Kvc9Guy7U8x82uK2jNoBO33c+SMjM=";
+    sha256 = "sha256-SIZZP8aIsM3M0x5ey+Wv560b7iOqaeZnuHGv1d/GQMM=";
   };
+
+  patches = lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      # ld: library not found for -l:libmujs.a
+      name = "darwin-failures.patch";
+      url = "https://git.ghostscript.com/?p=mujs.git;a=patch;h=d592c785c0b2f9fea982ac3fe7b88fdd7c4817fc";
+      sha256 = "sha256-/57A7S65LWZFyQIGe+LtqDMu85K1N/hbztXB+/nCDJk=";
+      revert = true;
+    })
+  ];
 
   buildInputs = [ readline ];
 


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2022-44789.

https://git.ghostscript.com/?p=mujs.git;a=shortlog;h=refs/tags/1.3.2
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>gnome-mpv</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>minitube</li>
  </ul>
</details>
<details>
  <summary>35 packages built:</summary>
  <ul>
    <li>adl</li>
    <li>ani-cli</li>
    <li>anime-downloader</li>
    <li>anki</li>
    <li>ankisyncd</li>
    <li>celluloid</li>
    <li>curseradio</li>
    <li>dmlive</li>
    <li>ff2mpv</li>
    <li>haruna</li>
    <li>hydrus</li>
    <li>hypnotix</li>
    <li>jellyfin-media-player</li>
    <li>jellyfin-mpv-shim</li>
    <li>jftui</li>
    <li>manga-cli</li>
    <li>mnemosyne</li>
    <li>mpc-qt</li>
    <li>mpv</li>
    <li>mpv-unwrapped</li>
    <li>mpvScripts.mpris</li>
    <li>mpvpaper</li>
    <li>mujs</li>
    <li>plex-media-player</li>
    <li>plex-mpv-shim</li>
    <li>python310Packages.mpv</li>
    <li>python39Packages.mpv</li>
    <li>qimgv</li>
    <li>radioboat</li>
    <li>sioyek</li>
    <li>somafm-cli</li>
    <li>stremio</li>
    <li>sublime-music</li>
    <li>ytfzf</li>
    <li>zathura</li>
  </ul>
</details>

No new failures.