### PR TITLE
teams-for-linux: init at 1.0.45

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -15,7 +15,7 @@ appimageTools.wrapType2 rec {
   inherit pname version src;
 
   extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs)
-    ++ [ pkgs.libdrm pkgs.pipewire ];
+    ++ with pkgs; [ libdrm pipewire ];
 
   extraInstallCommands = ''
     mv $out/bin/{${pname}-${version},${pname}}

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -1,0 +1,39 @@
+{ lib, fetchurl, appimageTools, libdrm, pipewire }:
+
+let
+  pname = "teams-for-linux";
+  version = "1.0.45";
+
+  src = fetchurl {
+    url = "https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v${version}/teams-for-linux-${version}.AppImage";
+    sha256 = "sha256-aZFKczf+ZHMRHkk++BQ8WlsYGtrM8AuJ8Y3sU5rgYHs=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 rec {
+  inherit pname version src;
+
+  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs)
+    ++ [ pkgs.libdrm pkgs.pipewire ];
+
+  extraInstallCommands = ''
+    mv $out/bin/{${pname}-${version},${pname}}
+    install -m 444 \
+        -D ${appimageContents}/teams-for-linux.desktop \
+        -t $out/share/applications
+    substituteInPlace \
+        $out/share/applications/teams-for-linux.desktop \
+        --replace 'Exec=AppRun' 'Exec=${pname}'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "An unofficial Microsoft Teams client";
+    homepage = "https://github.com/IsmaelMartinez/teams-for-linux";
+    license = licenses.gpl3;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.aacebedo ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -32,7 +32,7 @@ appimageTools.wrapType2 rec {
     description = "An unofficial Microsoft Teams client";
     homepage = "https://github.com/IsmaelMartinez/teams-for-linux";
     license = licenses.gpl3;
-    sourceProvenance = with sourceTypes; [ fromSource ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     platforms = platforms.linux;
     maintainers = [ maintainers.aacebedo ];
   };

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -15,7 +15,7 @@ appimageTools.wrapType2 rec {
   inherit pname version src;
 
   extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs)
-    ++ with pkgs; [ libdrm pipewire ];
+    ++ (with pkgs; [ libdrm pipewire libappindicator ]);
 
   extraInstallCommands = ''
     mv $out/bin/{${pname}-${version},${pname}}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32306,6 +32306,8 @@ with pkgs;
 
   teams = callPackage ../applications/networking/instant-messengers/teams { };
 
+  teams-for-linux = callPackage ../applications/networking/instant-messengers/teams-for-linux { };
+
   teamspeak_client = libsForQt5.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
   teamspeak5_client = callPackage ../applications/networking/instant-messengers/teamspeak/client5.nix { };
   teamspeak_server = callPackage ../applications/networking/instant-messengers/teamspeak/server.nix { };


### PR DESCRIPTION
###### Description of changes

This tool can replace current native client which is rumoured to be phased out this month.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
