### PR TITLE
treewide: use bindgenhook where possible

### DIFF
--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -24,8 +24,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-p4t+G13XaCl7+IbX5YyBFF0PmARbw4XlRvnA0PRcjvQ=";
 
   # needed for librocksdb-sys
-  nativeBuildInputs = [ llvmPackages.clang ];
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
 
   # link rocksdb dynamically
   ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";

--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -34,13 +34,11 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = [ "modern" "gnosis" ];
 
-  nativeBuildInputs = [ clang cmake perl protobuf ];
+  nativeBuildInputs = [ rustPlatform.bindgenHook cmake perl protobuf ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
     Security
   ];
-
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
   depositContractSpec = fetchurl {
     url = "https://raw.githubusercontent.com/ethereum/eth2.0-specs/v${depositContractSpecVersion}/deposit_contract/contracts/validator_registration.json";

--- a/pkgs/applications/blockchains/nearcore/default.nix
+++ b/pkgs/applications/blockchains/nearcore/default.nix
@@ -42,13 +42,11 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
     protobuf
+    rustPlatform.bindgenHook
   ];
 
   # fat LTO requires ~3.4GB RAM
   requiredSystemFeatures = [ "big-parallel" ];
-
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-  BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion llvmPackages.clang}/include";
 
   meta = with lib; {
     description = "Reference client for NEAR Protocol";

--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -36,14 +36,13 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 
-  nativeBuildInputs = [ clang ];
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
 
   preBuild = ''
     export SUBSTRATE_CLI_GIT_COMMIT_HASH=$(cat .git_commit)
     rm .git_commit
   '';
 
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   PROTOC = "${protobuf}/bin/protoc";
 
   # NOTE: We don't build the WASM runtimes since this would require a more

--- a/pkgs/applications/blockchains/snarkos/default.nix
+++ b/pkgs/applications/blockchains/snarkos/default.nix
@@ -23,14 +23,12 @@ rustPlatform.buildRustPackage rec {
 
   # buildAndTestSubdir = "cli";
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [ pkg-config llvmPackages.clang ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ pkg-config rustPlatform.bindgenHook ];
 
   # Needed to get openssl-sys to use pkg-config.
   OPENSSL_NO_VENDOR = 1;
   OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
   OPENSSL_DIR="${lib.getDev openssl}";
-
-  LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
 
   # TODO check why rust compilation fails by including the rocksdb from nixpkgs
   # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would

--- a/pkgs/applications/blockchains/solana-validator/default.nix
+++ b/pkgs/applications/blockchains/solana-validator/default.nix
@@ -68,12 +68,9 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = builtins.map (n: "--bin=${n}") solanaPkgs;
 
   # weird errors. see https://github.com/NixOS/nixpkgs/issues/52447#issuecomment-852079285
-  LIBCLANG_PATH = "${libclang.lib}/lib";
-  BINDGEN_EXTRA_CLANG_ARGS =
-    "-isystem ${libclang.lib}/lib/clang/${lib.getVersion clang}/include";
-  LLVM_CONFIG_PATH = "${llvm}/bin/llvm-config";
+  # LLVM_CONFIG_PATH = "${llvm}/bin/llvm-config";
 
-  nativeBuildInputs = [ clang llvm pkg-config protobuf rustfmt perl ];
+  nativeBuildInputs = [ pkg-config protobuf rustfmt perl rustPlatform.bindgenHook ];
   buildInputs =
     [ openssl zlib libclang hidapi ] ++ (lib.optionals stdenv.isLinux [ udev ]);
   strictDeps = true;

--- a/pkgs/applications/blockchains/teos/default.nix
+++ b/pkgs/applications/blockchains/teos/default.nix
@@ -38,11 +38,8 @@ let
     perl  # used by openssl-sys to configure
     protobuf
     rustfmt
-    llvmPackages.clang
+    rustPlatform.bindgenHook
   ];
-
-
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 in
 {
   teos = rustPlatform.buildRustPackage {
@@ -50,7 +47,7 @@ in
     cargoSha256 = "sha256-7VYYYSMJ2JP1KuA8sD0X3wInubH/jbA/sgzsTsomyEc=";
     buildAndTestSubdir = "teos";
 
-    inherit version src cargoPatches buildInputs nativeBuildInputs LIBCLANG_PATH;
+    inherit version src cargoPatches buildInputs nativeBuildInputs;
 
     meta = common.meta // {
       description = "A Lightning watchtower compliant with BOLT13, written in Rust";
@@ -66,7 +63,7 @@ in
     cargoSha256 = "sha256-xL+DiEfgBYJQ1UJm7LAr1/f34pkU8FRl4Seic8MFAlM=";
     buildAndTestSubdir = "watchtower-plugin";
 
-    inherit version src cargoPatches buildInputs nativeBuildInputs LIBCLANG_PATH;
+    inherit version src cargoPatches buildInputs nativeBuildInputs;
 
     meta = common.meta // {
       description = "A Lightning watchtower plugin for clightning";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/default.nix
@@ -43,12 +43,8 @@ let
 
     pname = "tsc-dyn";
 
-    nativeBuildInputs = [ clang ];
+    nativeBuildInputs = [ rustPlatform.bindgenHook ];
     sourceRoot = "source/core";
-
-    configurePhase = ''
-      export LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib"
-    '';
 
     postInstall = ''
       LIB=($out/lib/libtsc_dyn.*)

--- a/pkgs/applications/misc/authenticator/default.nix
+++ b/pkgs/applications/misc/authenticator/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     appstream-glib
-    clang
     desktop-file-utils
     meson
     ninja
@@ -52,6 +51,7 @@ stdenv.mkDerivation rec {
     cargoSetupHook
     rust.cargo
     rust.rustc
+    bindgenHook
   ]);
 
   buildInputs = [
@@ -68,8 +68,6 @@ stdenv.mkDerivation rec {
     wayland
     zbar
   ];
-
-  LIBCLANG_PATH = "${lib.getLib libclang}/lib";
 
   meta = {
     description = "Two-factor authentication code generator for GNOME";

--- a/pkgs/applications/misc/clipcat/default.nix
+++ b/pkgs/applications/misc/clipcat/default.nix
@@ -14,8 +14,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1n4il3l59m2a6ca54vfaivzg25abf8s4w5kpd5q51p13624iz0kb";
 
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-
   # needed for internal protobuf c wrapper library
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";
@@ -23,8 +21,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
 
-    clang
-    llvmPackages.libclang
+    rustPlatform.bindgenHook
 
     rustfmt
     protobuf

--- a/pkgs/applications/misc/imag/default.nix
+++ b/pkgs/applications/misc/imag/default.nix
@@ -21,12 +21,10 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0f9915f083z5qqcxyavj0w6m973c8m1x7kfb89pah5agryy5mkaq";
   };
 
-  nativeBuildInputs = [ installShellFiles pkg-config ];
+  nativeBuildInputs = [ installShellFiles pkg-config rustPlatform.bindgenHook ];
   buildInputs = [ openssl ]
     ++ lib.optional stdenv.isDarwin Security;
   checkInputs = [ gitMinimal util-linuxMinimal ];
-
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
   cargoSha256 = "1vnrc72g2271i2p847z30kplxmdpi60n3dzpw0s7dahg33g14ai6";
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

goal: people copy pasting stuff from nixpkgs use bindgenHook instead of preparing the environment themselves

it's only about a third of them because it takes forever to build rust locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
