### PR TITLE
[22.05] mujs: add patch for CVE-2022-44789

### DIFF
--- a/pkgs/development/interpreters/mujs/default.nix
+++ b/pkgs/development/interpreters/mujs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, readline }:
+{ lib, stdenv, fetchurl, readline, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "mujs";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "https://mujs.com/downloads/mujs-${version}.tar.xz";
     sha256 = "sha256-ZpdtHgajUnVKI0Kvc9Guy7U8x82uK2jNoBO33c+SMjM=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-44789.patch";
+      url = "https://git.ghostscript.com/?p=mujs.git;a=patch;h=edb50ad66f7601ca9a3544a0e9045e8a8c60561f";
+      sha256 = "sha256-KHBJlDchrXTmN5vEuyQ+saX12F5hyUlJFguiDsZkGqc=";
+    })
+  ];
 
   buildInputs = [ readline ];
 

--- a/pkgs/development/interpreters/mujs/default.nix
+++ b/pkgs/development/interpreters/mujs/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
       url = "https://git.ghostscript.com/?p=mujs.git;a=patch;h=edb50ad66f7601ca9a3544a0e9045e8a8c60561f";
       sha256 = "sha256-KHBJlDchrXTmN5vEuyQ+saX12F5hyUlJFguiDsZkGqc=";
     })
+    (fetchpatch {
+      name = "regex-compilation-stack-overflow.patch";
+      url = "https://git.ghostscript.com/?p=mujs.git;a=patch;h=160ae29578054dc09fd91e5401ef040d52797e61";
+      sha256 = "sha256-R0gTPj10fKtHbVe5RM6HNL772hVl9rXylkPw5qQWt0w=";
+    })
   ];
 
   buildInputs = [ readline ];


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-44789

As opposed to backporting the bump in #203664

Patch quite a straightforward change. Debian ship this patch against their 1.1.0 version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
