### PR TITLE
Plasma Mobile Gear: 22.09 -> 22.11

### DIFF
--- a/pkgs/applications/plasma-mobile/alligator.nix
+++ b/pkgs/applications/plasma-mobile/alligator.nix
@@ -7,6 +7,7 @@
 , kconfig
 , kcoreaddons
 , ki18n
+, kirigami-addons
 , kirigami2
 , qtquickcontrols2
 , syndication
@@ -24,6 +25,7 @@ mkDerivation rec {
     kconfig
     kcoreaddons
     ki18n
+    kirigami-addons
     kirigami2
     qtquickcontrols2
     syndication

--- a/pkgs/applications/plasma-mobile/angelfish.nix
+++ b/pkgs/applications/plasma-mobile/angelfish.nix
@@ -19,8 +19,8 @@
 , srcs
 
 # These must be updated in tandem with package updates.
-, cargoShaForVersion ? "22.09"
-, cargoSha256 ? "sha256-uxLvAhRV185srZZ0ZMsLRevAyMmajXERPRYotMcnLJA="
+, cargoShaForVersion ? "22.11"
+, cargoSha256 ? "sha256-l1+nRXGt6Oga9yFJ3sVNitUN4XNcVjT1bJwi2XlleF4="
 }:
 
 # Guard against incomplete updates.

--- a/pkgs/applications/plasma-mobile/audiotube.nix
+++ b/pkgs/applications/plasma-mobile/audiotube.nix
@@ -8,6 +8,7 @@
 , kcrash
 , ki18n
 , kirigami2
+, qtimageformats
 , qtmultimedia
 , qtquickcontrols2
 , python3Packages
@@ -30,6 +31,7 @@ mkDerivation rec {
     kcrash
     ki18n
     kirigami2
+    qtimageformats
     qtmultimedia
     qtquickcontrols2
   ] ++ pythonPath;

--- a/pkgs/applications/plasma-mobile/audiotube.nix
+++ b/pkgs/applications/plasma-mobile/audiotube.nix
@@ -3,7 +3,9 @@
 
 , extra-cmake-modules
 , gcc11
+, wrapGAppsHook
 
+, gst_all_1
 , kcoreaddons
 , kcrash
 , ki18n
@@ -19,6 +21,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     extra-cmake-modules
+    wrapGAppsHook
     gcc11 # doesn't build with GCC 9 from stdenv on aarch64
     python3Packages.wrapPython
     python3Packages.pybind11
