### PR TITLE
Encourage :+1:'s for prioritisation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,3 +39,10 @@ Please run `nix-shell -p nix-info --run "nix-info -m"` and paste the result.
 [user@system:~]$ nix-shell -p nix-info --run "nix-info -m"
 output here
 ```
+
+### Priorities
+
+Add a :+1: [reaction] to [issues you find important].
+
+[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+[issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/build_failure.md
+++ b/.github/ISSUE_TEMPLATE/build_failure.md
@@ -37,3 +37,10 @@ Please run `nix-shell -p nix-info --run "nix-info -m"` and paste the result.
 [user@system:~]$ nix-shell -p nix-info --run "nix-info -m"
 output here
 ```
+
+### Priorities
+
+Add a :+1: [reaction] to [issues you find important].
+
+[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+[issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/missing_documentation.md
+++ b/.github/ISSUE_TEMPLATE/missing_documentation.md
@@ -30,3 +30,9 @@ assignees: ''
 [open documentation issues]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+label%3A%229.needs%3A+documentation%22
 [open documentation pull requests]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+is%3Apr+label%3A%228.has%3A+documentation%22%2C%226.topic%3A+documentation%22
 
+### Priorities
+
+Add a :+1: [reaction] to [issues you find important].
+
+[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+[issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
+++ b/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
@@ -26,3 +26,10 @@ There's a high chance that you'll have the new version right away while helping 
 -----
 
 Note for maintainers: Please tag this issue in your PR.
+
+**Priorities**
+
+Add a :+1: [reaction] to [issues you find important].
+
+[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+[issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/packaging_request.md
+++ b/.github/ISSUE_TEMPLATE/packaging_request.md
@@ -17,3 +17,10 @@ assignees: ''
 * source URL:
 * license: mit, bsd, gpl2+ , ...
 * platforms: unix, linux, darwin, ...
+
+**Priorities**
+
+Add a :+1: [reaction] to [issues you find important].
+
+[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+[issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/ISSUE_TEMPLATE/unreproducible_package.md
+++ b/.github/ISSUE_TEMPLATE/unreproducible_package.md
@@ -85,3 +85,10 @@ nix log $(nix path-info --derivation nixpkgs#<package>)
 
 (please share the relevant fragment of the diffoscope output here, and any
 additional analysis you may have done)
+
+### Priorities
+
+Add a :+1: [reaction] to [issues you find important].
+
+[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+[issues you find important]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,3 +40,10 @@ Thanks a lot if you do!
 List of open PRs: https://github.com/NixOS/nixpkgs/pulls
 Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
 -->
+
+### Priorities
+
+Add a :+1: [reaction] to [pull requests you find important].
+
+[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
+[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


### PR DESCRIPTION
Adds a small text to each issue and the PR template to encourage people to use :+1:'s for issues they're also interested in. See https://github.com/NixOS/nix.dev/issues/359 for more information

This was done in the @NixOS/documentation-team