### PR TITLE
nixos/firejail: remove the need for qualifications

### DIFF
--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -8,18 +8,21 @@ let
   wrappedBins = pkgs.runCommand "firejail-wrapped-binaries"
     { preferLocalBuild = true;
       allowSubstitutes = false;
+      # take precedence over non-firejailed versions
+      meta.priority = -1;
     }
     ''
       mkdir -p $out/bin
+      mkdir -p $out/share/applications
       ${lib.concatStringsSep "\n" (lib.mapAttrsToList (command: value:
       let
         opts = if builtins.isAttrs value
         then value
-        else { executable = value; profile = null; extraArgs = []; };
+        else { executable = value; desktop = null; profile = null; extraArgs = []; };
         args = lib.escapeShellArgs (
           opts.extraArgs
           ++ (optional (opts.profile != null) "--profile=${toString opts.profile}")
-          );
+        );
       in
       ''
         cat <<_EOF >$out/bin/${command}
@@ -27,6 +30,11 @@ let
         exec /run/wrappers/bin/firejail ${args} -- ${toString opts.executable} "\$@"
         _EOF
         chmod 0755 $out/bin/${command}
+
+        ${lib.optionalString (opts.desktop != null) ''
+          substitute ${opts.desktop} $out/share/applications/$(basename ${opts.desktop}) \
+            --replace ${opts.executable} $out/bin/${command}
+        ''}
       '') cfg.wrappedBinaries)}
     '';
 
@@ -41,6 +49,12 @@ in {
             type = types.path;
             description = lib.mdDoc "Executable to run sandboxed";
             example = literalExpression ''"''${lib.getBin pkgs.firefox}/bin/firefox"'';
+          };
+          desktop = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = lib.mkDoc ".desktop file to modify. Only necessary if it uses the absolute path to the executable.";
+            example = literalExpression ''"''${pkgs.firefox}/share/applications/firefox.desktop"'';
           };
           profile = mkOption {
             type = types.nullOr types.path;
@@ -71,12 +85,6 @@ in {
       '';
       description = lib.mdDoc ''
         Wrap the binaries in firejail and place them in the global path.
-
-        You will get file collisions if you put the actual application binary in
-        the global environment (such as by adding the application package to
-        `environment.systemPackages`), and applications started via
-        .desktop files are not wrapped if they specify the absolute path to the
-        binary.
       '';
     };
   };


### PR DESCRIPTION
###### Description of changes

Right now there are some qualifications on the `programs.firejail.wrappedBinaries` option, described as follows:

> Wrap the binaries in firejail and place them in the global path. You will get file collisions if you put the actual application binary in the global environment (such as by adding the application package to `environment.systemPackages`), and applications started via .desktop files are not wrapped if they specify the absolute path to the binary.

I implemented fixes for both of these. First, setting `meta.priority = -1;` causes the firejailed binaries to take precedence. Second, providing people an option to specify a `.desktop` file, which will have absolute paths to the executable replaced with paths to the wrapped executable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
