### PR TITLE
[22.11] Release note backports

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -355,7 +355,7 @@
         <para>
           <link xlink:href="https://gitlab.com/CalcProgrammer1/OpenRGB/-/tree/master">OpenRGB</link>,
           a FOSS tool for controlling RGB lighting. Available as
-          <link xlink:href="options.html#opt-services-hardware-openrgb-enable">services.hardware.openrgb.enable</link>.
+          <link xlink:href="options.html#opt-services.hardware.openrgb.enable">services.hardware.openrgb.enable</link>.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -13,6 +13,62 @@
     <itemizedlist>
       <listitem>
         <para>
+          Software that uses the <literal>crypt</literal> password
+          hashing API is now using the implementation provided by
+          <link xlink:href="https://github.com/besser82/libxcrypt"><literal>libxcrypt</literal></link>
+          instead of glibc’s, which enables support for more secure
+          algorithms.
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              Support for algorithms that <literal>libxcrypt</literal>
+              <link xlink:href="https://github.com/besser82/libxcrypt/blob/v4.4.28/lib/hashes.conf#L41">does
+              not consider strong</link> are
+              <emphasis role="strong">deprecated</emphasis> as of this
+              release, and will be removed in NixOS 23.05.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              This includes system login passwords. Given this, we
+              <emphasis role="strong">strongly encourage</emphasis> all
+              users to update their system passwords, as you will be
+              unable to login if password hashes are not migrated by the
+              time their support is removed.
+            </para>
+            <itemizedlist spacing="compact">
+              <listitem>
+                <para>
+                  When using
+                  <literal>users.users.&lt;name&gt;.hashedPassword</literal>
+                  to configure user passwords, run
+                  <literal>mkpasswd</literal>, and use the yescrypt hash
+                  that is provided as the new value.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  On the other hand, for interactively configured user
+                  passwords, simply re-set the passwords for all users
+                  with <literal>passwd</literal>.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  This release introduces warnings for the use of
+                  deprecated hash algorithms for both methods of
+                  configuring passwords. To make sure you migrated
+                  correctly, run
+                  <literal>nixos-rebuild switch</literal>.
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
           GNOME has been upgraded to version 43. Please take a look at
           their <link xlink:href="https://release.gnome.org/43/">Release
           Notes</link> for details.

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1,21 +1,177 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-release-22.11">
   <title>Release 22.11 (“Raccoon”, 2022.11/??)</title>
   <para>
-    Support is planned until the end of June 2023, handing over to
-    23.05.
+    This release is supported until the end of June 2023, handing over
+    to NixOS 23.05.
   </para>
   <section xml:id="sec-release-22.11-highlights">
     <title>Highlights</title>
     <para>
       In addition to numerous new and upgraded packages, this release
-      has the following highlights:
+      includes the following highlights:
     </para>
     <itemizedlist>
       <listitem>
         <para>
-          GNOME has been upgraded to 43. Please take a look at their
-          <link xlink:href="https://release.gnome.org/43/">Release
+          GNOME has been upgraded to version 43. Please take a look at
+          their <link xlink:href="https://release.gnome.org/43/">Release
           Notes</link> for details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          KDE Plasma has been upgraded from v5.24 to v5.26. Please see
+          the release notes for
+          <link xlink:href="https://kde.org/announcements/plasma/5/5.25.0/">v5.25</link>
+          and
+          <link xlink:href="https://kde.org/announcements/plasma/5/5.26.0/">v5.26</link>
+          for more details on the included changes.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Cinnamon has been updated to 5.4, and the Cinnamon module now
+          defaults to Blueman as the Bluetooth manager and slick-greeter
+          as the LightDM greeter, to match upstream.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          PHP now defaults to PHP 8.1, updated from 8.0.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          PHP is now built in <literal>NTS</literal> (Non-Thread Safe)
+          mode by default.
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              For Apache and <literal>mod_php</literal> usage, we enable
+              <literal>ZTS</literal> (Zend Thread Safe) mode. This has
+              been a common practice for a long time in other
+              distributions.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
+          Perl has been updated to 5.36, and its core module
+          <literal>HTTP::Tiny</literal> was patched to verify SSL/TLS
+          certificates by default.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>nscd</literal> functionality, necessary to provide
+          non-glibc-builtin NSS modules (such as
+          <literal>nss_systemd</literal> or <literal>nss_ldap</literal>)
+          can now be provided by <literal>nsncd</literal>, by setting
+          <literal>services.nscd.enableNsncd</literal> to
+          <literal>true</literal>.
+        </para>
+        <para>
+          The <literal>nscd</literal> daemon provided by glibc, which is
+          currently used by NixOS isn’t very reliable. For example, it’s
+          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/135888">not
+          fully possible to disable caching functionality</link>,
+          causing various issues and failed lookups.
+        </para>
+        <para>
+          In contrast to nscd’s behavior of caching module responses on
+          its own, nsncd merely forwards requests to NSS modules, which
+          might cache or not.
+        </para>
+        <para>
+          We plan to use <literal>nsncd</literal> by default in NixOS
+          23.05.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>emacs</literal> package now makes use of native
+          compilation which means:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              Emacs packages from Nixpkgs, builtin or not, will do
+              native compilation ahead of time so you can enjoy the
+              benefit of native compilation without compiling them on
+              you machine;
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Emacs packages from somewhere else, e.g.
+              <literal>package-install</literal>, will perform
+              asynchronously deferred native compilation. If you do not
+              want this, maybe to avoid CPU consumption for compilation,
+              you can use
+              <literal>(setq native-comp-deferred-compilation nil)</literal>
+              to disable it while still benefiting from native
+              compilation for packages from Nixpkgs.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>nixos-generate-config</literal> now generates
+          configurations that can be built in pure mode. This is
+          achieved by setting the new
+          <literal>nixpkgs.hostPlatform</literal> option.
+        </para>
+        <para>
+          You may have to unset the <literal>system</literal> parameter
+          in <literal>lib.nixosSystem</literal>, or similarly remove
+          definitions of the
+          <literal>nixpkgs.{system,localSystem,crossSystem}</literal>
+          options.
+        </para>
+        <para>
+          Alternatively, you can remove the
+          <literal>hostPlatform</literal> line and use NixOS like you
+          would in NixOS 22.05 and earlier.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          It is now possible to generate NixOS images for the Linode
+          cloud provider, via
+          <literal>system.build.linodeImage</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>hardware.nvidia</literal> has a new option,
+          <literal>hardware.nvidia.open</literal>, that can be used to
+          enable the usage of NVIDIA’s open-source kernel driver. Note
+          that the driver’s support for GeForce and Workstation GPUs is
+          still alpha quality, see
+          <link xlink:href="https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/">the
+          release announcement</link> for more information.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </section>
+  <section xml:id="sec-release-22.11-internal">
+    <title>Internal changes</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Improved performances of
+          <literal>lib.closePropagation</literal> which was previously
+          quadratic. This is used in e.g.
+          <literal>ghcWithPackages</literal>. Please see backward
+          incompatibilities notes below.
         </para>
       </listitem>
       <listitem>
@@ -77,97 +233,998 @@
           with any supported NixOS release.
         </para>
       </listitem>
+    </itemizedlist>
+  </section>
+  <section xml:id="sec-release-22.11-incompatibilities">
+    <title>Backward Incompatibilities</title>
+    <itemizedlist>
       <listitem>
         <para>
-          <literal>nscd</literal> functionality, necessary to provide
-          non-glibc-builtin NSS modules (such as
-          <literal>nss_systemd</literal> or <literal>nss_ldap</literal>)
-          can now be provided by <literal>nsncd</literal>, by setting
-          <literal>services.nscd.enableNsncd</literal> to
-          <literal>true</literal>.
-        </para>
-        <para>
-          The <literal>nscd</literal> daemon provided by glibc, which is
-          currently used by NixOS isn’t very reliable. For example, it’s
-          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/135888">not
-          fully possible to disable caching functionality</link>,
-          causing various issues and failed lookups.
-        </para>
-        <para>
-          In contrast to nscd’s behavior of caching module responses on
-          its own, nsncd merely forwards requests to NSS modules, which
-          might cache or not.
-        </para>
-        <para>
-          We plan to use <literal>nsncd</literal> by default in NixOS
-          23.05.
+          Nixpkgs now requires Nix 2.3 or newer.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>emacs</literal> enables native compilation which
-          means:
+          The <literal>isCompatible</literal> predicate checking CPU
+          compatibility is no longer exposed by the platform sets
+          generated using <literal>lib.systems.elaborate</literal>. In
+          most cases you will want to use the new
+          <literal>canExecute</literal> predicate instead which also
+          considers the kernel / syscall interface. It is briefly
+          described in the release’s
+          <link linkend="sec-release-22.11-highlights">highlights
+          section</link>.
+          <literal>lib.systems.parse.isCompatible</literal> still
+          exists, but has changed semantically: Architectures with
+          differing endianness modes are <emphasis>no longer considered
+          compatible</emphasis>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>ngrok</literal> has been upgraded from 2.3.40 to
+          3.0.4. Please see
+          <link xlink:href="https://ngrok.com/docs/guides/upgrade-v2-v3">the
+          upgrade guide</link> and
+          <link xlink:href="https://ngrok.com/docs/ngrok-agent/changelog">changelog</link>.
+          Notably, breaking changes are that the config file format has
+          changed and support for single hyphen arguments was dropped.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>i18n.supportedLocales</literal> is now only generated
+          with the locales set in <literal>i18n.defaultLocale</literal>
+          and <literal>i18n.extraLocaleSettings</literal>.
         </para>
         <itemizedlist spacing="compact">
           <listitem>
             <para>
-              emacs packages from nixpkgs, builtin or not, will do
-              native compilation ahead of time so you can enjoy the
-              benefit of native compilation without compiling them on
-              you machine;
+              This reduces the final system closure size by up to 200MB.
             </para>
           </listitem>
           <listitem>
             <para>
-              emacs packages from somewhere else, e.g.
-              <literal>package-install</literal>, will do asynchronously
-              deferred native compilation. If you do not want this,
-              maybe to avoid CPU consumption for compilation, you can
-              use
-              <literal>(setq native-comp-deferred-compilation nil)</literal>
-              to disable it while still enjoy the benefit of native
-              compilation for packages from nixpkgs.
+              If you require all locales installed, set the option to
+              <literal>[ &quot;all&quot; ]</literal>.
             </para>
           </listitem>
         </itemizedlist>
       </listitem>
       <listitem>
         <para>
-          <literal>nixos-generate-config</literal> now generates
-          configurations that can be built in pure mode. This is
-          achieved by setting the new
-          <literal>nixpkgs.hostPlatform</literal> option.
-        </para>
-        <para>
-          You may have to unset the <literal>system</literal> parameter
-          in <literal>lib.nixosSystem</literal>, or similarly remove
-          definitions of the
-          <literal>nixpkgs.{system,localSystem,crossSystem}</literal>
-          options.
-        </para>
-        <para>
-          Alternatively, you can remove the
-          <literal>hostPlatform</literal> line and use NixOS like you
-          would in NixOS 22.05 and earlier.
+          Deprecated settings <literal>logrotate.paths</literal> and
+          <literal>logrotate.extraConfig</literal> have been removed.
+          Please convert any uses to
+          <link linkend="opt-services.logrotate.settings">services.logrotate.settings</link>
+          instead.
         </para>
       </listitem>
       <listitem>
         <para>
-          PHP now defaults to PHP 8.1, updated from 8.0.
+          The <literal>isPowerPC</literal> predicate, found on
+          <literal>platform</literal> attrsets
+          (<literal>hostPlatform</literal>,
+          <literal>buildPlatform</literal>,
+          <literal>targetPlatform</literal>, etc) has been removed in
+          order to reduce confusion. The predicate was was defined such
+          that it matches only the 32-bit big-endian members of the
+          POWER/PowerPC family, despite having a name which would imply
+          a broader set of systems. If you were using this predicate,
+          you can replace <literal>foo.isPowerPC</literal> with
+          <literal>(with foo; isPower &amp;&amp; is32bit &amp;&amp; isBigEndian)</literal>.
         </para>
       </listitem>
       <listitem>
         <para>
-          PHP is now built <literal>NTS</literal> (Non-Thread Safe)
-          style by default, for Apache and <literal>mod_php</literal>
-          usage we still enable <literal>ZTS</literal> (Zend Thread
-          Safe). This has been a common practice for a long time in
-          other distributions.
+          The <literal>fetchgit</literal> fetcher now uses
+          <link xlink:href="https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalscone_mode_handling">cone
+          mode</link> by default for sparse checkouts.
+          <link xlink:href="https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems">Non-cone
+          mode</link> can be enabled by passing
+          <literal>nonConeMode = true</literal>, but note that non-cone
+          mode is deprecated and this option may be removed alongside a
+          future Git update without notice.
         </para>
       </listitem>
       <listitem>
         <para>
