### PR TITLE
open-watcom-v2-unwrapped: unstable-2022-10-03 -> unstable-2023-01-30, more platforms

### DIFF
--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -13,19 +13,19 @@
 stdenv.mkDerivation rec {
   pname = "${passthru.prettyName}-unwrapped";
   # nixpkgs-update: no auto update
-  version = "unstable-2022-10-03";
+  version = "unstable-2023-01-30";
 
   src = fetchFromGitHub {
     owner = "open-watcom";
     repo = "open-watcom-v2";
-    rev = "61538429a501a09f369366d832799f2e3b196a02";
-    sha256 = "sha256-YvqRw0klSqOxIuO5QFKjcUp6aRWlO2j3L+T1ekx8SfA=";
+    rev = "996740acdbb173499ec1bf2ba6c8942f2a374220";
+    sha256 = "sha256-9m+0e2v1Hk8jYZHqJwb1mN02WgGDArsWbF7Ut3Z5OIg=";
   };
 
   postPatch = ''
     patchShebangs *.sh
 
-    for dateSource in cmnvars.sh bld/wipfc/configure; do
+    for dateSource in bld/wipfc/configure; do
       substituteInPlace $dateSource \
         --replace '`date ' '`date -ud "@$SOURCE_DATE_EPOCH" '
     done
@@ -35,14 +35,17 @@ stdenv.mkDerivation rec {
       --replace '__TIME__' "\"$(date -ud "@$SOURCE_DATE_EPOCH" +'%T')\""
 
     substituteInPlace build/makeinit \
-      --replace '%__CYEAR__' '%OWCYEAR'
+      --replace '$+$(%__CYEAR__)$-' "$(date -ud "@$SOURCE_DATE_EPOCH" +'%Y')"
   '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     substituteInPlace build/mif/local.mif \
       --replace '-static' ""
   '';
 
-  nativeBuildInputs = [ dosbox ]
-    ++ lib.optional withDocs ghostscript;
+  nativeBuildInputs = [
+    dosbox
+  ] ++ lib.optionals withDocs [
+    ghostscript
+  ];
 
   configurePhase = ''
     runHook preConfigure
@@ -120,7 +123,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://open-watcom.github.io";
     license = licenses.watcom;
-    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "x86_64-windows" "i686-windows" ];
+    platforms = with platforms; windows ++ unix;
+    badPlatforms = platforms.riscv ++ [ "powerpc64-linux" "powerpc64le-linux" "mips64el-linux" ];
     maintainers = with maintainers; [ OPNA2608 ];
   };
 }

--- a/pkgs/development/compilers/open-watcom/wrapper.nix
+++ b/pkgs/development/compilers/open-watcom/wrapper.nix
@@ -13,16 +13,29 @@ let
   wrapper =
     {}:
     let
+      archToBindir = with stdenv.hostPlatform; if isx86 then
+        "bin"
+      else if isAarch then
+        "arm"
+      # we don't support running on AXP
+      # don't know what MIPS, PPC bindirs are called
+      else throw "Don't know where ${system} binaries are located!";
+
       binDirs = with stdenv.hostPlatform; if isWindows then [
-        (lib.optionalString is64bit "binnt64")
-        "binnt"
-        (lib.optionalString is32bit "binw")
-      ] else if (isDarwin && is64bit) then [
-        "bino64"
+        (lib.optionalString is64bit "${archToBindir}nt64")
+        "${archToBindir}nt"
+        (lib.optionalString is32bit "${archToBindir}w")
+      ] else if (isDarwin) then [
+        (lib.optionalString is64bit "${archToBindir}o64")
+        # modern Darwin cannot execute 32-bit code anymore
+        (lib.optionalString is32bit "${archToBindir}o")
       ] else [
-        (lib.optionalString is64bit "binl64")
-        "binl"
+        (lib.optionalString is64bit "${archToBindir}l64")
+        "${archToBindir}l"
       ];
+      # TODO
+      # This works good enough as-is, but should really only be targetPlatform-specific
+      # but we don't support targeting DOS, OS/2, 16-bit Windows etc Nixpkgs-wide so this needs extra logic
       includeDirs = with stdenv.hostPlatform; [
         "h"
       ]
@@ -71,9 +84,9 @@ let
             }
             EOF
             cat test.c
-            # Darwin target not supported, only host
             wcl386 -fe=test_c test.c
-            ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "./test_c"}
+            # Only test execution if hostPlatform is targetable
+            ${lib.optionalString (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isAarch) "./test_c"}
 
             cat <<EOF >test.cpp
             #include <string>
@@ -91,9 +104,9 @@ let
             }
             EOF
             cat test.cpp
-            # Darwin target not supported, only host
             wcl386 -fe=test_cpp test.cpp
-            ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "./test_cpp"}
+            # Only test execution if hostPlatform is targetable
+            ${lib.optionalString (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isAarch) "./test_cpp"}
             touch $out
           '';
           cross = runCommand "${name}-test-cross" { nativeBuildInputs = [ wrapped file ]; } ''


### PR DESCRIPTION
###### Description of changes

- bump
- adjust patching to some changes to the date embedding
- enable on more platforms
  - [Aarch64](https://github.com/open-watcom/open-watcom-v2/blob/6609ddae017214cf702b8ed541a0d378abcb16ca/build/makeinit#L111) (new, tested on aarch64-linux, aarch64-darwin untested)
  - [32-bit ARM](https://github.com/open-watcom/open-watcom-v2/blob/6609ddae017214cf702b8ed541a0d378abcb16ca/build/makeinit#L107) (already existed but I can't test it)
  - [MIPS](https://github.com/open-watcom/open-watcom-v2/blob/6609ddae017214cf702b8ed541a0d378abcb16ca/build/makeinit#L101) (32-bit support should be there but the wrapper won't know where the binaries are placed, feedback from anyone on this would be appreciated!)

(PPC should be supported too but there's no convenient entry for that in doubles.nix, wrapper also won't know where the binaries are)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
