### PR TITLE
python310Packages.django-postgresql-netfields: 1.2.2 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -10,8 +10,11 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.3.0";
   pname = "django-postgresql-netfields";
+  version = "1.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "jimfunk";
@@ -19,6 +22,12 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-I+X4yfadtiiZlW7QhfwVbK1qyWn/khH9fWXszCo9uro=";
   };
+
+  propagatedBuildInputs = [
+    django
+    netaddr
+    six
+  ];
 
   # tests need a postgres database
   doCheck = false;
@@ -33,15 +42,15 @@ buildPythonPackage rec {
     # psycopg2
   # ];
 
-  propagatedBuildInputs = [
-    django
-    netaddr
-    six
+  pythonImportsCheck = [
+    "netfields"
   ];
 
   meta = with lib; {
     description = "Django PostgreSQL netfields implementation";
     homepage = "https://github.com/jimfunk/django-postgresql-netfields";
+    changelog = "https://github.com/jimfunk/django-postgresql-netfields/blob/v${version}/CHANGELOG";
     license = licenses.bsd2;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -7,18 +7,17 @@
 # required for tests
 #, djangorestframework
 #, psycopg2
-#, unittest2
 }:
 
 buildPythonPackage rec {
-  version = "1.2.2";
+  version = "1.3.0";
   pname = "django-postgresql-netfields";
 
   src = fetchFromGitHub {
     owner = "jimfunk";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1rrh38f3zl3jk5ijs6g75dxxvxygf4lczbgc7ahrgzf58g4a48lm";
+    hash = "sha256-I+X4yfadtiiZlW7QhfwVbK1qyWn/khH9fWXszCo9uro=";
   };
 
   # tests need a postgres database
@@ -32,7 +31,6 @@ buildPythonPackage rec {
   # buildInputs = [
     # djangorestframework
     # psycopg2
-    # unittest2
   # ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -4,6 +4,7 @@
 , netaddr
 , six
 , fetchFromGitHub
+, pythonOlder
 # required for tests
 #, djangorestframework
 #, psycopg2

--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -43,9 +43,10 @@ buildPythonPackage rec {
     # psycopg2
   # ];
 
-  pythonImportsCheck = [
-    "netfields"
-  ];
+  # Requires psycopg2
+  # pythonImportsCheck = [
+  #   "netfields"
+  # ];
 
   meta = with lib; {
     description = "Django PostgreSQL netfields implementation";


### PR DESCRIPTION
###### Description of changes

https://github.com/jimfunk/django-postgresql-netfields/blob/master/CHANGELOG

I've kept the commented out test code in case it helps someone in the future, but the commented out `unittest2` reference can be removed wholesale because v1.3.0 only includes it for Python 2.7, for which we are phasing out support in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
