### PR TITLE
calico-various,calicoctl,confd-calico: init at 3.24.5

### DIFF
--- a/pkgs/applications/networking/cluster/calico/default.nix
+++ b/pkgs/applications/networking/cluster/calico/default.nix
@@ -1,0 +1,81 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+builtins.mapAttrs (pname: { doCheck ? true, mainProgram ? pname, subPackages }: buildGoModule rec {
+  inherit pname;
+  version = "3.24.5";
+
+  src = fetchFromGitHub {
+    owner = "projectcalico";
+    repo = "calico";
+    rev = "v${version}";
+    hash = "sha256-fB9FHiIqVieVkPfHmBvcaUmUqkT1ZbDT26+DUE9lbdc=";
+  };
+
+  vendorHash = "sha256-ogQ/REf5cngoGAFIBN++txew6UqOw1hqCVsixyuGtug=";
+
+  inherit doCheck subPackages;
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    homepage = "https://projectcalico.docs.tigera.io";
+    changelog = "https://github.com/projectcalico/calico/releases/tag/v${version}";
+    description = "Cloud native networking and network security";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ urandom ];
+    inherit mainProgram;
+  };
+}) {
+  calico-apiserver = {
+    mainProgram = "apiserver";
+    subPackages = [
+      "apiserver/cmd/..."
+    ];
+  };
+  calico-app-policy = {
+    # integration tests require network
+    doCheck = false;
+    mainProgram = "dikastes";
+    subPackages = [
+      "app-policy/cmd/..."
+    ];
+  };
+  calico-cni-plugin = {
+    mainProgram = "calico";
+    subPackages = [
+      "cni-plugin/cmd/..."
+    ];
+  };
+  calico-kube-controllers = {
+    # integration tests require network and docker
+    doCheck = false;
+    mainProgram = "kube-controllers";
+    subPackages = [
+      "kube-controllers/cmd/..."
+    ];
+  };
+  calico-pod2daemon = {
+    mainProgram = "flexvol";
+    subPackages = [
+      "pod2daemon/csidriver"
+      "pod2daemon/flexvol"
+      "pod2daemon/nodeagent"
+    ];
+  };
+  calico-typha = {
+    subPackages = [
+      "typha/cmd/..."
+    ];
+  };
+  calicoctl = {
+    subPackages = [
+      "calicoctl/calicoctl"
+    ];
+  };
+  confd-calico = {
+    mainProgram = "confd";
+    subPackages = [
+      "confd"
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27822,6 +27822,17 @@ with pkgs;
 
   calibre-web = callPackage ../servers/calibre-web { };
 
+  # calico-felix and calico-node have not been packaged due to libbpf, linking issues
+  inherit (callPackage ../applications/networking/cluster/calico {})
+    calico-apiserver
+    calico-app-policy
+    calico-cni-plugin
+    calico-kube-controllers
+    calico-pod2daemon
+    calico-typha
+    calicoctl
+    confd-calico;
+
   calligra = libsForQt5.callPackage ../applications/office/calligra { };
 
   perkeep = callPackage ../applications/misc/perkeep { };


### PR DESCRIPTION
###### Description of changes

As calico internally builds a series of images, we have had to segregate the various components up into different derivations.

The cgo build process also proved to be quite tricky, so for now calico-felix and calico-node, both of which depend on libbpf, have not been packaged.

Updates #124071

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
