### PR TITLE
gotrue{,-supabase}: init

### DIFF
--- a/pkgs/tools/security/gotrue/default.nix
+++ b/pkgs/tools/security/gotrue/default.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, lib }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "gotrue";
@@ -16,7 +16,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/netlify/gotrue/cmd.Version=${version}"
+    "-X=github.com/netlify/gotrue/cmd.Version=${version}"
   ];
 
   # integration tests require network access

--- a/pkgs/tools/security/gotrue/default.nix
+++ b/pkgs/tools/security/gotrue/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "gotrue";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "netlify";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-9h6CyCY7741tJR+qWDLwgPkAtE/kmaoTqlXEY+mOW58=";
+  };
+
+  vendorHash = "sha256-x96+l9EBzYplGRFHsfQazSjqZs35bdXQEJv3pBuaJVo=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/netlify/gotrue/cmd.Version=${version}"
+  ];
+
+  # integration tests require network access
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/netlify/gotrue";
+    description = "An SWT based API for managing users and issuing SWT tokens";
+    changelog = "https://github.com/netlify/gotrue/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/tools/security/gotrue/supabase.nix
+++ b/pkgs/tools/security/gotrue/supabase.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "gotrue";
+  version = "2.35.0";
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-uFE2pcEpGhrl8LcZLvYEMlq8sgRmFkltf3H8huZzXpM=";
+  };
+
+  vendorHash = "sha256-uchgHxUczb4IIUkUdHWyeXWr2LXda6eWwjQxUBcPDoA=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/netlify/gotrue/utilities.Version=${version}"
+  ];
+
+  # integration tests require network to connect to postgres database
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/supabase/gotrue";
+    description = "A JWT based API for managing users and issuing JWT tokens";
+    changelog = "https://github.com/supabase/gotrue/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36645,6 +36645,8 @@ with pkgs;
 
   gotestwaf = callPackage ../tools/security/gotestwaf { };
 
+  gotrue = callPackage ../tools/security/gotrue {};
+
   gowitness = callPackage ../tools/security/gowitness { };
 
   guetzli = callPackage ../applications/graphics/guetzli { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36647,6 +36647,8 @@ with pkgs;
 
   gotrue = callPackage ../tools/security/gotrue {};
 
+  gotrue-supabase = callPackage ../tools/security/gotrue/supabase.nix {};
+
   gowitness = callPackage ../tools/security/gowitness { };
 
   guetzli = callPackage ../applications/graphics/guetzli { };


### PR DESCRIPTION
###### Description of changes

the explicit packaging request asked for [supabase/gotrue](https://github.com/supabase/gotrue), but this is a fork of an upstream tool. as such, we have added both, but chosen to name the requested package `gotrue-supabase`, as it is a fork.

Fixes #170203

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
