### PR TITLE
pw-viz: init at 0.1.0

### DIFF
--- a/pkgs/applications/misc/pw-viz/default.nix
+++ b/pkgs/applications/misc/pw-viz/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, libGL
+, pipewire
+, xorg
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pw-viz";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ax9d";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1d46m7w6rzzjpxc2fxwka9xbz49szbfrl63kxlv6kw4lknrladjn";
+  };
+
+  cargoSha256 = "sha256-jx1mUP6ezpwUhmDD9tCJBhHCHU8fEMlB738yYfB1psc=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libGL
+    pipewire
+    rustPlatform.bindgenHook
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libxcb
+  ];
+
+  postFixup = ''
+    patchelf $out/bin/pw-viz --add-rpath ${lib.makeLibraryPath [ libGL xorg.libXrandr ]}
+  '';
+
+  meta = with lib; {
+    description = "A simple and elegant pipewire graph editor ";
+    homepage = "https://github.com/ax9d/pw-viz";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ figsoda ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9758,6 +9758,8 @@ with pkgs;
 
   pwsafe = callPackage ../applications/misc/pwsafe { };
 
+  pw-viz = callPackage ../applications/misc/pw-viz { };
+
   napi-rs-cli = callPackage ../development/tools/napi-rs-cli { };
 
   neil = callPackage ../development/tools/neil { };


### PR DESCRIPTION
###### Description of changes

fixes #203557 

tested under x11, ~~not sure if it works on wayland~~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
