### PR TITLE
nqptp: init at unstable-2022-09-12

### DIFF
--- a/pkgs/tools/networking/nqptp/default.nix
+++ b/pkgs/tools/networking/nqptp/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2022-09-12";
+  pname = "nqptp";
+
+  src = fetchFromGitHub {
+    owner = "mikebrady";
+    repo = pname;
+    rev = "476e69697d2ec1a28d399432aed23c580e3e570a";
+    hash = "sha256-UPUYEX5YUl//OcsBKuGgKLaAMzn2F+ksNRQJ3/pkbKc=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mikebrady/nqptp";
+    description = "Daemon and companion application to Shairport Sync that monitors timing data from any PTP clocks";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ jordanisaacs ];
+    platforms = platforms.linux ++ platforms.freebsd;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30582,6 +30582,8 @@ with pkgs;
     buildGoModule = buildGo118Module; # tests fail with 1.19
   };
 
+  nqptp = callPackage ../tools/networking/nqptp { };
+
   mailspring = callPackage ../applications/networking/mailreaders/mailspring {};
 
   mm = callPackage ../applications/networking/instant-messengers/mm { };


### PR DESCRIPTION
###### Description of changes

Init [nqptp](https://github.com/mikebrady/nqptp). It is a daemon that monitors timing data from any [PTP](https://en.wikipedia.org/wiki/Precision_Time_Protocol) clocks. It is used as a companion to Shairport Sync (currently packaged for nixpkgs) for Airplay 2 support. There are not any tags so I am utilizing the git commit where the changelog was updated for the version.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The resulting binary seems to run correctly. It does not emit any errors. However, I am not able to test full functionality until I also update the shairport sync package to allow for airplay 2 support which actually interacts with nqptp.
