### PR TITLE
shairport-sync: 3.3.9 -> 4.1.1

### DIFF
--- a/pkgs/servers/shairport-sync/default.nix
+++ b/pkgs/servers/shairport-sync/default.nix
@@ -1,58 +1,106 @@
-{ lib, stdenv, fetchFromGitHub
-, autoreconfHook, pkg-config
-, openssl, avahi, alsa-lib, glib, libdaemon, popt, libconfig, libpulseaudio, soxr
-, enableDbus ? stdenv.isLinux
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, openssl_1_1
+, avahi
+, alsa-lib
+, libplist
+, glib
+, libdaemon
+, libsodium
+, libgcrypt
+, ffmpeg
+, libuuid
+, unixtools
+, popt
+, libconfig
+, libpulseaudio
+, libjack2
+, pipewire
+, soxr
+, enableAirplay2 ? false
+, enableStdout ? true
+, enableAlsa ? true
+, enablePulse ? true
+, enablePipe ? true
+, enablePipewire ? true
+, enableJack ? true
 , enableMetadata ? false
 , enableMpris ? stdenv.isLinux
+, enableDbus ? stdenv.isLinux
+, enableSoxr ? true
+, enableLibdaemon ? false
 }:
 
-with lib;
 stdenv.mkDerivation rec {
-  version = "3.3.9";
+  version = "4.1.1";
   pname = "shairport-sync";
 
   src = fetchFromGitHub {
-    sha256 = "sha256-JLgnsLjswj0qus1Vd5ZtPQbbIp3dp2pI7OfQG4JrdW8=";
     rev = version;
     repo = "shairport-sync";
     owner = "mikebrady";
+    hash = "sha256-EKt5mH9GmzeR4zdPDFOt26T9STpG1khVrY4DFIv5Maw=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
-  buildInputs = [
-    openssl
+  buildInputs = with lib; [
+    openssl_1_1
     avahi
-    alsa-lib
-    libdaemon
     popt
     libconfig
-    libpulseaudio
-    soxr
-  ] ++ optional stdenv.isLinux glib;
+  ]
+  ++ optional enableLibdaemon libdaemon
+  ++ optional enableAlsa alsa-lib
+  ++ optional enablePulse libpulseaudio
+  ++ optional enablePipewire pipewire
+  ++ optional enableJack libjack2
+  ++ optional enableSoxr soxr
+  ++ optionals enableAirplay2 [
+    libplist
+    libsodium
+    libgcrypt
+    libuuid
+    ffmpeg
+    unixtools.xxd
+  ]
+  ++ optional stdenv.isLinux glib;
 
-  prePatch = ''
+  postPatch = ''
     sed -i -e 's/G_BUS_TYPE_SYSTEM/G_BUS_TYPE_SESSION/g' dbus-service.c
     sed -i -e 's/G_BUS_TYPE_SYSTEM/G_BUS_TYPE_SESSION/g' mpris-service.c
   '';
 
   enableParallelBuilding = true;
 
-  configureFlags = [
-    "--with-alsa" "--with-pipe" "--with-pa" "--with-stdout"
-    "--with-avahi" "--with-ssl=openssl" "--with-soxr"
+  configureFlags = with lib; [
     "--without-configfiles"
     "--sysconfdir=/etc"
+    "--with-ssl=openssl"
+    "--with-stdout"
+    "--with-avahi"
   ]
-    ++ optional enableDbus "--with-dbus-interface"
-    ++ optional enableMetadata "--with-metadata"
-    ++ optional enableMpris "--with-mpris-interface";
+  ++ optional enablePulse "--with-pa"
+  ++ optional enablePipewire "--with-pw"
+  ++ optional enableAlsa "--with-alsa"
+  ++ optional enableJack "--with-jack"
+  ++ optional enableStdout "--with-stdout"
+  ++ optional enablePipe "--with-pipe"
+  ++ optional enableSoxr "--with-soxr"
+  ++ optional enableDbus "--with-dbus-interface"
+  ++ optional enableMetadata "--with-metadata"
+  ++ optional enableMpris "--with-mpris-interface"
+  ++ optional enableLibdaemon "--with-libdaemon"
+  ++ optional enableAirplay2 "--with-airplay-2";
 
   meta = with lib; {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/mikebrady/shairport-sync";
     description = "Airtunes server and emulator with multi-room capabilities";
     license = licenses.mit;
-    maintainers =  with maintainers; [ lnl7 ];
+    maintainers = with maintainers; [ lnl7 jordanisaacs ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

Update shairport-sync from 3.9 to 4.1.1. Additionally it is now formatted and enables configuration using function arguments. Differences from the previous version are enabling jack and pipewire backends by default. Airplay 2 is disabled by default to not break the nixos module as running it is much more complicated (requires [nqptp](https://github.com/NixOS/nixpkgs/pull/203867)). Added myself as a maintainer.

Closes #198387

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Built each `enableXXX` option successfully and ran the `--help` command. Ran nixpkgs default build successfully with the pipewire backend. I have not tested the existing nixos module.

Pinging @LnL7 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
