### PR TITLE
nixos/grafana: fix 22.11 release notes

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1127,9 +1127,9 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
           <listitem>
             <para>
               Previously, the options
-              <xref linkend="opt-services.grafana.provision.datasources" />
+              <link linkend="opt-services.grafana.provision.datasources">services.grafana.provision.datasources</link>
               and
-              <xref linkend="opt-services.grafana.provision.dashboards" />
+              <link linkend="opt-services.grafana.provision.dashboards">services.grafana.provision.dashboards</link>
               expected lists of datasources or dashboards for the
               <link xlink:href="https://grafana.com/docs/grafana/latest/administration/provisioning/">declarative
               provisioning</link>.
@@ -1142,14 +1142,14 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
                 <para>
                   <emphasis role="strong">datasources</emphasis>, please
                   rename your declarations to
-                  <xref linkend="opt-services.grafana.provision.datasources.settings.datasources" />.
+                  <link linkend="opt-services.grafana.provision.datasources.settings.datasources">services.grafana.provision.datasources.settings.datasources</link>.
                 </para>
               </listitem>
               <listitem>
                 <para>
                   <emphasis role="strong">dashboards</emphasis>, please
                   rename your declarations to
-                  <xref linkend="opt-services.grafana.provision.dashboards.settings.providers" />.
+                  <link linkend="opt-services.grafana.provision.dashboards.settings.providers">services.grafana.provision.dashboards.settings.providers</link>.
                 </para>
               </listitem>
             </itemizedlist>
@@ -1162,9 +1162,9 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
                   It’s possible to declare the
                   <literal>apiVersion</literal> of your dashboards and
                   datasources by
-                  <xref linkend="opt-services.grafana.provision.datasources.settings.apiVersion" />
+                  <link linkend="opt-services.grafana.provision.datasources.settings.apiVersion">services.grafana.provision.datasources.settings.apiVersion</link>
                   (or
-                  <xref linkend="opt-services.grafana.provision.dashboards.settings.apiVersion" />).
+                  <link linkend="opt-services.grafana.provision.dashboards.settings.apiVersion">services.grafana.provision.dashboards.settings.apiVersion</link>).
                 </para>
               </listitem>
               <listitem>
@@ -1172,9 +1172,9 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
                   Instead of declaring datasources and dashboards in
                   pure Nix, it’s also possible to specify configuration
                   files (or directories) with YAML instead using
-                  <xref linkend="opt-services.grafana.provision.datasources.path" />
+                  <link linkend="opt-services.grafana.provision.datasources.path">services.grafana.provision.datasources.path</link>
                   (or
-                  <xref linkend="opt-services.grafana.provision.dashboards.path" />.
+                  <link linkend="opt-services.grafana.provision.dashboards.path">services.grafana.provision.dashboards.path</link>.
                   This is useful when having provisioning files from
                   non-NixOS Grafana instances that you also want to
                   deploy to NixOS.
@@ -1189,9 +1189,9 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
               </listitem>
               <listitem>
                 <para>
-                  <xref linkend="opt-services.grafana.provision.notifiers" />
+                  <link linkend="opt-services.grafana.provision.notifiers">services.grafana.provision.notifiers</link>
                   is not affected by this change because this feature is
-                  deprecated by Grafana and will probably removed in
+                  deprecated by Grafana and will probably be removed in
                   Grafana 10. It’s recommended to use
                   <literal>services.grafana.provision.alerting.contactPoints</literal>
                   instead.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -341,32 +341,32 @@ In addition to numerous new and upgraded packages, this release includes the fol
     Alternatively you can also set all your values from `extraOptions` to
     `systemd.services.grafana.environment`, make sure you don't forget to add
     the `GF_` prefix though!
-  - Previously, the options [](#opt-services.grafana.provision.datasources) and
-    [](#opt-services.grafana.provision.dashboards) expected lists of datasources
+  - Previously, the options [services.grafana.provision.datasources](#opt-services.grafana.provision.datasources) and
+    [services.grafana.provision.dashboards](#opt-services.grafana.provision.dashboards) expected lists of datasources
     or dashboards for the [declarative provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/).
 
     To declare lists of
-    - **datasources**, please rename your declarations to [](#opt-services.grafana.provision.datasources.settings.datasources).
-    - **dashboards**, please rename your declarations to [](#opt-services.grafana.provision.dashboards.settings.providers).
+    - **datasources**, please rename your declarations to [services.grafana.provision.datasources.settings.datasources](#opt-services.grafana.provision.datasources.settings.datasources).
+    - **dashboards**, please rename your declarations to [services.grafana.provision.dashboards.settings.providers](#opt-services.grafana.provision.dashboards.settings.providers).
 
     This change was made to support more features for that:
 
     - It's possible to declare the `apiVersion` of your dashboards and datasources
-      by [](#opt-services.grafana.provision.datasources.settings.apiVersion) (or
-      [](#opt-services.grafana.provision.dashboards.settings.apiVersion)).
+      by [services.grafana.provision.datasources.settings.apiVersion](#opt-services.grafana.provision.datasources.settings.apiVersion) (or
+      [services.grafana.provision.dashboards.settings.apiVersion](#opt-services.grafana.provision.dashboards.settings.apiVersion)).
 
     - Instead of declaring datasources and dashboards in pure Nix, it's also possible
       to specify configuration files (or directories) with YAML instead using
-      [](#opt-services.grafana.provision.datasources.path) (or
-      [](#opt-services.grafana.provision.dashboards.path). This is useful when having
+      [services.grafana.provision.datasources.path](#opt-services.grafana.provision.datasources.path) (or
+      [services.grafana.provision.dashboards.path](#opt-services.grafana.provision.dashboards.path). This is useful when having
       provisioning files from non-NixOS Grafana instances that you also want to
       deploy to NixOS.
 
       __Note:__ secrets from these files will be leaked into the store unless you use a
       [**file**-provider or env-var](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#file-provider) for secrets!
 
-    - [](#opt-services.grafana.provision.notifiers) is not affected by this change because
-      this feature is deprecated by Grafana and will probably removed in Grafana 10.
+    - [services.grafana.provision.notifiers](#opt-services.grafana.provision.notifiers) is not affected by this change because
+      this feature is deprecated by Grafana and will probably be removed in Grafana 10.
       It's recommended to use `services.grafana.provision.alerting.contactPoints` instead.
 
 - The `services.grafana.provision.alerting` option was added. It includes suboptions for every alerting-related objects (with the exception of `notifiers`), which means it's now possible to configure modern Grafana alerting declaratively.


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
How it looks currently:
    To declare lists of
    - **datasources**, please rename your declarations to [](#opt-services.grafana.provision.datasources.settings.datasources).
    - **dashboards**, please rename your declarations to [](#opt-services.grafana.provision.dashboards.settings.providers).

How it should look:
    To declare lists of
    - **datasources**, please rename your declarations to [services.grafana.provision.dashboards.settings.providers](#opt-services.grafana.provision.datasources.settings.datasources).
    - **dashboards**, please rename your declarations to [services.grafana.provision.dashboards.settings.providers](#opt-services.grafana.provision.dashboards.settings.providers).
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
