### PR TITLE
cc-wrapper: Unconditionally warn about skipped native flags

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -111,7 +111,7 @@ if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
     # Old bash empty array hack
     for p in ${params+"${params[@]}"}; do
         if [[ "$p" = -m*=native ]]; then
-            skip "$p"
+            >&2 echo "warning: Skipping impure flag $p because NIX_ENFORCE_NO_NATIVE is set"
         else
             kept+=("$p")
         fi


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR makes `cc-wrapper` warn about skipped `native` flags (e.g., `-march=native`) unconditionally, so the behavior is more visible for users using the wrapped compilers in a Nix shell environment where they would expect such flags to work.

Currently, `cc-wrapper` [strips out such flags silently](https://github.com/NixOS/nixpkgs/blob/211ab6181a5825b5805c8e8570aee19fb28d481e/pkgs/build-support/cc-wrapper/cc-wrapper.sh#L108-L121) when `NIX_ENFORCE_NO_NATIVE` is enabled (the default in `stdenv`). A message is only emitted if `NIX_DEBUG` is set. This makes sense for reproduciblility, but the behavior can be surprising/undesirable to users using it interactively. The compiler shouldn't silently not do what is specified without informing the user.

The downside of adding such an unconditional warning is log spam during builds that specify any `native` flag. However, we should fix the affected packages to not use such flags in the first place. Currently, a full build of `stdenv` with this PR applied does not emit such warnings.

###### Alternative solutions

1. Make `cc-wrapper` simply exit with a non-zero code when such flags are passed and `NIX_ENFORCE_NO_NATIVE` is enabled. This will probably break some packages, but is a cleaner solution.
2. Make the default `mkShell` environment not have `NIX_ENFORCE_NO_NATIVE`.

###### Workarounds

1. `NIX_CFLAGS_COMPILE=-march=native` produces the expected result since the flags are appended after filtering, but the effect pollutes the entire shell/build environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (built `stdenv` on [master](https://github.com/zhaofengli/nixpkgs/tree/warn-enforce-no-native-master))
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
