### PR TITLE
adds protoc-gen-[prost, prost-crate, prost-serde, tonic]

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12824,6 +12824,12 @@
     githubId = 74881555;
     name = "Fofanov Sergey";
   };
+  sitaaax = {
+    email = "johannes@kle1n.com";
+    github = "SitAAAx";
+    githubId = 74413170;
+    name = "Johannes Klein";
+  };
   sivteck = {
     email = "sivaram1992@gmail.com";
     github = "sivteck";

--- a/pkgs/development/tools/protoc-gen-prost-crate/default.nix
+++ b/pkgs/development/tools/protoc-gen-prost-crate/default.nix
@@ -1,0 +1,25 @@
+{ fetchCrate
+, lib
+, rustPlatform
+, protobuf
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "protoc-gen-prost-crate";
+  version = "0.3.1";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-MtGeU2PnVYPXb3nly2UaryjmjMz1lxcvYDjFiwf58FA=";
+  };
+
+  cargoSha256 = "sha256-dcKJRX/iHIWEmBD2nTMyQozxld8b7dhxxB85quPUysg=";
+
+  meta = with lib; {
+    description = "A protoc plugin that generates Cargo crates and include files for `protoc-gen-prost`";
+    homepage = "https://github.com/neoeinstein/protoc-gen-prost";
+    changelog = "https://github.com/neoeinstein/protoc-gen-prost/blob/main/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ felschr sitaaax ];
+  };
+}

--- a/pkgs/development/tools/protoc-gen-prost-serde/default.nix
+++ b/pkgs/development/tools/protoc-gen-prost-serde/default.nix
@@ -1,0 +1,25 @@
+{ fetchCrate
+, lib
+, rustPlatform
+, protobuf
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "protoc-gen-prost-serde";
+  version = "0.2.3";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-V2Z6m9y/bBwrr1mgKXKZjVg+LqTe+GalN/AeaICyE64=";
+  };
+
+  cargoSha256 = "sha256-l27+Rs4TYIJXZVLj7Tjw8M5+7ivWEY0TXbLtbuzwxLw=";
+
+  meta = with lib; {
+    description = "A protoc plugin that generates serde serialization implementations for `protoc-gen-prost`";
+    homepage = "https://github.com/neoeinstein/protoc-gen-prost";
+    changelog = "https://github.com/neoeinstein/protoc-gen-prost/blob/main/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ felschr sitaaax ];
+  };
+}

--- a/pkgs/development/tools/protoc-gen-prost/default.nix
+++ b/pkgs/development/tools/protoc-gen-prost/default.nix
@@ -1,0 +1,25 @@
+{ fetchCrate
+, lib
+, rustPlatform
+, protobuf
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "protoc-gen-prost";
+  version = "0.2.3";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-QTt5mSUe41r2fxrgWj1l6fHC/utMVIgMi2ySsdGyl/Y=";
+  };
+
+  cargoSha256 = "sha256-ghXcyxG9zqUOFKGvUza29OgC3XiEtesqsAsfI/lFT08=";
+
+  meta = with lib; {
+    description = "Protocol Buffers compiler plugin powered by Prost";
+    homepage = "https://github.com/neoeinstein/protoc-gen-prost";
+    changelog = "https://github.com/neoeinstein/protoc-gen-prost/blob/main/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ felschr sitaaax ];
+  };
+}

--- a/pkgs/development/tools/protoc-gen-tonic/default.nix
+++ b/pkgs/development/tools/protoc-gen-tonic/default.nix
@@ -1,0 +1,25 @@
+{ fetchCrate
+, lib
+, rustPlatform
+, protobuf
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "protoc-gen-tonic";
+  version = "0.3.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-jgU1XvUxIrZ72dLNPqDGHCONMlHsjW4k4vkO626iqxs=";
+  };
+
+  cargoSha256 = "sha256-FrkvL/uJitMkSyOytVSmlwr26yMVM12S2n+EaSw11CE=";
+
+  meta = with lib; {
+    description = "A protoc plugin that generates Tonic gRPC server and client code using the Prost code generation engine";
+    homepage = "https://github.com/neoeinstein/protoc-gen-prost";
+    changelog = "https://github.com/neoeinstein/protoc-gen-prost/blob/main/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ felschr sitaaax ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -550,6 +550,8 @@ with pkgs;
 
   protoc-gen-prost = callPackage ../development/tools/protoc-gen-prost { };
 
+  protoc-gen-prost-crate = callPackage ../development/tools/protoc-gen-prost-crate { };
+
   protoc-gen-rust = callPackage ../development/tools/protoc-gen-rust { };
 
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -556,6 +556,8 @@ with pkgs;
 
   protoc-gen-rust = callPackage ../development/tools/protoc-gen-rust { };
 
+  protoc-gen-tonic = callPackage ../development/tools/protoc-gen-tonic { };
+
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };
 
   protoc-gen-twirp_php = callPackage ../development/tools/protoc-gen-twirp_php { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -552,6 +552,8 @@ with pkgs;
 
   protoc-gen-prost-crate = callPackage ../development/tools/protoc-gen-prost-crate { };
 
+  protoc-gen-prost-serde = callPackage ../development/tools/protoc-gen-prost-serde { };
+
   protoc-gen-rust = callPackage ../development/tools/protoc-gen-rust { };
 
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -548,6 +548,8 @@ with pkgs;
 
   protoc-gen-connect-go = callPackage ../development/tools/protoc-gen-connect-go { };
 
+  protoc-gen-prost = callPackage ../development/tools/protoc-gen-prost { };
+
   protoc-gen-rust = callPackage ../development/tools/protoc-gen-rust { };
 
   protoc-gen-twirp = callPackage ../development/tools/protoc-gen-twirp { };


### PR DESCRIPTION
###### Description of changes

protoc-gen-prost: init at 0.2.3
protoc-gen-prost-crate: init at 0.3.1
protoc-gen-prost-serde: init at 0.2.3
protoc-gen-tonic: init at 0.3.0

Protobuf plugins for generating Rust (inclusive gRPC) code.

The code of all mentioned packages lives at: https://github.com/neoeinstein/protoc-gen-prost
Their crates - which are used for packaging - come from:
https://crates.io/crates/protoc-gen-prost
https://crates.io/crates/protoc-gen-prost-crate
https://crates.io/crates/protoc-gen-prost-serde
https://crates.io/crates/protoc-gen-tonic

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).