### PR TITLE
jobber: init at 1.4.4

### DIFF
--- a/pkgs/tools/system/jobber/default.nix
+++ b/pkgs/tools/system/jobber/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildGoModule, fetchFromGitHub, gotools }:
+
+buildGoModule rec {
+  pname = "jobber";
+  version = "1.4.4";
+
+  src = fetchFromGitHub {
+    owner = "dshearer";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-mLYyrscvT/VK9ehwkPUq4RbwHb+6Wjvt7ZXk/fI0HT4=";
+  };
+
+  vendorHash = null;
+
+  nativeBuildInputs = [ gotools ];
+
+  postConfigure = "go generate ./...";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/dshearer/jobber/common.jobberVersion=${version}"
+    "-X github.com/dshearer/jobber/common.etcDirPath=${placeholder "out"}/etc"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc $out/libexec
+    $out/bin/jobbermaster defprefs --libexec $out/libexec > $out/etc/jobber.conf
+    mv $out/bin/jobber{master,runner} $out/libexec/
+  '';
+
+  meta = with lib; {
+    homepage = "https://dshearer.github.io/jobber";
+    changelog = "https://github.com/dshearer/jobber/releases/tag/v${version}";
+    description = "An alternative to cron, with sophisticated status-reporting and error-handling";
+    license = licenses.mit;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1395,6 +1395,8 @@ with pkgs;
 
   httm = callPackage ../tools/filesystems/httm { };
 
+  jobber = callPackage ../tools/system/jobber {};
+
   kanata = callPackage ../tools/system/kanata { };
 
   kanata-with-cmd = kanata.override { withCmd = true; };


### PR DESCRIPTION
###### Description of changes

Fixes #126268

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
