### PR TITLE
visidata: 2.9.1 -> 2.10.2

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -20,19 +20,22 @@
 , wcwidth
 , zstandard
 , setuptools
+, importlib-metadata
 , git
 , withPcap ? true, dpkt, dnslib
 , withXclip ? stdenv.isLinux, xclip
+, testers
+, visidata
 }:
 buildPythonApplication rec {
   pname = "visidata";
-  version = "2.9.1";
+  version = "2.10.2";
 
   src = fetchFromGitHub {
     owner = "saulpw";
     repo = "visidata";
     rev = "v${version}";
-    hash = "sha256-PKj+imTSAGMpF1tkN0WmE3l/4FmWkm/ktIDzF2ku48s=";
+    hash = "sha256-OKCrlUWHgbaLZJPVvs9lnw4cD27pRoO7F9oel1NzT6A=";
   };
 
   propagatedBuildInputs = [
@@ -64,6 +67,7 @@ buildPythonApplication rec {
     zstandard
     odfpy
     setuptools
+    importlib-metadata
   ] ++ lib.optionals withPcap [ dpkt dnslib ]
   ++ lib.optional withXclip xclip;
 
@@ -75,6 +79,7 @@ buildPythonApplication rec {
   doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
 
   checkPhase = ''
+    runHook preCheck
     # disable some tests which require access to the network
     rm tests/load-http.vd            # http
     rm tests/graph-cursor-nosave.vd  # http
@@ -87,13 +92,21 @@ buildPythonApplication rec {
 
     substituteInPlace dev/test.sh --replace "bin/vd" "$out/bin/vd"
     bash dev/test.sh
+    runHook postCheck
   '';
+
+  pythonImportsCheck = ["visidata"];
+
+  passthru.tests.version = testers.testVersion {
+    package = visidata;
+    version = "v${version}";
+  };
 
   meta = {
     description = "Interactive terminal multitool for tabular data";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ raskin markus1189 ];
-    homepage = "http://visidata.org/";
+    homepage = "https://visidata.org/";
     changelog = "https://github.com/saulpw/visidata/blob/v${version}/CHANGELOG.md";
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/saulpw/visidata/blob/v2.10.2/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
