### PR TITLE
cplay-ng: init at 5.1.0

### DIFF
--- a/pkgs/applications/audio/cplay-ng/default.nix
+++ b/pkgs/applications/audio/cplay-ng/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, python3
+, fetchFromGitHub
+, makeWrapper
+, mpv
+, pulseaudio
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "cplay-ng";
+  version = "5.1.0";
+
+  src = fetchFromGitHub {
+    owner = "xi";
+    repo = "cplay-ng";
+    rev = version;
+    hash = "sha256-pmuZ1NgrQKEJLoJEVC9wp5deFWc6DiX5DpnISeOOw4k=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/cplay-ng \
+      --prefix PATH : ${lib.makeBinPath [ mpv pulseaudio ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/xi/cplay-ng";
+    description = "Simple curses audio player";
+    longDescription = ''
+      cplay is a minimalist music player with a textual user interface written
+      in Python. It aims to provide a power-user-friendly interface with simple
+      filelist and playlist control.
+
+      Instead of building an elaborate database of your music library, cplay
+      allows you to quickly browse the filesystem and enqueue files,
+      directories, and playlists.
+
+      The original cplay was started by Ulf Betlehem in 1998 and is no longer
+      maintained. This is a rewrite that aims to stay true to the original
+      design while evolving with a shifting environment.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27887,6 +27887,8 @@ with pkgs;
 
   cozy-drive = callPackage ../applications/networking/cozy-drive {};
 
+  cplay-ng = callPackage ../applications/audio/cplay-ng { };
+
   cq-editor = libsForQt5.callPackage ../applications/graphics/cq-editor {
     python3Packages = python37Packages;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
