### PR TITLE
nixos/grocy: fix file uploads

### DIFF
--- a/pkgs/servers/grocy/0001-Define-configs-with-env-vars.patch
+++ b/pkgs/servers/grocy/0001-Define-configs-with-env-vars.patch
@@ -1,4 +1,4 @@
-From 035709eeac697945a26276cc17b996c1a0678ddc Mon Sep 17 00:00:00 2001
+From 05b762c6ca58ecb5fd631a019fbda69b0647785f Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
 Date: Tue, 22 Dec 2020 15:38:56 +0100
 Subject: [PATCH] Define configs with env vars
@@ -33,10 +33,10 @@ index 17ba6a99..89f48089 100644
  
  $container->set('UrlManager', function (Container $container) {
 diff --git a/services/DatabaseService.php b/services/DatabaseService.php
-index dfcd5d4b..bc8d1a1d 100644
+index c093f361..0894791f 100644
 --- a/services/DatabaseService.php
 +++ b/services/DatabaseService.php
-@@ -107,6 +107,6 @@ class DatabaseService
+@@ -114,6 +114,6 @@ class DatabaseService
  			return GROCY_DATAPATH . '/grocy_' . $dbSuffix . '.db';
  		}
  
@@ -45,23 +45,23 @@ index dfcd5d4b..bc8d1a1d 100644
  	}
  }
 diff --git a/services/FilesService.php b/services/FilesService.php
-index 7d070350..fba2e923 100644
+index 7d070350..a6dd4b08 100644
 --- a/services/FilesService.php
 +++ b/services/FilesService.php
-@@ -103,7 +103,7 @@ class FilesService extends BaseService
+@@ -10,7 +10,7 @@ class FilesService extends BaseService
  
- 	public function GetFilePath($group, $fileName)
+ 	public function __construct()
  	{
--		$groupFolderPath = $this->StoragePath . '/' . $group;
+-		$this->StoragePath = GROCY_DATAPATH . '/storage';
 +		$this->StoragePath = getenv('GROCY_STORAGE_DIR');
- 
- 		if (!file_exists($groupFolderPath))
+ 		if (!file_exists($this->StoragePath))
  		{
+ 			mkdir($this->StoragePath);
 diff --git a/services/StockService.php b/services/StockService.php
-index f73ac5bd..6b6e693a 100644
+index 85f57803..15556112 100644
 --- a/services/StockService.php
 +++ b/services/StockService.php
-@@ -1589,8 +1589,7 @@ class StockService extends BaseService
+@@ -1704,8 +1704,7 @@ class StockService extends BaseService
  			throw new \Exception('No barcode lookup plugin defined');
  		}
  
@@ -72,5 +72,5 @@ index f73ac5bd..6b6e693a 100644
  		{
  			require_once $path;
 -- 
-2.31.1
+2.38.1
 


### PR DESCRIPTION
###### Description of changes

This commit fixes file uploads by restoring the proper setting of `$this->StoragePath` using `GROCY_STORAGE_DIR` in `FilesService`.

The previous iteration of this patch mistakenly patches out the setting of `$groupFolderPath` in the `GetFilePath` method, which the method subsequently tries to return. This causes `GetFilePath` to return, for example, `/file.png` (an incorrect root path) for files instead of `/var/lib/grocy/userpictures/file.png`.

Fixes #136486

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