-          PHP 8.2.0 RC 7 is available.
+          The <literal>fetchgit</literal> fetcher supports sparse
+          checkouts via the <literal>sparseCheckout</literal> option.
+          This used to accept a multi-line string with
+          directories/patterns to check out, but now requires a list of
+          strings
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>openssh</literal> was updated to version 9.1,
+          disabling the generation of DSA keys when using
+          <literal>ssh-keygen -A</literal> as they are insecure. Also,
+          <literal>SetEnv</literal> directives in
+          <literal>ssh_config</literal> and
+          <literal>sshd_config</literal> are now first-match-wins
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>bsp-layout</literal> no longer uses the command
+          <literal>cycle</literal> to switch to other window layouts, as
+          it got replaced by the commands <literal>previous</literal>
+          and <literal>next</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The Barco ClickShare driver/client package
+          <literal>pkgs.clickshare-csc1</literal> and the option
+          <literal>programs.clickshare-csc1.enable</literal> have been
+          removed, as it requires <literal>qt4</literal>, which reached
+          its end-of-life 2015 and will no longer be supported by
+          nixpkgs.
+          <link xlink:href="https://www.barco.com/de/support/knowledge-base/4380-can-i-use-linux-os-with-clickshare-base-units">According
+          to Barco</link> many of their base unit models can be used
+          with Google Chrome and the Google Cast extension.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>services.hbase</literal> has been renamed to
+          <literal>services.hbase-standalone</literal>. For production
+          HBase clusters, use <literal>services.hadoop.hbase</literal>
+          instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>p4</literal> package now only includes the
+          open-source Perforce Helix Core command-line client and APIs.
+          It no longer installs the unfree Helix Core Server binaries
+          <literal>p4d</literal>, <literal>p4broker</literal>, and
+          <literal>p4p</literal>. To install the Helix Core Server
+          binaries, use the <literal>p4d</literal> package instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The OpenSSL extension for the PHP interpreter used by
+          Nextcloud is built against OpenSSL 1.1 if
+          <xref linkend="opt-system.stateVersion" /> is below
+          <literal>22.11</literal>. This is to make sure that people
+          using
+          <link xlink:href="https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html">server-side
+          encryption</link> don’t lose access to their files.
+        </para>
+        <para>
+          In any other case, it’s safe to use OpenSSL 3 for PHP’s
+          OpenSSL extension. This can be done by setting
+          <xref linkend="opt-services.nextcloud.enableBrokenCiphersForSSE" />
+          to <literal>false</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>coq</literal> package and versioned variants
+          starting at <literal>coq_8_14</literal> no longer include
+          CoqIDE, which is now available through
+          <literal>coqPackages.coqide</literal>. It is still possible to
+          get CoqIDE as part of the <literal>coq</literal> package by
+          overriding the <literal>buildIde</literal> argument of the
+          derivation.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          PHP 7.4 is no longer supported due to upstream not supporting
+          this version for the entire lifecycle of the 22.11 release.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The ipfs package and module were renamed to kubo. The kubo
+          module now uses an RFC42-style <literal>settings</literal>
+          option instead of <literal>extraConfig</literal> and the
+          <literal>gatewayAddress</literal>,
+          <literal>apiAddress</literal> and
+          <literal>swarmAddress</literal> options were renamed. Using
+          the old names will print a warning but still work.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>pkgs.cosign</literal> does not provide the
+          <literal>cosigned</literal> binary anymore. The
+          <literal>sget</literal> binary has been moved into its own
+          package.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Emacs now uses the Lucid toolkit by default instead of GTK
+          because of stability and compatibility issues. Users who still
+          wish to remain using GTK can do so by using
+          <literal>emacs-gtk</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>kanidm</literal> has been updated to 1.1.0-alpha.10
+          and now requires a TLS certificate and key. It will always
+          start <literal>https</literal> and-–-if enabled-–-an LDAPS
+          server and no HTTP and LDAP server anymore
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          riak package removed along with
+          <literal>services.riak</literal> module, due to lack of
+          maintainer to update the package.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          ppd files in <literal>pkgs.cups-drv-rastertosag-gdi</literal>
+          are now gzipped. If you refer to such a ppd file with its path
+          (e.g. via
+          <link xlink:href="options.html#opt-hardware.printers.ensurePrinters">hardware.printers.ensurePrinters</link>)
+          you will need to append <literal>.gz</literal> to the path.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          xow package removed along with the
+          <literal>hardware.xow</literal> module, due to the project
+          being deprecated in favor of <literal>xone</literal>, which is
+          available via the <literal>hardware.xone</literal> module.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          dd-agent package removed along with the
+          <literal>services.dd-agent</literal> module, due to the
+          project being deprecated in favor of
+          <literal>datadog-agent</literal>, which is available via the
+          <literal>services.datadog-agent</literal> module.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>teleport</literal> has been upgraded to major version
+          10. Please see upstream
+          <link xlink:href="https://goteleport.com/docs/ver/10.0/management/operations/upgrading/">upgrade
+          instructions</link> and
+          <link xlink:href="https://goteleport.com/docs/ver/10.0/changelog/#1000">release
+          notes</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>lib.closePropagation</literal> now needs that all
+          gathered sets have an <literal>outPath</literal> attribute.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          lemmy module option
+          <literal>services.lemmy.settings.database.createLocally</literal>
+          moved to
+          <literal>services.lemmy.database.createLocally</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          virtlyst package and <literal>services.virtlyst</literal>
+          module removed, due to lack of maintainers.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>nix.checkConfig</literal> option now fully
+          disables the config check. The new
+          <literal>nix.checkAllErrors</literal> option behaves like
+          <literal>nix.checkConfig</literal> previously did.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>generateOptparseApplicativeCompletions</literal> and
+          <literal>generateOptparseApplicativeCompletion</literal> from
+          <literal>haskell.lib.compose</literal> (and
+          <literal>haskell.lib</literal>) have been deprecated in favor
+          of <literal>generateOptparseApplicativeCompletions</literal>
+          (plural!) as provided by the haskell package sets (so
+          <literal>haskellPackages.generateOptparseApplicativeCompletions</literal>
+          etc.). The latter allows for cross-compilation (by
+          automatically disabling generation of completion in the cross
+          case). For it to work properly you need to make sure that the
+          function comes from the same context as the package you are
+          trying to override, i.e. always use the same package set as
+          your package is coming from or – even better – use
+          <literal>self.generateOptparseApplicativeCompletions</literal>
+          if you are overriding a haskell package set. The old functions
+          are retained for backwards compatibility, but yield are
+          warning.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>services.graphite.api</literal> and
+          <literal>services.graphite.beacon</literal> NixOS options, and
+          the <literal>python3.pkgs.graphite_api</literal>,
+          <literal>python3.pkgs.graphite_beacon</literal> and
+          <literal>python3.pkgs.influxgraph</literal> packages, have
+          been removed due to lack of upstream maintenance.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>trace</literal> binary from
+          <literal>perf-linux</literal> package has been removed, due to
+          being a duplicate of the <literal>perf</literal> binary.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>aws</literal> package has been removed due to
+          being abandoned by the upstream. It is recommended to use
+          <literal>awscli</literal> or <literal>awscli2</literal>
+          instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The
+          <link xlink:href="https://ce-programming.github.io/CEmu">CEmu
+          TI-84 Plus CE emulator</link> package has been renamed to
+          <literal>cemu-ti</literal>. The
+          <link xlink:href="https://cemu.info">Cemu Wii U
+          emulator</link> is now packaged as <literal>cemu</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>systemd-networkd</literal> v250 deprecated, renamed,
+          and moved some sections and settings which leads to the
+          following breaking module changes:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              <literal>systemd.network.networks.&lt;name&gt;.dhcpV6PrefixDelegationConfig</literal>
+              is renamed to
+              <literal>systemd.network.networks.&lt;name&gt;.dhcpPrefixDelegationConfig</literal>.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>systemd.network.networks.&lt;name&gt;.dhcpV6Config</literal>
+              no longer accepts the
+              <literal>ForceDHCPv6PDOtherInformation=</literal> setting.
+              Please use the <literal>WithoutRA=</literal> and
+              <literal>UseDelegatedPrefix=</literal> settings in your
+              <literal>systemd.network.networks.&lt;name&gt;.dhcpV6Config</literal>
+              and the <literal>DHCPv6Client=</literal> setting in your
+              <literal>systemd.network.networks.&lt;name&gt;.ipv6AcceptRAConfig</literal>
+              to control when the DHCPv6 client is started and how the
+              delegated prefixes are handled by the DHCPv6 client.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>systemd.network.networks.&lt;name&gt;.networkConfig</literal>
+              no longer accepts the <literal>IPv6Token=</literal>
+              setting. Use the <literal>Token=</literal> setting in your
+              <literal>systemd.network.networks.&lt;name&gt;.ipv6AcceptRAConfig</literal>
+              instead. The
+              <literal>systemd.network.networks.&lt;name&gt;.ipv6Prefixes.*.ipv6PrefixConfig</literal>
+              now also accepts the <literal>Token=</literal> setting.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>arangodb</literal> versions 3.3, 3.4, and 3.5 have
+          been removed because they are at EOL upstream. The default is
+          now 3.10.0. Support for aarch64-linux has been removed since
+          the target cannot be built reproducibly. By default
+          <literal>arangodb</literal> is now built for the
+          <literal>haswell</literal> architecture. If you wish to build
+          for a different architecture, you may override the
+          <literal>targetArchitecture</literal> argument with a value
+          from
+          <link xlink:href="https://github.com/arangodb/arangodb/blob/207ec6937e41a46e10aea34953879341f0606841/cmake/OptimizeForArchitecture.cmake#L594">this
+          list supported upstream</link>. Some architecture specific
+          optimizations are also conditionally enabled. You may alter
+          this behavior by overriding the
+          <literal>asmOptimizations</literal> parameter. You may also
+          add additional architecture support by adding more
+          <literal>-DHAS_XYZ</literal> flags to
+          <literal>cmakeFlags</literal> via
+          <literal>overrideAttrs</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>meta.mainProgram</literal> attribute of packages
+          in <literal>wineWowPackages</literal> now defaults to
+          <literal>&quot;wine64&quot;</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>paperless</literal> module now defaults
+          <literal>PAPERLESS_TIME_ZONE</literal> to your configured
+          system timezone.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The top-level <literal>termonad-with-packages</literal> alias
+          for <literal>termonad</literal> has been removed.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Linux 4.9 has been removed because it will reach its end of
+          life within the lifespan of 22.11.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          (Neo)Vim can not be configured with
+          <literal>configure.pathogen</literal> anymore to reduce
+          maintainance burden. Use <literal>configure.packages</literal>
+          instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Neovim can not be configured with plug anymore (still works
+          for vim).
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>adguardhome</literal> module no longer uses
+          <literal>host</literal> and <literal>port</literal> options,
+          use <literal>settings.bind_host</literal> and
+          <literal>settings.bind_port</literal> instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The default <literal>kops</literal> version is now 1.25.1 and
+          support for 1.22 and older has been dropped.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>zrepl</literal> package has been updated from
+          0.5.0 to 0.6.0. See the
+          <link xlink:href="https://zrepl.github.io/changelog.html">changelog</link>
+          for details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>k3s</literal> no longer supports Docker as runtime
+          due to upstream dropping support.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>cassandra_2_1</literal> and
+          <literal>cassandra_2_2</literal> have been removed. Please
+          update to <literal>cassandra_3_11</literal> or
+          <literal>cassandra_3_0</literal>. See the
+          <link xlink:href="https://github.com/apache/cassandra/blob/cassandra-3.11.14/NEWS.txt">changelog</link>
+          for more information about the upgrade process.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>mysql57</literal> has been removed. Please update to
+          <literal>mysql80</literal> or <literal>mariadb</literal>. See
+          the
+          <link xlink:href="https://mariadb.com/kb/en/upgrading-from-mysql-to-mariadb/">upgrade
+          guide</link> for more information.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Consequently, <literal>cqrlog</literal> and
+          <literal>amorok</literal> now use <literal>mariadb</literal>
+          instead of <literal>mysql57</literal> for their embedded
+          databases. Running <literal>mysql_upgrade</literal> may be
+          neccesary.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>k3s</literal> supports <literal>clusterInit</literal>
+          option, and it is enabled by default, for servers.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>percona-server56</literal> has been removed. Please
+          migrate to <literal>mysql</literal> or
+          <literal>mariadb</literal> if possible.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>obs-studio</literal> hase been updated to version 28.
+          If you have packaged custom plugins, check if they are
+          compatible. <literal>obs-websocket</literal> has been
+          integrated into <literal>obs-studio</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>signald</literal> has been bumped to
+          <literal>0.23.0</literal>. For the upgrade, a migration
+          process is necessary. It can be done by running a command like
+          this before starting <literal>signald.service</literal>:
+        </para>
+        <programlisting>
+signald -d /var/lib/signald/db \
+  --database sqlite:/var/lib/signald/db \
+  --migrate-data
+</programlisting>
+        <para>
+          For further information, please read the upstream changelogs.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>stylua</literal> no longer accepts
+          <literal>lua52Support</literal> and
+          <literal>luauSupport</literal> overrides. Use
+          <literal>features</literal> instead, which defaults to
+          <literal>[ &quot;lua54&quot; &quot;luau&quot; ]</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>ocamlPackages.ocaml_extlib</literal> has been renamed
+          to <literal>ocamlPackages.extlib</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>pkgs.fetchNextcloudApp</literal> has been rewritten
+          to circumvent impurities in e.g. tarballs from GitHub and to
+          make it easier to apply patches. This means that your hashes
+          are out-of-date and the (previously required) attributes
+          <literal>name</literal> and <literal>version</literal> are no
+          longer accepted.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The Syncthing service now only allows absolute paths—starting
+          with <literal>/</literal> or <literal>~/</literal>—for
+          <literal>services.syncthing.folders.&lt;name&gt;.path</literal>.
+          In a future release other paths will be allowed again and
+          interpreted relative to
+          <literal>services.syncthing.dataDir</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>services.github-runner</literal> and
+          <literal>services.github-runners.&lt;name&gt;</literal> gained
+          the option <literal>serviceOverrides</literal> which allows
+          overriding the systemd <literal>serviceConfig</literal>. If
+          you have been overriding the systemd service configuration
+          (i.e., by defining
+          <literal>systemd.services.github-runner.serviceConfig</literal>),
+          you have to use the <literal>serviceOverrides</literal> option
+          now. Example:
+        </para>
+        <programlisting>
+services.github-runner.serviceOverrides.SupplementaryGroups = [
+  &quot;docker&quot;
+];
+</programlisting>
+      </listitem>
+    </itemizedlist>
+  </section>
+  <section xml:id="sec-release-22.11-notable-changes">
+    <title>Other Notable Changes</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <literal>firefox</literal>, <literal>thunderbird</literal> and
+          <literal>librewolf</literal> now come with Wayland support by
+          default. The <literal>firefox-wayland</literal>,
+          <literal>firefox-esr-wayland</literal>,
+          <literal>thunderbird-wayland</literal> and
+          <literal>librewolf-wayland</literal> attributes are obsolete
+          and have been aliased to their generic attribute.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>xplr</literal> package has been updated from
+          0.18.0 to 0.19.0, which brings some breaking changes. See the
+          <link xlink:href="https://github.com/sayanarijit/xplr/releases/tag/v0.19.0">upstream
+          release notes</link> for more details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Configuring multiple GitHub runners is now possible through
+          <literal>services.github-runners.&lt;name&gt;</literal>. The
+          options under <literal>services.github-runner</literal>
+          remain, to configure a single runner.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>github-runner</literal> gained support for ephemeral
+          runners and registrations using a personal access token (PAT)
+          instead of a registration token. See
+          <literal>services.github-runner.ephemeral</literal> and
+          <literal>services.github-runner.tokenFile</literal> for
+          details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          A new module was added to provide hardware support for the
+          Saleae Logic device family, providing the options
+          <literal>hardware.saleae-logic.enable</literal> and
+          <literal>hardware.saleae-logic.package</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          ZFS module will no longer allow hibernation by default.
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              This is a safety measure to prevent data loss cases like
+              the ones described at
+              <link xlink:href="https://github.com/openzfs/zfs/issues/260">OpenZFS/260</link>
+              and
+              <link xlink:href="https://github.com/openzfs/zfs/issues/12842">OpenZFS/12842</link>.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Use the <literal>boot.zfs.allowHibernation</literal>
+              option to configure this behaviour.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
+          Mastodon now automatically removes remote media attachments
+          older than 30 days. This is configurable through
+          <literal>services.mastodon.mediaAutoRemove</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The Redis module now disables RDB persistence when
+          <literal>services.redis.servers.&lt;name&gt;.save = []</literal>
+          instead of using the Redis default.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Neo4j was updated from version 3 to version 4. See upstream’s
+          <link xlink:href="https://neo4j.com/docs/upgrade-migration-guide/current/">migration
+          guide</link> for information on how to migrate your instance.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>networking.wireguard</literal> module now can set
+          the mtu on interfaces and tag its packets with an fwmark.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The option <literal>overrideStrategy</literal> was added to
+          the different systemd unit options
+          (<literal>systemd.services.&lt;name&gt;</literal>,
+          <literal>systemd.sockets.&lt;name&gt;</literal>, …) to allow
+          enforcing the creation of a dropin file, rather than the main
+          unit file, by setting it to <literal>asDropin</literal>. This
+          is useful in cases where the existence of the main unit file
+          is not known to Nix at evaluation time, for example when the
+          main unit file is provided by adding a package to
+          <literal>systemd.packages</literal>. See the fix proposed in
+          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/135557#issuecomment-1295392470">NixOS’s
+          systemd abstraction doesn’t work with systemd template
+          units</link> for an example.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>polymc</literal> package has been removed due to
+          a rogue maintainer. It has been replaced by
+          <literal>prismlauncher</literal>, a fork by the rest of the
+          maintainers. For more details, see
+          <link xlink:href="https://github.com/NixOS/nixpkgs/pull/196624">the
+          PR that made this change</link> and
+          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/196460">the
+          issue detailing the vulnerability</link>. Users with existing
+          installations should rename
+          <literal>~/.local/share/polymc</literal> to
+          <literal>~/.local/share/PrismLauncher</literal>. The main
+          config file’s path has also moved from
+          <literal>~/.local/share/polymc/polymc.cfg</literal> to
+          <literal>~/.local/share/PrismLauncher/prismlauncher.cfg</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>bloat</literal> package has been updated from
+          unstable-2022-03-31 to unstable-2022-10-25, which brings a
+          breaking change. See
+          <link xlink:href="https://git.freesoftwareextremist.com/bloat/commit/?id=887ed241d64ba5db3fd3d87194fb5595e5ad7d73">this
+          upstream commit message</link> for details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Synapse’s systemd unit has been hardened.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The module <literal>services.grafana</literal> was refactored
+          to be compliant with
+          <link xlink:href="https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md">RFC
+          0042</link>. To be precise, this means that the following
+          things have changed:
+        </para>
+        <itemizedlist>
+          <listitem>
+            <para>
+              The newly introduced option
+              <xref linkend="opt-services.grafana.settings" /> is an
+              attribute-set that will be converted into Grafana’s INI
+              format. This means that the configuration from
+              <link xlink:href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/">Grafana’s
+              configuration reference</link> can be directly written as
+              attribute-set in Nix within this option.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              The option
+              <literal>services.grafana.extraOptions</literal> has been
+              removed. This option was an association of environment
+              variables for Grafana. If you had an expression like
+            </para>
+            <programlisting language="bash">
+{
+  services.grafana.extraOptions.SECURITY_ADMIN_USER = &quot;foobar&quot;;
+}
+</programlisting>
+            <para>
+              your Grafana instance was running with
+              <literal>GF_SECURITY_ADMIN_USER=foobar</literal> in its
+              environment.
+            </para>
+            <para>
+              For the migration, it is recommended to turn it into the
+              INI format, i.e. to declare
+            </para>
+            <programlisting language="bash">
+{
+  services.grafana.settings.security.admin_user = &quot;foobar&quot;;
+}
+</programlisting>
+            <para>
+              instead.
+            </para>
+            <para>
+              The keys in
+              <literal>services.grafana.extraOptions</literal> have the
+              format
+              <literal>&lt;INI section name&gt;_&lt;Key Name&gt;</literal>.
+              Further details are outlined in the
+              <link xlink:href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables">configuration
+              reference</link>.
+            </para>
+            <para>
+              Alternatively you can also set all your values from
+              <literal>extraOptions</literal> to
+              <literal>systemd.services.grafana.environment</literal>,
+              make sure you don’t forget to add the
+              <literal>GF_</literal> prefix though!
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Previously, the options
+              <xref linkend="opt-services.grafana.provision.datasources" />
+              and
+              <xref linkend="opt-services.grafana.provision.dashboards" />
+              expected lists of datasources or dashboards for the
+              <link xlink:href="https://grafana.com/docs/grafana/latest/administration/provisioning/">declarative
+              provisioning</link>.
+            </para>
+            <para>
+              To declare lists of
+            </para>
+            <itemizedlist spacing="compact">
+              <listitem>
+                <para>
+                  <emphasis role="strong">datasources</emphasis>, please
+                  rename your declarations to
+                  <xref linkend="opt-services.grafana.provision.datasources.settings.datasources" />.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  <emphasis role="strong">dashboards</emphasis>, please
+                  rename your declarations to
+                  <xref linkend="opt-services.grafana.provision.dashboards.settings.providers" />.
+                </para>
+              </listitem>
+            </itemizedlist>
+            <para>
+              This change was made to support more features for that:
+            </para>
+            <itemizedlist>
+              <listitem>
+                <para>
+                  It’s possible to declare the
+                  <literal>apiVersion</literal> of your dashboards and
+                  datasources by
+                  <xref linkend="opt-services.grafana.provision.datasources.settings.apiVersion" />
+                  (or
+                  <xref linkend="opt-services.grafana.provision.dashboards.settings.apiVersion" />).
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  Instead of declaring datasources and dashboards in
+                  pure Nix, it’s also possible to specify configuration
+                  files (or directories) with YAML instead using
+                  <xref linkend="opt-services.grafana.provision.datasources.path" />
+                  (or
+                  <xref linkend="opt-services.grafana.provision.dashboards.path" />.
+                  This is useful when having provisioning files from
+                  non-NixOS Grafana instances that you also want to
+                  deploy to NixOS.
+                </para>
+                <para>
+                  <emphasis role="strong">Note:</emphasis> secrets from
+                  these files will be leaked into the store unless you
+                  use a
+                  <link xlink:href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#file-provider"><emphasis role="strong">file</emphasis>-provider
+                  or env-var</link> for secrets!
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  <xref linkend="opt-services.grafana.provision.notifiers" />
+                  is not affected by this change because this feature is
+                  deprecated by Grafana and will probably removed in
+                  Grafana 10. It’s recommended to use
+                  <literal>services.grafana.provision.alerting.contactPoints</literal>
+                  instead.
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>services.grafana.provision.alerting</literal>
+          option was added. It includes suboptions for every
+          alerting-related objects (with the exception of
+          <literal>notifiers</literal>), which means it’s now possible
+          to configure modern Grafana alerting declaratively.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Synapse now requires entries in the
+          <literal>state_group_edges</literal> table to be unique, in
+          order to prevent accidentally introducing duplicate
+          information (for example, because a database backup was
+          restored multiple times). If your Synapse database already has
+          duplicate rows in this table, this could fail with an error
+          and require manual remediation.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>diamond</literal> package has been update from
+          0.8.36 to 2.0.15. See the
+          <link xlink:href="https://github.com/bbuchfink/diamond/releases">upstream
+          release notes</link> for more details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>guake</literal> package has been updated from
+          3.6.3 to 3.9.0, see the
+          <link xlink:href="https://github.com/Guake/guake/releases">changelog</link>
+          for more details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>netlify-cli</literal> package has been updated
+          from 6.13.2 to 12.2.4, see the
+          <link xlink:href="https://github.com/netlify/cli/releases">changelog</link>
+          for more details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>dockerTools.buildImage</literal>’s
+          <literal>contents</literal> parameter has been deprecated in
+          favor of <literal>copyToRoot</literal>. Use
+          <literal>copyToRoot = buildEnv { ... };</literal> or similar
+          if you intend to add packages to <literal>/bin</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>proxmox.qemuConf.bios</literal> option was added,
+          it corresponds to <literal>Hardware-&gt;BIOS</literal> field
+          in Proxmox web interface. Use
+          <literal>&quot;ovmf&quot;</literal> value to build UEFI image,
+          default value remains <literal>&quot;bios&quot;</literal>. New
+          option <literal>proxmox.partitionTableType</literal> defaults
+          to either <literal>&quot;legacy&quot;</literal> or
+          <literal>&quot;efi&quot;</literal>, depending on the
+          <literal>bios</literal> value. Setting
+          <literal>partitionTableType</literal> to
+          <literal>&quot;hybrid&quot;</literal> results in an image,
+          which supports both methods
+          (<literal>&quot;bios&quot;</literal> and
+          <literal>&quot;ovmf&quot;</literal>), thereby remaining
+          bootable after change to Proxmox
+          <literal>Hardware-&gt;BIOS</literal> field.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2.
+          It is now the upstream version from https://www.memtest.org/,
+          as coreboot’s fork is no longer available.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Option descriptions, examples, and defaults writting in
+          DocBook are now deprecated. Using CommonMark is preferred and
+          will become the default in a future release.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The
+          <literal>documentation.nixos.options.allowDocBook</literal>
+          option was added to ease the transition to CommonMark option
+          documentation. Setting this option to <literal>false</literal>
+          causes an error for every option included in the manual that
+          uses DocBook documentation; it defaults to
+          <literal>true</literal> to preserve the previous behavior and
+          will be removed once the transition to CommonMark is complete.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The Redis module now persists each instance’s configuration
+          file in the state directory, in order to support some more
+          advanced use cases like Sentinel.
         </para>
       </listitem>
       <listitem>
@@ -179,49 +1236,214 @@
       </listitem>
       <listitem>
         <para>
-          Perl has been updated to 5.36, and its core module
-          <literal>HTTP::Tiny</literal> was patched to verify SSL/TLS
-          certificates by default.
+          The udisks2 service, available at
+          <literal>services.udisks2.enable</literal>, is now disabled by
+          default. It will automatically be enabled through services and
+          desktop environments as needed. This also means that polkit
+          will now actually be disabled by default. The default for
+          <literal>security.polkit.enable</literal> was already flipped
+          in the previous release, but udisks2 being enabled by default
+          re-enabled it.
         </para>
       </listitem>
       <listitem>
         <para>
-          Improved performances of
-          <literal>lib.closePropagation</literal> which was previously
-          quadratic. This is used in e.g.
-          <literal>ghcWithPackages</literal>. Please see backward
-          incompatibilities notes below.
+          Nextcloud has been updated to version
+          <emphasis role="strong">25</emphasis>. Additionally the
+          following things have changed for Nextcloud in NixOS:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              For Nextcloud <emphasis role="strong">&gt;=24</emphasis>,
+              the default PHP version is 8.1.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Nextcloud <emphasis role="strong">23</emphasis> has been
+              removed since it will reach its
+              <link xlink:href="https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule/d76576a12a626d53305d480a6065b57cab705d3d">end
+              of life in December 2022</link>.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              If <literal>system.stateVersion</literal> is
+              <emphasis role="strong">&gt;=22.11</emphasis>, Nextcloud
+              25 will be installed by default. For older versions,
+              Nextcloud 24 will be installed.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Please ensure that you only upgrade one major release at a
+              time! Nextcloud doesn’t support upgrades across multiple
+              versions, i.e. an upgrade from
+              <emphasis role="strong">23</emphasis> to
+              <emphasis role="strong">25</emphasis> is only possible
+              when upgrading to <emphasis role="strong">24</emphasis>
+              first.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
+          systemd-oomd is enabled by default. Depending on which systemd
+          units have <literal>ManagedOOMSwap=kill</literal> or
+          <literal>ManagedOOMMemoryPressure=kill</literal>, systemd-oomd
+          will SIGKILL all the processes under the appropriate
+          descendant cgroups when the configured limits are exceeded.
+          NixOS does currently not configure cgroups with oomd by
+          default, this can be enabled using
+          <link xlink:href="options.html#opt-systemd.oomd.enableRootSlice">systemd.oomd.enableRootSlice</link>,
+          <link xlink:href="options.html#opt-systemd.oomd.enableSystemSlice">systemd.oomd.enableSystemSlice</link>,
+          and
+          <link xlink:href="options.html#opt-systemd.oomd.enableUserServices">systemd.oomd.enableUserServices</link>.
         </para>
       </listitem>
       <listitem>
         <para>
-          Cinnamon has been updated to 5.4. While at it, the cinnamon
-          module now defaults to blueman as bluetooth manager and
-          slick-greeter as lightdm greeter to match upstream.
+          The <literal>tt-rss</literal> service performs two database
+          migrations when you first use its web UI after upgrade.
+          Consider backing up its database before updating.
         </para>
       </listitem>
       <listitem>
         <para>
-          OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
+          The <literal>pass-secret-service</literal> package now
+          includes systemd units from upstream, so adding it to the
+          NixOS <literal>services.dbus.packages</literal> option will
+          make it start automatically as a systemd user service when an
+          application tries to talk to the libsecret D-Bus API.
         </para>
       </listitem>
       <listitem>
         <para>
-          An image configuration and generator has been added for Linode
-          images, largely based on the present GCE configuration and
-          image.
+          The Wordpress module now has support for installing language
+          packs through a new option,
+          <literal>services.wordpress.sites.&lt;site&gt;.languages</literal>.
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>hardware.nvidia</literal> has a new option
-          <literal>open</literal> that can be used to opt in the
-          opensource version of NVIDIA kernel driver. Note that the
-          driver’s support for GeForce and Workstation GPUs is still
-          alpha quality, see
-          <link xlink:href="https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/">NVIDIA
-          Releases Open-Source GPU Kernel Modules</link> for the
-          official announcement.
+          The default package for
+          <literal>services.mullvad-vpn.package</literal> was changed to
+          <literal>pkgs.mullvad</literal>, allowing cross-platform usage
+          of Mullvad. <literal>pkgs.mullvad</literal> only contains the
+          Mullvad CLI tool, so users who rely on the Mullvad GUI will
+          want to change it back to <literal>pkgs.mullvad-vpn</literal>,
+          or add <literal>pkgs.mullvad-vpn</literal> to their
+          environment.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          PowerDNS has been updated from v4.6.2 to v4.7.2. Please be
+          sure to review the
+          <link xlink:href="https://doc.powerdns.com/authoritative/upgrading.html#to-4-7-0-or-master">Upgrade
+          Notes</link> provided by upstream before upgrading. Worth
+          specifically noting is that the new Catalog Zones feature
+          comes with a mandatory schema change for the GSQL database
+          backends, which has to be manually applied.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          There is a new module for the <literal>thunar</literal>
+          program (the Xfce file manager), which depends on the
+          <literal>xfconf</literal> dbus service, and also has a dbus
+          service and a systemd unit. The option
+          <literal>services.xserver.desktopManager.xfce.thunarPlugins</literal>
+          has been renamed to
+          <literal>programs.thunar.plugins</literal>, and may be removed
+          in a future release.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          There is a new module for <literal>xfconf</literal> (the Xfce
+          configuration storage system), which has a dbus service.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The Mastodon package has been upgraded to v4.0.0. See the
+          <link xlink:href="https://github.com/mastodon/mastodon/releases/tag/v4.0.0">v4.0.0
+          release notes</link> for a list of changes. On standard
+          setups, no manual migration steps are required. Nevertheless,
+          a database backup is recommended.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>nomad</literal> package now defaults to v1.3,
+          which no longer has a downgrade path to v1.2 or older.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>nodePackages</literal> package set now defaults
+          to the LTS release in the <literal>nodejs</literal> package
+          again, instead of being pinned to
+          <literal>nodejs-14_x</literal>. Several updates to node2nix
+          have been made for compatibility with newer Node.js and npm
+          versions and a new <literal>postRebuild</literal> hook has
+          been added for packages to perform extra build steps before
+          the npm install step prunes dev dependencies.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>boot.kernel.sysctl</literal> is defined as a
+          freeformType and adds a custom merge option for
+          <literal>net.core.rmem_max</literal> (taking the highest value
+          defined to avoid conflicts between 2 services trying to set
+          that value).
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>mame</literal> package does not ship with its
+          tools anymore in the default output. They were moved to a
+          separate <literal>tools</literal> output instead. For
+          convenience, <literal>mame-tools</literal> package was added
+          for those who want to use it.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          A NixOS module for Firefox has been added which allows
+          preferences and
+          <link xlink:href="https://github.com/mozilla/policy-templates/blob/master/README.md">policies</link>
+          to be set. This also allows extensions to be installed via the
+          <literal>ExtensionSettings</literal> policy. The new options
+          are under <literal>programs.firefox</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The option
+          <literal>services.picom.experimentalBackends</literal> was
+          removed since it is now the default and the option will cause
+          <literal>picom</literal> to quit instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>haskellPackage.callHackage</literal> is not always
+          invalidated if <literal>all-cabal-hashes</literal> changes,
+          leading to less rebuilds of haskell dependencies.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>haskellPackages.callHackage</literal> and
+          <literal>haskellPackages.callCabal2nix</literal> (and related
+          functions) no longer keep a reference to the
+          <literal>cabal2nix</literal> call used to generate them. As a
+          result, they will be garbage collected more often.
         </para>
       </listitem>
     </itemizedlist>
@@ -528,1229 +1750,6 @@
           fast, simple, hackable OSM map viewer for mobile and desktop
           Linux. Available as
           <link linkend="opt-programs.mepo.enable">programs.mepo.enable</link>.
-        </para>
-      </listitem>
-    </itemizedlist>
-  </section>
-  <section xml:id="sec-release-22.11-incompatibilities">
-    <title>Backward Incompatibilities</title>
-    <itemizedlist>
-      <listitem>
-        <para>
-          Nixpkgs now requires Nix 2.3 or newer.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>isCompatible</literal> predicate checking CPU
-          compatibility is no longer exposed by the platform sets
-          generated using <literal>lib.systems.elaborate</literal>. In
-          most cases you will want to use the new
-          <literal>canExecute</literal> predicate instead which also
-          considers the kernel / syscall interface. It is briefly
-          described in the release’s
-          <link linkend="sec-release-22.11-highlights">highlights
-          section</link>.
-          <literal>lib.systems.parse.isCompatible</literal> still
-          exists, but has changed semantically: Architectures with
-          differing endianness modes are <emphasis>no longer considered
-          compatible</emphasis>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>ngrok</literal> has been upgraded from 2.3.40 to
-          3.0.4. Please see
-          <link xlink:href="https://ngrok.com/docs/guides/upgrade-v2-v3">the
-          upgrade guide</link> and
-          <link xlink:href="https://ngrok.com/docs/ngrok-agent/changelog">changelog</link>.
-          Notably, breaking changes are that the config file format has
-          changed and support for single hypen arguments was dropped.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>i18n.supportedLocales</literal> is now by default
-          only generated with the locales set in
-          <literal>i18n.defaultLocale</literal> and
-          <literal>i18n.extraLocaleSettings</literal>. This got
-          partially copied over from the minimal profile and reduces the
-          final system size by up to 200MB. If you require all locales
-          installed set the option to
-          <literal>[ &quot;all&quot; ]</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Deprecated settings <literal>logrotate.paths</literal> and
-          <literal>logrotate.extraConfig</literal> have been removed.
-          Please convert any uses to
-          <link linkend="opt-services.logrotate.settings">services.logrotate.settings</link>
-          instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>isPowerPC</literal> predicate, found on
-          <literal>platform</literal> attrsets
-          (<literal>hostPlatform</literal>,
-          <literal>buildPlatform</literal>,
-          <literal>targetPlatform</literal>, etc) has been removed in
-          order to reduce confusion. The predicate was was defined such
-          that it matches only the 32-bit big-endian members of the
-          POWER/PowerPC family, despite having a name which would imply
-          a broader set of systems. If you were using this predicate,
-          you can replace <literal>foo.isPowerPC</literal> with
-          <literal>(with foo; isPower &amp;&amp; is32bit &amp;&amp; isBigEndian)</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>fetchgit</literal> fetcher now uses
-          <link xlink:href="https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalscone_mode_handling">cone
-          mode</link> by default for sparse checkouts.
-          <link xlink:href="https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems">Non-cone
-          mode</link> can be enabled by passing
-          <literal>nonConeMode = true</literal>, but note that non-cone
-          mode is deprecated and this option may be removed alongside a
-          future Git update without notice.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>fetchgit</literal> fetcher supports sparse
-          checkouts via the <literal>sparseCheckout</literal> option.
-          This used to accept a multi-line string with
-          directories/patterns to check out, but now requires a list of
-          strings.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>openssh</literal> was updated to version 9.1,
-          disabling the generation of DSA keys when using
-          <literal>ssh-keygen -A</literal> as they are insecure. Also,
-          <literal>SetEnv</literal> directives in
-          <literal>ssh_config</literal> and
-          <literal>sshd_config</literal> are now first-match-wins
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>bsp-layout</literal> no longer uses the command
-          <literal>cycle</literal> to switch to other window layouts, as
-          it got replaced by the commands <literal>previous</literal>
-          and <literal>next</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The Barco ClickShare driver/client package
-          <literal>pkgs.clickshare-csc1</literal> and the option
-          <literal>programs.clickshare-csc1.enable</literal> have been
-          removed, as it requires <literal>qt4</literal>, which reached
-          its end-of-life 2015 and will no longer be supported by
-          nixpkgs.
-          <link xlink:href="https://www.barco.com/de/support/knowledge-base/4380-can-i-use-linux-os-with-clickshare-base-units">According
-          to Barco</link> many of their base unit models can be used
-          with Google Chrome and the Google Cast extension.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>services.hbase</literal> has been renamed to
-          <literal>services.hbase-standalone</literal>. For production
-          HBase clusters, use <literal>services.hadoop.hbase</literal>
-          instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>p4</literal> package now only includes the
-          open-source Perforce Helix Core command-line client and APIs.
-          It no longer installs the unfree Helix Core Server binaries
-          <literal>p4d</literal>, <literal>p4broker</literal>, and
-          <literal>p4p</literal>. To install the Helix Core Server
-          binaries, use the <literal>p4d</literal> package instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>openssl</literal>-extension for the PHP
-          interpreter used by Nextcloud is built against OpenSSL 1.1 if
-          <xref linkend="opt-system.stateVersion" /> is below
-          <literal>22.11</literal>. This is to make sure that people
-          using
-          <link xlink:href="https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html">server-side
-          encryption</link> don’t lose access to their files.
-        </para>
-        <para>
-          In any other case it’s safe to use OpenSSL 3 for PHP’s openssl
-          extension. This can be done by setting
-          <xref linkend="opt-services.nextcloud.enableBrokenCiphersForSSE" />
-          to <literal>false</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>coq</literal> package and versioned variants
-          starting at <literal>coq_8_14</literal> no longer include
-          CoqIDE, which is now available through
-          <literal>coqPackages.coqide</literal>. It is still possible to
-          get CoqIDE as part of the <literal>coq</literal> package by
-          overriding the <literal>buildIde</literal> argument of the
-          derivation.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          PHP 7.4 is no longer supported due to upstream not supporting
-          this version for the entire lifecycle of the 22.11 release.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The ipfs package and module were renamed to kubo. The kubo
-          module now uses an RFC42-style <literal>settings</literal>
-          option instead of <literal>extraConfig</literal> and the
-          <literal>gatewayAddress</literal>,
-          <literal>apiAddress</literal> and
-          <literal>swarmAddress</literal> options were renamed. Using
-          the old names will print a warning but still work.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>pkgs.cosign</literal> does not provide the
-          <literal>cosigned</literal> binary anymore. The
-          <literal>sget</literal> binary has been moved into its own
-          package.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Emacs now uses the Lucid toolkit by default instead of GTK
-          because of stability and compatibility issues. Users who still
-          wish to remain using GTK can do so by using
-          <literal>emacs-gtk</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>kanidm</literal> has been updated to 1.1.0-alpha.10
-          and now requires a tls certificate and key. It will always
-          start an https and – if enabled – an ldaps server and no http
-          and ldap server anymore.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          riak package removed along with
-          <literal>services.riak</literal> module, due to lack of
-          maintainer to update the package.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          ppd files in <literal>pkgs.cups-drv-rastertosag-gdi</literal>
-          are now gzipped. If you refer to such a ppd file with its path
-          (e.g. via
-          <link xlink:href="options.html#opt-hardware.printers.ensurePrinters">hardware.printers.ensurePrinters</link>)
-          you will need to append <literal>.gz</literal> to the path.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          xow package removed along with the
-          <literal>hardware.xow</literal> module, due to the project
-          being deprecated in favor of <literal>xone</literal>, which is
-          available via the <literal>hardware.xone</literal> module.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          dd-agent package removed along with the
-          <literal>services.dd-agent</literal> module, due to the
-          project being deprecated in favor of
-          <literal>datadog-agent</literal>, which is available via the
-          <literal>services.datadog-agent</literal> module.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>teleport</literal> has been upgraded to major version
-          10. Please see upstream
-          <link xlink:href="https://goteleport.com/docs/ver/10.0/management/operations/upgrading/">upgrade
-          instructions</link> and
-          <link xlink:href="https://goteleport.com/docs/ver/10.0/changelog/#1000">release
-          notes</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>lib.closePropagation</literal> now needs that all
-          gathered sets have an <literal>outPath</literal> attribute.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          lemmy module option
-          <literal>services.lemmy.settings.database.createLocally</literal>
-          moved to
-          <literal>services.lemmy.database.createLocally</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          virtlyst package and <literal>services.virtlyst</literal>
-          module removed, due to lack of maintainers.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>nix.checkConfig</literal> option now fully
-          disables the config check. The new
-          <literal>nix.checkAllErrors</literal> option behaves like
-          <literal>nix.checkConfig</literal> previously did.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>nix.buildMachines</literal> got a new submodule
-          option <literal>protocol</literal>. An undocumented hack to
-          set the protocol via <literal>hostName</literal> is no longer
-          working and the <literal>protocol</literal> option should be
-          used instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>generateOptparseApplicativeCompletions</literal> and
-          <literal>generateOptparseApplicativeCompletion</literal> from
-          <literal>haskell.lib.compose</literal> (and
-          <literal>haskell.lib</literal>) have been deprecated in favor
-          of <literal>generateOptparseApplicativeCompletions</literal>
-          (plural!) as provided by the haskell package sets (so
-          <literal>haskellPackages.generateOptparseApplicativeCompletions</literal>
-          etc.). The latter allows for cross-compilation (by
-          automatically disabling generation of completion in the cross
-          case). For it to work properly you need to make sure that the
-          function comes from the same context as the package you are
-          trying to override, i.e. always use the same package set as
-          your package is coming from or – even better – use
-          <literal>self.generateOptparseApplicativeCompletions</literal>
-          if you are overriding a haskell package set. The old functions
-          are retained for backwards compatibility, but yield are
-          warning.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>services.graphite.api</literal> and
-          <literal>services.graphite.beacon</literal> NixOS options, and
-          the <literal>python3.pkgs.graphite_api</literal>,
-          <literal>python3.pkgs.graphite_beacon</literal> and
-          <literal>python3.pkgs.influxgraph</literal> packages, have
-          been removed due to lack of upstream maintenance.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>trace</literal> binary from
-          <literal>perf-linux</literal> package has been removed, due to
-          being a duplicate of the <literal>perf</literal> binary.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>aws</literal> package has been removed due to
-          being abandoned by the upstream. It is recommended to use
-          <literal>awscli</literal> or <literal>awscli2</literal>
-          instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The
-          <link xlink:href="https://ce-programming.github.io/CEmu">CEmu
-          TI-84 Plus CE emulator</link> package has been renamed to
-          <literal>cemu-ti</literal>. The
-          <link xlink:href="https://cemu.info">Cemu Wii U
-          emulator</link> is now packaged as <literal>cemu</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>systemd-networkd</literal> v250 deprecated, renamed,
-          and moved some sections and settings which leads to the
-          following breaking module changes:
-        </para>
-        <itemizedlist spacing="compact">
-          <listitem>
-            <para>
-              <literal>systemd.network.networks.&lt;name&gt;.dhcpV6PrefixDelegationConfig</literal>
-              is renamed to
-              <literal>systemd.network.networks.&lt;name&gt;.dhcpPrefixDelegationConfig</literal>.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              <literal>systemd.network.networks.&lt;name&gt;.dhcpV6Config</literal>
-              no longer accepts the
-              <literal>ForceDHCPv6PDOtherInformation=</literal> setting.
-              Please use the <literal>WithoutRA=</literal> and
-              <literal>UseDelegatedPrefix=</literal> settings in your
-              <literal>systemd.network.networks.&lt;name&gt;.dhcpV6Config</literal>
-              and the <literal>DHCPv6Client=</literal> setting in your
-              <literal>systemd.network.networks.&lt;name&gt;.ipv6AcceptRAConfig</literal>
-              to control when the DHCPv6 client is started and how the
-              delegated prefixes are handled by the DHCPv6 client.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              <literal>systemd.network.networks.&lt;name&gt;.networkConfig</literal>
-              no longer accepts the <literal>IPv6Token=</literal>
-              setting. Use the <literal>Token=</literal> setting in your
-              <literal>systemd.network.networks.&lt;name&gt;.ipv6AcceptRAConfig</literal>
-              instead. The
-              <literal>systemd.network.networks.&lt;name&gt;.ipv6Prefixes.*.ipv6PrefixConfig</literal>
-              now also accepts the <literal>Token=</literal> setting.
-            </para>
-          </listitem>
-        </itemizedlist>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>arangodb</literal> versions 3.3, 3.4, and 3.5 have
-          been removed because they are at EOL upstream. The default is
-          now 3.10.0. Support for aarch64-linux has been removed since
-          the target cannot be built reproducibly. By default
-          <literal>arangodb</literal> is now built for the
-          <literal>haswell</literal> architecture. If you wish to build
-          for a different architecture, you may override the
-          <literal>targetArchitecture</literal> argument with a value
-          from
-          <link xlink:href="https://github.com/arangodb/arangodb/blob/207ec6937e41a46e10aea34953879341f0606841/cmake/OptimizeForArchitecture.cmake#L594">this
-          list supported upstream</link>. Some architecture specific
-          optimizations are also conditionally enabled. You may alter
-          this behavior by overriding the
-          <literal>asmOptimizations</literal> parameter. You may also
-          add additional architecture support by adding more
-          <literal>-DHAS_XYZ</literal> flags to
-          <literal>cmakeFlags</literal> via
-          <literal>overrideAttrs</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>meta.mainProgram</literal> attribute of packages
-          in <literal>wineWowPackages</literal> now defaults to
-          <literal>&quot;wine64&quot;</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>paperless</literal> module now defaults
-          <literal>PAPERLESS_TIME_ZONE</literal> to your configured
-          system timezone.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The top-level <literal>termonad-with-packages</literal> alias
-          for <literal>termonad</literal> has been removed.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Linux 4.9 has been removed because it will reach its end of
-          life within the lifespan of 22.11.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          (Neo)Vim can not be configured with
-          <literal>configure.pathogen</literal> anymore to reduce
-          maintainance burden. Use <literal>configure.packages</literal>
-          instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Neovim can not be configured with plug anymore (still works
-          for vim).
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>adguardhome</literal> module no longer uses
-          <literal>host</literal> and <literal>port</literal> options,
-          use <literal>settings.bind_host</literal> and
-          <literal>settings.bind_port</literal> instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The default <literal>kops</literal> version is now 1.25.1 and
-          support for 1.22 and older has been dropped.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>zrepl</literal> package has been updated from
-          0.5.0 to 0.6.0. See the
-          <link xlink:href="https://zrepl.github.io/changelog.html">changelog</link>
-          for details.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>k3s</literal> no longer supports docker as runtime
-          due to upstream dropping support.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>cassandra_2_1</literal> and
-          <literal>cassandra_2_2</literal> have been removed. Please
-          update to <literal>cassandra_3_11</literal> or
-          <literal>cassandra_3_0</literal>. See the
-          <link xlink:href="https://github.com/apache/cassandra/blob/cassandra-3.11.14/NEWS.txt">changelog</link>
-          for more information about the upgrade process.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>mysql57</literal> has been removed. Please update to
-          <literal>mysql80</literal> or <literal>mariadb</literal>. See
-          the
-          <link xlink:href="https://mariadb.com/kb/en/upgrading-from-mysql-to-mariadb/">upgrade
-          guide</link> for more information.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Consequently, <literal>cqrlog</literal> and
-          <literal>amorok</literal> now use <literal>mariadb</literal>
-          instead of <literal>mysql57</literal> for their embedded
-          databases. Running <literal>mysql_upgrade</literal> may be
-          neccesary.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>k3s</literal> supports <literal>clusterInit</literal>
-          option, and it is enabled by default, for servers.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>percona-server56</literal> has been removed. Please
-          migrate to <literal>mysql</literal> or
-          <literal>mariadb</literal> if possible.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>obs-studio</literal> hase been updated to version 28.
-          If you have packaged custom plugins, check if they are
-          compatible. <literal>obs-websocket</literal> has been
-          integrated into <literal>obs-studio</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>signald</literal> has been bumped to
-          <literal>0.23.0</literal>. For the upgrade, a migration
-          process is necessary. It can be done by running a command like
-          this before starting <literal>signald.service</literal>:
-        </para>
-        <programlisting>
-signald -d /var/lib/signald/db \
-  --database sqlite:/var/lib/signald/db \
-  --migrate-data
-</programlisting>
-        <para>
-          For further information, please read the upstream changelogs.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>stylua</literal> no longer accepts
-          <literal>lua52Support</literal> and
-          <literal>luauSupport</literal> overrides, use
-          <literal>features</literal> instead, which defaults to
-          <literal>[ &quot;lua54&quot; &quot;luau&quot; ]</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>ocamlPackages.ocaml_extlib</literal> has been renamed
-          to <literal>ocamlPackages.extlib</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>pkgs.fetchNextcloudApp</literal> has been rewritten
-          to circumvent impurities in e.g. tarballs from GitHub and to
-          make it easier to apply patches. This means that your hashes
-          are out-of-date and the (previously required) attributes
-          <literal>name</literal> and <literal>version</literal> are no
-          longer accepted.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The Syncthing service now only allows absolute paths—starting
-          with <literal>/</literal> or <literal>~/</literal>—for
-          <literal>services.syncthing.folders.&lt;name&gt;.path</literal>.
-          In a future release other paths will be allowed again and
-          interpreted relative to
-          <literal>services.syncthing.dataDir</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>services.github-runner</literal> and
-          <literal>services.github-runners.&lt;name&gt;</literal> gained
-          the option <literal>serviceOverrides</literal> which allows
-          overriding the systemd <literal>serviceConfig</literal>. If
-          you have been overriding the systemd service configuration
-          (i.e., by defining
-          <literal>systemd.services.github-runner.serviceConfig</literal>),
-          you have to use the <literal>serviceOverrides</literal> option
-          now. Example:
-        </para>
-        <programlisting>
-services.github-runner.serviceOverrides.SupplementaryGroups = [
-  &quot;docker&quot;
-];
-</programlisting>
-      </listitem>
-    </itemizedlist>
-  </section>
-  <section xml:id="sec-release-22.11-notable-changes">
-    <title>Other Notable Changes</title>
-    <itemizedlist>
-      <listitem>
-        <para>
-          <literal>firefox</literal>, <literal>thunderbird</literal> and
-          <literal>librewolf</literal> come with enabled Wayland support
-          by default. The <literal>firefox-wayland</literal>,
-          <literal>firefox-esr-wayland</literal>,
-          <literal>thunderbird-wayland</literal> and
-          <literal>librewolf-wayland</literal> attributes are obsolete
-          and have been aliased to their generic attribute.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>xplr</literal> package has been updated from
-          0.18.0 to 0.19.0, which brings some breaking changes. See the
-          <link xlink:href="https://github.com/sayanarijit/xplr/releases/tag/v0.19.0">upstream
-          release notes</link> for more details.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Configuring multiple GitHub runners is now possible through
-          <literal>services.github-runners.&lt;name&gt;</literal>. The
-          option <literal>services.github-runner</literal> remains.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>github-runner</literal> gained support for ephemeral
-          runners and registrations using a personal access token (PAT)
-          instead of a registration token. See
-          <literal>services.github-runner.ephemeral</literal> and
-          <literal>services.github-runner.tokenFile</literal> for
-          details.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          A new module was added for the Saleae Logic device family,
-          providing the options
-          <literal>hardware.saleae-logic.enable</literal> and
-          <literal>hardware.saleae-logic.package</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          ZFS module will not allow hibernation by default, this is a
-          safety measure to prevent data loss cases like the ones
-          described at
-          <link xlink:href="https://github.com/openzfs/zfs/issues/260">OpenZFS/260</link>
-          and
-          <link xlink:href="https://github.com/openzfs/zfs/issues/12842">OpenZFS/12842</link>.
-          Use the <literal>boot.zfs.allowHibernation</literal> option to
-          configure this behaviour.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>mastodon</literal> now automatically removes remote
-          media attachments older than 30 days. This is configurable
-          through <literal>services.mastodon.mediaAutoRemove</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The Redis module now disables RDB persistence when
-          <literal>services.redis.servers.&lt;name&gt;.save = []</literal>
-          instead of using the Redis default.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Neo4j was updated from version 3 to version 4. See this
-          <link xlink:href="https://neo4j.com/docs/upgrade-migration-guide/current/">migration
-          guide</link> on how to migrate your Neo4j instance.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>networking.wireguard</literal> module now can set
-          the mtu on interfaces and tag its packets with an fwmark.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The option <literal>overrideStrategy</literal> was added to
-          the different systemd unit options
-          (<literal>systemd.services.&lt;name&gt;</literal>,
-          <literal>systemd.sockets.&lt;name&gt;</literal>, …) to allow
-          enforcing the creation of a dropin file, rather than the main
-          unit file, by setting it to <literal>asDropin</literal>. This
-          is useful in cases where the existence of the main unit file
-          is not known to Nix at evaluation time, for example when the
-          main unit file is provided by adding a package to
-          <literal>systemd.packages</literal>. See the fix proposed in
-          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/135557#issuecomment-1295392470">NixOS’s
-          systemd abstraction doesn’t work with systemd template
-          units</link> for an example.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>polymc</literal> package has been removed due to
-          a rogue maintainer. It has been replaced by
-          <literal>prismlauncher</literal>, a fork by the rest of the
-          maintainers. For more details, see
-          <link xlink:href="https://github.com/NixOS/nixpkgs/pull/196624">the
-          pull request that made this change</link> and
-          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/196460">this
-          issue detailing the vulnerability</link>. Users with existing
-          installations should rename
-          <literal>~/.local/share/polymc</literal> to
-          <literal>~/.local/share/PrismLauncher</literal>. The main
-          config file’s path has also moved from
-          <literal>~/.local/share/polymc/polymc.cfg</literal> to
-          <literal>~/.local/share/PrismLauncher/prismlauncher.cfg</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>bloat</literal> package has been updated from
-          unstable-2022-03-31 to unstable-2022-10-25, which brings a
-          breaking change. See
-          <link xlink:href="https://git.freesoftwareextremist.com/bloat/commit/?id=887ed241d64ba5db3fd3d87194fb5595e5ad7d73">this
-          upstream commit message</link> for details.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>services.matrix-synapse</literal> systemd unit
-          has been hardened.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The module <literal>services.grafana</literal> was refactored
-          to be compliant with
-          <link xlink:href="https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md">RFC
-          0042</link>. To be precise, this means that the following
-          things have changed:
-        </para>
-        <itemizedlist>
-          <listitem>
-            <para>
-              The newly introduced option
-              <xref linkend="opt-services.grafana.settings" /> is an
-              attribute-set that will be converted into Grafana’s INI
-              format. This means that the configuration from
-              <link xlink:href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/">Grafana’s
-              configuration reference</link> can be directly written as
-              attribute-set in Nix within this option.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              The option
-              <literal>services.grafana.extraOptions</literal> has been
-              removed. This option was an association of environment
-              variables for Grafana. If you had an expression like
-            </para>
-            <programlisting language="bash">
-{
-  services.grafana.extraOptions.SECURITY_ADMIN_USER = &quot;foobar&quot;;
-}
-</programlisting>
-            <para>
-              your Grafana instance was running with
-              <literal>GF_SECURITY_ADMIN_USER=foobar</literal> in its
-              environment.
-            </para>
-            <para>
-              For the migration, it is recommended to turn it into the
-              INI format, i.e. to declare
-            </para>
-            <programlisting language="bash">
-{
-  services.grafana.settings.security.admin_user = &quot;foobar&quot;;
-}
-</programlisting>
-            <para>
-              instead.
-            </para>
-            <para>
-              The keys in
-              <literal>services.grafana.extraOptions</literal> have the
-              format
-              <literal>&lt;INI section name&gt;_&lt;Key Name&gt;</literal>.
-              Further details are outlined in the
-              <link xlink:href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables">configuration
-              reference</link>.
-            </para>
-            <para>
-              Alternatively you can also set all your values from
-              <literal>extraOptions</literal> to
-              <literal>systemd.services.grafana.environment</literal>,
-              make sure you don’t forget to add the
-              <literal>GF_</literal> prefix though!
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              Previously, the options
-              <xref linkend="opt-services.grafana.provision.datasources" />
-              and
-              <xref linkend="opt-services.grafana.provision.dashboards" />
-              expected lists of datasources or dashboards for the
-              <link xlink:href="https://grafana.com/docs/grafana/latest/administration/provisioning/">declarative
-              provisioning</link>.
-            </para>
-            <para>
-              To declare lists of
-            </para>
-            <itemizedlist spacing="compact">
-              <listitem>
-                <para>
-                  <emphasis role="strong">datasources</emphasis>, please
-                  rename your declarations to
-                  <xref linkend="opt-services.grafana.provision.datasources.settings.datasources" />.
-                </para>
-              </listitem>
-              <listitem>
-                <para>
-                  <emphasis role="strong">dashboards</emphasis>, please
-                  rename your declarations to
-                  <xref linkend="opt-services.grafana.provision.dashboards.settings.providers" />.
-                </para>
-              </listitem>
-            </itemizedlist>
-            <para>
-              This change was made to support more features for that:
-            </para>
-            <itemizedlist>
-              <listitem>
-                <para>
-                  It’s possible to declare the
-                  <literal>apiVersion</literal> of your dashboards and
-                  datasources by
-                  <xref linkend="opt-services.grafana.provision.datasources.settings.apiVersion" />
-                  (or
-                  <xref linkend="opt-services.grafana.provision.dashboards.settings.apiVersion" />).
-                </para>
-              </listitem>
-              <listitem>
-                <para>
-                  Instead of declaring datasources and dashboards in
-                  pure Nix, it’s also possible to specify configuration
-                  files (or directories) with YAML instead using
-                  <xref linkend="opt-services.grafana.provision.datasources.path" />
-                  (or
-                  <xref linkend="opt-services.grafana.provision.dashboards.path" />.
-                  This is useful when having provisioning files from
-                  non-NixOS Grafana instances that you also want to
-                  deploy to NixOS.
-                </para>
-                <para>
-                  <emphasis role="strong">Note:</emphasis> secrets from
-                  these files will be leaked into the store unless you
-                  use a
-                  <link xlink:href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#file-provider"><emphasis role="strong">file</emphasis>-provider
-                  or env-var</link> for secrets!
-                </para>
-              </listitem>
-              <listitem>
-                <para>
-                  <xref linkend="opt-services.grafana.provision.notifiers" />
-                  is not affected by this change because this feature is
-                  deprecated by Grafana and will probably removed in
-                  Grafana 10. It’s recommended to use
-                  <literal>services.grafana.provision.alerting.contactPoints</literal>
-                  instead.
-                </para>
-              </listitem>
-            </itemizedlist>
-          </listitem>
-        </itemizedlist>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>services.grafana.provision.alerting</literal>
-          option was added. It includes suboptions for every
-          alerting-related objects (with the exception of
-          <literal>notifiers</literal>), which means it’s now possible
-          to configure modern Grafana alerting declaratively.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Matrix Synapse now requires entries in the
-          <literal>state_group_edges</literal> table to be unique, in
-          order to prevent accidentally introducing duplicate
-          information (for example, because a database backup was
-          restored multiple times). If your Synapse database already has
-          duplicate rows in this table, this could fail with an error
-          and require manual remediation.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>diamond</literal> package has been update from
-          0.8.36 to 2.0.15. See the
-          <link xlink:href="https://github.com/bbuchfink/diamond/releases">upstream
-          release notes</link> for more details.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>guake</literal> package has been updated from
-          3.6.3 to 3.9.0, see the
-          <link xlink:href="https://github.com/Guake/guake/releases">changelog</link>
-          for more details.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>netlify-cli</literal> package has been updated
-          from 6.13.2 to 12.2.4, see the
-          <link xlink:href="https://github.com/netlify/cli/releases">changelog</link>
-          for more details.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>dockerTools.buildImage</literal> deprecates the
-          misunderstood <literal>contents</literal> parameter, in favor
-          of <literal>copyToRoot</literal>. Use
-          <literal>copyToRoot = buildEnv { ... };</literal> or similar
-          if you intend to add packages to <literal>/bin</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>proxmox.qemuConf.bios</literal> option was added,
-          it corresponds to <literal>Hardware-&gt;BIOS</literal> field
-          in Proxmox web interface. Use
-          <literal>&quot;ovmf&quot;</literal> value to build UEFI image,
-          default value remains <literal>&quot;bios&quot;</literal>. New
-          option <literal>proxmox.partitionTableType</literal> defaults
-          to either <literal>&quot;legacy&quot;</literal> or
-          <literal>&quot;efi&quot;</literal>, depending on the
-          <literal>bios</literal> value. Setting
-          <literal>partitionTableType</literal> to
-          <literal>&quot;hybrid&quot;</literal> results in an image,
-          which supports both methods
-          (<literal>&quot;bios&quot;</literal> and
-          <literal>&quot;ovmf&quot;</literal>), thereby remaining
-          bootable after change to Proxmox
-          <literal>Hardware-&gt;BIOS</literal> field.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2.
-          It is now the upstream version from https://www.memtest.org/,
-          as coreboot’s fork is no longer available.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Option descriptions, examples, and defaults writting in
-          DocBook are now deprecated. Using CommonMark is preferred and
-          will become the default in a future release.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The
-          <literal>documentation.nixos.options.allowDocBook</literal>
-          option was added to ease the transition to CommonMark option
-          documentation. Setting this option to <literal>false</literal>
-          causes an error for every option included in the manual that
-          uses DocBook documentation; it defaults to
-          <literal>true</literal> to preserve the previous behavior and
-          will be removed once the transition to CommonMark is complete.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The redis module now persists each instance’s configuration
-          file in the state directory, in order to support some more
-          advanced use cases like sentinel.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The udisks2 service, available at
-          <literal>services.udisks2.enable</literal>, is now disabled by
-          default. It will automatically be enabled through services and
-          desktop environments as needed. This also means that polkit
-          will now actually be disabled by default. The default for
-          <literal>security.polkit.enable</literal> was already flipped
-          in the previous release, but udisks2 being enabled by default
-          re-enabled it.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Nextcloud has been updated to version
-          <emphasis role="strong">25</emphasis>. Additionally the
-          following things have changed for Nextcloud in NixOS:
-        </para>
-        <itemizedlist spacing="compact">
-          <listitem>
-            <para>
-              For Nextcloud <emphasis role="strong">&gt;=24</emphasis>,
-              the default PHP version is 8.1.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              Nextcloud <emphasis role="strong">23</emphasis> has been
-              removed since it will reach its
-              <link xlink:href="https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule/d76576a12a626d53305d480a6065b57cab705d3d">end
-              of life in December 2022</link>.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              For <literal>system.stateVersion</literal> being
-              <emphasis role="strong">&gt;=22.11</emphasis>, Nextcloud
-              25 will be installed by default. For older versions,
-              Nextcloud 24 will be installed.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              Please ensure that you only upgrade on major release at a
-              time! Nextcloud doesn’t support upgrades across multiple
-              versions, i.e. an upgrade from
-              <emphasis role="strong">23</emphasis> to
-              <emphasis role="strong">25</emphasis> is only possible
-              when upgrading to <emphasis role="strong">24</emphasis>
-              first.
-            </para>
-          </listitem>
-        </itemizedlist>
-      </listitem>
-      <listitem>
-        <para>
-          Add udev rules for the Teensy family of microcontrollers.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The Qt QML disk cache is now disabled by default. This fixes a
-          long-standing issue where updating Qt/KDE apps would sometimes
-          cause them to crash or behave strangely without explanation.
-          Those concerned about the small (~10%) performance hit to
-          application startup can re-enable the cache (and expose
-          themselves to gremlins) by setting the envrionment variable
-          <literal>QML_FORCE_DISK_CACHE</literal> to
-          <literal>1</literal> using e.g. the
-          <literal>environment.sessionVariables</literal> NixOS option.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          systemd-oomd is enabled by default. Depending on which systemd
-          units have <literal>ManagedOOMSwap=kill</literal> or
-          <literal>ManagedOOMMemoryPressure=kill</literal>, systemd-oomd
-          will SIGKILL all the processes under the appropriate
-          descendant cgroups when the configured limits are exceeded.
-          NixOS does currently not configure cgroups with oomd by
-          default, this can be enabled using
-          <link xlink:href="options.html#opt-systemd.oomd.enableRootSlice">systemd.oomd.enableRootSlice</link>,
-          <link xlink:href="options.html#opt-systemd.oomd.enableSystemSlice">systemd.oomd.enableSystemSlice</link>,
-          and
-          <link xlink:href="options.html#opt-systemd.oomd.enableUserServices">systemd.oomd.enableUserServices</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>tt-rss</literal> service performs two database
-          migrations when you first use its web UI after upgrade.
-          Consider backing up its database before updating.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>pass-secret-service</literal> package now
-          includes systemd units from upstream, so adding it to the
-          NixOS <literal>services.dbus.packages</literal> option will
-          make it start automatically as a systemd user service when an
-          application tries to talk to the libsecret D-Bus API.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          There is a new module for AMD SEV CPU functionality, which
-          grants access to the hardware.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The Wordpress module got support for installing language packs
-          through
-          <literal>services.wordpress.sites.&lt;site&gt;.languages</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The default package for
-          <literal>services.mullvad-vpn.package</literal> was changed to
-          <literal>pkgs.mullvad</literal>, allowing cross-platform usage
-          of Mullvad. <literal>pkgs.mullvad</literal> only contains the
-          Mullvad CLI tool, so users who rely on the Mullvad GUI will
-          want to change it back to <literal>pkgs.mullvad-vpn</literal>,
-          or add <literal>pkgs.mullvad-vpn</literal> to their
-          environment.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          PowerDNS has been updated from <literal>4.6.x</literal> to
-          <literal>4.7.x</literal>. Please be sure to review the
-          <link xlink:href="https://doc.powerdns.com/authoritative/upgrading.html#to-4-7-0-or-master">Upgrade
-          Notes</link> provided by upstream before upgrading. Worth
-          specifically noting is that the new Catalog Zones feature
-          comes with a mandatory schema change for the gsql database
-          backends, which has to be manually applied.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          There is a new module for the <literal>thunar</literal>
-          program (the Xfce file manager), which depends on the
-          <literal>xfconf</literal> dbus service, and also has a dbus
-          service and a systemd unit. The option
-          <literal>services.xserver.desktopManager.xfce.thunarPlugins</literal>
-          has been renamed to
-          <literal>programs.thunar.plugins</literal>, and in a future
-          release it may be removed.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          There is a new module for the <literal>xfconf</literal>
-          program (the Xfce configuration storage system), which has a
-          dbus service.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The Mastodon package got upgraded from the major version 3 to
-          4. See the
-          <link xlink:href="https://github.com/mastodon/mastodon/releases/tag/v4.0.0">v4.0.0
-          release notes</link> for a list of changes. On standard
-          setups, no manual migration steps are required. Nevertheless,
-          a database backup is recommended.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>nomad</literal> package now defaults to 1.3,
-          which no longer has a downgrade path to releases 1.2 or older.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>nodePackages</literal> package set now defaults
-          to the LTS release in the <literal>nodejs</literal> package
-          again, instead of being pinned to
-          <literal>nodejs-14_x</literal>. Several updates to node2nix
-          have been made for compatibility with newer Node.js and npm
-          versions and a new <literal>postRebuild</literal> hook has
-          been added for packages to perform extra build steps before
-          the npm install step prunes dev dependencies.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>boot.kernel.sysctl</literal> is defined as a
-          freeformType and adds a custom merge option for
-          <quote>net.core.rmem_max</quote> (taking the highest value
-          defined to avoid conflicts between 2 services trying to set
-          that value).
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The <literal>mame</literal> package does not ship with its
-          tools anymore in the default output. They were moved to a
-          separate <literal>tools</literal> output instead. For
-          convenience, <literal>mame-tools</literal> package was added
-          for those who want to use it.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          A NixOS module for Firefox has been added which allows
-          preferences and
-          <link xlink:href="https://github.com/mozilla/policy-templates/blob/master/README.md">policies</link>
-          to be set. This also allows extensions to be installed via the
-          <literal>ExtensionSettings</literal> policy. The new options
-          are under <literal>programs.firefox</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          The option
-          <literal>services.picom.experimentalBackends</literal> was
-          removed since it is now the default and the option will cause
-          <literal>picom</literal> to quit instead.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>haskellPackage.callHackage</literal> is not always
-          invalidated if <literal>all-cabal-hashes</literal> changes,
-          leading to less rebuilds of haskell dependencies.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>haskellPackages.callHackage</literal> and
-          <literal>haskellPackages.callCabal2nix</literal> (and related
-          functions) no longer keep a reference to the
-          <literal>cabal2nix</literal> call used to generate them. As a
-          result, they will be garbage collected more often.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1464,6 +1464,26 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
+          The <literal>proxmox.qemuConf.bios</literal> option was added,
+          it corresponds to <literal>Hardware-&gt;BIOS</literal> field
+          in Proxmox web interface. Use
+          <literal>&quot;ovmf&quot;</literal> value to build UEFI image,
+          default value remains <literal>&quot;bios&quot;</literal>. New
+          option <literal>proxmox.partitionTableType</literal> defaults
+          to either <literal>&quot;legacy&quot;</literal> or
+          <literal>&quot;efi&quot;</literal>, depending on the
+          <literal>bios</literal> value. Setting
+          <literal>partitionTableType</literal> to
+          <literal>&quot;hybrid&quot;</literal> results in an image,
+          which supports both methods
+          (<literal>&quot;bios&quot;</literal> and
+          <literal>&quot;ovmf&quot;</literal>), thereby remaining
+          bootable after change to Proxmox
+          <literal>Hardware-&gt;BIOS</literal> field.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2.
           It is now the upstream version from https://www.memtest.org/,
           as coreboot’s fork is no longer available.

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -216,6 +216,23 @@
           release announcement</link> for more information.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>aarch64-linux</literal> is now included in the
+          <literal>nixos-22.11</literal> and
+          <literal>nixos-22.11-small</literal> channels. This means that
+          <literal>x86_64-linux</literal> and
+          <literal>aarch64-linux</literal> will recieve updates at the
+          same time.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>aarch64-linux</literal> ISOs are now available on the
+          <link xlink:href="https://nixos.org/download.html">downloads
+          page</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.11-internal">

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -2,7 +2,7 @@
   <title>Release 22.11 (“Raccoon”, 2022.11/??)</title>
   <para>
     The NixOS release team is happy to announce a new version of NixOS
-    22.11. NixOS is both a linux distribution, and a set of packages
+    22.11. NixOS is both a Linux distribution, and a set of packages
     usable on other Linux systems and macOS.
   </para>
   <para>
@@ -190,9 +190,10 @@
       <listitem>
         <para>
           For cross-compilation targets that can also run on the
-          building machine, we also enabled running tests now. This is
-          for example the case for the pkgsStatic and pkgsLLVm package
-          sets or i686 packages on <literal>x86_64</literal> machine.
+          building machine, we now run tests. This, for example, is the
+          case for the <literal>pkgsStatic</literal> and
+          <literal>pkgsLLVM</literal> package sets or i686 packages on
+          <literal>x86_64</literal> machines.
         </para>
       </listitem>
       <listitem>
@@ -242,9 +243,12 @@
     <itemizedlist>
       <listitem>
         <para>
-          Nix has been upgraded from
-          <link xlink:href="https://github.com/NixOS/nix/compare/2.8.1...2.11.0">v2.8.1
-          to v2.11.0</link>
+          Nix has been upgraded from v2.8.1 to v2.11.0. For more
+          information, please see the release notes for
+          <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.9.html">2.9</link>,
+          <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.10.html">2.10</link>
+          and
+          <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.11.html">2.11</link>.
         </para>
       </listitem>
       <listitem>
@@ -254,9 +258,9 @@
       </listitem>
       <listitem>
         <para>
-          GNOME has been upgraded to version 43. Please take a look at
-          their <link xlink:href="https://release.gnome.org/43/">Release
-          Notes</link> for details.
+          GNOME has been upgraded to version 43. Please see the
+          <link xlink:href="https://release.gnome.org/43/">release
+          notes</link> for details.
         </para>
       </listitem>
       <listitem>
@@ -290,7 +294,7 @@
       </listitem>
       <listitem>
         <para>
-          Python now defalts to 3.10, updated from 3.9.
+          Python now defaults to 3.10, updated from 3.9.
         </para>
       </listitem>
     </itemizedlist>
@@ -393,7 +397,7 @@
           checkouts via the <literal>sparseCheckout</literal> option.
           This used to accept a multi-line string with
           directories/patterns to check out, but now requires a list of
-          strings
+          strings.
         </para>
       </listitem>
       <listitem>
@@ -403,7 +407,7 @@
           <literal>ssh-keygen -A</literal> as they are insecure. Also,
           <literal>SetEnv</literal> directives in
           <literal>ssh_config</literal> and
-          <literal>sshd_config</literal> are now first-match-wins
+          <literal>sshd_config</literal> are now first-match-wins.
         </para>
       </listitem>
       <listitem>
@@ -511,7 +515,7 @@
           <literal>kanidm</literal> has been updated to 1.1.0-alpha.10
           and now requires a TLS certificate and key. It will always
           start <literal>https</literal> and-–-if enabled-–-an LDAPS
-          server and no HTTP and LDAP server anymore
+          server and no HTTP and LDAP server anymore.
         </para>
       </listitem>
       <listitem>
@@ -1529,9 +1533,24 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
     <itemizedlist>
       <listitem>
         <para>
+          <link xlink:href="https://git.sr.ht/~migadu/alps">alps</link>,
+          a simple and extensible webmail. Available as
+          <link linkend="opt-services.alps.enable">services.alps</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/jollheef/appvm">appvm</link>,
           Nix based app VMs. Available as
           <link xlink:href="options.html#opt-virtualisation.appvm.enable">virtualisation.appvm</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://www.ausweisapp.bund.de/">AusweisApp2</link>,
+          the authentication software for the German ID card. Available
+          as
+          <link linkend="opt-programs.ausweisapp.enable">programs.ausweisapp</link>.
         </para>
       </listitem>
       <listitem>
@@ -1544,18 +1563,10 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
-          [xray] (https://github.com/XTLS/Xray-core), a fully compatible
-          v2ray-core replacement. Features XTLS, which when enabled on
-          server and client, brings UDP FullCone NAT to proxy setups.
-          Available as
-          <link xlink:href="options.html#opt-services.xray.enable">services.xray</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/mozilla-services/syncstorage-rs">syncstorage-rs</link>,
-          a self-hostable sync server for Firefox. Available as
-          <link xlink:href="options.html#opt-services.firefox-syncserver.enable">services.firefox-syncserver</link>.
+          <link xlink:href="https://www.dolibarr.org/">Dolibarr</link>,
+          an enterprise resource planning and customer relationship
+          manager. Enable using
+          <link linkend="opt-services.dolibarr.enable">services.dolibarr</link>.
         </para>
       </listitem>
       <listitem>
@@ -1567,39 +1578,16 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://komga.org/">Komga</link>, a free and
-          open source comics/mangas media server. Available as
-          <link linkend="opt-services.komga.enable">services.komga</link>.
+          <link xlink:href="https://github.com/shizunge/endlessh-go">endlessh-go</link>,
+          an SSH tarpit that exposes Prometheus metrics. Available as
+          <link linkend="opt-services.endlessh-go.enable">services.endlessh-go</link>.
         </para>
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://tandoor.dev">Tandoor Recipes</link>,
-          a self-hosted multi-tenant recipe collection. Available as
-          <link xlink:href="options.html#opt-services.tandoor-recipes.enable">services.tandoor-recipes</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://hbase.apache.org/">HBase
-          cluster</link>, a distributed, scalable, big data store.
-          Available as
-          <link xlink:href="options.html#opt-services.hadoop.hbase.enable">services.hadoop.hbase</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/edneville/please">Please</link>,
-          a Sudo clone written in Rust. Available as
-          <link linkend="opt-security.please.enable">security.please</link>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/messagebird/sachet/">Sachet</link>,
-          an SMS alerting tool for the Prometheus Alertmanager.
-          Available as
-          <link linkend="opt-services.prometheus.sachet.enable">services.prometheus.sachet</link>.
+          <link xlink:href="https://github.com/skeeto/endlessh">endlessh</link>,
+          an SSH tarpit. Available as
+          <link linkend="opt-services.endlessh.enable">services.endlessh</link>.
         </para>
       </listitem>
       <listitem>
@@ -1614,17 +1602,53 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://github.com/leetronics/infnoise">infnoise</link>,
-          a hardware True Random Number Generator dongle. Available as
-          <link xlink:href="options.html#opt-services.infnoise.enable">services.infnoise</link>.
+          <link xlink:href="https://www.expressvpn.com">expressvpn</link>,
+          the CLI client for ExpressVPN. Available as
+          <link linkend="opt-services.expressvpn.enable">services.expressvpn</link>.
         </para>
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://github.com/prymitive/kthxbye">kthxbye</link>,
-          an alert acknowledgement management daemon for Prometheus
-          Alertmanager. Available as
-          <link xlink:href="options.html#opt-services.kthxbye.enable">services.kthxbye</link>
+          <link xlink:href="https://freshrss.org/">FreshRSS</link>, a
+          free, self-hostable RSS feed aggregator. Available as
+          <link linkend="opt-services.freshrss.enable">services.freshrss</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://garagehq.deuxfleurs.fr/">Garage</link>,
+          a simple object storage server for geodistributed deployments,
+          alternative to MinIO. Available as
+          <link linkend="opt-services.garage.enable">services.garage</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/L11R/go-autoconfig">go-autoconfig</link>,
+          IMAP/SMTP autodiscover server. Available as
+          <link linkend="opt-services.go-autoconfig.enable">services.go-autoconfig</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://www.grafana.com/oss/tempo/">Grafana
+          Tempo</link>, a distributed tracing store. Available as
+          <link linkend="opt-services.tempo.enable">services.tempo</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://hbase.apache.org/">HBase
+          cluster</link>, a distributed, scalable, big data store.
+          Available as
+          <link xlink:href="options.html#opt-services.hadoop.hbase.enable">services.hadoop.hbase</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/leetronics/infnoise">infnoise</link>,
+          a hardware True Random Number Generator dongle. Available as
+          <link xlink:href="options.html#opt-services.infnoise.enable">services.infnoise</link>.
         </para>
       </listitem>
       <listitem>
@@ -1644,9 +1668,60 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://komga.org/">Komga</link>, a free and
+          open source comics/mangas media server. Available as
+          <link linkend="opt-services.komga.enable">services.komga</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/prymitive/kthxbye">kthxbye</link>,
+          an alert acknowledgement management daemon for Prometheus
+          Alertmanager. Available as
+          <link xlink:href="options.html#opt-services.kthxbye.enable">services.kthxbye</link>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://languagetool.org/">languagetool</link>,
           a multilingual grammar, style, and spell checker. Available as
           <link xlink:href="options.html#opt-services.languagetool.enable">services.languagetool</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://listmonk.app">Listmonk</link>, a
+          self-hosted newsletter manager. Enable using
+          <link xlink:href="options.html#opt-services.listmonk.enable">services.listmonk</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://mepo.milesalan.com">Mepo</link>, a
+          fast, simple, hackable OSM map viewer for mobile and desktop
+          Linux. Available as
+          <link linkend="opt-programs.mepo.enable">programs.mepo.enable</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://troglobit.com/projects/merecat/">merecat</link>,
+          a small and easy HTTP server based on thttpd. Available as
+          <link linkend="opt-services.merecat.enable">services.merecat</link>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://netbird.io">netbird</link>, a zero
+          configuration VPN. Available as
+          <link xlink:href="options.html#opt-services.netbird.enable">services.netbird</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://ntfy.sh">ntfy.sh</link>, a push
+          notification service. Available as
+          <link linkend="opt-services.ntfy-sh.enable">services.ntfy-sh</link>
         </para>
       </listitem>
       <listitem>
@@ -1665,45 +1740,10 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://ntfy.sh">ntfy.sh</link>, a push
-          notification service. Available as
-          <link linkend="opt-services.ntfy-sh.enable">services.ntfy-sh</link>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://git.sr.ht/~migadu/alps">alps</link>,
-          a simple and extensible webmail. Available as
-          <link linkend="opt-services.alps.enable">services.alps</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/skeeto/endlessh">endlessh</link>,
-          an SSH tarpit. Available as
-          <link linkend="opt-services.endlessh.enable">services.endlessh</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/shizunge/endlessh-go">endlessh-go</link>,
-          an SSH tarpit that exposes Prometheus metrics. Available as
-          <link linkend="opt-services.endlessh-go.enable">services.endlessh-go</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://garagehq.deuxfleurs.fr/">Garage</link>,
-          a simple object storage server for geodistributed deployments,
-          alternative to MinIO. Available as
-          <link linkend="opt-services.garage.enable">services.garage</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://netbird.io">netbird</link>, a zero
-          configuration VPN. Available as
-          <link xlink:href="options.html#opt-services.netbird.enable">services.netbird</link>.
+          <link xlink:href="https://github.com/zalando/patroni">Patroni</link>,
+          a template for PostgreSQL HA with ZooKeeper, etcd or Consul.
+          Available as
+          <link xlink:href="options.html#opt-services.patroni.enable">services.patroni</link>.
         </para>
       </listitem>
       <listitem>
@@ -1717,6 +1757,29 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/edneville/please">Please</link>,
+          a Sudo clone written in Rust. Available as
+          <link linkend="opt-security.please.enable">security.please</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/prometheus-community/ipmi_exporter">Prometheus
+          IPMI exporter</link>, an IPMI exporter for Prometheus.
+          Available as
+          <link linkend="opt-services.prometheus.exporters.ipmi.enable">services.prometheus.exporters.ipmi</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/messagebird/sachet/">Sachet</link>,
+          an SMS alerting tool for the Prometheus Alertmanager.
+          Available as
+          <link linkend="opt-services.prometheus.sachet.enable">services.prometheus.sachet</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://schleuder.org/">schleuder</link>, a
           mailing list manager with PGP support. Enable using
           <link linkend="opt-services.schleuder.enable">services.schleuder</link>.
@@ -1724,38 +1787,16 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://www.dolibarr.org/">Dolibarr</link>,
-          an enterprise resource planning and customer relationship
-          manager. Enable using
-          <link linkend="opt-services.dolibarr.enable">services.dolibarr</link>.
+          <link xlink:href="https://github.com/mozilla-services/syncstorage-rs">syncstorage-rs</link>,
+          a self-hostable sync server for Firefox. Available as
+          <link xlink:href="options.html#opt-services.firefox-syncserver.enable">services.firefox-syncserver</link>.
         </para>
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://freshrss.org/">FreshRSS</link>, a
-          free, self-hostable RSS feed aggregator. Available as
-          <link linkend="opt-services.freshrss.enable">services.freshrss</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://www.expressvpn.com">expressvpn</link>,
-          the CLI client for ExpressVPN. Available as
-          <link linkend="opt-services.expressvpn.enable">services.expressvpn</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://troglobit.com/projects/merecat/">merecat</link>,
-          a small and easy HTTP server based on thttpd. Available as
-          <link linkend="opt-services.merecat.enable">services.merecat</link>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/L11R/go-autoconfig">go-autoconfig</link>,
-          IMAP/SMTP autodiscover server. Available as
-          <link linkend="opt-services.go-autoconfig.enable">services.go-autoconfig</link>.
+          <link xlink:href="https://tandoor.dev">Tandoor Recipes</link>,
+          a self-hosted multi-tenant recipe collection. Available as
+          <link xlink:href="options.html#opt-services.tandoor-recipes.enable">services.tandoor-recipes</link>.
         </para>
       </listitem>
       <listitem>
@@ -1769,33 +1810,9 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://www.grafana.com/oss/tempo/">Grafana
-          Tempo</link>, a distributed tracing store. Available as
-          <link linkend="opt-services.tempo.enable">services.tempo</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://www.ausweisapp.bund.de/">AusweisApp2</link>,
-          the authentication software for the German ID card. Available
-          as
-          <link linkend="opt-programs.ausweisapp.enable">programs.ausweisapp</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/zalando/patroni">Patroni</link>,
-          a template for PostgreSQL HA with ZooKeeper, etcd or Consul.
-          Available as
-          <link xlink:href="options.html#opt-services.patroni.enable">services.patroni</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/prometheus-community/ipmi_exporter">Prometheus
-          IPMI exporter</link>, an IPMI exporter for Prometheus.
-          Available as
-          <link linkend="opt-services.prometheus.exporters.ipmi.enable">services.prometheus.exporters.ipmi</link>.
+          <link xlink:href="https://uptime.kuma.pet/">Uptime
+          Kuma</link>, a fancy self-hosted monitoring tool. Available as
+          <link linkend="opt-services.uptime-kuma.enable">services.uptime-kuma</link>.
         </para>
       </listitem>
       <listitem>
@@ -1808,24 +1825,11 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
       </listitem>
       <listitem>
         <para>
-          <link xlink:href="https://listmonk.app">Listmonk</link>, a
-          self-hosted newsletter manager. Enable using
-          <link xlink:href="options.html#opt-services.listmonk.enable">services.listmonk</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://uptime.kuma.pet/">Uptime
-          Kuma</link>, a fancy self-hosted monitoring tool. Available as
-          <link linkend="opt-services.uptime-kuma.enable">services.uptime-kuma</link>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <link xlink:href="https://mepo.milesalan.com">Mepo</link>, a
-          fast, simple, hackable OSM map viewer for mobile and desktop
-          Linux. Available as
-          <link linkend="opt-programs.mepo.enable">programs.mepo.enable</link>.
+          [xray] (https://github.com/XTLS/Xray-core), a fully compatible
+          v2ray-core replacement. Features XTLS, which when enabled on
+          server and client, brings UDP FullCone NAT to proxy setups.
+          Available as
+          <link xlink:href="options.html#opt-services.xray.enable">services.xray</link>.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -1,8 +1,17 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-release-22.11">
   <title>Release 22.11 (“Raccoon”, 2022.11/??)</title>
   <para>
+    The NixOS release team is happy to announce a new version of NixOS
+    22.11. NixOS is both a linux distribution, and a set of packages
+    usable on other Linux systems and macOS.
+  </para>
+  <para>
     This release is supported until the end of June 2023, handing over
     to NixOS 23.05.
+  </para>
+  <para>
+    To upgrade to the latest release follow the
+    <link linkend="sec-upgrading">upgrade chapter</link>.
   </para>
   <section xml:id="sec-release-22.11-highlights">
     <title>Highlights</title>
@@ -69,85 +78,70 @@
       </listitem>
       <listitem>
         <para>
-          GNOME has been upgraded to version 43. Please take a look at
-          their <link xlink:href="https://release.gnome.org/43/">Release
-          Notes</link> for details.
+          The NixOS documentation is now generated from markdown. While
+          docbook is still part of the documentation build process, it’s
+          a big step towards the full migration.
         </para>
       </listitem>
       <listitem>
         <para>
-          KDE Plasma has been upgraded from v5.24 to v5.26. Please see
-          the release notes for
-          <link xlink:href="https://kde.org/announcements/plasma/5/5.25.0/">v5.25</link>
-          and
-          <link xlink:href="https://kde.org/announcements/plasma/5/5.26.0/">v5.26</link>
-          for more details on the included changes.
+          <literal>aarch64-linux</literal> is now included in the
+          <literal>nixos-22.11</literal> and
+          <literal>nixos-22.11-small</literal> channels. This means that
+          when those channel update, both
+          <literal>x86_64-linux</literal> and
+          <literal>aarch64-linux</literal> will be available in the
+          binary cache.
         </para>
       </listitem>
       <listitem>
         <para>
-          Cinnamon has been updated to 5.4, and the Cinnamon module now
-          defaults to Blueman as the Bluetooth manager and slick-greeter
-          as the LightDM greeter, to match upstream.
+          <literal>aarch64-linux</literal> ISOs are now available on the
+          <link xlink:href="https://nixos.org/download.html">downloads
+          page</link>.
         </para>
       </listitem>
       <listitem>
         <para>
-          OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
+          <literal>nsncd</literal> is now available as a replacement of
+          <literal>nscd</literal>.
         </para>
-      </listitem>
-      <listitem>
         <para>
-          PHP now defaults to PHP 8.1, updated from 8.0.
+          <literal>nscd</literal> is responsible for resolving
+          hostnames, users and more in NixOS and has been a long
+          standing source of bugs, such as sporadic network freezes.
         </para>
-      </listitem>
-      <listitem>
         <para>
-          PHP is now built in <literal>NTS</literal> (Non-Thread Safe)
-          mode by default.
+          More context in this
+          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/135888">issue</link>.
         </para>
-        <itemizedlist spacing="compact">
-          <listitem>
-            <para>
-              For Apache and <literal>mod_php</literal> usage, we enable
-              <literal>ZTS</literal> (Zend Thread Safe) mode. This has
-              been a common practice for a long time in other
-              distributions.
-            </para>
-          </listitem>
-        </itemizedlist>
-      </listitem>
-      <listitem>
         <para>
-          Perl has been updated to 5.36, and its core module
-          <literal>HTTP::Tiny</literal> was patched to verify SSL/TLS
-          certificates by default.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>nscd</literal> functionality, necessary to provide
-          non-glibc-builtin NSS modules (such as
-          <literal>nss_systemd</literal> or <literal>nss_ldap</literal>)
-          can now be provided by <literal>nsncd</literal>, by setting
+          Help us test the new implementation by setting
           <literal>services.nscd.enableNsncd</literal> to
           <literal>true</literal>.
         </para>
         <para>
-          The <literal>nscd</literal> daemon provided by glibc, which is
-          currently used by NixOS isn’t very reliable. For example, it’s
-          <link xlink:href="https://github.com/NixOS/nixpkgs/issues/135888">not
-          fully possible to disable caching functionality</link>,
-          causing various issues and failed lookups.
-        </para>
-        <para>
-          In contrast to nscd’s behavior of caching module responses on
-          its own, nsncd merely forwards requests to NSS modules, which
-          might cache or not.
-        </para>
-        <para>
           We plan to use <literal>nsncd</literal> by default in NixOS
           23.05.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Linode cloud images are now supported by importing
+          <literal>${modulesPath}/virtualisation/linode-image.nix</literal>
+          and accessing <literal>system.build.linodeImage</literal> on
+          the output.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>hardware.nvidia</literal> has a new option,
+          <literal>hardware.nvidia.open</literal>, that can be used to
+          enable the usage of NVIDIA’s open-source kernel driver. Note
+          that the driver’s support for GeForce and Workstation GPUs is
+          still alpha quality, see
+          <link xlink:href="https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/">the
+          release announcement</link> for more information.
         </para>
       </listitem>
       <listitem>
@@ -178,61 +172,6 @@
           </listitem>
         </itemizedlist>
       </listitem>
-      <listitem>
-        <para>
-          <literal>nixos-generate-config</literal> now generates
-          configurations that can be built in pure mode. This is
-          achieved by setting the new
-          <literal>nixpkgs.hostPlatform</literal> option.
-        </para>
-        <para>
-          You may have to unset the <literal>system</literal> parameter
-          in <literal>lib.nixosSystem</literal>, or similarly remove
-          definitions of the
-          <literal>nixpkgs.{system,localSystem,crossSystem}</literal>
-          options.
-        </para>
-        <para>
-          Alternatively, you can remove the
-          <literal>hostPlatform</literal> line and use NixOS like you
-          would in NixOS 22.05 and earlier.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          It is now possible to generate NixOS images for the Linode
-          cloud provider, via
-          <literal>system.build.linodeImage</literal>.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>hardware.nvidia</literal> has a new option,
-          <literal>hardware.nvidia.open</literal>, that can be used to
-          enable the usage of NVIDIA’s open-source kernel driver. Note
-          that the driver’s support for GeForce and Workstation GPUs is
-          still alpha quality, see
-          <link xlink:href="https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/">the
-          release announcement</link> for more information.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>aarch64-linux</literal> is now included in the
-          <literal>nixos-22.11</literal> and
-          <literal>nixos-22.11-small</literal> channels. This means that
-          <literal>x86_64-linux</literal> and
-          <literal>aarch64-linux</literal> will recieve updates at the
-          same time.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <literal>aarch64-linux</literal> ISOs are now available on the
-          <link xlink:href="https://nixos.org/download.html">downloads
-          page</link>.
-        </para>
-      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.11-internal">
@@ -240,38 +179,28 @@
     <itemizedlist>
       <listitem>
         <para>
-          Improved performances of
-          <literal>lib.closePropagation</literal> which was previously
-          quadratic. This is used in e.g.
-          <literal>ghcWithPackages</literal>. Please see backward
-          incompatibilities notes below.
+          Haskell <literal>ghcWithPackages</literal> is now up to 15
+          times faster to evaluate, thanks to changing
+          <literal>lib.closePropagation</literal> from a quadratic to
+          linear complexity. Please see backward incompatibilities notes
+          below.
+          <link xlink:href="https://github.com/NixOS/nixpkgs/pull/194391">https://github.com/NixOS/nixpkgs/pull/194391</link>
         </para>
       </listitem>
       <listitem>
         <para>
-          During cross-compilation, tests are now executed if the test
-          suite can be executed by the build platform. This is the case
-          when doing “native” cross-compilation where the build and host
-          platforms are largely the same, but the nixpkgs’ cross
-          compilation infrastructure is used, e.g.
-          <literal>pkgsStatic</literal> and <literal>pkgsLLVM</literal>.
-          Another possibility is that the build platform is a superset
-          of the host platform, e.g. when cross-compiling from
-          <literal>x86_64-unknown-linux</literal> to
-          <literal>i686-unknown-linux</literal>. The predicate gating
-          test suite execution is the newly added
-          <literal>canExecute</literal> predicate: You can e.g. check if
-          <literal>stdenv.buildPlatform</literal> can execute binaries
-          built for <literal>stdenv.hostPlatform</literal> (i.e.
-          produced by <literal>stdenv.cc</literal>) by evaluating
-          <literal>stdenv.buildPlatform.canExecute stdenv.hostPlatform</literal>.
+          For cross-compilation targets that can also run on the
+          building machine, we also enabled running tests now. This is
+          for example the case for the pkgsStatic and pkgsLLVm package
+          sets or i686 packages on <literal>x86_64</literal> machine.
         </para>
       </listitem>
       <listitem>
         <para>
-          The <literal>nixpkgs.hostPlatform</literal> and
-          <literal>nixpkgs.buildPlatform</literal> options have been
-          added. These cover and override the
+          To simplify cross-compilation in NixOS, this release
+          introduces the <literal>nixpkgs.hostPlatform</literal> and
+          <literal>nixpkgs.buildPlatform</literal> options. These cover
+          and override the
           <literal>nixpkgs.{system,localSystem,crossSystem}</literal>
           options.
         </para>
@@ -304,6 +233,64 @@
           the change and to allow for a transition period so that in
           time the ecosystem can switch without breaking compatibility
           with any supported NixOS release.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </section>
+  <section xml:id="sec-release-22.11-version-updates">
+    <title>Notable version updates</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Nix has been upgraded from
+          <link xlink:href="https://github.com/NixOS/nix/compare/2.8.1...2.11.0">v2.8.1
+          to v2.11.0</link>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          GNOME has been upgraded to version 43. Please take a look at
+          their <link xlink:href="https://release.gnome.org/43/">Release
+          Notes</link> for details.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          KDE Plasma has been upgraded from v5.24 to v5.26. Please see
+          the release notes for
+          <link xlink:href="https://kde.org/announcements/plasma/5/5.25.0/">v5.25</link>
+          and
+          <link xlink:href="https://kde.org/announcements/plasma/5/5.26.0/">v5.26</link>
+          for more details on the included changes.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Cinnamon has been updated to 5.4, and the Cinnamon module now
+          defaults to Blueman as the Bluetooth manager and slick-greeter
+          as the LightDM greeter, to match upstream.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          PHP now defaults to PHP 8.1, updated from 8.0.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Perl has been updated to 5.36, and its core module
+          <literal>HTTP::Tiny</literal> was patched to verify SSL/TLS
+          certificates by default.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Python now defalts to 3.10, updated from 3.9.
         </para>
       </listitem>
     </itemizedlist>
@@ -908,6 +895,22 @@ services.github-runner.serviceOverrides.SupplementaryGroups = [
   <section xml:id="sec-release-22.11-notable-changes">
     <title>Other Notable Changes</title>
     <itemizedlist>
+      <listitem>
+        <para>
+          PHP is now built in <literal>NTS</literal> (Non-Thread Safe)
+          mode by default.
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              For Apache and <literal>mod_php</literal> usage, we enable
+              <literal>ZTS</literal> (Zend Thread Safe) mode. This has
+              been a common practice for a long time in other
+              distributions.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
       <listitem>
         <para>
           <literal>firefox</literal>, <literal>thunderbird</literal> and

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -6,6 +6,13 @@ This release is supported until the end of June 2023, handing over to NixOS 23.0
 
 In addition to numerous new and upgraded packages, this release includes the following highlights:
 
+- Software that uses the `crypt` password hashing API is now using the implementation provided by [`libxcrypt`](https://github.com/besser82/libxcrypt) instead of glibc's, which enables support for more secure algorithms.
+  - Support for algorithms that `libxcrypt` [does not consider strong](https://github.com/besser82/libxcrypt/blob/v4.4.28/lib/hashes.conf#L41) are **deprecated** as of this release, and will be removed in NixOS 23.05.
+  - This includes system login passwords. Given this, we **strongly encourage** all users to update their system passwords, as you will be unable to login if password hashes are not migrated by the time their support is removed.
+    - When using `users.users.<name>.hashedPassword` to configure user passwords, run `mkpasswd`, and use the yescrypt hash that is provided as the new value.
+    - On the other hand, for interactively configured user passwords, simply re-set the passwords for all users with `passwd`.
+    - This release introduces warnings for the use of deprecated hash algorithms for both methods of configuring passwords. To make sure you migrated correctly, run `nixos-rebuild switch`.
+
 - GNOME has been upgraded to version 43. Please take a look at their [Release Notes](https://release.gnome.org/43/) for details.
 
 - KDE Plasma has been upgraded from v5.24 to v5.26. Please see the release notes for [v5.25](https://kde.org/announcements/plasma/5/5.25.0/) and [v5.26](https://kde.org/announcements/plasma/5/5.26.0/) for more details on the included changes.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -1,6 +1,10 @@
 # Release 22.11 (“Raccoon”, 2022.11/??) {#sec-release-22.11}
 
+The NixOS release team is happy to announce a new version of NixOS 22.11. NixOS is both a linux distribution, and a set of packages usable on other Linux systems and macOS.
+
 This release is supported until the end of June 2023, handing over to NixOS 23.05.
+
+To upgrade to the latest release follow the [upgrade chapter](#sec-upgrading).
 
 ## Highlights {#sec-release-22.11-highlights}
 
@@ -13,74 +17,37 @@ In addition to numerous new and upgraded packages, this release includes the fol
     - On the other hand, for interactively configured user passwords, simply re-set the passwords for all users with `passwd`.
     - This release introduces warnings for the use of deprecated hash algorithms for both methods of configuring passwords. To make sure you migrated correctly, run `nixos-rebuild switch`.
 
-- GNOME has been upgraded to version 43. Please take a look at their [Release Notes](https://release.gnome.org/43/) for details.
+- The NixOS documentation is now generated from markdown. While docbook is still part of the documentation build process, it's a big step towards the full migration.
 
-- KDE Plasma has been upgraded from v5.24 to v5.26. Please see the release notes for [v5.25](https://kde.org/announcements/plasma/5/5.25.0/) and [v5.26](https://kde.org/announcements/plasma/5/5.26.0/) for more details on the included changes.
+- `aarch64-linux` is now included in the `nixos-22.11` and `nixos-22.11-small` channels. This means that when those channel update, both `x86_64-linux` and `aarch64-linux` will be available in the binary cache.
 
-- Cinnamon has been updated to 5.4, and the Cinnamon module now defaults to
-  Blueman as the Bluetooth manager and slick-greeter as the LightDM greeter, to match upstream.
+- `aarch64-linux` ISOs are now available on the [downloads page](https://nixos.org/download.html).
 
-- OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
+- `nsncd` is now available as a replacement of `nscd`.
 
-- PHP now defaults to PHP 8.1, updated from 8.0.
+  `nscd` is responsible for resolving hostnames, users and more in NixOS and has been a long standing source of bugs, such as sporadic network freezes.
+  
+  More context in this [issue](https://github.com/NixOS/nixpkgs/issues/135888).
+  
+  Help us test the new implementation by setting `services.nscd.enableNsncd` to `true`.
 
-- PHP is now built in `NTS` (Non-Thread Safe) mode by default.
-  - For Apache and `mod_php` usage, we enable `ZTS` (Zend Thread Safe) mode. This has been a
-  common practice for a long time in other distributions.
+  We plan to use `nsncd` by default in NixOS 23.05.
 
-- Perl has been updated to 5.36, and its core module `HTTP::Tiny` was patched to verify SSL/TLS certificates by default.
+- Linode cloud images are now supported by importing `${modulesPath}/virtualisation/linode-image.nix` and accessing `system.build.linodeImage` on the output.
 
-- `nscd` functionality, necessary to provide non-glibc-builtin NSS
-   modules (such as `nss_systemd` or `nss_ldap`) can now be provided by
-   `nsncd`, by setting `services.nscd.enableNsncd` to `true`.
-
-   The `nscd` daemon provided by glibc, which is currently used by NixOS isn't
-   very reliable. For example, it's [not fully possible to disable caching
-   functionality](https://github.com/NixOS/nixpkgs/issues/135888), causing
-   various issues and failed lookups.
-
-   In contrast to nscd's behavior of caching module responses on its own,
-   nsncd merely forwards requests to NSS modules, which might cache or not.
-
-   We plan to use `nsncd` by default in NixOS 23.05.
+- `hardware.nvidia` has a new option, `hardware.nvidia.open`, that can be used to enable the usage of NVIDIA's open-source kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [the release announcement](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for more information.
 
 - The `emacs` package now makes use of native compilation which means:
   - Emacs packages from Nixpkgs, builtin or not, will do native compilation ahead of time so you can enjoy the benefit of native compilation without compiling them on you machine;
   - Emacs packages from somewhere else, e.g. `package-install`, will perform asynchronously deferred native compilation. If you do not want this, maybe to avoid CPU consumption for compilation, you can use `(setq native-comp-deferred-compilation nil)` to disable it while still benefiting from native compilation for packages from Nixpkgs.
 
-- `nixos-generate-config` now generates configurations that can be built in pure
-  mode. This is achieved by setting the new `nixpkgs.hostPlatform` option.
-
-  You may have to unset the `system` parameter in `lib.nixosSystem`, or similarly
-  remove definitions of the `nixpkgs.{system,localSystem,crossSystem}` options.
-
-  Alternatively, you can remove the `hostPlatform` line and use NixOS like you
-  would in NixOS 22.05 and earlier.
-
-- It is now possible to generate NixOS images for the Linode cloud provider, via `system.build.linodeImage`.
-
-- `hardware.nvidia` has a new option, `hardware.nvidia.open`, that can be used to enable the usage of NVIDIA's open-source kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [the release announcement](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for more information.
-
-- `aarch64-linux` is now included in the `nixos-22.11` and `nixos-22.11-small` channels. This means that `x86_64-linux` and `aarch64-linux` will recieve updates at the same time.
-
-- `aarch64-linux` ISOs are now available on the [downloads page](https://nixos.org/download.html).
-
 ## Internal changes {#sec-release-22.11-internal}
 
-- Improved performances of `lib.closePropagation` which was previously quadratic. This is used in e.g. `ghcWithPackages`. Please see backward incompatibilities notes below.
-- During cross-compilation, tests are now executed if the test suite can be executed
-  by the build platform. This is the case when doing “native” cross-compilation
-  where the build and host platforms are largely the same, but the nixpkgs' cross
-  compilation infrastructure is used, e.g. `pkgsStatic` and `pkgsLLVM`. Another
-  possibility is that the build platform is a superset of the host platform, e.g. when
-  cross-compiling from `x86_64-unknown-linux` to `i686-unknown-linux`.
-  The predicate gating test suite execution is the newly added `canExecute`
-  predicate: You can e.g. check if `stdenv.buildPlatform` can execute binaries
-  built for `stdenv.hostPlatform` (i.e. produced by `stdenv.cc`) by evaluating
-  `stdenv.buildPlatform.canExecute stdenv.hostPlatform`.
+- Haskell `ghcWithPackages` is now up to 15 times faster to evaluate, thanks to changing `lib.closePropagation` from a quadratic to linear complexity. Please see backward incompatibilities notes below. <https://github.com/NixOS/nixpkgs/pull/194391>
 
-- The `nixpkgs.hostPlatform` and `nixpkgs.buildPlatform` options have been added.
-  These cover and override the `nixpkgs.{system,localSystem,crossSystem}` options.
+- For cross-compilation targets that can also run on the building machine, we also enabled running tests now. This is for example the case for the pkgsStatic and pkgsLLVm package sets or i686 packages on `x86_64` machine.
+
+- To simplify cross-compilation in NixOS, this release introduces the `nixpkgs.hostPlatform` and `nixpkgs.buildPlatform` options. These cover and override the `nixpkgs.{system,localSystem,crossSystem}` options.
 
    - `hostPlatform` is the platform or "`system`" string of the NixOS system
      described by the configuration.
@@ -96,6 +63,25 @@ In addition to numerous new and upgraded packages, this release includes the fol
   been formally deprecated, to allow for evaluation of the change and to allow
   for a transition period so that in time the ecosystem can switch without
   breaking compatibility with any supported NixOS release.
+
+## Notable version updates {#sec-release-22.11-version-updates}
+
+- Nix has been upgraded from [v2.8.1 to v2.11.0](https://github.com/NixOS/nix/compare/2.8.1...2.11.0)
+
+- OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
+
+- GNOME has been upgraded to version 43. Please take a look at their [Release Notes](https://release.gnome.org/43/) for details.
+
+- KDE Plasma has been upgraded from v5.24 to v5.26. Please see the release notes for [v5.25](https://kde.org/announcements/plasma/5/5.25.0/) and [v5.26](https://kde.org/announcements/plasma/5/5.26.0/) for more details on the included changes.
+
+- Cinnamon has been updated to 5.4, and the Cinnamon module now defaults to
+  Blueman as the Bluetooth manager and slick-greeter as the LightDM greeter, to match upstream.
+
+- PHP now defaults to PHP 8.1, updated from 8.0.
+
+- Perl has been updated to 5.36, and its core module `HTTP::Tiny` was patched to verify SSL/TLS certificates by default.
+
+- Python now defalts to 3.10, updated from 3.9.
 
 ## Backward Incompatibilities {#sec-release-22.11-incompatibilities}
 
@@ -278,6 +264,10 @@ In addition to numerous new and upgraded packages, this release includes the fol
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Other Notable Changes {#sec-release-22.11-notable-changes}
+
+- PHP is now built in `NTS` (Non-Thread Safe) mode by default.
+  - For Apache and `mod_php` usage, we enable `ZTS` (Zend Thread Safe) mode. This has been a
+  common practice for a long time in other distributions.
 
 - `firefox`, `thunderbird` and `librewolf` now come with Wayland support by default. The `firefox-wayland`, `firefox-esr-wayland`, `thunderbird-wayland` and `librewolf-wayland` attributes are obsolete and have been aliased to their generic attribute.
 

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -1,14 +1,62 @@
 # Release 22.11 (“Raccoon”, 2022.11/??) {#sec-release-22.11}
 
-Support is planned until the end of June 2023, handing over to 23.05.
+This release is supported until the end of June 2023, handing over to NixOS 23.05.
 
 ## Highlights {#sec-release-22.11-highlights}
 
-In addition to numerous new and upgraded packages, this release has the following highlights:
+In addition to numerous new and upgraded packages, this release includes the following highlights:
 
-- GNOME has been upgraded to 43. Please take a look at their [Release
-  Notes](https://release.gnome.org/43/) for details.
+- GNOME has been upgraded to version 43. Please take a look at their [Release Notes](https://release.gnome.org/43/) for details.
 
+- KDE Plasma has been upgraded from v5.24 to v5.26. Please see the release notes for [v5.25](https://kde.org/announcements/plasma/5/5.25.0/) and [v5.26](https://kde.org/announcements/plasma/5/5.26.0/) for more details on the included changes.
+
+- Cinnamon has been updated to 5.4, and the Cinnamon module now defaults to
+  Blueman as the Bluetooth manager and slick-greeter as the LightDM greeter, to match upstream.
+
+- OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
+
+- PHP now defaults to PHP 8.1, updated from 8.0.
+
+- PHP is now built in `NTS` (Non-Thread Safe) mode by default.
+  - For Apache and `mod_php` usage, we enable `ZTS` (Zend Thread Safe) mode. This has been a
+  common practice for a long time in other distributions.
+
+- Perl has been updated to 5.36, and its core module `HTTP::Tiny` was patched to verify SSL/TLS certificates by default.
+
+- `nscd` functionality, necessary to provide non-glibc-builtin NSS
+   modules (such as `nss_systemd` or `nss_ldap`) can now be provided by
+   `nsncd`, by setting `services.nscd.enableNsncd` to `true`.
+
+   The `nscd` daemon provided by glibc, which is currently used by NixOS isn't
+   very reliable. For example, it's [not fully possible to disable caching
+   functionality](https://github.com/NixOS/nixpkgs/issues/135888), causing
+   various issues and failed lookups.
+
+   In contrast to nscd's behavior of caching module responses on its own,
+   nsncd merely forwards requests to NSS modules, which might cache or not.
+
+   We plan to use `nsncd` by default in NixOS 23.05.
+
+- The `emacs` package now makes use of native compilation which means:
+  - Emacs packages from Nixpkgs, builtin or not, will do native compilation ahead of time so you can enjoy the benefit of native compilation without compiling them on you machine;
+  - Emacs packages from somewhere else, e.g. `package-install`, will perform asynchronously deferred native compilation. If you do not want this, maybe to avoid CPU consumption for compilation, you can use `(setq native-comp-deferred-compilation nil)` to disable it while still benefiting from native compilation for packages from Nixpkgs.
+
+- `nixos-generate-config` now generates configurations that can be built in pure
+  mode. This is achieved by setting the new `nixpkgs.hostPlatform` option.
+
+  You may have to unset the `system` parameter in `lib.nixosSystem`, or similarly
+  remove definitions of the `nixpkgs.{system,localSystem,crossSystem}` options.
+
+  Alternatively, you can remove the `hostPlatform` line and use NixOS like you
+  would in NixOS 22.05 and earlier.
+
+- It is now possible to generate NixOS images for the Linode cloud provider, via `system.build.linodeImage`.
+
+- `hardware.nvidia` has a new option, `hardware.nvidia.open`, that can be used to enable the usage of NVIDIA's open-source kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [the release announcement](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for more information.
+
+## Internal changes {#sec-release-22.11-internal}
+
+- Improved performances of `lib.closePropagation` which was previously quadratic. This is used in e.g. `ghcWithPackages`. Please see backward incompatibilities notes below.
 - During cross-compilation, tests are now executed if the test suite can be executed
   by the build platform. This is the case when doing “native” cross-compilation
   where the build and host platforms are largely the same, but the nixpkgs' cross
@@ -38,55 +86,366 @@ In addition to numerous new and upgraded packages, this release has the followin
   for a transition period so that in time the ecosystem can switch without
   breaking compatibility with any supported NixOS release.
 
-- `nscd` functionality, necessary to provide non-glibc-builtin NSS
-  modules (such as `nss_systemd` or `nss_ldap`) can now be provided by
-  `nsncd`, by setting `services.nscd.enableNsncd` to `true`.
+## Backward Incompatibilities {#sec-release-22.11-incompatibilities}
 
-  The `nscd` daemon provided by glibc, which is currently used by NixOS isn't
-  very reliable. For example, it's [not fully possible to disable caching
-  functionality](https://github.com/NixOS/nixpkgs/issues/135888), causing
-  various issues and failed lookups.
+- Nixpkgs now requires Nix 2.3 or newer.
 
-  In contrast to nscd's behavior of caching module responses on its own,
-  nsncd merely forwards requests to NSS modules, which might cache or not.
+- The `isCompatible` predicate checking CPU compatibility is no longer exposed
+  by the platform sets generated using `lib.systems.elaborate`. In most cases
+  you will want to use the new `canExecute` predicate instead which also
+  considers the kernel / syscall interface. It is briefly described in the
+  release's [highlights section](#sec-release-22.11-highlights).
+  `lib.systems.parse.isCompatible` still exists, but has changed semantically:
+  Architectures with differing endianness modes are *no longer considered compatible*.
 
-  We plan to use `nsncd` by default in NixOS 23.05.
+- `ngrok` has been upgraded from 2.3.40 to 3.0.4. Please see [the upgrade guide](https://ngrok.com/docs/guides/upgrade-v2-v3)
+  and [changelog](https://ngrok.com/docs/ngrok-agent/changelog). Notably, breaking changes are that the config file format has
+  changed and support for single hyphen arguments was dropped.
 
-- `emacs` enables native compilation which means:
-  - emacs packages from nixpkgs, builtin or not, will do native compilation ahead of time so you can enjoy the benefit of native compilation without compiling them on you machine;
-  - emacs packages from somewhere else, e.g. `package-install`, will do asynchronously deferred native compilation. If you do not want this, maybe to avoid CPU consumption for compilation, you can use `(setq native-comp-deferred-compilation nil)` to disable it while still enjoy the benefit of native compilation for packages from nixpkgs.
+- `i18n.supportedLocales` is now only generated with the locales set in `i18n.defaultLocale` and `i18n.extraLocaleSettings`.
+  - This reduces the final system closure size by up to 200MB.
+  - If you require all locales installed, set the option to ``[ "all" ]``.
 
-- `nixos-generate-config` now generates configurations that can be built in pure
-  mode. This is achieved by setting the new `nixpkgs.hostPlatform` option.
+- Deprecated settings `logrotate.paths` and `logrotate.extraConfig` have
+  been removed. Please convert any uses to
+  [services.logrotate.settings](#opt-services.logrotate.settings) instead.
 
-  You may have to unset the `system` parameter in `lib.nixosSystem`, or similarly
-  remove definitions of the `nixpkgs.{system,localSystem,crossSystem}` options.
+- The `isPowerPC` predicate, found on `platform` attrsets (`hostPlatform`, `buildPlatform`, `targetPlatform`, etc) has been removed in order to reduce confusion.  The predicate was was defined such that it matches only the 32-bit big-endian members of the POWER/PowerPC family, despite having a name which would imply a broader set of systems.  If you were using this predicate, you can replace `foo.isPowerPC` with `(with foo; isPower && is32bit && isBigEndian)`.
 
-  Alternatively, you can remove the `hostPlatform` line and use NixOS like you
-  would in NixOS 22.05 and earlier.
+- The `fetchgit` fetcher now uses [cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalscone_mode_handling) by default for sparse checkouts. [Non-cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems) can be enabled by passing `nonConeMode = true`, but note that non-cone mode is deprecated and this option may be removed alongside a future Git update without notice.
 
-- PHP now defaults to PHP 8.1, updated from 8.0.
+- The `fetchgit` fetcher supports sparse checkouts via the `sparseCheckout` option. This used to accept a multi-line string with directories/patterns to check out, but now requires a list of strings
 
-- PHP is now built `NTS` (Non-Thread Safe) style by default, for Apache and
-  `mod_php` usage we still enable `ZTS` (Zend Thread Safe). This has been a
-  common practice for a long time in other distributions.
+- `openssh` was updated to version 9.1, disabling the generation of DSA keys when using `ssh-keygen -A` as they are insecure. Also, `SetEnv` directives in `ssh_config` and `sshd_config` are now first-match-wins
 
-- PHP 8.2.0 RC 7 is available.
+- `bsp-layout` no longer uses the command `cycle` to switch to other window layouts, as it got replaced by the commands `previous` and `next`.
+
+- The Barco ClickShare driver/client package `pkgs.clickshare-csc1` and the option `programs.clickshare-csc1.enable` have been removed,
+  as it requires `qt4`, which reached its end-of-life 2015 and will no longer be supported by nixpkgs.
+  [According to Barco](https://www.barco.com/de/support/knowledge-base/4380-can-i-use-linux-os-with-clickshare-base-units) many of their base unit models can be used with Google Chrome and the Google Cast extension.
+
+- `services.hbase` has been renamed to `services.hbase-standalone`.
+  For production HBase clusters, use `services.hadoop.hbase` instead.
+
+- The `p4` package now only includes the open-source Perforce Helix Core command-line client and APIs. It no longer installs the unfree Helix Core Server binaries `p4d`, `p4broker`, and `p4p`. To install the Helix Core Server binaries, use the `p4d` package instead.
+
+- The OpenSSL extension for the PHP interpreter used by Nextcloud is built against OpenSSL 1.1 if
+  [](#opt-system.stateVersion) is below `22.11`. This is to make sure that people using [server-side encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html)
+  don't lose access to their files.
+
+  In any other case, it's safe to use OpenSSL 3 for PHP's OpenSSL extension. This can be done by setting
+  [](#opt-services.nextcloud.enableBrokenCiphersForSSE) to `false`.
+
+- The `coq` package and versioned variants starting at `coq_8_14` no
+  longer include CoqIDE, which is now available through
+  `coqPackages.coqide`. It is still possible to get CoqIDE as part of
+  the `coq` package by overriding the `buildIde` argument of the
+  derivation.
+
+- PHP 7.4 is no longer supported due to upstream not supporting this
+  version for the entire lifecycle of the 22.11 release.
+
+- The ipfs package and module were renamed to kubo. The kubo module now uses an RFC42-style `settings` option instead of `extraConfig` and the `gatewayAddress`, `apiAddress` and `swarmAddress` options were renamed. Using the old names will print a warning but still work.
+
+- `pkgs.cosign` does not provide the `cosigned` binary anymore. The `sget` binary has been moved into its own package.
+
+- Emacs now uses the Lucid toolkit by default instead of GTK because of stability and compatibility issues.
+  Users who still wish to remain using GTK can do so by using `emacs-gtk`.
+
+- `kanidm` has been updated to 1.1.0-alpha.10 and now requires a TLS certificate and key. It will always start `https` and-–-if enabled-–-an LDAPS server and no HTTP and LDAP server anymore
+
+- riak package removed along with `services.riak` module, due to lack of maintainer to update the package.
+
+- ppd files in `pkgs.cups-drv-rastertosag-gdi` are now gzipped.  If you refer to such a ppd file with its path (e.g. via [hardware.printers.ensurePrinters](options.html#opt-hardware.printers.ensurePrinters)) you will need to append `.gz` to the path.
+
+- xow package removed along with the `hardware.xow` module, due to the project being deprecated in favor of `xone`,  which is available via the `hardware.xone` module.
+
+- dd-agent package removed along with the `services.dd-agent` module, due to the project being deprecated in favor of `datadog-agent`,  which is available via the `services.datadog-agent` module.
+
+- `teleport` has been upgraded to major version 10. Please see upstream [upgrade instructions](https://goteleport.com/docs/ver/10.0/management/operations/upgrading/) and [release notes](https://goteleport.com/docs/ver/10.0/changelog/#1000).
+
+- `lib.closePropagation` now needs that all gathered sets have an `outPath` attribute.
+
+- lemmy module option `services.lemmy.settings.database.createLocally`
+  moved to `services.lemmy.database.createLocally`.
+
+- virtlyst package and `services.virtlyst` module removed, due to lack of maintainers.
+
+- The `nix.checkConfig` option now fully disables the config check. The new `nix.checkAllErrors` option behaves like `nix.checkConfig`  previously did.
+
+- `generateOptparseApplicativeCompletions` and `generateOptparseApplicativeCompletion` from `haskell.lib.compose`
+  (and `haskell.lib`) have been deprecated in favor of `generateOptparseApplicativeCompletions` (plural!) as
+  provided by the haskell package sets (so `haskellPackages.generateOptparseApplicativeCompletions` etc.).
+  The latter allows for cross-compilation (by automatically disabling generation of completion in the cross case).
+  For it to work properly you need to make sure that the function comes from the same context as the package
+  you are trying to override, i.e. always use the same package set as your package is coming from or – even
+  better – use `self.generateOptparseApplicativeCompletions` if you are overriding a haskell package set.
+  The old functions are retained for backwards compatibility, but yield are warning.
+
+- The `services.graphite.api` and `services.graphite.beacon` NixOS options, and
+  the `python3.pkgs.graphite_api`, `python3.pkgs.graphite_beacon` and
+  `python3.pkgs.influxgraph` packages, have been removed due to lack of upstream
+  maintenance.
+
+- The `trace` binary from `perf-linux` package has been removed, due to being a duplicate of the `perf` binary.
+
+- The `aws` package has been removed due to being abandoned by the upstream. It is recommended to use `awscli` or `awscli2` instead.
+
+- The [CEmu TI-84 Plus CE emulator](https://ce-programming.github.io/CEmu) package has been renamed to `cemu-ti`. The [Cemu Wii U emulator](https://cemu.info) is now packaged as `cemu`.
+
+- `systemd-networkd` v250 deprecated, renamed, and moved some sections and settings which leads to the following breaking module changes:
+
+   * `systemd.network.networks.<name>.dhcpV6PrefixDelegationConfig` is renamed to `systemd.network.networks.<name>.dhcpPrefixDelegationConfig`.
+   * `systemd.network.networks.<name>.dhcpV6Config` no longer accepts the `ForceDHCPv6PDOtherInformation=` setting. Please use the `WithoutRA=` and `UseDelegatedPrefix=` settings in your `systemd.network.networks.<name>.dhcpV6Config` and the `DHCPv6Client=` setting in your `systemd.network.networks.<name>.ipv6AcceptRAConfig` to control when the DHCPv6 client is started and how the delegated prefixes are handled by the DHCPv6 client.
+   * `systemd.network.networks.<name>.networkConfig` no longer accepts the `IPv6Token=` setting. Use the `Token=` setting in your `systemd.network.networks.<name>.ipv6AcceptRAConfig` instead. The `systemd.network.networks.<name>.ipv6Prefixes.*.ipv6PrefixConfig` now also accepts the `Token=` setting.
+
+- `arangodb` versions 3.3, 3.4, and 3.5 have been removed because they are at EOL upstream. The default is now 3.10.0. Support for aarch64-linux has been removed since the target cannot be built reproducibly. By default `arangodb` is now built for the `haswell` architecture. If you wish to build for a different architecture, you may override the `targetArchitecture` argument with a value from [this list supported upstream](https://github.com/arangodb/arangodb/blob/207ec6937e41a46e10aea34953879341f0606841/cmake/OptimizeForArchitecture.cmake#L594). Some architecture specific optimizations are also conditionally enabled. You may alter this behavior by overriding the `asmOptimizations` parameter. You may also add additional architecture support by adding more `-DHAS_XYZ` flags to `cmakeFlags` via `overrideAttrs`.
+
+- The `meta.mainProgram` attribute of packages in `wineWowPackages` now defaults to `"wine64"`.
+
+- The `paperless` module now defaults `PAPERLESS_TIME_ZONE` to your configured system timezone.
+
+- The top-level `termonad-with-packages` alias for `termonad` has been removed.
+
+- Linux 4.9 has been removed because it will reach its end of life within the lifespan of 22.11.
+
+- (Neo)Vim can not be configured with `configure.pathogen` anymore to reduce maintainance burden.
+  Use `configure.packages` instead.
+- Neovim can not be configured with plug anymore (still works for vim).
+
+- The `adguardhome` module no longer uses `host` and `port` options, use `settings.bind_host` and `settings.bind_port` instead.
+
+- The default `kops` version is now 1.25.1 and support for 1.22 and older has been dropped.
+
+- The `zrepl` package has been updated from 0.5.0 to 0.6.0. See the [changelog](https://zrepl.github.io/changelog.html) for details.
+
+- `k3s` no longer supports Docker as runtime due to upstream dropping support.
+
+- `cassandra_2_1` and `cassandra_2_2` have been removed. Please update to `cassandra_3_11` or `cassandra_3_0`. See the [changelog](https://github.com/apache/cassandra/blob/cassandra-3.11.14/NEWS.txt) for more information about the upgrade process.
+
+- `mysql57` has been removed. Please update to `mysql80` or `mariadb`. See the [upgrade guide](https://mariadb.com/kb/en/upgrading-from-mysql-to-mariadb/) for more information.
+
+- Consequently, `cqrlog` and `amorok` now use `mariadb` instead of `mysql57` for their embedded databases. Running `mysql_upgrade` may be neccesary.
+- `k3s` supports `clusterInit` option, and it is enabled by default, for servers.
+
+- `percona-server56` has been removed. Please migrate to `mysql` or `mariadb` if possible.
+
+- `obs-studio` hase been updated to version 28. If you have packaged custom plugins, check if they are compatible. `obs-websocket` has been integrated into `obs-studio`.
+
+- `signald` has been bumped to `0.23.0`. For the upgrade, a migration process is necessary. It can be
+  done by running a command like this before starting `signald.service`:
+
+  ```
+  signald -d /var/lib/signald/db \
+    --database sqlite:/var/lib/signald/db \
+    --migrate-data
+  ```
+
+  For further information, please read the upstream changelogs.
+
+- `stylua` no longer accepts `lua52Support` and `luauSupport` overrides. Use `features` instead, which defaults to `[ "lua54" "luau" ]`.
+
+- `ocamlPackages.ocaml_extlib` has been renamed to `ocamlPackages.extlib`.
+
+- `pkgs.fetchNextcloudApp` has been rewritten to circumvent impurities in e.g. tarballs from GitHub and to make it easier to
+  apply patches. This means that your hashes are out-of-date and the (previously required) attributes `name` and `version`
+  are no longer accepted.
+
+- The Syncthing service now only allows absolute paths---starting with `/` or
+  `~/`---for `services.syncthing.folders.<name>.path`.
+  In a future release other paths will be allowed again and interpreted
+  relative to `services.syncthing.dataDir`.
+
+- `services.github-runner` and `services.github-runners.<name>` gained the option `serviceOverrides` which allows overriding the systemd `serviceConfig`. If you have been overriding the systemd service configuration (i.e., by defining `systemd.services.github-runner.serviceConfig`), you have to use the `serviceOverrides` option now. Example:
+
+  ```
+  services.github-runner.serviceOverrides.SupplementaryGroups = [
+    "docker"
+  ];
+  ```
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
+## Other Notable Changes {#sec-release-22.11-notable-changes}
+
+- `firefox`, `thunderbird` and `librewolf` now come with Wayland support by default. The `firefox-wayland`, `firefox-esr-wayland`, `thunderbird-wayland` and `librewolf-wayland` attributes are obsolete and have been aliased to their generic attribute.
+
+- The `xplr` package has been updated from 0.18.0 to 0.19.0, which brings some breaking changes. See the [upstream release notes](https://github.com/sayanarijit/xplr/releases/tag/v0.19.0) for more details.
+
+- Configuring multiple GitHub runners is now possible through `services.github-runners.<name>`. The options under `services.github-runner` remain, to configure a single runner.
+
+- `github-runner` gained support for ephemeral runners and registrations using a personal access token (PAT) instead of a registration token. See `services.github-runner.ephemeral` and `services.github-runner.tokenFile` for details.
+
+- A new module was added to provide hardware support for the Saleae Logic device family, providing the options `hardware.saleae-logic.enable` and `hardware.saleae-logic.package`.
+
+- ZFS module will no longer allow hibernation by default.
+  - This is a safety measure to prevent data loss cases like the ones described at [OpenZFS/260](https://github.com/openzfs/zfs/issues/260) and [OpenZFS/12842](https://github.com/openzfs/zfs/issues/12842).
+  - Use the `boot.zfs.allowHibernation` option to configure this behaviour.
+
+- Mastodon now automatically removes remote media attachments older than 30 days. This is configurable through `services.mastodon.mediaAutoRemove`.
+
+- The Redis module now disables RDB persistence when `services.redis.servers.<name>.save = []` instead of using the Redis default.
+
+- Neo4j was updated from version 3 to version 4. See upstream's [migration guide](https://neo4j.com/docs/upgrade-migration-guide/current/) for information on how to migrate your instance.
+
+- The `networking.wireguard` module now can set the mtu on interfaces and tag its packets with an fwmark.
+
+- The option `overrideStrategy` was added to the different systemd unit options (`systemd.services.<name>`, `systemd.sockets.<name>`, …) to allow enforcing the creation of a dropin file, rather than the main unit file, by setting it to `asDropin`.
+  This is useful in cases where the existence of the main unit file is not known to Nix at evaluation time, for example when the main unit file is provided by adding a package to `systemd.packages`.
+  See the fix proposed in [NixOS's systemd abstraction doesn't work with systemd template units](https://github.com/NixOS/nixpkgs/issues/135557#issuecomment-1295392470) for an example.
+
+- The `polymc` package has been removed due to a rogue maintainer. It has been
+  replaced by `prismlauncher`, a fork by the rest of the maintainers. For more
+  details, see [the PR that made this change](https://github.com/NixOS/nixpkgs/pull/196624) and
+  [the issue detailing the vulnerability](https://github.com/NixOS/nixpkgs/issues/196460).
+  Users with existing installations should rename `~/.local/share/polymc` to
+  `~/.local/share/PrismLauncher`. The main config file's path has also moved
+  from `~/.local/share/polymc/polymc.cfg` to
+  `~/.local/share/PrismLauncher/prismlauncher.cfg`.
+
+- The `bloat` package has been updated from unstable-2022-03-31 to unstable-2022-10-25, which brings a breaking change. See [this upstream commit message](https://git.freesoftwareextremist.com/bloat/commit/?id=887ed241d64ba5db3fd3d87194fb5595e5ad7d73) for details.
+
+- Synapse's systemd unit has been hardened.
+
+- The module `services.grafana` was refactored to be compliant with [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md). To be precise, this means that the following things have changed:
+  - The newly introduced option [](#opt-services.grafana.settings) is an attribute-set that
+    will be converted into Grafana's INI format. This means that the configuration from
+    [Grafana's configuration reference](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/)
+    can be directly written as attribute-set in Nix within this option.
+  - The option `services.grafana.extraOptions` has been removed. This option was an association
+    of environment variables for Grafana. If you had an expression like
+
+    ```nix
+    {
+      services.grafana.extraOptions.SECURITY_ADMIN_USER = "foobar";
+    }
+    ```
+
+    your Grafana instance was running with `GF_SECURITY_ADMIN_USER=foobar` in its environment.
+
+    For the migration, it is recommended to turn it into the INI format, i.e.
+    to declare
+
+    ```nix
+    {
+      services.grafana.settings.security.admin_user = "foobar";
+    }
+    ```
+
+    instead.
+
+    The keys in `services.grafana.extraOptions` have the format `<INI section name>_<Key Name>`.
+    Further details are outlined in the [configuration reference](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables).
+
+    Alternatively you can also set all your values from `extraOptions` to
+    `systemd.services.grafana.environment`, make sure you don't forget to add
+    the `GF_` prefix though!
+  - Previously, the options [](#opt-services.grafana.provision.datasources) and
+    [](#opt-services.grafana.provision.dashboards) expected lists of datasources
+    or dashboards for the [declarative provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/).
+
+    To declare lists of
+    - **datasources**, please rename your declarations to [](#opt-services.grafana.provision.datasources.settings.datasources).
+    - **dashboards**, please rename your declarations to [](#opt-services.grafana.provision.dashboards.settings.providers).
+
+    This change was made to support more features for that:
+
+    - It's possible to declare the `apiVersion` of your dashboards and datasources
+      by [](#opt-services.grafana.provision.datasources.settings.apiVersion) (or
+      [](#opt-services.grafana.provision.dashboards.settings.apiVersion)).
+
+    - Instead of declaring datasources and dashboards in pure Nix, it's also possible
+      to specify configuration files (or directories) with YAML instead using
+      [](#opt-services.grafana.provision.datasources.path) (or
+      [](#opt-services.grafana.provision.dashboards.path). This is useful when having
+      provisioning files from non-NixOS Grafana instances that you also want to
+      deploy to NixOS.
+
+      __Note:__ secrets from these files will be leaked into the store unless you use a
+      [**file**-provider or env-var](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#file-provider) for secrets!
+
+    - [](#opt-services.grafana.provision.notifiers) is not affected by this change because
+      this feature is deprecated by Grafana and will probably removed in Grafana 10.
+      It's recommended to use `services.grafana.provision.alerting.contactPoints` instead.
+
+- The `services.grafana.provision.alerting` option was added. It includes suboptions for every alerting-related objects (with the exception of `notifiers`), which means it's now possible to configure modern Grafana alerting declaratively.
+
+- Synapse now requires entries in the `state_group_edges` table to be unique, in order to prevent accidentally introducing duplicate information (for example, because a database backup was restored multiple times). If your Synapse database already has duplicate rows in this table, this could fail with an error and require manual remediation.
+
+- The `diamond` package has been update from 0.8.36 to 2.0.15. See the [upstream release notes](https://github.com/bbuchfink/diamond/releases) for more details.
+
+- The `guake` package has been updated from 3.6.3 to 3.9.0, see the [changelog](https://github.com/Guake/guake/releases) for more details.
+
+- The `netlify-cli` package has been updated from 6.13.2 to 12.2.4, see the [changelog](https://github.com/netlify/cli/releases) for more details.
+
+- `dockerTools.buildImage`'s `contents` parameter has been deprecated in favor of `copyToRoot`.
+  Use `copyToRoot = buildEnv { ... };` or similar if you intend to add packages to `/bin`.
+
+- The `proxmox.qemuConf.bios` option was added, it corresponds to `Hardware->BIOS` field in Proxmox web interface. Use `"ovmf"` value to build UEFI image, default value remains `"bios"`. New option `proxmox.partitionTableType` defaults to either `"legacy"` or `"efi"`, depending on the `bios` value. Setting `partitionTableType` to `"hybrid"` results in an image, which supports both methods (`"bios"` and `"ovmf"`), thereby remaining bootable after change to Proxmox `Hardware->BIOS` field.
+
+- memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2. It is now the upstream version from https://www.memtest.org/, as coreboot's fork is no longer available.
+
+- Option descriptions, examples, and defaults writting in DocBook are now deprecated. Using CommonMark is preferred and will become the default in a future release.
+
+- The `documentation.nixos.options.allowDocBook` option was added to ease the transition to CommonMark option documentation. Setting this option to `false` causes an error for every option included in the manual that uses DocBook documentation; it defaults to `true` to preserve the previous behavior and will be removed once the transition to CommonMark is complete.
+
+- The Redis module now persists each instance's configuration file in the state directory, in order to support some more advanced use cases like Sentinel.
 
 - `protonup` has been aliased to and replaced by `protonup-ng` due to upstream not maintaining it.
 
-- Perl has been updated to 5.36, and its core module `HTTP::Tiny` was patched to verify SSL/TLS certificates by default.
+- The udisks2 service, available at `services.udisks2.enable`, is now disabled by default. It will automatically be enabled through services and desktop environments as needed.
+  This also means that polkit will now actually be disabled by default. The default for `security.polkit.enable` was already flipped in the previous release, but udisks2 being enabled by default re-enabled it.
 
-- Improved performances of `lib.closePropagation` which was previously quadratic. This is used in e.g. `ghcWithPackages`. Please see backward incompatibilities notes below.
+- Nextcloud has been updated to version **25**. Additionally the following things have changed
+  for Nextcloud in NixOS:
+  - For Nextcloud **>=24**, the default PHP version is 8.1.
+  - Nextcloud **23** has been removed since it will reach its [end of life in December 2022](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule/d76576a12a626d53305d480a6065b57cab705d3d).
+  - If `system.stateVersion` is **>=22.11**, Nextcloud 25 will be installed by default. For older versions,
+    Nextcloud 24 will be installed.
+  - Please ensure that you only upgrade one major release at a time! Nextcloud doesn't support
+    upgrades across multiple versions, i.e. an upgrade from **23** to **25** is only possible
+    when upgrading to **24** first.
 
-- Cinnamon has been updated to 5.4. While at it, the cinnamon module now defaults to
-  blueman as bluetooth manager and slick-greeter as lightdm greeter to match upstream.
+- systemd-oomd is enabled by default. Depending on which systemd units have
+  `ManagedOOMSwap=kill` or `ManagedOOMMemoryPressure=kill`, systemd-oomd will
+  SIGKILL all the processes under the appropriate descendant cgroups when the
+  configured limits are exceeded. NixOS does currently not configure cgroups
+  with oomd by default, this can be enabled using
+  [systemd.oomd.enableRootSlice](options.html#opt-systemd.oomd.enableRootSlice),
+  [systemd.oomd.enableSystemSlice](options.html#opt-systemd.oomd.enableSystemSlice),
+  and [systemd.oomd.enableUserServices](options.html#opt-systemd.oomd.enableUserServices).
 
-- OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
+- The `tt-rss` service performs two database migrations when you first use its web UI after upgrade. Consider backing up its database before updating.
 
-- An image configuration and generator has been added for Linode images, largely based on the present GCE configuration and image.
+- The `pass-secret-service` package now includes systemd units from upstream, so adding it to the NixOS `services.dbus.packages` option will make it start automatically as a systemd user service when an application tries to talk to the libsecret D-Bus API.
 
-- `hardware.nvidia` has a new option `open` that can be used to opt in the opensource version of NVIDIA kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [NVIDIA Releases Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for the official announcement.
+- The Wordpress module now has support for installing language packs through a new option, `services.wordpress.sites.<site>.languages`.
+
+- The default package for `services.mullvad-vpn.package` was changed to `pkgs.mullvad`, allowing cross-platform usage of Mullvad. `pkgs.mullvad` only contains the Mullvad CLI tool, so users who rely on the Mullvad GUI will want to change it back to `pkgs.mullvad-vpn`, or add `pkgs.mullvad-vpn` to their environment.
+
+- PowerDNS has been updated from v4.6.2 to v4.7.2. Please be sure to review the [Upgrade Notes](https://doc.powerdns.com/authoritative/upgrading.html#to-4-7-0-or-master) provided by upstream before upgrading. Worth specifically noting is that the new Catalog Zones feature comes with a mandatory schema change for the GSQL database backends, which has to be manually applied.
+
+- There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and may be removed in a future release.
+
+- There is a new module for `xfconf` (the Xfce configuration storage system), which has a dbus service.
+
+- The Mastodon package has been upgraded to v4.0.0. See the [v4.0.0 release notes](https://github.com/mastodon/mastodon/releases/tag/v4.0.0) for a list of changes. On standard setups, no manual migration steps are required. Nevertheless, a database backup is recommended.
+
+- The `nomad` package now defaults to v1.3, which no longer has a downgrade path to v1.2 or older.
+
+- The `nodePackages` package set now defaults to the LTS release in the `nodejs` package again, instead of being pinned to `nodejs-14_x`. Several updates to node2nix have been made for compatibility with newer Node.js and npm versions and a new `postRebuild` hook has been added for packages to perform extra build steps before the npm install step prunes dev dependencies.
+
+- `boot.kernel.sysctl` is defined as a freeformType and adds a custom merge option for `net.core.rmem_max` (taking the highest value defined to avoid conflicts between 2 services trying to set that value).
+
+- The `mame` package does not ship with its tools anymore in the default output. They were moved to a separate `tools` output instead. For convenience, `mame-tools` package was added for those who want to use it.
+
+- A NixOS module for Firefox has been added which allows preferences and [policies](https://github.com/mozilla/policy-templates/blob/master/README.md) to be set. This also allows extensions to be installed via the `ExtensionSettings` policy. The new options are under `programs.firefox`.
+
+- The option `services.picom.experimentalBackends` was removed since it is now the default and the option will cause `picom` to quit instead.
+
+- `haskellPackage.callHackage` is not always invalidated if `all-cabal-hashes` changes, leading to less rebuilds of haskell dependencies.
+
+- `haskellPackages.callHackage` and `haskellPackages.callCabal2nix` (and related functions) no longer keep a reference to the `cabal2nix` call used to generate them. As a result, they will be garbage collected more often.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
@@ -176,379 +535,5 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 - [Uptime Kuma](https://uptime.kuma.pet/), a fancy self-hosted monitoring tool. Available as [services.uptime-kuma](#opt-services.uptime-kuma.enable).
 
 - [Mepo](https://mepo.milesalan.com), a fast, simple, hackable OSM map viewer for mobile and desktop Linux. Available as [programs.mepo.enable](#opt-programs.mepo.enable).
-
-<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
-
-## Backward Incompatibilities {#sec-release-22.11-incompatibilities}
-
-- Nixpkgs now requires Nix 2.3 or newer.
-
-- The `isCompatible` predicate checking CPU compatibility is no longer exposed
-  by the platform sets generated using `lib.systems.elaborate`. In most cases
-  you will want to use the new `canExecute` predicate instead which also
-  considers the kernel / syscall interface. It is briefly described in the
-  release's [highlights section](#sec-release-22.11-highlights).
-  `lib.systems.parse.isCompatible` still exists, but has changed semantically:
-  Architectures with differing endianness modes are *no longer considered compatible*.
-
-- `ngrok` has been upgraded from 2.3.40 to 3.0.4. Please see [the upgrade guide](https://ngrok.com/docs/guides/upgrade-v2-v3)
-  and [changelog](https://ngrok.com/docs/ngrok-agent/changelog). Notably, breaking changes are that the config file format has
-  changed and support for single hypen arguments was dropped.
-
-- `i18n.supportedLocales` is now by default only generated with the locales set in `i18n.defaultLocale` and `i18n.extraLocaleSettings`.
-  This got partially copied over from the minimal profile and reduces the final system size by up to 200MB.
-  If you require all locales installed set the option to ``[ "all" ]``.
-
-- Deprecated settings `logrotate.paths` and `logrotate.extraConfig` have
-  been removed. Please convert any uses to
-  [services.logrotate.settings](#opt-services.logrotate.settings) instead.
-
-- The `isPowerPC` predicate, found on `platform` attrsets (`hostPlatform`, `buildPlatform`, `targetPlatform`, etc) has been removed in order to reduce confusion.  The predicate was was defined such that it matches only the 32-bit big-endian members of the POWER/PowerPC family, despite having a name which would imply a broader set of systems.  If you were using this predicate, you can replace `foo.isPowerPC` with `(with foo; isPower && is32bit && isBigEndian)`.
-
-- The `fetchgit` fetcher now uses [cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalscone_mode_handling) by default for sparse checkouts. [Non-cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems) can be enabled by passing `nonConeMode = true`, but note that non-cone mode is deprecated and this option may be removed alongside a future Git update without notice.
-
-- The `fetchgit` fetcher supports sparse checkouts via the `sparseCheckout` option. This used to accept a multi-line string with directories/patterns to check out, but now requires a list of strings.
-
-- `openssh` was updated to version 9.1, disabling the generation of DSA keys when using `ssh-keygen -A` as they are insecure. Also, `SetEnv` directives in `ssh_config` and `sshd_config` are now first-match-wins
-
-- `bsp-layout` no longer uses the command `cycle` to switch to other window layouts, as it got replaced by the commands `previous` and `next`.
-
-- The Barco ClickShare driver/client package `pkgs.clickshare-csc1` and the option `programs.clickshare-csc1.enable` have been removed,
-  as it requires `qt4`, which reached its end-of-life 2015 and will no longer be supported by nixpkgs.
-  [According to Barco](https://www.barco.com/de/support/knowledge-base/4380-can-i-use-linux-os-with-clickshare-base-units) many of their base unit models can be used with Google Chrome and the Google Cast extension.
-
-- `services.hbase` has been renamed to `services.hbase-standalone`.
-  For production HBase clusters, use `services.hadoop.hbase` instead.
-
-- The `p4` package now only includes the open-source Perforce Helix Core command-line client and APIs. It no longer installs the unfree Helix Core Server binaries `p4d`, `p4broker`, and `p4p`. To install the Helix Core Server binaries, use the `p4d` package instead.
-
-- The `openssl`-extension for the PHP interpreter used by Nextcloud is built against OpenSSL 1.1 if
-  [](#opt-system.stateVersion) is below `22.11`. This is to make sure that people using [server-side encryption](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/encryption_configuration.html)
-  don't lose access to their files.
-
-  In any other case it's safe to use OpenSSL 3 for PHP's openssl extension. This can be done by setting
-  [](#opt-services.nextcloud.enableBrokenCiphersForSSE) to `false`.
-
-- The `coq` package and versioned variants starting at `coq_8_14` no
-  longer include CoqIDE, which is now available through
-  `coqPackages.coqide`. It is still possible to get CoqIDE as part of
-  the `coq` package by overriding the `buildIde` argument of the
-  derivation.
-
-- PHP 7.4 is no longer supported due to upstream not supporting this
-  version for the entire lifecycle of the 22.11 release.
-
-- The ipfs package and module were renamed to kubo. The kubo module now uses an RFC42-style `settings` option instead of `extraConfig` and the `gatewayAddress`, `apiAddress` and `swarmAddress` options were renamed. Using the old names will print a warning but still work.
-
-- `pkgs.cosign` does not provide the `cosigned` binary anymore. The `sget` binary has been moved into its own package.
-
-- Emacs now uses the Lucid toolkit by default instead of GTK because of stability and compatibility issues.
-  Users who still wish to remain using GTK can do so by using `emacs-gtk`.
-
-- `kanidm` has been updated to 1.1.0-alpha.10 and now requires a tls certificate and key. It will always start an https and – if enabled – an ldaps server and no http and ldap server anymore.
-
-- riak package removed along with `services.riak` module, due to lack of maintainer to update the package.
-
-- ppd files in `pkgs.cups-drv-rastertosag-gdi` are now gzipped.  If you refer to such a ppd file with its path (e.g. via [hardware.printers.ensurePrinters](options.html#opt-hardware.printers.ensurePrinters)) you will need to append `.gz` to the path.
-
-- xow package removed along with the `hardware.xow` module, due to the project being deprecated in favor of `xone`,  which is available via the `hardware.xone` module.
-
-- dd-agent package removed along with the `services.dd-agent` module, due to the project being deprecated in favor of `datadog-agent`,  which is available via the `services.datadog-agent` module.
-
-- `teleport` has been upgraded to major version 10. Please see upstream [upgrade instructions](https://goteleport.com/docs/ver/10.0/management/operations/upgrading/) and [release notes](https://goteleport.com/docs/ver/10.0/changelog/#1000).
-
-- `lib.closePropagation` now needs that all gathered sets have an `outPath` attribute.
-
-- lemmy module option `services.lemmy.settings.database.createLocally`
-  moved to `services.lemmy.database.createLocally`.
-
-- virtlyst package and `services.virtlyst` module removed, due to lack of maintainers.
-
-- The `nix.checkConfig` option now fully disables the config check. The new `nix.checkAllErrors` option behaves like `nix.checkConfig`  previously did.
-
-- `nix.buildMachines` got a new submodule option `protocol`. An undocumented hack to set the protocol via `hostName` is no longer working and the `protocol` option should be used instead.
-
-- `generateOptparseApplicativeCompletions` and `generateOptparseApplicativeCompletion` from `haskell.lib.compose`
-  (and `haskell.lib`) have been deprecated in favor of `generateOptparseApplicativeCompletions` (plural!) as
-  provided by the haskell package sets (so `haskellPackages.generateOptparseApplicativeCompletions` etc.).
-  The latter allows for cross-compilation (by automatically disabling generation of completion in the cross case).
-  For it to work properly you need to make sure that the function comes from the same context as the package
-  you are trying to override, i.e. always use the same package set as your package is coming from or – even
-  better – use `self.generateOptparseApplicativeCompletions` if you are overriding a haskell package set.
-  The old functions are retained for backwards compatibility, but yield are warning.
-
-- The `services.graphite.api` and `services.graphite.beacon` NixOS options, and
-  the `python3.pkgs.graphite_api`, `python3.pkgs.graphite_beacon` and
-  `python3.pkgs.influxgraph` packages, have been removed due to lack of upstream
-  maintenance.
-
-- The `trace` binary from `perf-linux` package has been removed, due to being a duplicate of the `perf` binary.
-
-- The `aws` package has been removed due to being abandoned by the upstream. It is recommended to use `awscli` or `awscli2` instead.
-
-- The [CEmu TI-84 Plus CE emulator](https://ce-programming.github.io/CEmu) package has been renamed to `cemu-ti`. The [Cemu Wii U emulator](https://cemu.info) is now packaged as `cemu`.
-
-- `systemd-networkd` v250 deprecated, renamed, and moved some sections and settings which leads to the following breaking module changes:
-
-   * `systemd.network.networks.<name>.dhcpV6PrefixDelegationConfig` is renamed to `systemd.network.networks.<name>.dhcpPrefixDelegationConfig`.
-   * `systemd.network.networks.<name>.dhcpV6Config` no longer accepts the `ForceDHCPv6PDOtherInformation=` setting. Please use the `WithoutRA=` and `UseDelegatedPrefix=` settings in your `systemd.network.networks.<name>.dhcpV6Config` and the `DHCPv6Client=` setting in your `systemd.network.networks.<name>.ipv6AcceptRAConfig` to control when the DHCPv6 client is started and how the delegated prefixes are handled by the DHCPv6 client.
-   * `systemd.network.networks.<name>.networkConfig` no longer accepts the `IPv6Token=` setting. Use the `Token=` setting in your `systemd.network.networks.<name>.ipv6AcceptRAConfig` instead. The `systemd.network.networks.<name>.ipv6Prefixes.*.ipv6PrefixConfig` now also accepts the `Token=` setting.
-
-- `arangodb` versions 3.3, 3.4, and 3.5 have been removed because they are at EOL upstream. The default is now 3.10.0. Support for aarch64-linux has been removed since the target cannot be built reproducibly. By default `arangodb` is now built for the `haswell` architecture. If you wish to build for a different architecture, you may override the `targetArchitecture` argument with a value from [this list supported upstream](https://github.com/arangodb/arangodb/blob/207ec6937e41a46e10aea34953879341f0606841/cmake/OptimizeForArchitecture.cmake#L594). Some architecture specific optimizations are also conditionally enabled. You may alter this behavior by overriding the `asmOptimizations` parameter. You may also add additional architecture support by adding more `-DHAS_XYZ` flags to `cmakeFlags` via `overrideAttrs`.
-
-- The `meta.mainProgram` attribute of packages in `wineWowPackages` now defaults to `"wine64"`.
-
-- The `paperless` module now defaults `PAPERLESS_TIME_ZONE` to your configured system timezone.
-
-- The top-level `termonad-with-packages` alias for `termonad` has been removed.
-
-- Linux 4.9 has been removed because it will reach its end of life within the lifespan of 22.11.
-
-- (Neo)Vim can not be configured with `configure.pathogen` anymore to reduce maintainance burden.
-  Use `configure.packages` instead.
-- Neovim can not be configured with plug anymore (still works for vim).
-
-- The `adguardhome` module no longer uses `host` and `port` options, use `settings.bind_host` and `settings.bind_port` instead.
-
-- The default `kops` version is now 1.25.1 and support for 1.22 and older has been dropped.
-
-- The `zrepl` package has been updated from 0.5.0 to 0.6.0. See the [changelog](https://zrepl.github.io/changelog.html) for details.
-
-- `k3s` no longer supports docker as runtime due to upstream dropping support.
-
-- `cassandra_2_1` and `cassandra_2_2` have been removed. Please update to `cassandra_3_11` or `cassandra_3_0`. See the [changelog](https://github.com/apache/cassandra/blob/cassandra-3.11.14/NEWS.txt) for more information about the upgrade process.
-
-- `mysql57` has been removed. Please update to `mysql80` or `mariadb`. See the [upgrade guide](https://mariadb.com/kb/en/upgrading-from-mysql-to-mariadb/) for more information.
-
-- Consequently, `cqrlog` and `amorok` now use `mariadb` instead of `mysql57` for their embedded databases. Running `mysql_upgrade` may be neccesary.
-- `k3s` supports `clusterInit` option, and it is enabled by default, for servers.
-
-- `percona-server56` has been removed. Please migrate to `mysql` or `mariadb` if possible.
-
-- `obs-studio` hase been updated to version 28. If you have packaged custom plugins, check if they are compatible. `obs-websocket` has been integrated into `obs-studio`.
-
-- `signald` has been bumped to `0.23.0`. For the upgrade, a migration process is necessary. It can be
-  done by running a command like this before starting `signald.service`:
-
-  ```
-  signald -d /var/lib/signald/db \
-    --database sqlite:/var/lib/signald/db \
-    --migrate-data
-  ```
-
-  For further information, please read the upstream changelogs.
-
-- `stylua` no longer accepts `lua52Support` and `luauSupport` overrides, use `features` instead, which defaults to `[ "lua54" "luau" ]`.
-
-- `ocamlPackages.ocaml_extlib` has been renamed to `ocamlPackages.extlib`.
-
-- `pkgs.fetchNextcloudApp` has been rewritten to circumvent impurities in e.g. tarballs from GitHub and to make it easier to
-  apply patches. This means that your hashes are out-of-date and the (previously required) attributes `name` and `version`
-  are no longer accepted.
-
-- The Syncthing service now only allows absolute paths---starting with `/` or
-  `~/`---for `services.syncthing.folders.<name>.path`.
-  In a future release other paths will be allowed again and interpreted
-  relative to `services.syncthing.dataDir`.
-
-- `services.github-runner` and `services.github-runners.<name>` gained the option `serviceOverrides` which allows overriding the systemd `serviceConfig`. If you have been overriding the systemd service configuration (i.e., by defining `systemd.services.github-runner.serviceConfig`), you have to use the `serviceOverrides` option now. Example:
-
-  ```
-  services.github-runner.serviceOverrides.SupplementaryGroups = [
-    "docker"
-  ];
-  ```
-
-<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
-
-## Other Notable Changes {#sec-release-22.11-notable-changes}
-
-- `firefox`, `thunderbird` and `librewolf` come with enabled Wayland support by default. The `firefox-wayland`, `firefox-esr-wayland`, `thunderbird-wayland` and `librewolf-wayland` attributes are obsolete and have been aliased to their generic attribute.
-
-- The `xplr` package has been updated from 0.18.0 to 0.19.0, which brings some breaking changes. See the [upstream release notes](https://github.com/sayanarijit/xplr/releases/tag/v0.19.0) for more details.
-
-- Configuring multiple GitHub runners is now possible through `services.github-runners.<name>`. The option `services.github-runner` remains.
-
-- `github-runner` gained support for ephemeral runners and registrations using a personal access token (PAT) instead of a registration token. See `services.github-runner.ephemeral` and `services.github-runner.tokenFile` for details.
-
-- A new module was added for the Saleae Logic device family, providing the options `hardware.saleae-logic.enable` and `hardware.saleae-logic.package`.
-
-- ZFS module will not allow hibernation by default, this is a safety measure to prevent data loss cases like the ones described at [OpenZFS/260](https://github.com/openzfs/zfs/issues/260) and [OpenZFS/12842](https://github.com/openzfs/zfs/issues/12842). Use the `boot.zfs.allowHibernation` option to configure this behaviour.
-
-- `mastodon` now automatically removes remote media attachments older than 30 days. This is configurable through `services.mastodon.mediaAutoRemove`.
-
-- The Redis module now disables RDB persistence when `services.redis.servers.<name>.save = []` instead of using the Redis default.
-
-- Neo4j was updated from version 3 to version 4. See this [migration guide](https://neo4j.com/docs/upgrade-migration-guide/current/) on how to migrate your Neo4j instance.
-
-- The `networking.wireguard` module now can set the mtu on interfaces and tag its packets with an fwmark.
-
-- The option `overrideStrategy` was added to the different systemd unit options (`systemd.services.<name>`, `systemd.sockets.<name>`, …) to allow enforcing the creation of a dropin file, rather than the main unit file, by setting it to `asDropin`.
-  This is useful in cases where the existence of the main unit file is not known to Nix at evaluation time, for example when the main unit file is provided by adding a package to `systemd.packages`.
-  See the fix proposed in [NixOS's systemd abstraction doesn't work with systemd template units](https://github.com/NixOS/nixpkgs/issues/135557#issuecomment-1295392470) for an example.
-
-- The `polymc` package has been removed due to a rogue maintainer. It has been
-  replaced by `prismlauncher`, a fork by the rest of the maintainers. For more
-  details, see [the pull request that made this
-  change](https://github.com/NixOS/nixpkgs/pull/196624) and [this issue
-  detailing the vulnerability](https://github.com/NixOS/nixpkgs/issues/196460).
-  Users with existing installations should rename `~/.local/share/polymc` to
-  `~/.local/share/PrismLauncher`. The main config file's path has also moved
-  from `~/.local/share/polymc/polymc.cfg` to
-  `~/.local/share/PrismLauncher/prismlauncher.cfg`.
-
-- The `bloat` package has been updated from unstable-2022-03-31 to unstable-2022-10-25, which brings a breaking change. See [this upstream commit message](https://git.freesoftwareextremist.com/bloat/commit/?id=887ed241d64ba5db3fd3d87194fb5595e5ad7d73) for details.
-
-- The `services.matrix-synapse` systemd unit has been hardened.
-
-- The module `services.grafana` was refactored to be compliant with [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md). To be precise, this means that the following things have changed:
-  - The newly introduced option [](#opt-services.grafana.settings) is an attribute-set that
-    will be converted into Grafana's INI format. This means that the configuration from
-    [Grafana's configuration reference](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/)
-    can be directly written as attribute-set in Nix within this option.
-  - The option `services.grafana.extraOptions` has been removed. This option was an association
-    of environment variables for Grafana. If you had an expression like
-
-    ```nix
-    {
-      services.grafana.extraOptions.SECURITY_ADMIN_USER = "foobar";
-    }
-    ```
-
-    your Grafana instance was running with `GF_SECURITY_ADMIN_USER=foobar` in its environment.
-
-    For the migration, it is recommended to turn it into the INI format, i.e.
-    to declare
-
-    ```nix
-    {
-      services.grafana.settings.security.admin_user = "foobar";
-    }
-    ```
-
-    instead.
-
-    The keys in `services.grafana.extraOptions` have the format `<INI section name>_<Key Name>`.
-    Further details are outlined in the [configuration reference](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables).
-
-    Alternatively you can also set all your values from `extraOptions` to
-    `systemd.services.grafana.environment`, make sure you don't forget to add
-    the `GF_` prefix though!
-  - Previously, the options [](#opt-services.grafana.provision.datasources) and
-    [](#opt-services.grafana.provision.dashboards) expected lists of datasources
-    or dashboards for the [declarative provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/).
-
-    To declare lists of
-    - **datasources**, please rename your declarations to [](#opt-services.grafana.provision.datasources.settings.datasources).
-    - **dashboards**, please rename your declarations to [](#opt-services.grafana.provision.dashboards.settings.providers).
-
-    This change was made to support more features for that:
-
-    - It's possible to declare the `apiVersion` of your dashboards and datasources
-      by [](#opt-services.grafana.provision.datasources.settings.apiVersion) (or
-      [](#opt-services.grafana.provision.dashboards.settings.apiVersion)).
-
-    - Instead of declaring datasources and dashboards in pure Nix, it's also possible
-      to specify configuration files (or directories) with YAML instead using
-      [](#opt-services.grafana.provision.datasources.path) (or
-      [](#opt-services.grafana.provision.dashboards.path). This is useful when having
-      provisioning files from non-NixOS Grafana instances that you also want to
-      deploy to NixOS.
-
-      __Note:__ secrets from these files will be leaked into the store unless you use a
-      [**file**-provider or env-var](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#file-provider) for secrets!
-
-    - [](#opt-services.grafana.provision.notifiers) is not affected by this change because
-      this feature is deprecated by Grafana and will probably removed in Grafana 10.
-      It's recommended to use `services.grafana.provision.alerting.contactPoints` instead.
-
-- The `services.grafana.provision.alerting` option was added. It includes suboptions for every alerting-related objects (with the exception of `notifiers`), which means it's now possible to configure modern Grafana alerting declaratively.
-
-- Matrix Synapse now requires entries in the `state_group_edges` table to be unique, in order to prevent accidentally introducing duplicate information (for example, because a database backup was restored multiple times). If your Synapse database already has duplicate rows in this table, this could fail with an error and require manual remediation.
-
-- The `diamond` package has been update from 0.8.36 to 2.0.15. See the [upstream release notes](https://github.com/bbuchfink/diamond/releases) for more details.
-
-- The `guake` package has been updated from 3.6.3 to 3.9.0, see the [changelog](https://github.com/Guake/guake/releases) for more details.
-
-- The `netlify-cli` package has been updated from 6.13.2 to 12.2.4, see the [changelog](https://github.com/netlify/cli/releases) for more details.
-
-- `dockerTools.buildImage` deprecates the misunderstood `contents` parameter, in favor of `copyToRoot`.
-  Use `copyToRoot = buildEnv { ... };` or similar if you intend to add packages to `/bin`.
-
-- The `proxmox.qemuConf.bios` option was added, it corresponds to `Hardware->BIOS` field in Proxmox web interface. Use `"ovmf"` value to build UEFI image, default value remains `"bios"`. New option `proxmox.partitionTableType` defaults to either `"legacy"` or `"efi"`, depending on the `bios` value. Setting `partitionTableType` to `"hybrid"` results in an image, which supports both methods (`"bios"` and `"ovmf"`), thereby remaining bootable after change to Proxmox `Hardware->BIOS` field.
-
-- memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2. It is now the upstream version from https://www.memtest.org/, as coreboot's fork is no longer available.
-
-- Option descriptions, examples, and defaults writting in DocBook are now deprecated. Using CommonMark is preferred and will become the default in a future release.
-
-- The `documentation.nixos.options.allowDocBook` option was added to ease the transition to CommonMark option documentation. Setting this option to `false` causes an error for every option included in the manual that uses DocBook documentation; it defaults to `true` to preserve the previous behavior and will be removed once the transition to CommonMark is complete.
-
-- The redis module now persists each instance's configuration file in the state directory, in order to support some more advanced use cases like sentinel.
-
-- The udisks2 service, available at `services.udisks2.enable`, is now disabled by default. It will automatically be enabled through services and desktop environments as needed.
-  This also means that polkit will now actually be disabled by default. The default for `security.polkit.enable` was already flipped in the previous release, but udisks2 being enabled by default re-enabled it.
-
-- Nextcloud has been updated to version **25**. Additionally the following things have changed
-  for Nextcloud in NixOS:
-  - For Nextcloud **>=24**, the default PHP version is 8.1.
-  - Nextcloud **23** has been removed since it will reach its [end of life in December 2022](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule/d76576a12a626d53305d480a6065b57cab705d3d).
-  - For `system.stateVersion` being **>=22.11**, Nextcloud 25 will be installed by default. For older versions,
-    Nextcloud 24 will be installed.
-  - Please ensure that you only upgrade on major release at a time! Nextcloud doesn't support
-    upgrades across multiple versions, i.e. an upgrade from **23** to **25** is only possible
-    when upgrading to **24** first.
-
-- Add udev rules for the Teensy family of microcontrollers.
-
-- The Qt QML disk cache is now disabled by default. This fixes a
-  long-standing issue where updating Qt/KDE apps would sometimes cause
-  them to crash or behave strangely without explanation. Those concerned
-  about the small (~10%) performance hit to application startup can
-  re-enable the cache (and expose themselves to gremlins) by setting the
-  envrionment variable `QML_FORCE_DISK_CACHE` to `1` using e.g. the
-  `environment.sessionVariables` NixOS option.
-
-- systemd-oomd is enabled by default. Depending on which systemd units have
-  `ManagedOOMSwap=kill` or `ManagedOOMMemoryPressure=kill`, systemd-oomd will
-  SIGKILL all the processes under the appropriate descendant cgroups when the
-  configured limits are exceeded. NixOS does currently not configure cgroups
-  with oomd by default, this can be enabled using
-  [systemd.oomd.enableRootSlice](options.html#opt-systemd.oomd.enableRootSlice),
-  [systemd.oomd.enableSystemSlice](options.html#opt-systemd.oomd.enableSystemSlice),
-  and [systemd.oomd.enableUserServices](options.html#opt-systemd.oomd.enableUserServices).
-
-- The `tt-rss` service performs two database migrations when you first use its web UI after upgrade. Consider backing up its database before updating.
-
-- The `pass-secret-service` package now includes systemd units from upstream, so adding it to the NixOS `services.dbus.packages` option will make it start automatically as a systemd user service when an application tries to talk to the libsecret D-Bus API.
-
-- There is a new module for AMD SEV CPU functionality, which grants access to the hardware.
-
-- The Wordpress module got support for installing language packs through `services.wordpress.sites.<site>.languages`.
-
-- The default package for `services.mullvad-vpn.package` was changed to `pkgs.mullvad`, allowing cross-platform usage of Mullvad. `pkgs.mullvad` only contains the Mullvad CLI tool, so users who rely on the Mullvad GUI will want to change it back to `pkgs.mullvad-vpn`, or add `pkgs.mullvad-vpn` to their environment.
-
-- PowerDNS has been updated from `4.6.x` to `4.7.x`. Please be sure to review the [Upgrade Notes](https://doc.powerdns.com/authoritative/upgrading.html#to-4-7-0-or-master) provided by upstream before upgrading. Worth specifically noting is that the new Catalog Zones feature comes with a mandatory schema change for the gsql database backends, which has to be manually applied.
-
-- There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and in a future release it may be removed.
-
-- There is a new module for the `xfconf` program (the Xfce configuration storage system), which has a dbus service.
-
-- The Mastodon package got upgraded from the major version 3 to 4. See the [v4.0.0 release notes](https://github.com/mastodon/mastodon/releases/tag/v4.0.0) for a list of changes. On standard setups, no manual migration steps are required. Nevertheless, a database backup is recommended.
-
-- The `nomad` package now defaults to 1.3, which no longer has a downgrade path to releases 1.2 or older.
-
-- The `nodePackages` package set now defaults to the LTS release in the `nodejs` package again, instead of being pinned to `nodejs-14_x`. Several updates to node2nix have been made for compatibility with newer Node.js and npm versions and a new `postRebuild` hook has been added for packages to perform extra build steps before the npm install step prunes dev dependencies.
-
-- `boot.kernel.sysctl` is defined as a freeformType and adds a custom merge option for "net.core.rmem_max" (taking the highest value defined to avoid conflicts between 2 services trying to set that value).
-
-- The `mame` package does not ship with its tools anymore in the default output. They were moved to a separate `tools` output instead. For convenience, `mame-tools` package was added for those who want to use it.
-
-- A NixOS module for Firefox has been added which allows preferences and [policies](https://github.com/mozilla/policy-templates/blob/master/README.md) to be set. This also allows extensions to be installed via the `ExtensionSettings` policy. The new options are under `programs.firefox`.
-
-- The option `services.picom.experimentalBackends` was removed since it is now the default and the option will cause `picom` to quit instead.
-
-- `haskellPackage.callHackage` is not always invalidated if `all-cabal-hashes` changes, leading to less rebuilds of haskell dependencies.
-
-- `haskellPackages.callHackage` and `haskellPackages.callCabal2nix` (and related functions) no longer keep a reference to the `cabal2nix` call used to generate them. As a result, they will be garbage collected more often.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -61,6 +61,10 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - `hardware.nvidia` has a new option, `hardware.nvidia.open`, that can be used to enable the usage of NVIDIA's open-source kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [the release announcement](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for more information.
 
+- `aarch64-linux` is now included in the `nixos-22.11` and `nixos-22.11-small` channels. This means that `x86_64-linux` and `aarch64-linux` will recieve updates at the same time.
+
+- `aarch64-linux` ISOs are now available on the [downloads page](https://nixos.org/download.html).
+
 ## Internal changes {#sec-release-22.11-internal}
 
 - Improved performances of `lib.closePropagation` which was previously quadratic. This is used in e.g. `ghcWithPackages`. Please see backward incompatibilities notes below.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -1,6 +1,6 @@
 # Release 22.11 (“Raccoon”, 2022.11/??) {#sec-release-22.11}
 
-The NixOS release team is happy to announce a new version of NixOS 22.11. NixOS is both a linux distribution, and a set of packages usable on other Linux systems and macOS.
+The NixOS release team is happy to announce a new version of NixOS 22.11. NixOS is both a Linux distribution, and a set of packages usable on other Linux systems and macOS.
 
 This release is supported until the end of June 2023, handing over to NixOS 23.05.
 
@@ -26,9 +26,9 @@ In addition to numerous new and upgraded packages, this release includes the fol
 - `nsncd` is now available as a replacement of `nscd`.
 
   `nscd` is responsible for resolving hostnames, users and more in NixOS and has been a long standing source of bugs, such as sporadic network freezes.
-  
+
   More context in this [issue](https://github.com/NixOS/nixpkgs/issues/135888).
-  
+
   Help us test the new implementation by setting `services.nscd.enableNsncd` to `true`.
 
   We plan to use `nsncd` by default in NixOS 23.05.
@@ -45,7 +45,7 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - Haskell `ghcWithPackages` is now up to 15 times faster to evaluate, thanks to changing `lib.closePropagation` from a quadratic to linear complexity. Please see backward incompatibilities notes below. <https://github.com/NixOS/nixpkgs/pull/194391>
 
-- For cross-compilation targets that can also run on the building machine, we also enabled running tests now. This is for example the case for the pkgsStatic and pkgsLLVm package sets or i686 packages on `x86_64` machine.
+- For cross-compilation targets that can also run on the building machine, we now run tests. This, for example, is the case for the `pkgsStatic` and `pkgsLLVM` package sets or i686 packages on `x86_64` machines.
 
 - To simplify cross-compilation in NixOS, this release introduces the `nixpkgs.hostPlatform` and `nixpkgs.buildPlatform` options. These cover and override the `nixpkgs.{system,localSystem,crossSystem}` options.
 
@@ -66,11 +66,11 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 ## Notable version updates {#sec-release-22.11-version-updates}
 
-- Nix has been upgraded from [v2.8.1 to v2.11.0](https://github.com/NixOS/nix/compare/2.8.1...2.11.0)
+- Nix has been upgraded from v2.8.1 to v2.11.0. For more information, please see the release notes for [2.9](https://nixos.org/manual/nix/stable/release-notes/rl-2.9.html), [2.10](https://nixos.org/manual/nix/stable/release-notes/rl-2.10.html) and [2.11](https://nixos.org/manual/nix/stable/release-notes/rl-2.11.html).
 
 - OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
 
-- GNOME has been upgraded to version 43. Please take a look at their [Release Notes](https://release.gnome.org/43/) for details.
+- GNOME has been upgraded to version 43. Please see the [release notes](https://release.gnome.org/43/) for details.
 
 - KDE Plasma has been upgraded from v5.24 to v5.26. Please see the release notes for [v5.25](https://kde.org/announcements/plasma/5/5.25.0/) and [v5.26](https://kde.org/announcements/plasma/5/5.26.0/) for more details on the included changes.
 
@@ -81,7 +81,7 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - Perl has been updated to 5.36, and its core module `HTTP::Tiny` was patched to verify SSL/TLS certificates by default.
 
-- Python now defalts to 3.10, updated from 3.9.
+- Python now defaults to 3.10, updated from 3.9.
 
 ## Backward Incompatibilities {#sec-release-22.11-incompatibilities}
 
@@ -111,9 +111,9 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - The `fetchgit` fetcher now uses [cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalscone_mode_handling) by default for sparse checkouts. [Non-cone mode](https://www.git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems) can be enabled by passing `nonConeMode = true`, but note that non-cone mode is deprecated and this option may be removed alongside a future Git update without notice.
 
-- The `fetchgit` fetcher supports sparse checkouts via the `sparseCheckout` option. This used to accept a multi-line string with directories/patterns to check out, but now requires a list of strings
+- The `fetchgit` fetcher supports sparse checkouts via the `sparseCheckout` option. This used to accept a multi-line string with directories/patterns to check out, but now requires a list of strings.
 
-- `openssh` was updated to version 9.1, disabling the generation of DSA keys when using `ssh-keygen -A` as they are insecure. Also, `SetEnv` directives in `ssh_config` and `sshd_config` are now first-match-wins
+- `openssh` was updated to version 9.1, disabling the generation of DSA keys when using `ssh-keygen -A` as they are insecure. Also, `SetEnv` directives in `ssh_config` and `sshd_config` are now first-match-wins.
 
 - `bsp-layout` no longer uses the command `cycle` to switch to other window layouts, as it got replaced by the commands `previous` and `next`.
 
@@ -149,7 +149,7 @@ In addition to numerous new and upgraded packages, this release includes the fol
 - Emacs now uses the Lucid toolkit by default instead of GTK because of stability and compatibility issues.
   Users who still wish to remain using GTK can do so by using `emacs-gtk`.
 
-- `kanidm` has been updated to 1.1.0-alpha.10 and now requires a TLS certificate and key. It will always start `https` and-–-if enabled-–-an LDAPS server and no HTTP and LDAP server anymore
+- `kanidm` has been updated to 1.1.0-alpha.10 and now requires a TLS certificate and key. It will always start `https` and-–-if enabled-–-an LDAPS server and no HTTP and LDAP server anymore.
 
 - riak package removed along with `services.riak` module, due to lack of maintainer to update the package.
 
@@ -452,89 +452,84 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 ## New Services {#sec-release-22.11-new-services}
 
+- [alps](https://git.sr.ht/~migadu/alps), a simple and extensible webmail. Available as [services.alps](#opt-services.alps.enable).
+
 - [appvm](https://github.com/jollheef/appvm), Nix based app VMs. Available as [virtualisation.appvm](options.html#opt-virtualisation.appvm.enable).
+
+- [AusweisApp2](https://www.ausweisapp.bund.de/), the authentication software for the German ID card. Available as [programs.ausweisapp](#opt-programs.ausweisapp.enable).
 
 - [automatic-timezoned](https://github.com/maxbrunet/automatic-timezoned). a Linux daemon to automatically update the system timezone based on location. Available as [services.automatic-timezoned](#opt-services.automatic-timezoned.enable).
 
-- [xray] (https://github.com/XTLS/Xray-core), a fully compatible v2ray-core replacement. Features XTLS, which when enabled on server and client, brings UDP FullCone NAT to proxy setups. Available as [services.xray](options.html#opt-services.xray.enable).
-
-- [syncstorage-rs](https://github.com/mozilla-services/syncstorage-rs), a self-hostable sync server for Firefox. Available as [services.firefox-syncserver](options.html#opt-services.firefox-syncserver.enable).
+- [Dolibarr](https://www.dolibarr.org/), an enterprise resource planning and customer relationship manager. Enable using [services.dolibarr](#opt-services.dolibarr.enable).
 
 - [dragonflydb](https://dragonflydb.io/), a modern replacement for Redis and Memcached. Available as [services.dragonflydb](#opt-services.dragonflydb.enable).
 
-- [Komga](https://komga.org/), a free and open source comics/mangas media server. Available as [services.komga](#opt-services.komga.enable).
+- [endlessh-go](https://github.com/shizunge/endlessh-go), an SSH tarpit that exposes Prometheus metrics. Available as [services.endlessh-go](#opt-services.endlessh-go.enable).
 
-- [Tandoor Recipes](https://tandoor.dev), a self-hosted multi-tenant recipe collection. Available as [services.tandoor-recipes](options.html#opt-services.tandoor-recipes.enable).
-
-- [HBase cluster](https://hbase.apache.org/), a distributed, scalable, big data store. Available as [services.hadoop.hbase](options.html#opt-services.hadoop.hbase.enable).
-
-- [Please](https://github.com/edneville/please), a Sudo clone written in Rust. Available as [security.please](#opt-security.please.enable)
-
-- [Sachet](https://github.com/messagebird/sachet/), an SMS alerting tool for the Prometheus Alertmanager. Available as [services.prometheus.sachet](#opt-services.prometheus.sachet.enable).
+- [endlessh](https://github.com/skeeto/endlessh), an SSH tarpit. Available as [services.endlessh](#opt-services.endlessh.enable).
 
 - [EVCC](https://evcc.io) is an EV charge controller with PV integration. It supports a multitude of chargers, meters, vehicle APIs and more and ties that together with a well-tested backend and a lightweight web frontend. Available as [services.evcc](#opt-services.evcc.enable).
 
-- [infnoise](https://github.com/leetronics/infnoise), a hardware True Random Number Generator dongle.
-  Available as [services.infnoise](options.html#opt-services.infnoise.enable).
+- [expressvpn](https://www.expressvpn.com), the CLI client for ExpressVPN. Available as [services.expressvpn](#opt-services.expressvpn.enable).
 
-- [kthxbye](https://github.com/prymitive/kthxbye), an alert acknowledgement management daemon for Prometheus Alertmanager. Available as [services.kthxbye](options.html#opt-services.kthxbye.enable)
+- [FreshRSS](https://freshrss.org/), a free, self-hostable RSS feed aggregator. Available as [services.freshrss](#opt-services.freshrss.enable).
 
-- [kanata](https://github.com/jtroo/kanata), a tool to improve keyboard comfort and usability with advanced customization.
-  Available as [services.kanata](options.html#opt-services.kanata.enable).
+- [Garage](https://garagehq.deuxfleurs.fr/), a simple object storage server for geodistributed deployments, alternative to MinIO. Available as [services.garage](#opt-services.garage.enable).
+
+- [go-autoconfig](https://github.com/L11R/go-autoconfig), IMAP/SMTP autodiscover server. Available as [services.go-autoconfig](#opt-services.go-autoconfig.enable).
+
+- [Grafana Tempo](https://www.grafana.com/oss/tempo/), a distributed tracing store. Available as [services.tempo](#opt-services.tempo.enable).
+
+- [HBase cluster](https://hbase.apache.org/), a distributed, scalable, big data store. Available as [services.hadoop.hbase](options.html#opt-services.hadoop.hbase.enable).
+
+- [infnoise](https://github.com/leetronics/infnoise), a hardware True Random Number Generator dongle. Available as [services.infnoise](options.html#opt-services.infnoise.enable).
+
+- [kanata](https://github.com/jtroo/kanata), a tool to improve keyboard comfort and usability with advanced customization. Available as [services.kanata](options.html#opt-services.kanata.enable).
 
 - [karma](https://github.com/prymitive/karma), an alert dashboard for Prometheus Alertmanager. Available as [services.karma](options.html#opt-services.karma.enable)
 
-- [languagetool](https://languagetool.org/), a multilingual grammar, style, and spell checker.
-  Available as [services.languagetool](options.html#opt-services.languagetool.enable).
+- [Komga](https://komga.org/), a free and open source comics/mangas media server. Available as [services.komga](#opt-services.komga.enable).
+
+- [kthxbye](https://github.com/prymitive/kthxbye), an alert acknowledgement management daemon for Prometheus Alertmanager. Available as [services.kthxbye](options.html#opt-services.kthxbye.enable)
+
+- [languagetool](https://languagetool.org/), a multilingual grammar, style, and spell checker. Available as [services.languagetool](options.html#opt-services.languagetool.enable).
+
+- [Listmonk](https://listmonk.app), a self-hosted newsletter manager. Enable using [services.listmonk](options.html#opt-services.listmonk.enable).
+
+- [Mepo](https://mepo.milesalan.com), a fast, simple, hackable OSM map viewer for mobile and desktop Linux. Available as [programs.mepo.enable](#opt-programs.mepo.enable).
+
+- [merecat](https://troglobit.com/projects/merecat/), a small and easy HTTP server based on thttpd. Available as [services.merecat](#opt-services.merecat.enable)
+
+- [netbird](https://netbird.io), a zero configuration VPN. Available as [services.netbird](options.html#opt-services.netbird.enable).
+
+- [ntfy.sh](https://ntfy.sh), a push notification service. Available as [services.ntfy-sh](#opt-services.ntfy-sh.enable)
 
 - [OpenRGB](https://gitlab.com/CalcProgrammer1/OpenRGB/-/tree/master), a FOSS tool for controlling RGB lighting. Available as [services.hardware.openrgb.enable](options.html#opt-services.hardware.openrgb.enable).
 
 - [Outline](https://www.getoutline.com/), a wiki and knowledge base similar to Notion. Available as [services.outline](#opt-services.outline.enable).
 
-- [ntfy.sh](https://ntfy.sh), a push notification service. Available as [services.ntfy-sh](#opt-services.ntfy-sh.enable)
-
-- [alps](https://git.sr.ht/~migadu/alps), a simple and extensible webmail. Available as [services.alps](#opt-services.alps.enable).
-
-- [endlessh](https://github.com/skeeto/endlessh), an SSH tarpit. Available as [services.endlessh](#opt-services.endlessh.enable).
-
-- [endlessh-go](https://github.com/shizunge/endlessh-go), an SSH tarpit that exposes Prometheus metrics. Available as [services.endlessh-go](#opt-services.endlessh-go.enable).
-
-- [Garage](https://garagehq.deuxfleurs.fr/), a simple object storage server for geodistributed deployments, alternative to MinIO. Available as [services.garage](#opt-services.garage.enable).
-
-- [netbird](https://netbird.io), a zero configuration VPN.
-  Available as [services.netbird](options.html#opt-services.netbird.enable).
+- [Patroni](https://github.com/zalando/patroni), a template for PostgreSQL HA with ZooKeeper, etcd or Consul. Available as [services.patroni](options.html#opt-services.patroni.enable).
 
 - [persistent-evdev](https://github.com/aiberia/persistent-evdev), a daemon to add virtual proxy devices that mirror a physical input device but persist even if the underlying hardware is hot-plugged. Available as [services.persistent-evdev](#opt-services.persistent-evdev.enable).
 
-- [schleuder](https://schleuder.org/), a mailing list manager with PGP support. Enable using [services.schleuder](#opt-services.schleuder.enable).
-
-- [Dolibarr](https://www.dolibarr.org/), an enterprise resource planning and customer relationship manager. Enable using [services.dolibarr](#opt-services.dolibarr.enable).
-
-- [FreshRSS](https://freshrss.org/), a free, self-hostable RSS feed aggregator. Available as [services.freshrss](#opt-services.freshrss.enable).
-
-- [expressvpn](https://www.expressvpn.com), the CLI client for ExpressVPN. Available as [services.expressvpn](#opt-services.expressvpn.enable).
-
-- [merecat](https://troglobit.com/projects/merecat/), a small and easy HTTP server based on thttpd. Available as [services.merecat](#opt-services.merecat.enable)
-
-- [go-autoconfig](https://github.com/L11R/go-autoconfig), IMAP/SMTP autodiscover server. Available as [services.go-autoconfig](#opt-services.go-autoconfig.enable).
-
-- [tmate-ssh-server](https://github.com/tmate-io/tmate-ssh-server), server side part of [tmate](https://tmate.io/). Available as [services.tmate-ssh-server](#opt-services.tmate-ssh-server.enable).
-
-- [Grafana Tempo](https://www.grafana.com/oss/tempo/), a distributed tracing store. Available as [services.tempo](#opt-services.tempo.enable).
-
-- [AusweisApp2](https://www.ausweisapp.bund.de/), the authentication software for the German ID card. Available as [programs.ausweisapp](#opt-programs.ausweisapp.enable).
-
-- [Patroni](https://github.com/zalando/patroni), a template for PostgreSQL HA with ZooKeeper, etcd or Consul.
-Available as [services.patroni](options.html#opt-services.patroni.enable).
+- [Please](https://github.com/edneville/please), a Sudo clone written in Rust. Available as [security.please](#opt-security.please.enable).
 
 - [Prometheus IPMI exporter](https://github.com/prometheus-community/ipmi_exporter), an IPMI exporter for Prometheus. Available as [services.prometheus.exporters.ipmi](#opt-services.prometheus.exporters.ipmi.enable).
 
-- [WriteFreely](https://writefreely.org), a simple blogging platform with ActivityPub support. Available as [services.writefreely](options.html#opt-services.writefreely.enable).
+- [Sachet](https://github.com/messagebird/sachet/), an SMS alerting tool for the Prometheus Alertmanager. Available as [services.prometheus.sachet](#opt-services.prometheus.sachet.enable).
 
-- [Listmonk](https://listmonk.app), a self-hosted newsletter manager. Enable using [services.listmonk](options.html#opt-services.listmonk.enable).
+- [schleuder](https://schleuder.org/), a mailing list manager with PGP support. Enable using [services.schleuder](#opt-services.schleuder.enable).
+
+- [syncstorage-rs](https://github.com/mozilla-services/syncstorage-rs), a self-hostable sync server for Firefox. Available as [services.firefox-syncserver](options.html#opt-services.firefox-syncserver.enable).
+
+- [Tandoor Recipes](https://tandoor.dev), a self-hosted multi-tenant recipe collection. Available as [services.tandoor-recipes](options.html#opt-services.tandoor-recipes.enable).
+
+- [tmate-ssh-server](https://github.com/tmate-io/tmate-ssh-server), server side part of [tmate](https://tmate.io/). Available as [services.tmate-ssh-server](#opt-services.tmate-ssh-server.enable).
 
 - [Uptime Kuma](https://uptime.kuma.pet/), a fancy self-hosted monitoring tool. Available as [services.uptime-kuma](#opt-services.uptime-kuma.enable).
 
-- [Mepo](https://mepo.milesalan.com), a fast, simple, hackable OSM map viewer for mobile and desktop Linux. Available as [programs.mepo.enable](#opt-programs.mepo.enable).
+- [WriteFreely](https://writefreely.org), a simple blogging platform with ActivityPub support. Available as [services.writefreely](options.html#opt-services.writefreely.enable).
+
+- [xray] (https://github.com/XTLS/Xray-core), a fully compatible v2ray-core replacement. Features XTLS, which when enabled on server and client, brings UDP FullCone NAT to proxy setups. Available as [services.xray](options.html#opt-services.xray.enable).
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -127,7 +127,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 - [languagetool](https://languagetool.org/), a multilingual grammar, style, and spell checker.
   Available as [services.languagetool](options.html#opt-services.languagetool.enable).
 
-- [OpenRGB](https://gitlab.com/CalcProgrammer1/OpenRGB/-/tree/master), a FOSS tool for controlling RGB lighting. Available as [services.hardware.openrgb.enable](options.html#opt-services-hardware-openrgb-enable).
+- [OpenRGB](https://gitlab.com/CalcProgrammer1/OpenRGB/-/tree/master), a FOSS tool for controlling RGB lighting. Available as [services.hardware.openrgb.enable](options.html#opt-services.hardware.openrgb.enable).
 
 - [Outline](https://www.getoutline.com/), a wiki and knowledge base similar to Notion. Available as [services.outline](#opt-services.outline.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -475,6 +475,8 @@ Available as [services.patroni](options.html#opt-services.patroni.enable).
 - `dockerTools.buildImage` deprecates the misunderstood `contents` parameter, in favor of `copyToRoot`.
   Use `copyToRoot = buildEnv { ... };` or similar if you intend to add packages to `/bin`.
 
+- The `proxmox.qemuConf.bios` option was added, it corresponds to `Hardware->BIOS` field in Proxmox web interface. Use `"ovmf"` value to build UEFI image, default value remains `"bios"`. New option `proxmox.partitionTableType` defaults to either `"legacy"` or `"efi"`, depending on the `bios` value. Setting `partitionTableType` to `"hybrid"` results in an image, which supports both methods (`"bios"` and `"ovmf"`), thereby remaining bootable after change to Proxmox `Hardware->BIOS` field.
+
 - memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2. It is now the upstream version from https://www.memtest.org/, as coreboot's fork is no longer available.
 
 - Option descriptions, examples, and defaults writting in DocBook are now deprecated. Using CommonMark is preferred and will become the default in a future release.


### PR DESCRIPTION
###### Description of changes

Backport all changes that were intended for 22.11 including the proxmox-image change that created merge conflicts on the release notes....

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
