### PR TITLE
qxmledit: 0.9.15  -> 0.9.17

### DIFF
--- a/pkgs/applications/editors/qxmledit/default.nix
+++ b/pkgs/applications/editors/qxmledit/default.nix
@@ -1,14 +1,24 @@
-{ lib, stdenv, fetchFromGitHub,
-  qmake, qtbase, qtxmlpatterns, qtsvg, qtscxml, qtquick1, libGLU }:
+{ lib, stdenv, fetchFromGitHub, qmake, qtbase, qtxmlpatterns, qtsvg, qtscxml
+, qtquick1, libGLU }:
 
 stdenv.mkDerivation rec {
-  pname = "qxmledit" ;
-  version = "0.9.15" ;
-  src = fetchFromGitHub ( lib.importJSON ./qxmledit.json ) ;
-  nativeBuildInputs = [ qmake ] ;
-  buildInputs = [ qtbase qtxmlpatterns qtsvg qtscxml qtquick1 libGLU ] ;
-  qmakeFlags = [ "CONFIG+=release" ] ;
-  outputs = [ "out" "doc" ] ;
+  pname = "qxmledit";
+  version = "0.9.17";
+
+  outputs = [ "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "lbellonda";
+    repo = pname;
+    rev = version;
+    hash = "sha256-UzN5U+aC/uKokSdeUG2zv8+mkaH4ndYZ0sfzkpQ3l1M=";
+  };
+
+  nativeBuildInputs = [ qmake ];
+
+  buildInputs = [ qtbase qtxmlpatterns qtsvg qtscxml qtquick1 libGLU ];
+
+  qmakeFlags = [ "CONFIG+=release" ];
 
   preConfigure = ''
     export QXMLEDIT_INST_DATA_DIR="$out/share/data"
@@ -23,9 +33,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     broken = stdenv.isDarwin;
-    description = "Simple XML editor based on qt libraries" ;
+    description = "Simple XML editor based on qt libraries";
     homepage = "https://sourceforge.net/projects/qxmledit";
     license = licenses.lgpl2;
-    platforms = platforms.all;
-  } ;
+    platforms = platforms.unix;
+    changelog = "https://github.com/lbellonda/qxmledit/blob/${version}/NEWS";
+  };
 }

--- a/pkgs/applications/editors/qxmledit/qxmledit.json
+++ b/pkgs/applications/editors/qxmledit/qxmledit.json
@@ -1,6 +1,0 @@
-{
-    "owner": "lbellonda",
-    "repo": "qxmledit",
-    "rev": "6136dca50ceb3b4447c91a7a18dcf84785ea11d1",
-    "sha256": "1wcnphalwf0a5gz9r44jgk8wcv1w2qipbwjkbzkra2kxanxns834"
-}


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/lbellonda/qxmledit/blob/0.9.17/NEWS

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).