### PR TITLE
haskellPackages.mkDerivation: Remove Darwin dynamic libraries workaround

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -375,37 +375,6 @@ stdenv.mkDerivation ({
       fi
   '' + ''
     done
-  ''
-  # only use the links hack if we're actually building dylibs. otherwise, the
-  # "dynamic-library-dirs" point to nonexistent paths, and the ln command becomes
-  # "ln -s $out/lib/links", which tries to recreate the links dir and fails
-  + (optionalString (stdenv.isDarwin && (enableSharedLibraries || enableSharedExecutables)) ''
-    # Work around a limit in the macOS Sierra linker on the number of paths
-    # referenced by any one dynamic library:
-    #
-    # Create a local directory with symlinks of the *.dylib (macOS shared
-    # libraries) from all the dependencies.
-    local dynamicLinksDir="$out/lib/links"
-    mkdir -p $dynamicLinksDir
-
-    # Unprettify all package conf files before reading/writing them
-    for d in "$packageConfDir/"*; do
-      # gawk -i inplace seems to strip the last newline
-      gawk -f ${unprettyConf} "$d" > tmp
-      mv tmp "$d"
-    done
-
-    for d in $(grep '^dynamic-library-dirs:' "$packageConfDir"/* | cut -d' ' -f2- | tr ' ' '\n' | sort -u); do
-      for lib in "$d/"*.{dylib,so}; do
-        # Allow overwriting because C libs can be pulled in multiple times.
-        ln -sf "$lib" "$dynamicLinksDir"
-      done
-    done
-    # Edit the local package DB to reference the links directory.
-    for f in "$packageConfDir/"*.conf; do
-      sed -i "s,dynamic-library-dirs: .*,dynamic-library-dirs: $dynamicLinksDir," "$f"
-    done
-  '') + ''
     ${ghcCommand}-pkg --${packageDbFlag}="$packageConfDir" recache
 
     runHook postSetupCompilerEnvironment


### PR DESCRIPTION
The workaround that this change deletes was initially contributed in #25537 to mitigate #22810 until a more permanent solution could be devised.  That more permanent solution was eventually contributed in #27536, which now obviates the initial workaround, so this change removes it.

I tested this on `aarch64-darwin` (macOS Ventura 13.1) on our main internal project at work which has:

- 200+ direct dependencies
- 800+ transitive dependencies
- `enableSharedExecutables = true;`

… and everything built successfully without this work-around.

It may be possible that this succeeded because of my macOS version; specifically, the work-around might still be necessary for older versions of macOS for some reason that I'm not aware of.  So keep that in mind when evaluating this PR.

###### Things done

- Built on platform(s)
  - [x] aarch64-darwin