### PR TITLE
tt-rss-plugin-auth-ldap: unstable-2022-10-31 -> unstable-2022-11-30

### DIFF
--- a/pkgs/servers/tt-rss/plugin-auth-ldap/default.nix
+++ b/pkgs/servers/tt-rss/plugin-auth-ldap/default.nix
@@ -2,32 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "tt-rss-plugin-auth-ldap";
-  version = "unstable-2022-10-31";
+  version = "unstable-2022-11-30";
 
   src = fetchFromGitHub {
     owner = "hydrian";
     repo = "TTRSS-Auth-LDAP";
-    rev = "0cc2a21441f99eef8368cfe0fbdbb78126e28d61";
-    sha256 = "sha256-pJWyvRnC38Ov1awVLgFZfp8+haADPniP+/P/C74qpcA=";
+    rev = "582ade49fd433a30b403caa1d0689fca5f3c99e1";
+    sha256 = "sha256-favz/2KvWqvv8ehTv3gc7TBbFDjkrOmutChnyKPgces=";
   };
-
-  patches = [
-    # https://github.com/hydrian/TTRSS-Auth-LDAP/pull/47
-    (fetchpatch {
-      url = "https://github.com/hydrian/TTRSS-Auth-LDAP/commit/003ca55bbd6e0a87fb729383e51eb269d918313d.patch";
-      sha256 = "sha256-0YD33JPNOOPH2dpGwA/RbV3Kg4i2oKazBjP3hBcUIes=";
-    })
-    # https://github.com/hydrian/TTRSS-Auth-LDAP/pull/40
-    (fetchpatch {
-      url = "https://github.com/hydrian/TTRSS-Auth-LDAP/commit/557811efa15bab3b5044c98416f9e37264f11c9a.patch";
-      sha256 = "sha256-KtDY0J1OYNTLwK7834lI+2XL1N1FkOk5zhinGY90/4A=";
-    })
-    # https://github.com/hydrian/TTRSS-Auth-LDAP/pull/34
-    (fetchpatch {
-      url = "https://github.com/hydrian/TTRSS-Auth-LDAP/commit/b1a873f6a7d18231d2ac804d0146d6e048c8382c.patch";
-      sha256 = "sha256-t5bDQM97dGwr7tHSS9cSO7qApf2M8KNaIuIxbAjExrs=";
-    })
-  ];
 
   installPhase = ''
     install -D plugins/auth_ldap/init.php $out/auth_ldap/init.php


### PR DESCRIPTION
Diff: https://github.com/hydrian/TTRSS-Auth-LDAP/compare/0cc2a21441f99eef8368cfe0fbdbb78126e28d61...582ade49fd433a30b403caa1d0689fca5f3c99e1

###### Description of changes

Tested on my server.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