@@ -32,7 +35,12 @@ mkDerivation rec {
     qtimageformats
     qtmultimedia
     qtquickcontrols2
-  ] ++ pythonPath;
+  ] ++ (with gst_all_1; [
+    gst-plugins-bad
+    gst-plugins-base
+    gst-plugins-good
+    gstreamer
+  ]) ++ pythonPath;
 
   pythonPath = with python3Packages; [
     yt-dlp
@@ -42,7 +50,9 @@ mkDerivation rec {
   preFixup = ''
     buildPythonPath "$pythonPath"
     qtWrapperArgs+=(--prefix PYTHONPATH : "$program_PYTHONPATH")
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
+  dontWrapGApps = true;
 
   meta = with lib; {
     description = "Client for YouTube Music";

--- a/pkgs/applications/plasma-mobile/audiotube.nix
+++ b/pkgs/applications/plasma-mobile/audiotube.nix
@@ -17,8 +17,6 @@
 mkDerivation rec {
   pname = "audiotube";
 
-  postPatch = "sed '1i#include <iostream>' -i src/ytmusic.cpp";
-
   nativeBuildInputs = [
     extra-cmake-modules
     gcc11 # doesn't build with GCC 9 from stdenv on aarch64

--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -77,7 +77,7 @@ let
       plasma-dialer = callPackage ./plasma-dialer.nix {};
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
       plasma-settings = callPackage ./plasma-settings.nix {};
-      plasmatube = callPackage ./plasmatube.nix {};
+      plasmatube = callPackage ./plasmatube {};
       spacebar = callPackage ./spacebar.nix { inherit srcs; };
     };
 

--- a/pkgs/applications/plasma-mobile/fetch.sh
+++ b/pkgs/applications/plasma-mobile/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma-mobile/22.09/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma-mobile/22.11/ -A '*.tar.xz' )

--- a/pkgs/applications/plasma-mobile/kclock.nix
+++ b/pkgs/applications/plasma-mobile/kclock.nix
@@ -8,6 +8,7 @@
 , kcoreaddons
 , kdbusaddons
 , ki18n
+, kirigami-addons
 , kirigami2
 , knotifications
 , plasma-framework
@@ -28,6 +29,7 @@ mkDerivation rec {
     kcoreaddons
     kdbusaddons
     ki18n
+    kirigami-addons
     kirigami2
     knotifications
     plasma-framework

--- a/pkgs/applications/plasma-mobile/krecorder.nix
+++ b/pkgs/applications/plasma-mobile/krecorder.nix
@@ -9,6 +9,7 @@
 , ki18n
 , kirigami2
 , kirigami-addons
+, kwindowsystem
 , qtmultimedia
 , qtquickcontrols2
 }:
@@ -27,6 +28,7 @@ mkDerivation rec {
     ki18n
     kirigami2
     kirigami-addons
+    kwindowsystem
     qtmultimedia
     qtquickcontrols2
   ];

--- a/pkgs/applications/plasma-mobile/neochat.nix
+++ b/pkgs/applications/plasma-mobile/neochat.nix
@@ -12,6 +12,7 @@
 , kdbusaddons
 , ki18n
 , kio
+, kirigami-addons
 , kirigami2
 , kitemmodels
 , knotifications
@@ -47,6 +48,7 @@ gcc11Stdenv.mkDerivation rec {
     kdbusaddons
     kio
     ki18n
+    kirigami-addons
     kirigami2
     kitemmodels
     knotifications

--- a/pkgs/applications/plasma-mobile/plasma-dialer.nix
+++ b/pkgs/applications/plasma-mobile/plasma-dialer.nix
@@ -10,6 +10,7 @@
 , kdbusaddons
 , ki18n
 , kio
+, kirigami-addons
 , kirigami2
 , knotifications
 , kpeople
@@ -44,6 +45,7 @@ mkDerivation rec {
     kdbusaddons
     ki18n
     kio
+    kirigami-addons
     kirigami2
     knotifications
     kpeople

--- a/pkgs/applications/plasma-mobile/plasmatube/0001-Add-placeholders-for-runtime-dependencies.patch
+++ b/pkgs/applications/plasma-mobile/plasmatube/0001-Add-placeholders-for-runtime-dependencies.patch
@@ -1,0 +1,25 @@
+From 7a9405ed02b0d86839644a2c237ca7ca8b891b76 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Wed, 30 Nov 2022 21:07:56 -0500
+Subject: [PATCH] Add placeholders for runtime dependencies
+
+---
+ src/videomodel.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/videomodel.cpp b/src/videomodel.cpp
+index 4bb3451..b558f31 100644
+--- a/src/videomodel.cpp
++++ b/src/videomodel.cpp
+@@ -121,7 +121,7 @@ QString VideoModel::remoteUrl()
+         return {};
+     }
+ 
+-    QString youtubeDl = QStringLiteral("yt-dlp");
++    QString youtubeDl = QStringLiteral("@yt-dlp@");
+     QStringList arguments;
+     arguments << QLatin1String("--dump-json")
+               << m_videoId;
+-- 
+2.38.0
+

--- a/pkgs/applications/plasma-mobile/plasmatube/default.nix
+++ b/pkgs/applications/plasma-mobile/plasmatube/default.nix
@@ -9,6 +9,7 @@
 , kirigami2
 , qtmultimedia
 , qtquickcontrols2
+, yt-dlp
 }:
 
 mkDerivation {
@@ -31,6 +32,15 @@ mkDerivation {
     gst-plugins-good
     gstreamer
   ]);
+
+  patches = [
+    ./0001-Add-placeholders-for-runtime-dependencies.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/videomodel.cpp \
+      --replace "@yt-dlp@" "${yt-dlp}/bin/yt-dlp"
+  '';
 
   meta = {
     description = "Youtube player powered by an invidious server";

--- a/pkgs/applications/plasma-mobile/plasmatube/default.nix
+++ b/pkgs/applications/plasma-mobile/plasmatube/default.nix
@@ -2,6 +2,7 @@
 , mkDerivation
 , cmake
 , extra-cmake-modules
+, wrapGAppsHook
 , gst_all_1
 , kcoreaddons
 , kdeclarative
@@ -17,6 +18,7 @@ mkDerivation {
 
   nativeBuildInputs = [
     extra-cmake-modules
+    wrapGAppsHook
   ];
 
   buildInputs = [
@@ -41,6 +43,11 @@ mkDerivation {
     substituteInPlace src/videomodel.cpp \
       --replace "@yt-dlp@" "${yt-dlp}/bin/yt-dlp"
   '';
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+  dontWrapGApps = true;
 
   meta = {
     description = "Youtube player powered by an invidious server";

--- a/pkgs/applications/plasma-mobile/srcs.nix
+++ b/pkgs/applications/plasma-mobile/srcs.nix
@@ -4,195 +4,195 @@
 
 {
   alligator = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/alligator-22.09.tar.xz";
-      sha256 = "0krys21df6mlyi2zxdxgqx02k1q7njliz0nsxcygxrd89ajxlslb";
-      name = "alligator-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/alligator-22.11.tar.xz";
+      sha256 = "02hg42mmvykq71my6wbgc3yri4c3mr4bp73b7p21j1b8m3x0ycsl";
+      name = "alligator-22.11.tar.xz";
     };
   };
   angelfish = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/angelfish-22.09.tar.xz";
-      sha256 = "1blhn84xka11zjwqimr30qv94jp5slfcmc44xcjxginl3n6hicwx";
-      name = "angelfish-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/angelfish-22.11.tar.xz";
+      sha256 = "07gp6468c7rhf3hzzk6qyz4kcah0s1wnn5r3mx7qmg777xaans9y";
+      name = "angelfish-22.11.tar.xz";
     };
   };
   audiotube = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/audiotube-22.09.tar.xz";
-      sha256 = "1ay3qrg8lnw209kwmgm2ll5k1gbp2q694g6w837xl2wjy792vqw8";
-      name = "audiotube-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/audiotube-22.11.tar.xz";
+      sha256 = "0ga7ag8v9l91j5rrn02kk73zl29lwigcql1xfh7yw5cnky3xd13q";
+      name = "audiotube-22.11.tar.xz";
     };
   };
   calindori = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/calindori-22.09.tar.xz";
-      sha256 = "1pwgdqznp76mhk0ikzjhy3c67qgk91kgv69ygqwzlh5hwiw5sl4n";
-      name = "calindori-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/calindori-22.11.tar.xz";
+      sha256 = "1mgdd61zmnjbpcwkaq2aiawksf1s86b05sq502by6gpdrwndhb5c";
+      name = "calindori-22.11.tar.xz";
     };
   };
   kalk = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/kalk-22.09.tar.xz";
-      sha256 = "0sci3jv3asjxahcdz2vkmh90fbffx8lfj1cy5kqnpijdxcm10gfq";
-      name = "kalk-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/kalk-22.11.tar.xz";
+      sha256 = "0ri39455341nw6bn0lphky6n2b4ib9g4i24f6gzc0adnbhbpxdiq";
+      name = "kalk-22.11.tar.xz";
     };
   };
   kasts = {
-    version = "22.09.2";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/kasts-22.09.2.tar.xz";
-      sha256 = "10i0b8k1k0ki8pq8hsj979y7np75iaq49bxkyj95zzci9g73vd59";
-      name = "kasts-22.09.2.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/kasts-22.11.tar.xz";
+      sha256 = "049700i15cw07c6053iml1q3h5mni24kdf8nvkdafdafhslb84i9";
+      name = "kasts-22.11.tar.xz";
     };
   };
   kclock = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/kclock-22.09.tar.xz";
