### PR TITLE
python310Packages.chat-downloader: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/development/python-modules/chat-downloader/default.nix
+++ b/pkgs/development/python-modules/chat-downloader/default.nix
@@ -1,34 +1,23 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , requests
 , isodate
 , docstring-parser
 , colorlog
 , websocket-client
 , pytestCheckHook
-, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "chat-downloader";
-  version = "0.2.0";
+  version = "0.2.1";
+  format = "setuptools";
 
-  # PyPI tarball is missing files
-  src = fetchFromGitHub {
-    owner = "xenova";
-    repo = "chat-downloader";
-    rev = "v${version}";
-    sha256 = "sha256-SVZyDTma6qAgmOz+QsPnudPrX1Eswtc0IKFRx1HnWLY=";
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "6b6d63124371dc1f89979662209aad11dc9954faf8fadb5fa73bf711ff07800d";
   };
-
-  patches = [
-    # Remove argparse from dependencies. https://github.com/xenova/chat-downloader/pull/167
-    (fetchpatch {
-      url = "https://github.com/xenova/chat-downloader/commit/cdaca5e3a334c8db1b37bebe191d181ebdfa576c.patch";
-      sha256 = "sha256-AgH305dJmNRZy23lAf1h40klDE67RSwEL8o2gxX0VGA=";
-    })
-  ];
 
   propagatedBuildInputs = [
     requests
@@ -48,6 +37,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A simple tool used to retrieve chat messages from livestreams, videos, clips and past broadcasts";
     homepage = "https://github.com/xenova/chat-downloader";
+    changelog = "https://github.com/xenova/chat-downloader/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ marsam ];
   };


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/xenova/chat-downloader/releases/tag/v0.2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
