### PR TITLE
mpvScripts.inhibit_gnome: init at 0.1.3

### DIFF
--- a/pkgs/applications/video/mpv/scripts/inhibit-gnome.nix
+++ b/pkgs/applications/video/mpv/scripts/inhibit-gnome.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, dbus, mpv-unwrapped }:
+
+stdenv.mkDerivation rec {
+  pname = "mpv-inhibit-gnome";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "Guldoman";
+    repo = "mpv_inhibit_gnome";
+    rev = "v${version}";
+    hash = "sha256-LSGg5gAQE2JpepBqhz6D6d3NlqYaU4bjvYf1F+oLphQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ dbus mpv-unwrapped ];
+
+  passthru.scriptName = "mpv_inhibit_gnome.so";
+
+  installPhase = ''
+    install -D ./lib/mpv_inhibit_gnome.so $out/share/mpv/scripts/mpv_inhibit_gnome.so
+  '';
+
+  meta = with lib; {
+    description = "This mpv plugin prevents screen blanking in GNOME";
+    homepage = "https://github.com/Guldoman/mpv_inhibit_gnome";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ myaats ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30679,6 +30679,7 @@ with pkgs;
   mpvScripts = recurseIntoAttrs {
     autoload = callPackage ../applications/video/mpv/scripts/autoload.nix {};
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
+    inhibit-gnome = callPackage ../applications/video/mpv/scripts/inhibit-gnome.nix {};
     mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
     mpv-playlistmanager = callPackage ../applications/video/mpv/scripts/mpv-playlistmanager.nix {};
     mpvacious = callPackage ../applications/video/mpv/scripts/mpvacious.nix {};


### PR DESCRIPTION
###### Description of changes

Package a mpv plugin that will inhibit GNOME suspend in Wayland sessions while visible video content is playing.

###### Things done

Packaged and verified, one can test it by using a GNOME Wayland session, one minute screen timeout and running mpv within this shell:
```bash
nix-shell -I nixpkgs=. -E "with import <nixpkgs> { };
(wrapMpv mpv-unwrapped {
  scripts = [ mpvScripts.inhibit_gnome ];
})"
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
