### PR TITLE
ocamlPackages.camlzip: 1.10 → 1.11

### DIFF
--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -1,17 +1,24 @@
 {lib, stdenv, fetchurl, zlib, ocaml, findlib}:
 
 let
-  param =
-    if lib.versionAtLeast ocaml.version "4.02"
-    then {
-      version = "1.10";
-      url = "https://github.com/xavierleroy/camlzip/archive/rel110.tar.gz";
-      sha256 = "X0YcczaQ3lFeJEiTIgjSSZ1zi32KFMtmZsP0FFpyfbI=";
+  common = {
       patches = [];
       postPatchInit = ''
         cp META-zip META-camlzip
         echo 'directory="../zip"' >> META-camlzip
       '';
+  };
+  param =
+    if lib.versionAtLeast ocaml.version "4.07"
+    then common // {
+      version = "1.11";
+      url = "https://github.com/xavierleroy/camlzip/archive/rel111.tar.gz";
+      sha256 = "sha256-/7vF3j4cE9wOWScjdtIy0u3pGzJ1UQY9R/3bdPHV7Tc=";
+    } else if lib.versionAtLeast ocaml.version "4.02"
+    then common // {
+      version = "1.10";
+      url = "https://github.com/xavierleroy/camlzip/archive/rel110.tar.gz";
+      sha256 = "X0YcczaQ3lFeJEiTIgjSSZ1zi32KFMtmZsP0FFpyfbI=";
     } else {
       version = "1.05";
       download_id = "1037";
@@ -25,7 +32,7 @@ let
 in
 
 stdenv.mkDerivation {
-  pname = "camlzip";
+  pname = "ocaml${ocaml.version}-camlzip";
   version = param.version;
 
   src = fetchurl {


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
