### PR TITLE
libjxl: 0.6.1 -> 0.7.0

### DIFF
--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libjxl";
-  version = "0.6.1";
+  version = "0.7.0";
 
   outputs = [ "out" "dev" ];
 
@@ -29,45 +29,14 @@ stdenv.mkDerivation rec {
     owner = "libjxl";
     repo = "libjxl";
     rev = "v${version}";
-    sha256 = "sha256-fTK5hyU9PZ6nigMsfzVugwviihgAXfEcLF+l+n5h+54=";
+    sha256 = "sha256-9DBLQ/gMyy2ZUm7PCWYJ7XOzkgQM0cAewJZzMNo8UPs=";
     # There are various submodules in `third_party/`.
     fetchSubmodules = true;
   };
 
+  # TODO: remove when #182883 is merged
   patches = [
-    # present in master, see https://github.com/libjxl/libjxl/pull/1403
-    (fetchpatch {
-      name = "prefixless-pkg-config.patch";
-      url = "https://github.com/libjxl/libjxl/commit/0b906564bfbfd8507d61c5d6a447f545f893227c.patch";
-      sha256 = "1g5c6lrsmgxb9j64pjy8lbdgbvw834m5jyfivy9ppmd8iiv0kkq4";
-    })
-
-    # present in master, remove after 0.7?
-    (fetchpatch {
-      name = "fix-link-lld-macho.patch";
-      url = "https://github.com/libjxl/libjxl/commit/88fe3fff3dc70c72405f57c69feffd9823930034.patch";
-      sha256 = "1419fyiq4srpj72cynwyvqy8ldi7vn9asvkp5fsbmiqkyhb15jpk";
-    })
-
-    # "robust statistics" have been removed in upstream mainline as they are
-    # conidered to cause "interoperability problems". sure enough the tests
-    # fail with precision issues on aarch64.
-    (fetchpatch {
-      name = "remove-robust-and-descriptive-statistics.patch";
-      url = "https://github.com/libjxl/libjxl/commit/204f87a5e4d684544b13900109abf040dc0b402b.patch";
-      sha256 = "sha256-DoAaYWLmQ+R9GZbHMTYGe0gBL9ZesgtB+2WhmbARna8=";
-    })
-
-    # fix build with asciidoc wrapped in shell script
-    (fetchpatch {
-      url = "https://github.com/libjxl/libjxl/commit/b8ec58c58c6281987f42ebec892f513824c0cc0e.patch";
-      hash = "sha256-g8U+YVhLfgSHJ+PWJgvVOI66+FElJSC8IgSRodNnsMw=";
-    })
-    (fetchpatch {
-      url = "https://github.com/libjxl/libjxl/commit/ca8e276aacf63a752346a6a44ba673b0af993237.patch";
-      excludes = [ "AUTHORS" ];
-      hash = "sha256-9VXy1LdJ0JhYbCGPNMySpnGLBxUrr8BYzE+oU3LnUGw=";
-    })
+    ./fix-embedded-highway-pc.patch
   ];
 
   nativeBuildInputs = [
@@ -123,8 +92,8 @@ stdenv.mkDerivation rec {
     # using the vendorered ones is easier.
     "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON"
 
-    # Use our version of highway, though it is still statically linked in
-    "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
+    # TODO: un-vendor this again when #182883 is merged
+    # "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
 
     # TODO: Update this package to enable this (overridably via an option):
     # Viewer tools for evaluation.

--- a/pkgs/development/libraries/libjxl/fix-embedded-highway-pc.patch
+++ b/pkgs/development/libraries/libjxl/fix-embedded-highway-pc.patch
@@ -1,0 +1,51 @@
+diff --git a/third_party/highway/CMakeLists.txt b/third_party/highway/CMakeLists.txt
+index 730586a..d54edd2 100644
+--- a/third_party/highway/CMakeLists.txt
++++ b/third_party/highway/CMakeLists.txt
+@@ -419,6 +419,19 @@ foreach (source ${HWY_TEST_SOURCES})
+   endif()
+ endforeach()
+ 
++# Allow adding prefix if CMAKE_INSTALL_INCLUDEDIR not absolute.
++if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
++    set(PKGCONFIG_TARGET_INCLUDES "${CMAKE_INSTALL_INCLUDEDIR}")
++else()
++    set(PKGCONFIG_TARGET_INCLUDES "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
++endif()
++# Allow adding prefix if CMAKE_INSTALL_LIBDIR not absolute.
++if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
++    set(PKGCONFIG_TARGET_LIBS "${CMAKE_INSTALL_LIBDIR}")
++else()
++    set(PKGCONFIG_TARGET_LIBS "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
++endif()
++
+ # Add a pkg-config file for libhwy and the contrib/test libraries.
+ set(HWY_LIBRARY_VERSION "${CMAKE_PROJECT_VERSION}")
+ set(HWY_PC_FILES libhwy.pc libhwy-test.pc)
+diff --git a/third_party/highway/libhwy-test.pc.in b/third_party/highway/libhwy-test.pc.in
+index 0416b10..e097fd7 100644
+--- a/third_party/highway/libhwy-test.pc.in
++++ b/third_party/highway/libhwy-test.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@PKGCONFIG_TARGET_LIBS@
++includedir=@PKGCONFIG_TARGET_INCLUDES@
+ 
+ Name: libhwy-test
+ Description: Efficient and performance-portable SIMD wrapper, test helpers.
+diff --git a/third_party/highway/libhwy.pc.in b/third_party/highway/libhwy.pc.in
+index 6439892..4026a20 100644
+--- a/third_party/highway/libhwy.pc.in
++++ b/third_party/highway/libhwy.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@PKGCONFIG_TARGET_LIBS@
++includedir=@PKGCONFIG_TARGET_INCLUDES@
+ 
+ Name: libhwy
+ Description: Efficient and performance-portable SIMD wrapper


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[A new version has been released](https://github.com/libjxl/libjxl/releases/tag/v0.7.0), and imagemagick is already requiring this new version.

Related PR: #182883, although libjxl ships a vendored copy that is re-enabled in this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested imagemagick with this PR applied and it can successfully encode and decode jpeg xl images.