### PR TITLE
module system: internalise prefix-stripping logic

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,7 +1,7 @@
-{ pkgs ? (import ./.. { }), nixpkgs ? { }}:
+{ pkgs ? import ./.. { } }:
 let
   lib = pkgs.lib;
-  doc-support = import ./doc-support { inherit pkgs nixpkgs; };
+  doc-support = import ./doc-support { inherit pkgs; };
 in pkgs.stdenv.mkDerivation {
   name = "nixpkgs-manual";
 

--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -1,9 +1,9 @@
-{ pkgs ? (import ../.. {}), nixpkgs ? { }}:
+{ pkgs ? import ../.. {} }:
 let
   inherit (pkgs) lib;
   inherit (lib) hasPrefix removePrefix;
 
-  locationsXml = import ./lib-function-locations.nix { inherit pkgs nixpkgs; };
+  locationsXml = import ./lib-function-locations.nix { inherit pkgs; };
   functionDocs = import ./lib-function-docs.nix { inherit locationsXml pkgs; };
   version = pkgs.lib.version;
 

--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -32,18 +32,6 @@ let
   optionsDoc = pkgs.nixosOptionsDoc {
     inherit (pkgs.lib.evalModules { modules = [ ../../pkgs/top-level/config.nix ]; }) options;
     documentType = "none";
-    transformOptions = opt:
-      opt // {
-        declarations =
-          map
-            (decl:
-              if hasPrefix (toString ../..) (toString decl)
-              then
-                let subpath = removePrefix "/" (removePrefix (toString ../..) (toString decl));
-                in { url = "https://github.com/NixOS/nixpkgs/blob/master/${subpath}"; name = subpath; }
-              else decl)
-            opt.declarations;
-        };
   };
 
 in pkgs.runCommand "doc-support" {}

--- a/doc/doc-support/lib-function-locations.nix
+++ b/doc/doc-support/lib-function-locations.nix
@@ -1,7 +1,5 @@
-{ pkgs ? (import ./.. { }), nixpkgs ? { }}:
+{ pkgs ? import ./.. { } }:
 let
