### PR TITLE
toolbox: init at 0.0.99.3

### DIFF
--- a/pkgs/applications/virtualization/toolbox/default.nix
+++ b/pkgs/applications/virtualization/toolbox/default.nix
@@ -1,0 +1,51 @@
+{ lib, buildGoModule, fetchFromGitHub, glibc, go-md2man, installShellFiles }:
+
+buildGoModule rec {
+  pname = "toolbox";
+  version = "0.0.99.3";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = pname;
+    rev = version;
+    hash = "sha256-9HiWgEtaMypLOwXJ6Xg3grLSZOQ4NInZtcvLPV51YO8=";
+  };
+
+  patches = [ ./glibc.patch ];
+
+  vendorHash = "sha256-k79TcC9voQROpJnyZ0RsqxJnBT83W5Z+D+D3HnuQGsI=";
+
+  postPatch = ''
+    substituteInPlace src/cmd/create.go --subst-var-by glibc ${glibc}
+  '';
+
+  modRoot = "src";
+
+  nativeBuildInputs = [ go-md2man installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/containers/toolbox/pkg/version.currentVersion=${version}"
+  ];
+
+  preCheck = "export PATH=$GOPATH/bin:$PATH";
+
+  postInstall = ''
+    cd ..
+    for d in doc/*.md; do
+      go-md2man -in $d -out ''${d%.md}
+    done
+    installManPage doc/*.[1-9]
+    installShellCompletion --bash completion/bash/toolbox
+    install profile.d/toolbox.sh -Dt $out/share/profile.d
+  '';
+
+  meta = with lib; {
+    homepage = "https://containertoolbx.org";
+    changelog = "https://github.com/containers/toolbox/releases/tag/${version}";
+    description = "Tool for containerized command line environments on Linux";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ urandom ];
+  };
+}

--- a/pkgs/applications/virtualization/toolbox/glibc.patch
+++ b/pkgs/applications/virtualization/toolbox/glibc.patch
@@ -1,0 +1,12 @@
+diff --git a/src/cmd/create.go b/src/cmd/create.go
+index 74e90b1..113ef80 100644
+--- a/src/cmd/create.go
++++ b/src/cmd/create.go
+@@ -423,6 +425,7 @@ func createContainer(container, image, release string, showCommandToEnter bool)
+ 		"--volume", toolboxPathMountArg,
+ 		"--volume", usrMountArg,
+ 		"--volume", runtimeDirectoryMountArg,
++		"--volume", "@glibc@:@glibc@:ro",
+ 	}...)
+ 
+ 	createArgs = append(createArgs, avahiSocketMount...)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12257,6 +12257,8 @@ with pkgs;
 
   todo = callPackage ../tools/misc/todo { };
 
+  toolbox = callPackage ../applications/virtualization/toolbox { };
+
   tor = callPackage ../tools/security/tor { };
 
   tor-browser-bundle-bin = callPackage ../applications/networking/browsers/tor-browser-bundle-bin { };


### PR DESCRIPTION
###### Description of changes

The two fetched patches from #110473 have been merged upstream, so they have been dropped, but we have carried through the glibc patch. It sounds like the ux of this is still pretty sharp, but I am happy to try and drive this one forward.

Fixes #96115
Closes #110473

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