-      sha256 = "18b5lncgh9vc94bgrdmzigi853j4l7hqrvggk4hfcklj4pnv1bav";
-      name = "kclock-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/kclock-22.11.tar.xz";
+      sha256 = "02v64zfbv1g3q4w79d0r8rxqiqsnxms7dgkjv09bp1gl1asqx354";
+      name = "kclock-22.11.tar.xz";
     };
   };
   keysmith = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/keysmith-22.09.tar.xz";
-      sha256 = "0w3vvmp9rn6ahly2fm9n6f4glfr7d84bfvj33mrs5pn7n99h7jgy";
-      name = "keysmith-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/keysmith-22.11.tar.xz";
+      sha256 = "1aimsgwk80yvncbsjnaxvr6aj8y4g40dpwfv0qi0k7b3xkrmqdk5";
+      name = "keysmith-22.11.tar.xz";
     };
   };
   khealthcertificate = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/khealthcertificate-22.09.tar.xz";
-      sha256 = "16vkjpyxwx34pvdpnci0l6mx2bdjialiscjvbdx53xbsq9ff701k";
-      name = "khealthcertificate-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/khealthcertificate-22.11.tar.xz";
+      sha256 = "0gw6j70k0nvbfb1vfj8b64vfipdckzd8hqqmp9vrmsg7y8g8n0hi";
+      name = "khealthcertificate-22.11.tar.xz";
     };
   };
   koko = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/koko-22.09.tar.xz";