-  revision = pkgs.lib.trivial.revisionWithDefault (nixpkgs.revision or "master");
-
   libDefPos = set:
     builtins.map
       (name: {
@@ -57,7 +55,7 @@ let
     [ "'"      ]
     [ "-prime" ];
 
-  urlPrefix = "https://github.com/NixOS/nixpkgs/blob/${revision}";
+  urlPrefix = "https://github.com/NixOS/nixpkgs/blob/${nixpkgsLib.trivial.manualRevision}";
   xmlstrings = (nixpkgsLib.strings.concatMapStrings
       ({ name, value }:
       ''

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -131,7 +131,7 @@ let
     inherit (self.options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption mergeUniqueOption
       getValues getFiles
-      optionAttrSetToDocList optionAttrSetToDocList'
+      optionAttrSetToDocList optionsToDocTemplate
       scrubOptionValue literalExpression literalExample literalDocBook
       showOption showOptionWithDefLocs showFiles
       unknownModule mkOption mkPackageOption

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -100,7 +100,7 @@ let
       escapeRegex escapeXML replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
-      getName getVersion
+      nixpkgsSource getName getVersion
       nameFromURL enableFeature enableFeatureAs withFeature
       withFeatureAs fixedWidthString fixedWidthNumber isStorePath
       toInt toIntBase10 readPathsFromFile fileContents;

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -330,7 +330,7 @@ rec {
          then v.__pretty v.val
       else if v == {} then "{ }"
       else if v ? type && v.type == "derivation" then
-        "<derivation ${v.drvPath or "???"}>"
+        "<derivation ${v.name or "???"}>"
       else "{" + introSpace
           + libStr.concatStringsSep introSpace (libAttr.mapAttrsToList
               (name: value:

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -289,7 +289,12 @@ rec {
        (This means fn is type Val -> String.) */
     allowPrettyValues ? false,
     /* If this option is true, the output is indented with newlines for attribute sets and lists */
-    multiline ? true
+    multiline ? true,
+    /* Render paths with these prefixes using angle bracket syntax, e.g.
+         toPretty { searchPath = [ { name = "foo"; root = "/path/to/foo"; } ]; } /path/to/foo/bar/qux
+         ==> "<foo/bar/qux>"
+       Type: [ { name = string; root = string or path; } ] */
+    searchPath ? []
   }:
     let
     go = indent: v: with builtins;
@@ -316,7 +321,10 @@ rec {
     else if true  ==   v then "true"
     else if false ==   v then "false"
     else if null  ==   v then "null"
-    else if isPath     v then toString v
+    else if isPath     v then
+      let res = libStr.lookupPrefix searchPath v; in
+      if res ? source then "<${res.source}${libStr.optionalString (res.path != "") "/"}${res.path}>"
+                      else res.path
     else if isList     v then
       if v == [] then "[ ]"
       else "[" + introSpace

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -278,8 +278,11 @@ rec {
         mapAny 0;
 
   /* Pretty print a value, akin to `builtins.trace`.
-    * Should probably be a builtin as well.
-    */
+   * Should probably be a builtin as well.
+   * The pretty-printed string should be suitable for rendering default values
+   * in the NixOS manual. In particular, it should be as close to a valid Nix expression
+   * as possible.
+   */
   toPretty = {
     /* If this option is true, attrsets like { __pretty = fn; val = …; }
        will use fn to convert val to a pretty printed representation.
@@ -294,7 +297,7 @@ rec {
             introSpace = if multiline then "\n${indent}  " else " ";
             outroSpace = if multiline then "\n${indent}" else " ";
     in if   isInt      v then toString v
-    else if isFloat    v then "~${toString v}"
+    else if isFloat    v then toString v
     else if isString   v then
       let
         lines = filter (v: ! isList v) (builtins.split "\n" v);
@@ -328,7 +331,7 @@ rec {
                          else "<function, args: {${showFnas}}>"
     else if isAttrs    v then
       # apply pretty values if allowed
-      if attrNames v == [ "__pretty" "val" ] && allowPrettyValues
+      if allowPrettyValues && v ? __pretty && v ? val
          then v.__pretty v.val
       else if v == {} then "{ }"
       else if v ? type && v.type == "derivation" then

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -132,7 +132,7 @@ let
   /*
     Filter sources by a list of regular expressions.
 
-    Example: src = sourceByRegex ./my-subproject [".*\.py$" "^database.sql$"]
+    Example: src = sourceByRegex ./my-subproject [".*\\.py" "database.sql"]
   */
   sourceByRegex = src: regexes:
     let

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -727,7 +727,7 @@ runTests {
       float = 0.1337;
       bool = true;
       emptystring = "";
-      string = ''fno"rd'';
+      string = "fn\${o}\"r\\d";
       newlinestring = "\n";
       path = /. + "/foo";
       null_ = null;
@@ -735,7 +735,7 @@ runTests {
       functionArgs = { arg ? 4, foo }: arg;
       list = [ 3 4 function [ false ] ];
       emptylist = [];
-      attrs = { foo = null; "foo bar" = "baz"; };
+      attrs = { foo = null; "foo b/ar" = "baz"; };
       emptyattrs = {};
       drv = deriv;
     };
@@ -744,7 +744,7 @@ runTests {
       float = "~0.133700";
       bool = "true";
       emptystring = ''""'';
-      string = ''"fno\"rd"'';
+      string = ''"fn\''${o}\"r\\d"'';
       newlinestring = "\"\\n\"";
       path = "/foo";
       null_ = "null";
@@ -752,7 +752,7 @@ runTests {
       functionArgs = "<function, args: {arg?, foo}>";
       list = "[ 3 4 ${function} [ false ] ]";
       emptylist = "[ ]";
-      attrs = "{ foo = null; \"foo bar\" = \"baz\"; }";
+      attrs = "{ foo = null; \"foo b/ar\" = \"baz\"; }";
       emptyattrs = "{ }";
       drv = "<derivation ${deriv.name}>";
     };
@@ -799,8 +799,8 @@ runTests {
       newlinestring = "\n";
       multilinestring = ''
         hello
-        there
-        test
+        ''${there}
+        te'''st
       '';
       multilinestring' = ''
         hello
@@ -827,8 +827,8 @@ runTests {
       multilinestring = ''
         '''
           hello
-          there
-          test
+          '''''${there}
+          te''''st
         ''''';
       multilinestring' = ''
         '''

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -754,7 +754,7 @@ runTests {
       emptylist = "[ ]";
       attrs = "{ foo = null; \"foo bar\" = \"baz\"; }";
       emptyattrs = "{ }";
-      drv = "<derivation ${deriv.drvPath}>";
+      drv = "<derivation ${deriv.name}>";
     };
   };
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -312,6 +312,16 @@ runTests {
     expected = true;
   };
 
+  testLookupPrefixMatch = {
+    expr = strings.lookupPrefix [ nixpkgsSource (nixpkgsSource // { name = "ignored"; }) ] ../strings.nix;
+    expected = { path = "lib/strings.nix"; source = "nixpkgs"; url = "https://github.com/NixOS/nixpkgs/blob/${trivial.manualRevision}/lib/strings.nix"; };
+  };
+
+  testLookupPrefixNoMatch = {
+    expr = strings.lookupPrefix [ nixpkgsSource ] "/foo/bar";
+    expected = { path = "/foo/bar"; };
+  };
+
   testNormalizePath = {
     expr = strings.normalizePath "//a/b//c////d/";
     expected = "/a/b/c/d/";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -731,8 +731,9 @@ runTests {
   testToPretty =
     let
       deriv = derivation { name = "test"; builder = "/bin/sh"; system = "aarch64-linux"; };
+      searchPath = [ { name = "foo"; root = /path/to/foo; } ];
     in {
-    expr = mapAttrs (const (generators.toPretty { multiline = false; })) rec {
+    expr = mapAttrs (const (generators.toPretty { multiline = false; inherit searchPath; })) rec {
       int = 42;
       float = 0.1337;
       bool = true;
@@ -740,6 +741,8 @@ runTests {
       string = "fn\${o}\"r\\d";
       newlinestring = "\n";
       path = /. + "/foo";
+      relativePath = /path/to/foo/bar/qux;
+      rootPath = /path/to/foo;
       null_ = null;
       function = x: x;
       functionArgs = { arg ? 4, foo }: arg;
@@ -757,6 +760,8 @@ runTests {
       string = ''"fn\''${o}\"r\\d"'';
       newlinestring = "\"\\n\"";
       path = "/foo";
+      relativePath = "<foo/bar/qux>";
+      rootPath = "<foo>";
       null_ = "null";
       function = "<function>";
       functionArgs = "<function, args: {arg?, foo}>";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -948,7 +948,7 @@ runTests {
           modules = [ module ];
         }).options;
 
-        locs = filter (o: ! o.internal) (optionAttrSetToDocList options);
+        locs = filter (o: ! o.internal) (optionsToDocTemplate { inherit options; });
       in map (o: o.loc) locs;
     expected = [ [ "_module" "args" ] [ "foo" ] [ "foo" "<name>" "bar" ] [ "foo" "bar" ] ];
   };

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -741,7 +741,7 @@ runTests {
     };
     expected = rec {
       int = "42";
-      float = "~0.133700";
+      float = "0.133700";
       bool = "true";
       emptystring = ''""'';
       string = ''"fn\''${o}\"r\\d"'';

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -222,6 +222,10 @@ rec {
 
   nixpkgsVersion = builtins.trace "`lib.nixpkgsVersion` is deprecated, use `lib.version` instead!" version;
 
+  /* The revision to which the manual should link.
+     Set this to "release-YY.MM" after branch-off. */
+  manualRevision = "master";
+
   /* Determine whether the function is being called from inside a Nix
      shell.
 

--- a/nixos/lib/eval-cacheable-options.nix
+++ b/nixos/lib/eval-cacheable-options.nix
@@ -1,23 +1,18 @@
-{ libPath
-, pkgsLibPath
-, nixosPath
-, modules
+{ modules
 , stateVersion
-, release
 }:
 
 let
-  lib = import libPath;
-  modulesPath = "${nixosPath}/modules";
+  lib = import <nixpkgs/lib>;
   # dummy pkgs set that contains no packages, only `pkgs.lib` from the full set.
   # not having `pkgs.lib` causes all users of `pkgs.formats` to fail.
-  pkgs = import pkgsLibPath {
+  pkgs = import <nixpkgs/pkgs/pkgs-lib> {
     inherit lib;
-    pkgs = null;
+    pkgs = throw "pkgs-lib tried to use pkgs for cacheable options build";
   };
-  utils = import "${nixosPath}/lib/utils.nix" {
+  utils = import <nixpkgs/nixos/lib/utils.nix> {
     inherit config lib;
-    pkgs = null;
+    pkgs = throw "utils.nix tried to use pkgs for cacheable options build";
   };
   # this is used both as a module and as specialArgs.
   # as a module it sets the _module special values, as specialArgs it makes `config`
@@ -28,26 +23,17 @@ let
     system.stateVersion = stateVersion;
   };
   eval = lib.evalModules {
-    modules = (map (m: "${modulesPath}/${m}") modules) ++ [
+    modules = (map (m: <nixpkgs/nixos/modules> + "/${m}") modules) ++ [
       config
     ];
     specialArgs = {
       inherit config pkgs utils;
     };
   };
-  docs = import "${nixosPath}/doc/manual" {
-    pkgs = pkgs // {
-      inherit lib;
-      # duplicate of the declaration in all-packages.nix
-      buildPackages.nixosOptionsDoc = attrs:
-        (import "${nixosPath}/lib/make-options-doc")
-          ({ inherit pkgs lib; } // attrs);
-    };
-    config = config.config;
-    options = eval.options;
-    version = release;
-    revision = "release-${release}";
-    prefix = modulesPath;
+  docs = import <nixpkgs/nixos/lib/make-options-doc> {
+    inherit lib;
+    pkgs = throw "make-options-doc tried to use pkgs for cacheable options build";
+    inherit (eval) options;
   };
 in
   docs.optionsNix

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -26,7 +26,7 @@
   # If you include more than one option list into a document, you need to
   # provide different ids.
 , variablelistId ? "configuration-variable-list"
-  # Strig to prefix to the option XML/HTML id attributes.
+  # String to prefix to the option XML/HTML id attributes.
 , optionIdPrefix ? "opt-"
 , revision ? "" # Specify revision for the options
 # a set of options the docs we are generating will be merged into, as if by recursiveUpdate.
@@ -45,28 +45,11 @@
 }:
 
 let
-  # Make a value safe for JSON. Functions are replaced by the string "<function>",
-  # derivations are replaced with an attrset
-  # { _type = "derivation"; name = <name of that derivation>; }.
-  # We need to handle derivations specially because consumers want to know about them,
-  # but we can't easily use the type,name subset of keys (since type is often used as
-  # a module option and might cause confusion). Use _type,name instead to the same
-  # effect, since _type is already used by the module system.
-  substSpecial = x:
-    if lib.isDerivation x then { _type = "derivation"; name = x.name; }
-    else if builtins.isAttrs x then lib.mapAttrs (name: substSpecial) x
-    else if builtins.isList x then map substSpecial x
-    else if lib.isFunction x then "<function>"
-    else x;
-
   rawOpts = lib.optionAttrSetToDocList options;
   transformedOpts = map transformOptions rawOpts;
   filteredOpts = lib.filter (opt: opt.visible && !opt.internal) transformedOpts;
   optionsList = lib.flip map filteredOpts
    (opt: opt
-    // lib.optionalAttrs (opt ? example) { example = substSpecial opt.example; }
-    // lib.optionalAttrs (opt ? default) { default = substSpecial opt.default; }
-    // lib.optionalAttrs (opt ? type) { type = substSpecial opt.type; }
     // lib.optionalAttrs (opt ? relatedPackages && opt.relatedPackages != []) { relatedPackages = genRelatedPackages opt.relatedPackages opt.name; }
    );
 

--- a/nixos/lib/make-options-doc/mergeJSON.py
+++ b/nixos/lib/make-options-doc/mergeJSON.py
@@ -237,12 +237,6 @@ for arg in sys.argv[1:]:
 options = pivot(json.load(open(sys.argv[1 + optOffset], 'r')))
 overrides = pivot(json.load(open(sys.argv[2 + optOffset], 'r')))
 
-# fix up declaration paths in lazy options, since we don't eval them from a full nixpkgs dir
-for (k, v) in options.items():
-    # The _module options are not declared in nixos/modules
-    if v.value['loc'][0] != "_module":
-        v.value['declarations'] = list(map(lambda s: f'nixos/modules/{s}' if isinstance(s, str) else s, v.value['declarations']))
-
 # merge both descriptions
 for (k, v) in overrides.items():
     cur = options.setdefault(k, v).value

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -48,10 +48,15 @@ let
         };
         scrubDerivations = namePrefix: pkgSet: mapAttrs
           (name: value:
-            let wholeName = "${namePrefix}.${name}"; in
-            if isAttrs value then
+            let
+              wholeName = "${namePrefix}.${name}";
+              guard = lib.warn "Attempt to evaluate package ${wholeName} in option documentation; this is not supported and will eventually be an error. Use `mkPackageOption` or `literalExpression` instead.";
+            in if isAttrs value then
               scrubDerivations wholeName value
-              // (optionalAttrs (isDerivation value) { outPath = "\${${wholeName}}"; })
+              // optionalAttrs (isDerivation value) {
+                outPath = guard "\${${wholeName}}";
+                drvPath = guard drvPath;
+              }
             else value
           )
           pkgSet;

--- a/nixos/modules/programs/htop.nix
+++ b/nixos/modules/programs/htop.nix
@@ -20,7 +20,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.htop;
-      defaultText = "pkgs.htop";
+      defaultText = lib.literalExpression "pkgs.htop";
       description = lib.mdDoc ''
         The htop package that should be used.
       '';

--- a/nixos/modules/programs/weylus.nix
+++ b/nixos/modules/programs/weylus.nix
@@ -29,7 +29,7 @@ in
     package = mkOption {
       type = package;
       default = pkgs.weylus;
-      defaultText = "pkgs.weylus";
+      defaultText = lib.literalExpression "pkgs.weylus";
       description = lib.mdDoc "Weylus package to install.";
     };
   };

--- a/nixos/modules/services/audio/liquidsoap.nix
+++ b/nixos/modules/services/audio/liquidsoap.nix
@@ -38,11 +38,13 @@ in
 
       default = {};
 
-      example = {
-        myStream1 = "/etc/liquidsoap/myStream1.liq";
-        myStream2 = literalExpression "./myStream2.liq";
-        myStream3 = "out(playlist(\"/srv/music/\"))";
-      };
+      example = literalExpression ''
+        {
+          myStream1 = "/etc/liquidsoap/myStream1.liq";
+          myStream2 = ./myStream2.liq;
+          myStream3 = "out(playlist(\"/srv/music/\"))";
+        }
+      '';
 
       type = types.attrsOf (types.either types.path types.str);
     };

--- a/nixos/modules/services/databases/clickhouse.nix
+++ b/nixos/modules/services/databases/clickhouse.nix
@@ -16,7 +16,7 @@ with lib;
       package = mkOption {
         type = types.package;
         default = pkgs.clickhouse;
-        defaultText = "pkgs.clickhouse";
+        defaultText = lib.literalExpression "pkgs.clickhouse";
         description = lib.mdDoc ''
           ClickHouse package to use.
         '';

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -160,10 +160,12 @@ in
           List of database names and their initial schemas that should be used to create databases on the first startup
           of MySQL. The schema attribute is optional: If not specified, an empty database is created.
         '';
-        example = [
-          { name = "foodatabase"; schema = literalExpression "./foodatabase.sql"; }
-          { name = "bardatabase"; }
-        ];
+        example = literalExpression ''
+          [
+            { name = "foodatabase"; schema = ./foodatabase.sql; }
+            { name = "bardatabase"; }
+          ]
+        '';
       };
 
       initialScript = mkOption {

--- a/nixos/modules/services/games/asf.nix
+++ b/nixos/modules/services/games/asf.nix
@@ -44,11 +44,12 @@ in
       type = types.submodule {
         options = {
           enable = mkEnableOption
-            (lib.mdDoc "Wheter to start the web-ui. This is the preferred way of configuring things such as the steam guard token");
+            (lib.mdDoc "Whether to start the web-ui. This is the preferred way of configuring things such as the steam guard token");
 
           package = mkOption {
             type = types.package;
             default = pkgs.ArchiSteamFarm.ui;
+            defaultText = lib.literalExpression "pkgs.ArchiSteamFarm.ui";
             description =
               lib.mdDoc "Web-UI package to use. Contents must be in lib/dist.";
           };
@@ -56,7 +57,6 @@ in
       };
       default = {
         enable = true;
-        package = pkgs.ArchiSteamFarm.ui;
       };
       example = {
         enable = false;
@@ -67,6 +67,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.ArchiSteamFarm;
+      defaultText = lib.literalExpression "pkgs.ArchiSteamFarm";
       description =
         lib.mdDoc "Package to use. Should always be the latest version, for security reasons, since this module uses very new features and to not get out of sync with the Steam API.";
     };

--- a/nixos/modules/services/games/terraria.nix
+++ b/nixos/modules/services/games/terraria.nix
@@ -116,7 +116,7 @@ in
       openFirewall = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc "Wheter to open ports in the firewall";
+        description = lib.mdDoc "Whether to open ports in the firewall";
       };
 
       dataDir = mkOption {

--- a/nixos/modules/services/hardware/argonone.nix
+++ b/nixos/modules/services/hardware/argonone.nix
@@ -9,7 +9,7 @@ in
     package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.argononed;
-      defaultText = "pkgs.argononed";
+      defaultText = lib.literalExpression "pkgs.argononed";
       description = lib.mdDoc ''
         The package implementing the Argon One driver
       '';

--- a/nixos/modules/services/hardware/joycond.nix
+++ b/nixos/modules/services/hardware/joycond.nix
@@ -14,7 +14,7 @@ with lib;
     package = mkOption {
       type = types.package;
       default = pkgs.joycond;
-      defaultText = "pkgs.joycond";
+      defaultText = lib.literalExpression "pkgs.joycond";
       description = lib.mdDoc ''
         The joycond package to use.
       '';

--- a/nixos/modules/services/matrix/conduit.nix
+++ b/nixos/modules/services/matrix/conduit.nix
@@ -23,8 +23,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.matrix-conduit;
-        defaultText = "pkgs.matrix-conduit";
-        example = "pkgs.matrix-conduit";
+        defaultText = lib.literalExpression "pkgs.matrix-conduit";
         description = lib.mdDoc ''
           Package of the conduit matrix server to use.
         '';

--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -286,6 +286,7 @@ in {
             log_config = mkOption {
               type = types.path;
               default = ./synapse-log_config.yaml;
+              defaultText = lib.literalExpression "nixos/modules/services/matrix/synapse-log_config.yaml";
               description = lib.mdDoc ''
                 The file that holds the logging configuration.
               '';

--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -286,7 +286,6 @@ in {
             log_config = mkOption {
               type = types.path;
               default = ./synapse-log_config.yaml;
-              defaultText = lib.literalExpression "nixos/modules/services/matrix/synapse-log_config.yaml";
               description = lib.mdDoc ''
                 The file that holds the logging configuration.
               '';

--- a/nixos/modules/services/misc/autorandr.nix
+++ b/nixos/modules/services/misc/autorandr.nix
@@ -258,7 +258,7 @@ in {
         type = hooksModule;
         description = lib.mdDoc "Global hook scripts";
         default = { };
-        example = ''
+        example = literalExpression ''
           {
             postswitch = {
               "notify-i3" = "''${pkgs.i3}/bin/i3-msg restart";
@@ -279,7 +279,7 @@ in {
                     exit 1
                 esac
                 echo "Xft.dpi: $DPI" | ''${pkgs.xorg.xrdb}/bin/xrdb -merge
-              '''
+              ''';
             };
           }
         '';

--- a/nixos/modules/services/misc/heisenbridge.nix
+++ b/nixos/modules/services/misc/heisenbridge.nix
@@ -28,8 +28,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.heisenbridge;
-      defaultText = "pkgs.heisenbridge";
-      example = "pkgs.heisenbridge.override { … = …; }";
+      defaultText = lib.literalExpression "pkgs.heisenbridge";
       description = lib.mdDoc ''
         Package of the application to run, exposed for overriding purposes.
       '';

--- a/nixos/modules/services/misc/portunus.nix
+++ b/nixos/modules/services/misc/portunus.nix
@@ -29,7 +29,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.portunus;
-      defaultText = "pkgs.portunus";
+      defaultText = lib.literalExpression "pkgs.portunus";
       description = lib.mdDoc "The Portunus package to use.";
     };
 
@@ -108,7 +108,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.openldap;
-        defaultText = "pkgs.openldap";
+        defaultText = lib.literalExpression "pkgs.openldap";
         description = lib.mdDoc "The OpenLDAP package to use.";
       };
 

--- a/nixos/modules/services/monitoring/grafana-agent.nix
+++ b/nixos/modules/services/monitoring/grafana-agent.nix
@@ -16,7 +16,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.grafana-agent;
-      defaultText = "pkgs.grafana-agent";
+      defaultText = lib.literalExpression "pkgs.grafana-agent";
       description = lib.mdDoc "The grafana-agent package to use.";
     };
 
@@ -49,17 +49,19 @@ in
       };
 
       default = { };
-      defaultText = ''
-        metrics = {
-          wal_directory = "\''${STATE_DIRECTORY}";
-          global.scrape_interval = "5s";
-        };
-        integrations = {
-          agent.enabled = true;
-          agent.scrape_integration = true;
-          node_exporter.enabled = true;
-          replace_instance_label = true;
-        };
+      defaultText = lib.literalExpression ''
+        {
+          metrics = {
+            wal_directory = "\''${STATE_DIRECTORY}";
+            global.scrape_interval = "5s";
+          };
+          integrations = {
+            agent.enabled = true;
+            agent.scrape_integration = true;
+            node_exporter.enabled = true;
+            replace_instance_label = true;
+          };
+        }
       '';
       example = {
         metrics.global.remote_write = [{

--- a/nixos/modules/services/monitoring/uptime-kuma.nix
+++ b/nixos/modules/services/monitoring/uptime-kuma.nix
@@ -13,9 +13,8 @@ in
 
       package = mkOption {
         type = types.package;
-        example = literalExpression "pkgs.uptime-kuma";
         default = pkgs.uptime-kuma;
-        defaultText = "pkgs.uptime-kuma";
+        defaultText = literalExpression "pkgs.uptime-kuma";
         description = lib.mdDoc "Uptime Kuma package to use.";
       };
 

--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -71,7 +71,7 @@ with lib;
       package = mkOption {
         type = package;
         default = pkgs.ddclient;
-        defaultText = "pkgs.ddclient";
+        defaultText = lib.literalExpression "pkgs.ddclient";
         description = lib.mdDoc ''
           The ddclient executable package run by the service.
         '';

--- a/nixos/modules/services/networking/multipath.nix
+++ b/nixos/modules/services/networking/multipath.nix
@@ -28,7 +28,7 @@ in {
       type = package;
       description = lib.mdDoc "multipath-tools package to use";
       default = pkgs.multipath-tools;
-      defaultText = "pkgs.multipath-tools";
+      defaultText = lib.literalExpression "pkgs.multipath-tools";
     };
 
     devices = mkOption {

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -67,7 +67,7 @@ in
           Additional plugins dir used to configure nomad.
         '';
         example = literalExpression ''
-          [ "<pluginDir>" "pkgs.<plugins-name>"]
+          [ "<pluginDir>" pkgs.<plugins-name> ]
         '';
       };
 

--- a/nixos/modules/services/networking/sabnzbd.nix
+++ b/nixos/modules/services/networking/sabnzbd.nix
@@ -20,7 +20,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.sabnzbd;
-        defaultText = "pkgs.sabnzbd";
+        defaultText = lib.literalExpression "pkgs.sabnzbd";
         description = lib.mdDoc "The sabnzbd executable package run by the service.";
       };
 

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -21,7 +21,7 @@ in
     package = mkOption {
       description = lib.mdDoc "The package to use for meilisearch. Use this if you require specific features to be enabled. The default package has no features.";
       default = pkgs.meilisearch;
-      defaultText = "pkgs.meilisearch";
+      defaultText = lib.literalExpression "pkgs.meilisearch";
       type = types.package;
     };
 

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -91,7 +91,7 @@ in {
             InterceptUnknown = mkOption {
               type = types.bool;
               description = mdDoc ''
-                Wheter to intercept spare connections.
+                Whether to intercept spare connections.
               '';
             };
 

--- a/nixos/modules/services/web-apps/code-server.nix
+++ b/nixos/modules/services/web-apps/code-server.nix
@@ -15,7 +15,7 @@ in {
 
       package = mkOption {
         default = pkgs.code-server;
-        defaultText = "pkgs.code-server";
+        defaultText = lib.literalExpression "pkgs.code-server";
         description = lib.mdDoc "Which code-server derivation to use.";
         type = types.package;
       };

--- a/nixos/modules/services/web-apps/invidious.nix
+++ b/nixos/modules/services/web-apps/invidious.nix
@@ -151,7 +151,7 @@ in
     package = lib.mkOption {
       type = types.package;
       default = pkgs.invidious;
-      defaultText = "pkgs.invidious";
+      defaultText = lib.literalExpression "pkgs.invidious";
       description = lib.mdDoc "The Invidious package to use.";
     };
 

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -106,7 +106,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.mattermost;
-        defaultText = "pkgs.mattermost";
+        defaultText = lib.literalExpression "pkgs.mattermost";
         description = lib.mdDoc "Mattermost derivation to use.";
       };
 
@@ -238,7 +238,7 @@ in
         package = mkOption {
           type = types.package;
           default = pkgs.matterircd;
-          defaultText = "pkgs.matterircd";
+          defaultText = lib.literalExpression "pkgs.matterircd";
           description = lib.mdDoc "matterircd derivation to use.";
         };
         parameters = mkOption {

--- a/nixos/modules/services/web-apps/onlyoffice.nix
+++ b/nixos/modules/services/web-apps/onlyoffice.nix
@@ -29,7 +29,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.onlyoffice-documentserver;
-      defaultText = "pkgs.onlyoffice-documentserver";
+      defaultText = lib.literalExpression "pkgs.onlyoffice-documentserver";
       description = lib.mdDoc "Which package to use for the OnlyOffice instance.";
     };
 

--- a/nixos/modules/services/web-servers/lighttpd/default.nix
+++ b/nixos/modules/services/web-servers/lighttpd/default.nix
@@ -137,7 +137,7 @@ in
 
       package = mkOption {
         default = pkgs.lighttpd;
-        defaultText = "pkgs.lighttpd";
+        defaultText = lib.literalExpression "pkgs.lighttpd";
         type = types.package;
         description = lib.mdDoc ''
           lighttpd package to use.

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -580,7 +580,7 @@ in
     virtualisation.host.pkgs = mkOption {
       type = options.nixpkgs.pkgs.type;
       default = pkgs;
-      defaultText = "pkgs";
+      defaultText = literalExpression "pkgs";
       example = literalExpression ''
         import pkgs.path { system = "x86_64-darwin"; }
       '';
@@ -595,7 +595,8 @@ in
         mkOption {
           type = types.package;
           default = cfg.host.pkgs.qemu_kvm;
-          example = "pkgs.qemu_test";
+          defaultText = literalExpression "config.virtualisation.host.pkgs.qemu_kvm";
+          example = literalExpression "pkgs.qemu_test";
           description = lib.mdDoc "QEMU package to use.";
         };
 
@@ -721,7 +722,7 @@ in
       firmware = mkOption {
         type = types.path;
         default = pkgs.OVMF.firmware;
-        defaultText = "pkgs.OVMF.firmware";
+        defaultText = literalExpression "pkgs.OVMF.firmware";
         description =
           lib.mdDoc ''
             Firmware binary for EFI implementation, defaults to OVMF.
@@ -731,7 +732,7 @@ in
       variables = mkOption {
         type = types.path;
         default = pkgs.OVMF.variables;
-        defaultText = "pkgs.OVMF.variables";
+        defaultText = literalExpression "pkgs.OVMF.variables";
         description =
           lib.mdDoc ''
             Platform-specific flash binary for EFI variables, implementation-dependent to the EFI firmware.

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -35,7 +35,7 @@ let
 
       metrics = import ./metrics.nix { inherit pkgs nixpkgs; };
 
-      manual = import ../../doc { inherit pkgs nixpkgs; };
+      manual = import ../../doc { inherit pkgs; };
       lib-tests = import ../../lib/tests/release.nix { inherit pkgs; };
       pkgs-lib-tests = import ../pkgs-lib/tests { inherit pkgs; };
 


### PR DESCRIPTION
Split out from https://github.com/NixOS/nixpkgs/pull/199363, see discussions there.

Based on top of that PR to avoid conflicts, the first new commit is e9fe624505cb6525be18852c7c53aa3542ce18f3.

Fixes https://github.com/NixOS/nixpkgs/issues/66917.

#### To do before merging:
- [ ] prepare nixos-search for the new declaration format

#### To do after merging:
- [ ] add information about `lib.trivial.manualRevision` to the [release wiki](https://github.com/NixOS/release-wiki)
- [ ] take advantage of these changes in nmd and home-manager
