### PR TITLE
fastddsgen: upgrade to openjdk17

### DIFF
--- a/pkgs/development/tools/fastddsgen/default.nix
+++ b/pkgs/development/tools/fastddsgen/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, runtimeShell, writeText, fetchFromGitHub, gradle, openjdk11, git, perl, cmake }:
+{ lib, stdenv, runtimeShell, writeText, fetchFromGitHub, gradle, openjdk17, git, perl, cmake }:
 let
   pname = "fastddsgen";
   version = "2.2.0";
@@ -15,7 +15,7 @@ let
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";
     inherit src version;
-    nativeBuildInputs = [ gradle openjdk11 perl ];
+    nativeBuildInputs = [ gradle openjdk17 perl ];
 
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d);
@@ -39,7 +39,7 @@ in
 stdenv.mkDerivation {
   inherit pname src version;
 
-  nativeBuildInputs = [ gradle openjdk11 ];
+  nativeBuildInputs = [ gradle openjdk17 ];
 
   # use our offline deps
   postPatch = ''
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
     # Override the default start script to use absolute java path
     cat  <<EOF >$out/bin/fastddsgen
     #!${runtimeShell}
-    exec ${openjdk11}/bin/java -jar "$out/share/fastddsgen/java/fastddsgen.jar" "\$@"
+    exec ${openjdk17}/bin/java -jar "$out/share/fastddsgen/java/fastddsgen.jar" "\$@"
     EOF
     chmod a+x "$out/bin/fastddsgen"
 
@@ -92,6 +92,6 @@ stdenv.mkDerivation {
       used to publish or subscribe.
     '';
     maintainers = with maintainers; [ wentasah ];
-    platforms = openjdk11.meta.platforms;
+    platforms = openjdk17.meta.platforms;
   };
 }


### PR DESCRIPTION
This prevents build dependency on Python 2.7 (see #201859).

Upstream recommends using openjdk8 or 11, but my tests show that using openjdk17 works well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
