### PR TITLE
pkgsCross.mingwW64.windows.mingw_w64: backport parallel build fixes

### DIFF
--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, windows, fetchurl }:
+{ lib
+, stdenv
+, windows
+, fetchurl
+, fetchpatch
+, autoreconfHook
+}:
 
 let
   version = "10.0.0";
@@ -11,6 +17,20 @@ in stdenv.mkDerivation {
     hash = "sha256-umtDCu1yxjo3aFMfaj/8Kw/eLFejslFFDc9ImolPCJQ=";
   };
 
+  patches = [
+    # Upstream patches to fix build parallelism
+    (fetchpatch {
+      name = "crt-suff-make-4.4.patch";
+      url = "https://github.com/mirror/mingw-w64/commit/953bcd32ae470c4647e94de8548dda5a8f07d82d.patch";
+      hash = "sha256-lrS4ZDa/Uwsj5DXajOUv+knZXan0JVU70KHHdIjJ07Y=";
+    })
+    (fetchpatch {
+      name = "dll-dep-make-4.4.patch";
+      url = "https://github.com/mirror/mingw-w64/commit/e1b0c1420bbd52ef505c71737c57393ac1397b0a.patch";
+      hash = "sha256-/56Cmmy0UYTaDKIWG7CgXsThvCHK6lSbekbBOoOJSIQ=";
+    })
+  ];
+
   outputs = [ "out" "dev" ];
 
   configureFlags = [
@@ -20,6 +40,7 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ windows.mingw_w64_headers ];
   hardeningDisable = [ "stackprotector" "fortify" ];
 


### PR DESCRIPTION
Without the change build frequently fails on `gnumake-4.4` as:

    x86_64-w64-mingw32-dlltool: cannot delete libmsvcr120d_defs02133.o: No such file or directory
    x86_64-w64-mingw32-dlltool: cannot delete libmsvcr120d_defs02134.o: No such file or directory

Pull upstream patches that fix temporary file collisions and add missing dll dependencies.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
