### PR TITLE
qemu: add patches for CVE-2022-4172 & CVE-2022-4144

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -117,6 +117,31 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/d307040b18bfcb1393b910f1bae753d5c12a4dc7.patch";
       sha256 = "sha256-YPhm580lBNuAv7G1snYccKZ2V5ycdV8Ri8mTw5jjFBc=";
     })
+    (fetchpatch {
+      name = "CVE-2022-4172.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/defb70980f6bed36100b74e84220f1764c0dd544.patch";
+      sha256 = "sha256-8HGe3UQB9/8mwYwSmv1vlDUCCfiqFGjk+Pf6Ibvbn9E=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-4144.part-1.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/61c34fc194b776ecadc39fb26b061331107e5599.patch";
+      sha256 = "sha256-g4NGE8P7+lLyL2XAtXt8xSLsrPnvDyi7vbRPTQXgSSE=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-4144.part-2.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/b1901de83a9456cde26fc755f71ca2b7b3ef50fc.patch";
+      sha256 = "sha256-rTFGzrH+ksx1oytMAym9CJJ9VJ5fX8MTjL4wo5/V94s=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-4144.part-3.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/8efec0ef8bbc1e75a7ebf6e325a35806ece9b39f.patch";
+      sha256 = "sha256-Xhe1HyYO6FFGQomwYhmlB+UBKLV6U/A9Rl46C5qhS4M=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-4144.part-4.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/6dbbf055148c6f1b7d8a3251a65bd6f3d1e1f622.patch";
+      sha256 = "sha256-fd2tqcih17LdaECAGhIOpRg8dXSbDa7C4M3hHxhisBE=";
+    })
   ]
   ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch;
 


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-4172
https://nvd.nist.gov/vuln/detail/CVE-2022-4144

The latter's patches are only in upstream's `staging` branch so far.

As is normal with the qemu tests, it's hard to get them to all pass at the same time, but I didn't see any one test that never passed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
