### PR TITLE
appflowy: 0.0.6.2 -> 0.0.8

### DIFF
--- a/pkgs/applications/office/appflowy/default.nix
+++ b/pkgs/applications/office/appflowy/default.nix
@@ -1,35 +1,35 @@
-{ stdenv,
-  lib,
-  fetchzip,
-  autoPatchelfHook,
-  makeWrapper,
-  copyDesktopItems,
-  makeDesktopItem,
-  gtk3,
-  openssl,
-  xdg-user-dirs,
-  keybinder3
+{ stdenv
+, lib
+, fetchzip
+, autoPatchelfHook
+, makeWrapper
+, copyDesktopItems
+, makeDesktopItem
+, gtk3
+, openssl
+, xdg-user-dirs
+, keybinder3
 }:
 
 stdenv.mkDerivation rec {
   pname = "appflowy";
-  version = "0.0.6.2";
+  version = "0.0.8";
 
   src = fetchzip {
     url = "https://github.com/AppFlowy-IO/appflowy/releases/download/${version}/AppFlowy-linux-x86.tar.gz";
-    sha256 = "sha256-LOrXGFctAaiz2z9M8ghrXsQ+qygwNPyYragmL/EjlDQ=";
+    sha256 = "sha256-+nizRA42c0ZzuN8D/puh0TFLnRJVgyAujcTmJZ1UVzo=";
   };
 
   nativeBuildInputs = [
-      autoPatchelfHook
-      makeWrapper
-      copyDesktopItems
+    autoPatchelfHook
+    makeWrapper
+    copyDesktopItems
   ];
 
   buildInputs = [
-      gtk3
-      openssl
-      keybinder3
+    gtk3
+    openssl
+    keybinder3
   ];
 
   dontBuild = true;
@@ -47,15 +47,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  preFixup = let
-    binPath = lib.makeBinPath [
-      xdg-user-dirs
-    ];
-  in ''
+  preFixup = ''
     # Add missing libraries to appflowy using the ones it comes with
     makeWrapper $out/opt/app_flowy $out/bin/appflowy \
-          --set LD_LIBRARY_PATH "$out/opt/lib/" \
-          --prefix PATH : "${binPath}"
+      --set LD_LIBRARY_PATH "$out/opt/lib/" \
+      --prefix PATH : "${lib.makeBinPath [ xdg-user-dirs ]}"
   '';
 
   desktopItems = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -185,9 +185,7 @@ with pkgs;
     meta.platforms = lib.platforms.linux;
   } ../build-support/setup-hooks/auto-patchelf.sh;
 
-  appflowy = callPackage ../applications/office/appflowy {
-    openssl = openssl_1_1;
-  };
+  appflowy = callPackage ../applications/office/appflowy { };
 
   appimageTools = callPackage ../build-support/appimage {
     buildFHSUserEnv = buildFHSUserEnvBubblewrap;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update appflowy to the [latest version](https://github.com/AppFlowy-IO/AppFlowy/releases/tag/0.0.8)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