-      sha256 = "1z3ysc2f1agbkmm2cxa87x5rk2nx9fjv3czlvcsn8s5ssfdws3gl";
-      name = "koko-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/koko-22.11.tar.xz";
+      sha256 = "1jqjjd9spyppdbijdnvci742wj80p10pfbjp1hyc0y4zdjic67bv";
+      name = "koko-22.11.tar.xz";
     };
   };
   kongress = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/kongress-22.09.tar.xz";
-      sha256 = "0pjp2s774sgw2dklqib8alm1a9fkixy3s92i2v8v00znx08zf2jz";
-      name = "kongress-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/kongress-22.11.tar.xz";
+      sha256 = "03r8xck9vxl3al3f5v6g0yzqzs3yxl3lg7zg73ik22q6z2rb1adb";
+      name = "kongress-22.11.tar.xz";
     };
   };
   krecorder = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/krecorder-22.09.tar.xz";
-      sha256 = "0kcgw7bsyw3bhai2djcq3qjn5ims7i4qbvpm7nwpjkm1p3m7fjii";
-      name = "krecorder-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/krecorder-22.11.tar.xz";
+      sha256 = "1wiihcp1c0wc7ssj9hj18rnzf8synaxmq6b0m2m286x4zibl50wb";
+      name = "krecorder-22.11.tar.xz";
     };
   };
   ktrip = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/ktrip-22.09.tar.xz";
-      sha256 = "0x9s4yh2nvy7zmg3ds9bn8ir6wx10i8d0mvfaylbzb39rcabpmrl";
-      name = "ktrip-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/ktrip-22.11.tar.xz";
+      sha256 = "07mjf9jpj20ixhswy4byqy3m4sr1qylwlvq2prabn11j42ahpsy7";
+      name = "ktrip-22.11.tar.xz";
     };
   };
   kweather = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/kweather-22.09.tar.xz";
-      sha256 = "0z3z659y1r1jry02w0hxwcpghkgxgqiwj1kqck07vlg8ks7lz1jz";
-      name = "kweather-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/kweather-22.11.tar.xz";
+      sha256 = "0sqc74yp5hvrjagax6nj0gm4qvbxqr66706yh12abcn9gpl33ndl";
+      name = "kweather-22.11.tar.xz";
     };
   };
   neochat = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/neochat-22.09.tar.xz";
-      sha256 = "1j8p6mv89q1krjjbc9n26r83csqpxwd03zzhvzxxm53334qwqdci";
-      name = "neochat-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/neochat-22.11.tar.xz";
+      sha256 = "1gnhk9hww05bc4y8jd4sg3146c6m96ds2saajrnzyc6963j2ndi5";
+      name = "neochat-22.11.tar.xz";
     };
   };
   plasma-dialer = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/plasma-dialer-22.09.tar.xz";
-      sha256 = "1wk8q5lc15d53viqyknsww1hgci1rxmnra4hj887fabnj0id29rs";
-      name = "plasma-dialer-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/plasma-dialer-22.11.tar.xz";
+      sha256 = "1qx7xmvfszpsrb2jylnwfs8rhr09kxvy5vnyzzcds248ljh5l6dy";
+      name = "plasma-dialer-22.11.tar.xz";
     };
   };
   plasma-phonebook = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/plasma-phonebook-22.09.tar.xz";
-      sha256 = "1wsv330sfjh78fg98kd2g6a4bsmdyf7gn9r3aqazci7p7i5n2ln0";
-      name = "plasma-phonebook-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/plasma-phonebook-22.11.tar.xz";
+      sha256 = "02sj6v18w63ixy0c93fm4j9n4q98497qrb509q84618gry4cazly";
+      name = "plasma-phonebook-22.11.tar.xz";
     };
   };
   plasma-settings = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/plasma-settings-22.09.tar.xz";
-      sha256 = "0jq2r7ckz27a8r41n4jn61wlrpcx0qwlasipig4jz7rc9i0ayfka";
-      name = "plasma-settings-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/plasma-settings-22.11.tar.xz";
+      sha256 = "0pg71plcbn4zkwxwcvay9swaa5xn3mnljdpnh4i8f86x2pa1pq5j";
+      name = "plasma-settings-22.11.tar.xz";
     };
   };
   plasmatube = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/plasmatube-22.09.tar.xz";
