### PR TITLE
headscale: 0.16.4 -> 0.17.0

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -82,7 +82,17 @@ in
         type = types.path;
         default = "${dataDir}/private.key";
         description = lib.mdDoc ''
-          Path to private key file, generated automatically if it does not exist.
+          Path to legacy TS2019 private key file, generated automatically if it
+          does not exist. Not used by headscale >= 0.17.0
+        '';
+      };
+
+      noisePrivateKeyFile = mkOption {
+        type = types.path;
+        default = "${dataDir}/noise_private.key";
+        description = lib.mdDoc ''
+          Path to noise TS2021 private key file, generated automatically if it
+          does not exist. Only used by headscale >= 0.17.0
         '';
       };
 
@@ -186,15 +196,6 @@ in
           default = "${dataDir}/db.sqlite";
           description = lib.mdDoc "Path to the sqlite3 database file.";
         };
-      };
-
-      logLevel = mkOption {
-        type = types.str;
-        default = "info";
-        description = lib.mdDoc ''
-          headscale log level.
-        '';
-        example = "debug";
       };
 
       dns = {
@@ -345,6 +346,11 @@ in
     };
 
   };
+
+  imports = [
+    (mkRenamedOptionModule [ "services" "headscale" "logLevel" ] [ "services" "headscale" "settings" "log" "level" ])
+  ];
+
   config = mkIf cfg.enable {
 
     services.headscale.settings = {
@@ -352,6 +358,7 @@ in
       listen_addr = mkDefault "${cfg.address}:${toString cfg.port}";
 
       private_key_path = mkDefault cfg.privateKeyFile;
+      noise.private_key_path = mkDefault cfg.noisePrivateKeyFile;
 
       derp = {
         urls = mkDefault cfg.derp.urls;
@@ -368,8 +375,6 @@ in
 
       db_type = mkDefault cfg.database.type;
       db_path = mkDefault cfg.database.path;
-
-      log_level = mkDefault cfg.logLevel;
 
       dns_config = {
         nameservers = mkDefault cfg.dns.nameservers;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -252,6 +252,7 @@ in {
   haste-server = handleTest ./haste-server.nix {};
   haproxy = handleTest ./haproxy.nix {};
   hardened = handleTest ./hardened.nix {};
+  headscale = handleTest ./headscale.nix {};
   healthchecks = handleTest ./web-apps/healthchecks.nix {};
   hbase2 = handleTest ./hbase.nix { package=pkgs.hbase2; };
   hbase_2_4 = handleTest ./hbase.nix { package=pkgs.hbase_2_4; };

--- a/nixos/tests/headscale.nix
+++ b/nixos/tests/headscale.nix
@@ -1,0 +1,17 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "headscale";
+  meta.maintainers = with lib.maintainers; [ misterio77 ];
+
+  nodes.machine = { ... }: {
+    services.headscale.enable = true;
+    environment.systemPackages = [ pkgs.headscale ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("headscale")
+    machine.wait_for_open_port(8080)
+    # Test basic funcionality
+    machine.succeed("headscale namespaces create test")
+    machine.succeed("headscale preauthkeys -n test create")
+  '';
+})

--- a/pkgs/servers/headscale/default.nix
+++ b/pkgs/servers/headscale/default.nix
@@ -2,20 +2,21 @@
 
 buildGoModule rec {
   pname = "headscale";
-  version = "0.16.4";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "juanfont";
     repo = "headscale";
     rev = "v${version}";
-    sha256 = "sha256-j5fbWxRMkYlsgL1QDEDlitKB3FOmDTy17FcuztALISw=";
+    sha256 = "sha256-KBTZpf9hHX1GeI2r0Tksa8oWdCVZz1wXKpy9htvk2RY=";
   };
 
-  vendorSha256 = "sha256-RzmnAh81BN4tbzAGzJbb6CMuws8kuPJDw7aPkRRnSS8=";
+  vendorSha256 = "sha256-Cq0WipTQ+kGcvnfP0kjyvjyonl2OC9W7Tj0MCuB1lDU=";
 
   ldflags = [ "-s" "-w" "-X github.com/juanfont/headscale/cmd/headscale/cli.Version=v${version}" ];
 
   nativeBuildInputs = [ installShellFiles ];
+  checkFlags = [ "-short" ];
 
   postInstall = ''
     installShellCompletion --cmd headscale \


### PR DESCRIPTION
###### Description of changes

This PR updates the headscale package to 0.17.0.
It also updates the corresponding module:
- deprecate `logLevel` option (instructing the user to use `settings.log.level` instead), as it has been renamed by upstream (https://github.com/juanfont/headscale/pull/768).
- add a `noisePrivateKey` option as it is now a required setting for
  headscale to run. The legacy `privateKey` should be deprecated in the
  future. (https://github.com/juanfont/headscale/pull/738)

I've also added a NixOS test for the module.

Fixes https://github.com/NixOS/nixpkgs/issues/203446

~Note: There's a few integration tests that are now failing, can we somehow make them work or disable them selectively? For now, I've set `doCheck` to false.~ Fixed!
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
