### PR TITLE
nc4nix: unstable-2022-11-30 -> unstable-2022-12-07

### DIFF
--- a/pkgs/development/tools/nc4nix/default.nix
+++ b/pkgs/development/tools/nc4nix/default.nix
@@ -1,21 +1,36 @@
 { lib
 , buildGoModule
-, fetchFromGitLab
+, fetchFromGitHub
 , nix
 , makeWrapper
+, fetchpatch
 }:
 
 buildGoModule rec {
   pname = "nc4nix";
-  version = "unstable-2022-11-13";
+  version = "unstable-2022-12-07";
 
-  src = fetchFromGitLab {
-    domain = "git.project-insanity.org";
-    owner = "onny";
+  src = fetchFromGitHub {
+    owner = "helsinki-systems";
     repo = "nc4nix";
-    rev = "857e789287692e42f3fcaae039d6f323b383543b";
-    sha256 = "sha256-ekuvqTyoaYiNju4yiQLPmxaXaGD4T3Wv9A8CHY1MZOI=";
+    rev = "c556a596b1d40ff69b71adab257ec5ae51ba4df1";
+    sha256 = "sha256-EIPCMiVTf0ryXRMRGhepORaOlimt3/funvUdORRbVa8=";
   };
+
+  patches = [
+    # Switch hash calculation method
+    (fetchpatch {
+      url = "https://github.com/helsinki-systems/nc4nix/commit/88c182fbdddef148e086fa86438dcd72208efd75.patch";
+      sha256 = "sha256-zAF0+t9wHrKhhyD0+/d58BiaavLHfxO8X5J6vNlEWx0=";
+      name = "switch_hash_calculation_method.patch";
+    })
+     # Add package selection command line argument
+    (fetchpatch {
+      url = "https://github.com/helsinki-systems/nc4nix/pull/2/commits/449eec89538df4e92106d06046831202eb84a1db.patch";
+      sha256 = "sha256-qAAbR1G748+2vwwfAhpe8luVEIKNGifqXqTV9QqaUFc=";
+      name = "add_package_selection_command_line_arg.patch";
+    })
+  ];
 
   vendorSha256 = "sha256-uhINWxFny/OY7M2vV3ehFzP90J6Z8cn5IZHWOuEg91M=";
 
@@ -31,8 +46,8 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Packaging helper for Nextcloud apps";
-    homepage = "https://git.project-insanity.org/onny/nc4nix";
-    license = licenses.unfree;
+    homepage = "https://github.com/helsinki-systems/nc4nix";
+    license = licenses.mit;
     maintainers = with maintainers; [ onny ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Description of changes

- change to new upstream source / url
- set new upstream license
- add patches used for packaging nextcloudPackages here in nixpkgs (were formerly applied in my custom downstream repo)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
