### PR TITLE
cbqn: add replxx option

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -4,17 +4,26 @@
 , genBytecode ? false
 , bqn-path ? null
 , mbqn-source ? null
+, enableReplxx ? false
 , libffi
 , pkg-config
 }:
 
 let
+  # TODO: these submodules should be separated libraries
   cbqn-bytecode-files = fetchFromGitHub {
     name = "cbqn-bytecode-files";
     owner = "dzaima";
     repo = "CBQN";
     rev = "3df8ae563a626ff7ae0683643092f0c3bc2481e5";
     hash = "sha256:0rh9qp1bdm9aa77l0kn9n4jdy08gl6l7898lncskxiq9id6xvyb8";
+  };
+  replxx-submodule = fetchFromGitHub {
+    name = "replxx-submodule";
+    owner = "dzaima";
+    repo = "replxx";
+    rev = "ba94c293caad52486df8712e808783df9a8f4501";
+    hash = "sha256-pMLvURksj/5k5b6BTwWxjomoROMOE5+GRjyaoqu/iYE=";
   };
 in
 assert genBytecode -> ((bqn-path != null) && (mbqn-source != null));
@@ -26,8 +35,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "dzaima";
     repo = "CBQN";
-    rev = "dbc7c83f7085d05e87721bedf1ee38931f671a8e";
-    hash = "sha256:0nal1fs9y7nyx4d5q1qw868lxk7mivzw2y16wc3hw97pq4qf0dpb";
+    rev = "49c0d9a355698f54fff2c0caa177e2b341fabb45";
+    hash = "sha256-jm2ZzFxhr9o4nFR2rjYJz/4GH+WFnfU4QDovrOPI3jQ=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +56,8 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"
-  ];
+  ]
+  ++ lib.optional enableReplxx "REPLXX=1";
 
   preBuild = ''
     # Purity: avoids git downloading bytecode files
@@ -56,7 +66,15 @@ stdenv.mkDerivation rec {
     ${bqn-path} ./build/genRuntime ${mbqn-source} build/bytecodeLocal/
   '' else ''
     cp ${cbqn-bytecode-files}/src/gen/{compiles,explain,formatter,runtime0,runtime1,src} build/bytecodeLocal/gen/
-  '');
+  '')
+  + lib.optionalString enableReplxx ''
+    cp -r ${replxx-submodule} build/replxxLocal/
+  ''
+  # Need to adjust ld flags for darwin manually
+  # https://github.com/dzaima/CBQN/issues/26
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    makeFlagsArray+=(LD_LIBS="-ldl -lffi")
+  '';
 
   installPhase = ''
      runHook preInstall

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15762,7 +15762,9 @@ with pkgs;
   mbqn = callPackage ../development/interpreters/bqn/mlochbaum-bqn { };
 
   cbqn = cbqn-bootstrap.phase2;
+  cbqn-replxx = cbqn-bootstrap.phase2-replxx;
   cbqn-standalone = cbqn-bootstrap.phase0;
+  cbqn-standalone-replxx = cbqn-bootstrap.phase0-replxx;
 
   # Below, the classic self-bootstrapping process
   cbqn-bootstrap = lib.dontRecurseIntoAttrs {
@@ -15787,6 +15789,14 @@ with pkgs;
       mbqn-source = null;
     };
 
+    phase0-replxx = callPackage ../development/interpreters/bqn/cbqn {
+      inherit (cbqn-bootstrap) stdenv;
+      genBytecode = false;
+      bqn-path = null;
+      mbqn-source = null;
+      enableReplxx = true;
+    };
+
     phase1 = callPackage ../development/interpreters/bqn/cbqn {
       inherit (cbqn-bootstrap) mbqn-source stdenv;
       genBytecode = true;
@@ -15797,6 +15807,13 @@ with pkgs;
       inherit (cbqn-bootstrap) mbqn-source stdenv;
       genBytecode = true;
       bqn-path = "${buildPackages.cbqn-bootstrap.phase1}/bin/cbqn";
+    };
+
+    phase2-replxx = callPackage ../development/interpreters/bqn/cbqn {
+      inherit (cbqn-bootstrap) mbqn-source stdenv;
+      genBytecode = true;
+      bqn-path = "${buildPackages.cbqn-bootstrap.phase1}/bin/cbqn";
+      enableReplxx = true;
     };
   };
 


### PR DESCRIPTION
###### Description of changes

- A new nifty feature was added to CBQN recently. So added it as a build option and enabled by default.
> Both the online REPL and the REPLXX build of CBQN (make REPLXX=1) support backslash input with no configuration required. 

  [BQN/editors at master · mlochbaum/BQN](https://github.com/mlochbaum/BQN/tree/master/editors#editor-support)

- ~~catch up to the latest version.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
