### PR TITLE
obfs4: 0.0.12 -> 0.0.14

### DIFF
--- a/pkgs/tools/networking/obfs4/default.nix
+++ b/pkgs/tools/networking/obfs4/default.nix
@@ -30,11 +30,10 @@ buildGoModule rec {
       specification, and its modular architecture allows it to support
       multiple pluggable transports.
     '';
-    homepage = "https://www.torproject.org/projects/obfsproxy";
+    homepage = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/obfs4";
     maintainers = with maintainers; [ thoughtpolice ];
     mainProgram = "obfs4proxy";
-    changelog = "https://gitweb.torproject.org/pluggable-transports/obfs4.git/plain/ChangeLog";
-    downloadPage = "https://gitweb.torproject.org/pluggable-transports/obfs4.git/";
+    changelog = "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/obfs4/-/raw/${src.rev}/ChangeLog";
     license = with lib.licenses; [ bsd2 bsd3 gpl3 ];
   };
 }

--- a/pkgs/tools/networking/obfs4/default.nix
+++ b/pkgs/tools/networking/obfs4/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitLab }:
+{ lib, buildGoModule, fetchFromGitLab, installShellFiles }:
 
 buildGoModule rec {
   pname = "obfs4";
@@ -16,6 +16,12 @@ buildGoModule rec {
   vendorHash = "sha256-7NF3yMouhjSM9SBNKHkeWV7qy0XTGnepEX28kBpbgdk=";
 
   ldflags = [ "-s" "-w" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage doc/obfs4proxy.1
+  '';
 
   meta = with lib; {
     description = "Circumvents censorship by transforming Tor traffic between clients and bridges";

--- a/pkgs/tools/networking/obfs4/default.nix
+++ b/pkgs/tools/networking/obfs4/default.nix
@@ -1,16 +1,21 @@
-{ lib, fetchgit, buildGoModule }:
+{ lib, buildGoModule, fetchFromGitLab }:
 
 buildGoModule rec {
   pname = "obfs4";
-  version = "0.0.12";
+  version = "0.0.14";
 
-  src = fetchgit {
-    url = "https://git.torproject.org/pluggable-transports/obfs4.git";
-    rev = "a564bc3840bc788605e1a8155f4b95ce0d70c6db"; # not tagged
-    sha256 = "0hqk540q94sh4wvm31jjcvpdklhf8r35in4yii7xnfn58a7amfkc";
+  src = fetchFromGitLab {
+    domain = "gitlab.torproject.org";
+    group = "tpo";
+    owner = "anti-censorship/pluggable-transports";
+    repo = "obfs4";
+    rev = "obfs4proxy-${version}";
+    sha256 = "sha256-/d1qub/mhEzzLQFytgAlhz8ukIC9d+GPK2Hfi3NMv+M=";
   };
 
-  vendorSha256 = "0yjanv5piygffpdfysviijl7cql2k0r05bsxnlj4hbamsriz9xqy";
+  vendorHash = "sha256-7NF3yMouhjSM9SBNKHkeWV7qy0XTGnepEX28kBpbgdk=";
+
+  ldflags = [ "-s" "-w" ];
 
   meta = with lib; {
     description = "Circumvents censorship by transforming Tor traffic between clients and bridges";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/obfs4/-/raw/obfs4proxy-0.0.14/ChangeLog
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
