### PR TITLE
matrix-appservice-slack: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/servers/matrix-synapse/matrix-appservice-slack/package.json
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-appservice-slack",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Matrix <--> Slack bridge",
   "engines": {
     "node": ">=16 <=18"
@@ -38,7 +38,7 @@
     "Slackdown": "git+https://Half-Shot@github.com/half-shot/slackdown.git",
     "axios": "^0.27.2",
     "escape-string-regexp": "^4.0.0",
-    "matrix-appservice-bridge": "^5.1.0",
+    "matrix-appservice-bridge": "^6.0.0",
     "minimist": "^1.2.6",
     "nedb": "^1.8.0",
     "node-emoji": "^1.10.0",

--- a/pkgs/servers/matrix-synapse/matrix-appservice-slack/pin.json
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-slack/pin.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.1",
-  "srcHash": "N7EzhqKL3GiuoU2d/Y33eZhKJSCvtLDRVO40mpIBEkw=",
-  "yarnHash": "1d9kyrzcs1c54xk0yl8n3jp61l3n8dzph1d5a4daifa7ad635hv7"
+  "version": "2.0.2",
+  "srcHash": "Z8PQuAOQbQMxmso/KV9n8fu2FqzqLsADqLczmm584QQ=",
+  "yarnHash": "1ngmgr9li7jagvzfl0jq4bxqw0q1sdqh8k9wlar6q292263g287z"
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Package bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
