### PR TITLE
tapaal: init at 3.9.3

### DIFF
--- a/pkgs/applications/science/programming/tapaal/default.nix
+++ b/pkgs/applications/science/programming/tapaal/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchurl, unzip, makeDesktopItem, openjdk17 }:
+
+let
+  desktopItem = makeDesktopItem {
+    name = "tapaal";
+    exec = "tapaal";
+    icon = "tapaal";
+    desktopName = "TAPAAL";
+    comment = "Tool for editing, simulation and verification of P/T and timed-arc Petri Nets.";
+    categories = [ "Science" "ComputerScience" ];
+  };
+
+  icon = fetchurl {
+    url = "https://www.tapaal.net/images/tapaal.png";
+    sha256 = "c25b1a2dd773692e4cf4c13c2e78ac30245cb2389bda7bc886361f7a263a7a57";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "tapaal";
+  version = "3.9.3";
+
+  src = fetchurl {
+    url = "https://download.tapaal.net/tapaal/tapaal-3.9/${pname}-${version}-linux64.zip";
+    sha256 = "234a8cd500420235a330349d38099643a774ed375ee96cb0552d3236c2a92b6f";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/opt
+    mkdir -p $out/share/doc
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons/hicolor/60x60/apps/
+
+    cp -r bin lib $out/opt
+    cp LICENSE.txt README.txt $out/share/doc
+
+    # Create wrapper script:
+    echo "#!/bin/sh" > $out/bin/tapaal
+    echo "${openjdk17}/bin/java -cp '$out/opt/lib/*' 'TAPAAL' 'tapaal'" >> $out/bin/tapaal
+    chmod +x $out/bin/tapaal
+
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+
+    cp ${icon} $out/share/icons/hicolor/60x60/apps/tapaal.png
+  '';
+
+  meta = with lib; {
+    description = "A tool for editing, simulation and verification of P/T and timed-arc Petri Nets";
+    homepage = "https://www.tapaal.net/";
+    license = licenses.osl3;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ joeriexelmans ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35759,6 +35759,8 @@ with pkgs;
 
   groove = callPackage ../applications/science/programming/groove { };
 
+  tapaal = callPackage ../applications/science/programming/tapaal { };
+
   plm = callPackage ../applications/science/programming/plm { };
 
   ### SCIENCE/LOGIC


### PR DESCRIPTION
###### Description of changes

Added new derivation for TAPAAL (Petri-Net tool), version 3.9.3.

(My first nixpkgs PR)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - **(this package does not have dependencies)**
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