-      sha256 = "00w9p5fcpv4s406lmcdcbrxf19sgkvf9yy8pfjmf1asvvvi8bpnk";
-      name = "plasmatube-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/plasmatube-22.11.tar.xz";
+      sha256 = "0vgxvyw4yl91kaj9cnjf455mpj4a5rh5f1z0in8k9p2jbs8wmjil";
+      name = "plasmatube-22.11.tar.xz";
     };
   };
   qmlkonsole = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/qmlkonsole-22.09.tar.xz";
-      sha256 = "19bf9f4vxa8arnl1zjappg6kh21br131cbsx902qnpv6y0r3swz1";
-      name = "qmlkonsole-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/qmlkonsole-22.11.tar.xz";
+      sha256 = "03hwyrl6rb7yidw0nadis6csb6snpfv137j46rbpl35vrqrnrh5i";
+      name = "qmlkonsole-22.11.tar.xz";
     };
   };
   spacebar = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/spacebar-22.09.tar.xz";
-      sha256 = "0fmk7fa7i67l8ff0amn80yxhf05vf0j9c42zj6qg5p30d1j31pbl";
-      name = "spacebar-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/spacebar-22.11.tar.xz";
+      sha256 = "1q0nyfvssiz5i19wyk4pvazax3vvk945cmknw4l51mpcc3hnc1v5";
+      name = "spacebar-22.11.tar.xz";
     };
   };
   telly-skout = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/telly-skout-22.09.tar.xz";
-      sha256 = "1byakylbjjxyz6bh59dydqnvh8c627jpx39ih1ylrdl8jlkd0scy";
-      name = "telly-skout-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/telly-skout-22.11.tar.xz";
+      sha256 = "0sfdia4jwcv24z5d3qykqv7ncr2c5v7ywq471nggwpcr22bwzn6x";
+      name = "telly-skout-22.11.tar.xz";
     };
   };
   tokodon = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/tokodon-22.09.tar.xz";
-      sha256 = "123vyq9vfl48l7ssrymvkhxlkwihplnssal0wvz4n2dk59byl46p";
-      name = "tokodon-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/tokodon-22.11.tar.xz";
+      sha256 = "0afrqih1bkgg0xqr81sq9q3glyhy8347p8vzddl42zsxax9wki59";
+      name = "tokodon-22.11.tar.xz";
     };
   };
   vakzination = {
-    version = "22.09";
+    version = "22.11";
     src = fetchurl {
-      url = "${mirror}/stable/plasma-mobile/22.09/vakzination-22.09.tar.xz";
-      sha256 = "01xzc1di57j0fgzkqwa39jng0fd90laya0rj85vjda7mbh2lxxk6";
-      name = "vakzination-22.09.tar.xz";
+      url = "${mirror}/stable/plasma-mobile/22.11/vakzination-22.11.tar.xz";
+      sha256 = "0587p5q9v0lh3nz00dfa8kym36xcgcg8n4alnchk6kr8c479kmk6";
+      name = "vakzination-22.11.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/kirigami-addons/default.nix
+++ b/pkgs/development/libraries/kirigami-addons/default.nix
@@ -12,14 +12,14 @@
 
 mkDerivation rec {
   pname = "kirigami-addons";
-  version = "0.4";
+  version = "0.6";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "libraries";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-3RPOab10kLcMVBngcRILDXbhOBI/BhjkMZqWVC0IPlM=";
+    sha256 = "sha256-RUu/0O/YRVRsRYeASfW8UQ/Ql2VbLOdVySVo9/hAmLw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

 - https://plasma-mobile.org/2022/11/30/plasma-mobile-gear-22-11/

Other than the update, this also includes some fixes for Plasma Tube.

I guess no one used it, since while yes it listed videos, it wouldn't play. I will note that it still seems broken. While videos now play, the controls don't work. I'm open to suggestions about ways to figure out why this is failing.

Note that this does not include shell changes. These will come with the next Plasma shell updates. *Plasma 5.27 will be released on February 9th, 2023*

###### Things tested

 - [x] alligator
 - [x] angelfish
 - [x] audiotube
 - [x] calindoi
 - [x] kalk
 - [x] kasts
 - [x] kclock
 - [x] keysmith
 - [x] koko
 - [x] krecorder
 - [x] kweather
 - [x] neochat
 - [x] plasma-dialer (without dialing)
 - [x] plasma-phonebook
 - [x] plasma-settings
 - [x] plasmatube (see preceding remarks)
 - [x] spacebar (without sending an SMS)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
