### PR TITLE
Add mkdocs-same-dir

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1709,6 +1709,14 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://oprypin.github.io/mkdocs-same-dir">mkdocs-same-dir</link>,
+          a Python plugin for mkdocs to allow placing
+          <literal>mkdocs.yml</literal> in the same directory as
+          documentation.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://netbird.io">netbird</link>, a zero
           configuration VPN. Available as
           <link xlink:href="options.html#opt-services.netbird.enable">services.netbird</link>.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -499,6 +499,8 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - [merecat](https://troglobit.com/projects/merecat/), a small and easy HTTP server based on thttpd. Available as [services.merecat](#opt-services.merecat.enable)
 
+- [mkdocs-same-dir](https://oprypin.github.io/mkdocs-same-dir), a Python plugin for mkdocs to allow placing `mkdocs.yml` in the same directory as documentation.
+
 - [netbird](https://netbird.io), a zero configuration VPN. Available as [services.netbird](options.html#opt-services.netbird.enable).
 
 - [ntfy.sh](https://ntfy.sh), a push notification service. Available as [services.ntfy-sh](#opt-services.ntfy-sh.enable)

--- a/pkgs/development/python-modules/mkdocs-same-dir/default.nix
+++ b/pkgs/development/python-modules/mkdocs-same-dir/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, callPackage
+, buildPythonPackage
+, fetchFromGitHub
+, mkdocs
+, poetry
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-same-dir";
+  version = "v0.1.2";
+
+  disabled = pythonOlder "3.7";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "oprypin";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-U83FAjytrmc3ezIrpGQSesflP6o7/d8FZcqDlCDxmiw=";
+  };
+
+  propagatedBuildInputs = [
+    mkdocs
+    poetry
+  ];
+
+  # No tests for python
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mkdocs"
+  ];
+
+  meta = with lib; {
+    description = "Material for mkdocs-same-dir";
+    homepage = "https://oprypin.github.io/mkdocs-same-dir/";
+    license = licenses.mit;
+    maintainers = [];
+  };
+}


### PR DESCRIPTION
Add the python package mkdocs-same-dir ( https://github.com/oprypin/mkdocs-same-dir ) to nixpkgs.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
