### PR TITLE
blobby: repair

### DIFF
--- a/pkgs/games/blobby/blobby.sh
+++ b/pkgs/games/blobby/blobby.sh
@@ -7,4 +7,4 @@ test -d ~/.blobby || {
   ( cd ~/.blobby; for i in *.zip; do @unzip@/bin/unzip "$i"; done )
 }
 
-@out@/bin/blobby.bin
+exec @out@/bin/blobby.bin "$@"

--- a/pkgs/games/blobby/default.nix
+++ b/pkgs/games/blobby/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, SDL2, SDL2_image, libGLU, libGL, cmake, physfs, boost, zip, zlib, pkg-config }:
+{ lib, stdenv, fetchurl, SDL2, SDL2_image, libGLU, libGL, cmake, physfs, boost, zip, zlib, unzip, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "blobby-volley";
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sed -e '1i#include <iostream>' -i src/NetworkMessage.cpp
   '';
 
+  inherit unzip;
+
   postInstall = ''
     cp ../data/Icon.bmp "$out/share/blobby/"
     mv "$out/bin"/blobby{,.bin}
@@ -28,7 +30,8 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ raskin ];
-    homepage = "http://blobby.sourceforge.net/";
+    homepage = "https://blobbyvolley.de/";
     downloadPage = "https://sourceforge.net/projects/blobby/files/Blobby%20Volley%202%20%28Linux%29/";
+    mainProgram = "blobby";
   };
 }


### PR DESCRIPTION
###### Description of changes

The game could not start because of the missing `unzip` reference.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).