### PR TITLE
initrd-network RFC: use kernel DHCP

### DIFF
--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -6,41 +6,6 @@ let
 
   cfg = config.boot.initrd.network;
 
-  dhcpInterfaces = lib.attrNames (lib.filterAttrs (iface: v: v.useDHCP == true) (config.networking.interfaces or {}));
-  doDhcp = config.networking.useDHCP || dhcpInterfaces != [];
-  dhcpIfShellExpr = if config.networking.useDHCP
-                      then "$(ls /sys/class/net/ | grep -v ^lo$)"
-                      else lib.concatMapStringsSep " " lib.escapeShellArg dhcpInterfaces;
-
-  udhcpcScript = pkgs.writeScript "udhcp-script"
-    ''
-      #! /bin/sh
-      if [ "$1" = bound ]; then
-        ip address add "$ip/$mask" dev "$interface"
-        if [ -n "$mtu" ]; then
-          ip link set mtu "$mtu" dev "$interface"
-        fi
-        if [ -n "$staticroutes" ]; then
-          echo "$staticroutes" \
-            | sed -r "s@(\S+) (\S+)@ ip route add \"\1\" via \"\2\" dev \"$interface\" ; @g" \
-            | sed -r "s@ via \"0\.0\.0\.0\"@@g" \
-            | /bin/sh
-        fi
-        if [ -n "$router" ]; then
-          ip route add "$router" dev "$interface" # just in case if "$router" is not within "$ip/$mask" (e.g. Hetzner Cloud)
-          ip route add default via "$router" dev "$interface"
-        fi
-        if [ -n "$dns" ]; then
-          rm -f /etc/resolv.conf
-          for server in $dns; do
-            echo "nameserver $server" >> /etc/resolv.conf
-          done
-        fi
-      fi
-    '';
-
-  udhcpcArgs = toString cfg.udhcpc.extraArgs;
-
 in
 
 {

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -126,7 +126,6 @@ let
     networking = {
       NET                = yes;
       IP_ADVANCED_ROUTER = yes;
-      IP_PNP             = no;
       IP_VS_PROTO_TCP    = yes;
       IP_VS_PROTO_UDP    = yes;
       IP_VS_PROTO_ESP    = yes;
@@ -235,6 +234,12 @@ let
       INFINIBAND = module;
       INFINIBAND_IPOIB = module;
       INFINIBAND_IPOIB_CM = yes;
+
+      # dhcp support for initrd
+      IP_PNP = yes;
+      IP_PNP_DHCP = yes;
+      IP_PNP_BOOTP = yes;
+      IP_PNP_RARP = yes;
     };
 
     wireless = {


### PR DESCRIPTION
###### Description of changes

This is request for comments to add (or reinstate? [it has been disabled at least since 2009](https://github.com/NixOS/nixpkgs/blob/f89876974e58adb47c4d77f3d8ba08abbd38b885/pkgs/top-level/all-packages.nix) cc @edolstra) DHCP for initialization stage 1 use. I successfully booted remote `squashfs` image using [a hack to init-1-sh](https://github.com/NixOS/nixpkgs/commit/649b7bd72098f6bf18695b7611e4fc911d80bfa4). The use-case is related to [booting rootfs systems over 2GB, which coincidentally has a bug currently](https://github.com/NixOS/nixpkgs/issues/203593). These changes are mutually exclusive -- you cannot use `boot.initrd.network.enable` with the kernel module and vice versa -- the configurations will be overwritten and the initrd won't have be able to resolve the network. I have successfully booted a rootfs over 2GB using my current changes.

I think this might be worth upstreaming, because compared to the current implementation, I see corollary benefits to the [`systemd` in init1 phase effort](https://github.com/NixOS/nixpkgs/projects/51) (for networking: see #169116). This is because using the kernel implementation simplifies the network configuration a lot -- the phase 1 `/init` script is not executed _before_ the network is up. This means there is less orchestration needed to wait for the interface to be configured -- which anecdotally is a burden with init1 stage systemd distros like Fedora CoreOS, in which a lot of the `dracut` generated systemd scripts have a dependency on network access. However, it's worth noting that the kernel DHCP implementation does not guarantee that the network will resolve -- DNS has to be configured separately, though this can integrate with already existing DNS configurations in Nix. 

I'm suspect that currently the feature is overlooked, but I might be wrong -- quick Googling shows that in one occasion the functionality to other distros have not been well-received (e.g., [ubuntu](https://groups.google.com/g/linux.debian.kernel/c/vcJnS95EIxQ)). Other threads say that network configuration belongs to the initrd, not the kernel, for which this feature should be disabled. However, I am not sure if I'm convinced that it's necessarily better to have a separate userspace DHCP client in the initrd. The kernel module abides to [the `/proc/cmdline` ip declaration](https://elixir.bootlin.com/linux/latest/source/Documentation/admin-guide/nfs/nfsroot.rst) which seems much easier than making a pick on userland DHCP tool to use, which often do the same thing nonetheless, which is to parse the parameter.

Any thoughts or people to ping? Current changes have not been tested, but are a draft of what I imagine it would roughly look like.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
