### PR TITLE
treewide: mark packages that never built ok broken

### DIFF
--- a/pkgs/applications/accessibility/contrast/default.nix
+++ b/pkgs/applications/accessibility/contrast/default.nix
@@ -70,6 +70,8 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }
 

--- a/pkgs/applications/audio/cardinal/default.nix
+++ b/pkgs/applications/audio/cardinal/default.nix
@@ -62,5 +62,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.all;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/audio/chuck/default.nix
+++ b/pkgs/applications/audio/chuck/default.nix
@@ -37,5 +37,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ftrvxmtrx ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/audio/snapcast/default.nix
+++ b/pkgs/applications/audio/snapcast/default.nix
@@ -45,5 +45,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fpletz ];
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.gpl3Plus;
+    # never built on x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/applications/blockchains/haven-cli/default.nix
+++ b/pkgs/applications/blockchains/haven-cli/default.nix
@@ -59,5 +59,7 @@ stdenv.mkDerivation rec {
     license     = licenses.bsd3;
     platforms   = platforms.all;
     maintainers = with maintainers; [ kim0 ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/blockchains/solana-validator/default.nix
+++ b/pkgs/applications/blockchains/solana-validator/default.nix
@@ -86,6 +86,8 @@ rustPlatform.buildRustPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ adjacentresearch ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
   passthru.updateScript = ./update.sh;
 }

--- a/pkgs/applications/editors/xedit/default.nix
+++ b/pkgs/applications/editors/xedit/default.nix
@@ -48,5 +48,7 @@ stdenv.mkDerivation rec {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ shamilton ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -39,5 +39,7 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ raskin ];
     license = licenses.gpl2;
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/graphics/foxotron/default.nix
+++ b/pkgs/applications/graphics/foxotron/default.nix
@@ -70,5 +70,7 @@ stdenv.mkDerivation rec {
     license = licenses.unlicense;
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/graphics/symbolic-preview/default.nix
+++ b/pkgs/applications/graphics/symbolic-preview/default.nix
@@ -23,5 +23,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ qyliss ];
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/misc/gnome-extension-manager/default.nix
+++ b/pkgs/applications/misc/gnome-extension-manager/default.nix
@@ -60,5 +60,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ foo-dogsquared ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/misc/oneko/default.nix
+++ b/pkgs/applications/misc/oneko/default.nix
@@ -35,5 +35,7 @@ stdenv.mkDerivation rec {
     license = with licenses; [ publicDomain ];
     maintainers = with maintainers; [ xaverdh irenes ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/misc/openbangla-keyboard/default.nix
+++ b/pkgs/applications/misc/openbangla-keyboard/default.nix
@@ -68,5 +68,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ hqurve ];
     platforms = platforms.linux;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/networking/cluster/docker-machine/xhyve.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/xhyve.nix
@@ -35,5 +35,7 @@ buildGoPackage rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ periklis ];
     platforms = platforms.darwin;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -217,7 +217,6 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "Kotatogram – experimental Telegram Desktop fork";
     longDescription = ''
       Unofficial desktop client for the Telegram messenger, based on Telegram Desktop.
@@ -229,5 +228,7 @@ stdenv.mkDerivation rec {
     homepage = "https://kotatogram.github.io";
     changelog = "https://github.com/kotatogram/kotatogram-desktop/releases/tag/k{version}";
     maintainers = with maintainers; [ ilya-fedin ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = (stdenv.isDarwin && stdenv.isAarch64) || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/applications/networking/instant-messengers/telepathy/mission-control/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/mission-control/default.nix
@@ -49,5 +49,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Only;
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/networking/mailreaders/sylpheed/default.nix
+++ b/pkgs/applications/networking/mailreaders/sylpheed/default.nix
@@ -45,5 +45,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ eelco ];
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.gpl2;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/networking/sync/lsyncd/default.nix
+++ b/pkgs/applications/networking/sync/lsyncd/default.nix
@@ -44,5 +44,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ bobvanderlinden ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/networking/umurmur/default.nix
+++ b/pkgs/applications/networking/umurmur/default.nix
@@ -24,5 +24,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     homepage = "https://github.com/umurmur/umurmur";
     platforms = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/radio/m17-cxx-demod/default.nix
+++ b/pkgs/applications/radio/m17-cxx-demod/default.nix
@@ -20,5 +20,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     platforms = platforms.unix;
     maintainers = teams.c3d2.members;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/science/astronomy/xearth/default.nix
+++ b/pkgs/applications/science/astronomy/xearth/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.mafo ];
     license = "xearth";
     platforms=platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 
 }

--- a/pkgs/applications/science/chemistry/gwyddion/default.nix
+++ b/pkgs/applications/science/chemistry/gwyddion/default.nix
@@ -68,5 +68,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = [ lib.maintainers.cge ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/science/physics/nnpdf/default.nix
+++ b/pkgs/applications/science/physics/nnpdf/default.nix
@@ -62,11 +62,12 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "An open-source machine learning framework for global analyses of parton distributions";
     homepage = "https://docs.nnpdf.science/";
     license = licenses.gpl3Only;
     maintainers = [ maintainers.veprbl ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = (stdenv.isDarwin && stdenv.isAarch64) || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/applications/science/physics/sacrifice/default.nix
+++ b/pkgs/applications/science/physics/sacrifice/default.nix
@@ -44,5 +44,7 @@ stdenv.mkDerivation {
     homepage    = "https://agile.hepforge.org/trac/wiki/Sacrifice";
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ veprbl ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/science/physics/sherpa/default.nix
+++ b/pkgs/applications/science/physics/sherpa/default.nix
@@ -34,5 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/sherpa-team/sherpa";
     platforms = platforms.unix;
     maintainers = with maintainers; [ veprbl ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/version-management/got/default.nix
+++ b/pkgs/applications/version-management/got/default.nix
@@ -46,5 +46,7 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ abbe afh ];
+    # never built on x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/applications/video/motion/default.nix
+++ b/pkgs/applications/video/motion/default.nix
@@ -22,5 +22,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ puffnfresh veprbl ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/video/obs-studio/plugins/input-overlay.nix
+++ b/pkgs/applications/video/obs-studio/plugins/input-overlay.nix
@@ -43,5 +43,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ glittershark ];
     license = licenses.gpl2;
     platforms = platforms.linux;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -34,5 +34,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = [ maintainers.balsoft ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
@@ -63,5 +63,7 @@ stdenv.mkDerivation rec {
     license = with licenses; gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/virtualization/xhyve/default.nix
+++ b/pkgs/applications/virtualization/xhyve/default.nix
@@ -33,5 +33,7 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.lnl7 ];
     license = licenses.bsd2;
     platforms = platforms.darwin;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/compilers/cakelisp/default.nix
+++ b/pkgs/development/compilers/cakelisp/default.nix
@@ -38,5 +38,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.darwin ++ platforms.linux;
     maintainers = [ maintainers.sbond75 ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -93,5 +93,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/compilers/inform7/default.nix
+++ b/pkgs/development/compilers/inform7/default.nix
@@ -22,11 +22,12 @@ in stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "A design system for interactive fiction";
     homepage = "http://inform7.com/";
     license = licenses.artistic2;
     maintainers = with maintainers; [ mbbx6spp ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = (stdenv.isDarwin && stdenv.isAarch64) || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/development/compilers/llvm/10/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/10/lldb/default.nix
@@ -94,6 +94,8 @@ stdenv.mkDerivation (rec {
       larger LLVM Project, such as the Clang expression parser and LLVM
       disassembler.
     '';
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 } // lib.optionalAttrs enableManpages {
   pname = "lldb-manpages";

--- a/pkgs/development/compilers/llvm/5/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/5/lldb/default.nix
@@ -82,5 +82,7 @@ stdenv.mkDerivation rec {
       larger LLVM Project, such as the Clang expression parser and LLVM
       disassembler.
     '';
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/compilers/llvm/6/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/6/lldb/default.nix
@@ -82,5 +82,7 @@ stdenv.mkDerivation rec {
       larger LLVM Project, such as the Clang expression parser and LLVM
       disassembler.
     '';
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/compilers/llvm/7/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/7/lldb/default.nix
@@ -85,5 +85,7 @@ stdenv.mkDerivation rec {
       larger LLVM Project, such as the Clang expression parser and LLVM
       disassembler.
     '';
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/compilers/polyml/5.7.nix
+++ b/pkgs/development/compilers/polyml/5.7.nix
@@ -44,5 +44,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21;
     platforms = with platforms; (linux ++ darwin);
     maintainers = with maintainers; [ maggesi ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -88,5 +88,7 @@ in stdenv.mkDerivation {
     platforms   = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ thoughtpolice ];
     mainProgram = "sml";
+    # never built on x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -89,5 +89,7 @@ in stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ jb55 seylerius thoughtpolice elliottslaughter ];
     license = licenses.mit;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/interpreters/bic/default.nix
+++ b/pkgs/development/interpreters/bic/default.nix
@@ -38,5 +38,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/hexagonal-sun/bic";
     platforms = platforms.unix;
     maintainers = with maintainers; [ hexagonal-sun ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/classads/default.nix
+++ b/pkgs/development/libraries/classads/default.nix
@@ -20,5 +20,7 @@ stdenv.mkDerivation rec {
     description = "The Classified Advertisements library provides a generic means for matching resources";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/enchant/1.x.nix
+++ b/pkgs/development/libraries/enchant/1.x.nix
@@ -18,5 +18,7 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     badPlatforms = [ "x86_64-darwin" ];
     license = licenses.lgpl21;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/garmintools/default.nix
+++ b/pkgs/development/libraries/garmintools/default.nix
@@ -13,5 +13,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     maintainers = [ ];
     platforms = lib.platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/gcc/libstdc++/5.nix
+++ b/pkgs/development/libraries/gcc/libstdc++/5.nix
@@ -113,5 +113,7 @@ stdenv.mkDerivation rec {
     description = "GNU Compiler Collection, version ${version} -- C++ standard library";
     platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/gmp/4.3.2.nix
+++ b/pkgs/development/libraries/gmp/4.3.2.nix
@@ -71,6 +71,8 @@ let self = stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
     badPlatforms = [ "x86_64-darwin" ];
+    # never built on aarch64-darwin, aarch64-linux since first introduction in nixpkgs
+    broken = (stdenv.isDarwin && stdenv.isAarch64) || (stdenv.isLinux && stdenv.isAarch64);
   };
 };
   in self

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -80,6 +80,8 @@ let self = stdenv.mkDerivation rec {
 
     platforms = platforms.all;
     badPlatforms = [ "x86_64-darwin" ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 };
   in self

--- a/pkgs/development/libraries/htmlcxx/default.nix
+++ b/pkgs/development/libraries/htmlcxx/default.nix
@@ -20,5 +20,7 @@ stdenv.mkDerivation rec {
     description = "A simple non-validating css1 and html parser for C++";
     license = licenses.lgpl2;
     platforms = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/imlib/default.nix
+++ b/pkgs/development/libraries/imlib/default.nix
@@ -58,5 +58,7 @@ stdenv.mkDerivation rec {
     description = "An image loading and rendering library for X11";
     platforms = platforms.unix;
     license = with licenses; [ gpl2Only lgpl2Only ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/libLAS/default.nix
+++ b/pkgs/development/libraries/libLAS/default.nix
@@ -31,5 +31,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.michelk ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/libbde/default.nix
+++ b/pkgs/development/libraries/libbde/default.nix
@@ -25,5 +25,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3;
     maintainers = with maintainers; [ eliasp ];
     platforms = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/libffcall/default.nix
+++ b/pkgs/development/libraries/libffcall/default.nix
@@ -24,5 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/libffcall/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/libffi/3.3.nix
+++ b/pkgs/development/libraries/libffi/3.3.nix
@@ -60,5 +60,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ armeenm ];
     platforms = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/libfreefare/default.nix
+++ b/pkgs/development/libraries/libfreefare/default.nix
@@ -21,5 +21,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/nfc-tools/libfreefare";
     maintainers = with maintainers; [bobvanderlinden];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -31,5 +31,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Only;
     platforms = platforms.unix;
     maintainers = [ maintainers.titanous ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/liboil/default.nix
+++ b/pkgs/development/libraries/liboil/default.nix
@@ -29,5 +29,7 @@ stdenv.mkDerivation rec {
     license     = licenses.bsd2;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/libsnark/default.nix
+++ b/pkgs/development/libraries/libsnark/default.nix
@@ -18,10 +18,11 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "C++ library for zkSNARKs";
     homepage = "https://github.com/scipr-lab/libsnark";
     license = licenses.mit;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = (stdenv.isDarwin && stdenv.isAarch64) || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/development/libraries/libticables2/default.nix
+++ b/pkgs/development/libraries/libticables2/default.nix
@@ -60,5 +60,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ siraben luc65r ];
     platforms = with platforms; linux ++ darwin;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/libtommath/default.nix
+++ b/pkgs/development/libraries/libtommath/default.nix
@@ -31,5 +31,7 @@ stdenv.mkDerivation rec {
     description = "A library for integer-based number-theoretic applications";
     license = with licenses; [ publicDomain wtfpl ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/openslp/default.nix
+++ b/pkgs/development/libraries/openslp/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ttuegel ];
     license = licenses.bsd3;
     platforms = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 
 }

--- a/pkgs/development/libraries/physics/hepmc3/default.nix
+++ b/pkgs/development/libraries/physics/hepmc3/default.nix
@@ -45,5 +45,7 @@ stdenv.mkDerivation rec {
     homepage = "http://hepmc.web.cern.ch/hepmc/";
     platforms = platforms.unix;
     maintainers = with maintainers; [ veprbl ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/physics/nlojet/default.nix
+++ b/pkgs/development/libraries/physics/nlojet/default.nix
@@ -19,5 +19,7 @@ stdenv.mkDerivation rec {
     description = "Implementation of calculation of the hadron jet cross sections";
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ veprbl ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/physics/thepeg/default.nix
+++ b/pkgs/development/libraries/physics/thepeg/default.nix
@@ -25,5 +25,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ veprbl ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/rlottie/default.nix
+++ b/pkgs/development/libraries/rlottie/default.nix
@@ -34,5 +34,7 @@ stdenv.mkDerivation rec {
     license = with licenses; [ mit bsd3 mpl11 ftl ];
     platforms = platforms.all;
     maintainers = with maintainers; [ CRTified ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/science/math/bonmin/default.nix
+++ b/pkgs/development/libraries/science/math/bonmin/default.nix
@@ -47,5 +47,7 @@ stdenv.mkDerivation rec {
     license = licenses.epl10;
     platforms = platforms.unix;
     maintainers = with maintainers; [ aanderse ];
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/libraries/science/math/m4rie/default.nix
+++ b/pkgs/development/libraries/science/math/m4rie/default.nix
@@ -35,5 +35,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = teams.sage.members;
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/science/math/mongoose/default.nix
+++ b/pkgs/development/libraries/science/math/mongoose/default.nix
@@ -26,5 +26,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [];
     platforms = with platforms; unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/science/networking/ns-3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns-3/default.nix
@@ -101,11 +101,12 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "fortify" "strictoverflow"];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     homepage = "http://www.nsnam.org";
     license = licenses.gpl3;
     description = "A discrete time event network simulator";
     platforms = with platforms; unix;
     maintainers = with maintainers; [ teto rgrunbla ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = (stdenv.isDarwin && stdenv.isAarch64) || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/development/libraries/subunit/default.nix
+++ b/pkgs/development/libraries/subunit/default.nix
@@ -23,5 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "https://launchpad.net/subunit";
     license = licenses.asl20;
     platforms = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/vc/0.7.nix
+++ b/pkgs/development/libraries/vc/0.7.nix
@@ -22,11 +22,12 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "Library for multiprecision complex arithmetic with exact rounding";
     homepage = "https://github.com/VcDevel/Vc";
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = (stdenv.isDarwin && stdenv.isAarch64) || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/development/tools/analysis/panopticon/default.nix
+++ b/pkgs/development/tools/analysis/panopticon/default.nix
@@ -36,7 +36,6 @@ rustPlatform.buildRustPackage rec {
      '';
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "A libre cross-platform disassembler";
     longDescription = ''
       Panopticon is a cross platform disassembler for reverse
@@ -47,5 +46,7 @@ rustPlatform.buildRustPackage rec {
     '';
     license = with licenses; [ gpl3 ];
     maintainers = with maintainers; [ leenaars ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isDarwin || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_3/default.nix
@@ -173,6 +173,8 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = lib.teams.bazel.members;
     inherit platforms;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 
   inherit src;

--- a/pkgs/development/tools/explain/default.nix
+++ b/pkgs/development/tools/explain/default.nix
@@ -42,5 +42,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ McSinyx ];
     platforms = platforms.unix;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/tools/glslviewer/default.nix
+++ b/pkgs/development/tools/glslviewer/default.nix
@@ -49,5 +49,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.hodapp ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/tools/lightningcss/default.nix
+++ b/pkgs/development/tools/lightningcss/default.nix
@@ -36,5 +36,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/parcel-bundler/lightningcss/releases/tag/v${version}";
     license = licenses.mpl20;
     maintainers = with maintainers; [ toastal ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/tools/misc/pwndbg/default.nix
+++ b/pkgs/development/tools/misc/pwndbg/default.nix
@@ -49,5 +49,7 @@ in stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ mic92 ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/tools/rojo/default.nix
+++ b/pkgs/development/tools/rojo/default.nix
@@ -38,5 +38,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/rojo-rbx/rojo/raw/v${version}/CHANGELOG.md";
     license = licenses.mpl20;
     maintainers = with maintainers; [ wackbyte ];
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/games/opendungeons/default.nix
+++ b/pkgs/games/opendungeons/default.nix
@@ -24,5 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://opendungeons.github.io";
     license = with licenses; [ gpl3Plus zlib mit cc-by-sa-30 cc0 ofl cc-by-30 ];
     platforms = platforms.linux;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -58,11 +58,12 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_LINK = "-lopenal";
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "A compatible client of Ace of Spades 0.75";
     homepage    = "https://github.com/yvt/openspades/";
     license     = licenses.gpl3;
     platforms   = platforms.all;
     maintainers = with maintainers; [ abbradar azahi ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isDarwin || (stdenv.isLinux && stdenv.isAarch64);
   };
 }

--- a/pkgs/games/quake3/quake3e/default.nix
+++ b/pkgs/games/quake3/quake3e/default.nix
@@ -48,5 +48,7 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ pmiddend ];
     badPlatforms = [ platforms.aarch64 ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/games/quantumminigolf/default.nix
+++ b/pkgs/games/quantumminigolf/default.nix
@@ -34,5 +34,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/games/scummvm/default.nix
+++ b/pkgs/games/scummvm/default.nix
@@ -45,5 +45,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.peterhoeg ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/games/solicurses/default.nix
+++ b/pkgs/games/solicurses/default.nix
@@ -33,5 +33,7 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ laalsaas ];
     license = licenses.gpl3Only;
     inherit (ncurses.meta) platforms;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -42,5 +42,7 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.mit; # expat version
     maintainers = [ ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/games/xskat/default.nix
+++ b/pkgs/games/xskat/default.nix
@@ -26,5 +26,7 @@ stdenv.mkDerivation rec {
     license = licenses.free;
     longDescription = "Play the german card game Skat against the AI or over IRC.";
     homepage = "http://www.xskat.de/";
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/games/xsok/default.nix
+++ b/pkgs/games/xsok/default.nix
@@ -42,5 +42,7 @@ stdenv.mkDerivation rec {
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.unix;
     homepage = "https://tracker.debian.org/pkg/xsok";
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/os-specific/darwin/noah/default.nix
+++ b/pkgs/os-specific/darwin/noah/default.nix
@@ -20,5 +20,7 @@ stdenv.mkDerivation rec {
     license = [ licenses.mit licenses.gpl2 ];
     maintainers = [ maintainers.marsam ];
     platforms = platforms.darwin;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/os-specific/linux/lsirec/default.nix
+++ b/pkgs/os-specific/linux/lsirec/default.nix
@@ -32,5 +32,7 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.bsd2;
     maintainers = with maintainers; [ Luflosi ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/os-specific/linux/nsncd/default.nix
+++ b/pkgs/os-specific/linux/nsncd/default.nix
@@ -26,5 +26,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/twosigma/nsncd";
     license = licenses.asl20;
     maintainers = with maintainers; [ flokli ninjatrappeur ];
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/servers/isso/default.nix
+++ b/pkgs/servers/isso/default.nix
@@ -63,5 +63,7 @@ with python3Packages; buildPythonApplication rec {
     homepage = "https://posativ.org/isso/";
     license = licenses.mit;
     maintainers = with maintainers; [ fgaz ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/servers/misc/qremotecontrol-server/default.nix
+++ b/pkgs/servers/misc/qremotecontrol-server/default.nix
@@ -54,5 +54,7 @@ stdenv.mkDerivation rec {
       keyboard, multimedia keys and buttons for starting applications. Even
       powering on the computer via Wake On Lan is supported.
     '';
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/servers/monitoring/lcdproc/default.nix
+++ b/pkgs/servers/monitoring/lcdproc/default.nix
@@ -74,5 +74,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/servers/mx-puppet-discord/default.nix
+++ b/pkgs/servers/mx-puppet-discord/default.nix
@@ -46,5 +46,7 @@ in myNodePackages.package.override {
     homepage = "https://gitlab.com/mx-puppet/discord/mx-puppet-discord";
     maintainers = with maintainers; [ expipiplus1 ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/servers/search/qdrant/default.nix
+++ b/pkgs/servers/search/qdrant/default.nix
@@ -37,5 +37,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/qdrant/qdrant";
     license = licenses.asl20;
     maintainers = with maintainers; [ dit7ya ];
+    # never built on x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/tools/archivers/gbl/default.nix
+++ b/pkgs/tools/archivers/gbl/default.nix
@@ -47,5 +47,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dac-gmbh/gbl";
     license = licenses.mit;
     maintainers = [ maintainers.raboof ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/compression/imagelol/default.nix
+++ b/pkgs/tools/compression/imagelol/default.nix
@@ -33,5 +33,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = [ maintainers.ivar ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/filesystems/securefs/default.nix
+++ b/pkgs/tools/filesystems/securefs/default.nix
@@ -42,5 +42,7 @@ stdenv.mkDerivation rec {
     '';
     license = with licenses; [ bsd2 mit ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -90,5 +90,7 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ raskin matejc ];
     platforms = lib.platforms.linux;
     license = lib.licenses.bsd3;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/graphics/esshader/default.nix
+++ b/pkgs/tools/graphics/esshader/default.nix
@@ -34,5 +34,7 @@ stdenv.mkDerivation {
     license = licenses.mit;
     maintainers = with maintainers; [ astro ];
     platforms = lib.platforms.unix;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
+++ b/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
@@ -55,5 +55,7 @@ stdenv.mkDerivation rec {
     platforms   = platforms.unix;
     license     = licenses.gpl2Only;
     maintainers = with maintainers; [ pedrohlc ];
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/misc/bmon/default.nix
+++ b/pkgs/tools/misc/bmon/default.nix
@@ -30,5 +30,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ bjornfor pSub ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/misc/cpuminer/default.nix
+++ b/pkgs/tools/misc/cpuminer/default.nix
@@ -30,5 +30,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.all;
     maintainers = with maintainers; [ pSub ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/misc/jsonwatch/default.nix
+++ b/pkgs/tools/misc/jsonwatch/default.nix
@@ -34,5 +34,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dbohdan/jsonwatch";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/misc/mynewt-newtmgr/default.nix
+++ b/pkgs/tools/misc/mynewt-newtmgr/default.nix
@@ -33,5 +33,7 @@ buildGoModule rec {
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ bezmuth ];
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/misc/usbimager/default.nix
+++ b/pkgs/tools/misc/usbimager/default.nix
@@ -43,5 +43,7 @@ stdenv.mkDerivation rec {
     # windows and darwin could work, but untested
     # feel free add them if you have a machine to test
     platforms = with platforms; linux;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/misc/vtm/default.nix
+++ b/pkgs/tools/misc/vtm/default.nix
@@ -25,5 +25,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ ahuzik ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -111,5 +111,7 @@ in buildGoModule rec {
     homepage    = "https://www.datadoghq.com";
     license     = licenses.bsd3;
     maintainers = with maintainers; [ thoughtpolice domenkozar rvl viraptor ];
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/networking/junkie/default.nix
+++ b/pkgs/tools/networking/junkie/default.nix
@@ -40,5 +40,7 @@ stdenv.mkDerivation rec {
       - a nettop tool;
       - a tool listing TLS certificates...
     '';
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/networking/netcat-openbsd/default.nix
+++ b/pkgs/tools/networking/netcat-openbsd/default.nix
@@ -44,5 +44,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.unix;
     mainProgram = "nc";
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/networking/srelay/default.nix
+++ b/pkgs/tools/networking/srelay/default.nix
@@ -20,5 +20,7 @@ stdenv.mkDerivation rec {
     homepage = "http://socks-relay.sourceforge.net/";
     platforms = lib.platforms.unix;
     license = lib.licenses.bsd3;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/networking/wrk2/default.nix
+++ b/pkgs/tools/networking/wrk2/default.nix
@@ -38,5 +38,7 @@ stdenv.mkDerivation rec {
     license     = lib.licenses.bsd3;
     platforms   = lib.platforms.linux;
     maintainers = with lib.maintainers; [ thoughtpolice ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/networking/x11-ssh-askpass/default.nix
+++ b/pkgs/tools/networking/x11-ssh-askpass/default.nix
@@ -30,5 +30,7 @@ stdenv.mkDerivation rec {
     description = "Lightweight passphrase dialog for OpenSSH or other open variants of SSH";
     license = licenses.mit;
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/security/feroxbuster/default.nix
+++ b/pkgs/tools/security/feroxbuster/default.nix
@@ -40,6 +40,8 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/epi052/feroxbuster";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }
 

--- a/pkgs/tools/security/john/default.nix
+++ b/pkgs/tools/security/john/default.nix
@@ -83,5 +83,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/openwall/john/";
     maintainers = with maintainers; [ offline matthewbauer ];
     platforms = platforms.unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/security/libacr38u/default.nix
+++ b/pkgs/tools/security/libacr38u/default.nix
@@ -38,5 +38,7 @@ stdenv.mkDerivation {
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ berce ];
     platforms = with platforms; unix;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/security/yersinia/default.nix
+++ b/pkgs/tools/security/yersinia/default.nix
@@ -58,5 +58,7 @@ stdenv.mkDerivation rec {
     # so not sure, but it could work on openbsd, illumos, and freebsd
     # if you have a machine to test with, feel free to add these
     platforms = with platforms; linux;
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -27,5 +27,7 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ mt-caret ];
     platforms = platforms.all;
+    # never built on aarch64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/tools/video/tsduck/default.nix
+++ b/pkgs/tools/video/tsduck/default.nix
@@ -79,5 +79,7 @@ stdenv.mkDerivation rec {
     license     = licenses.bsd2;
     maintainers = with maintainers; [ siriobalmelli ];
     platforms   = platforms.all;
+    # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/tools/virtualization/xe-guest-utilities/default.nix
+++ b/pkgs/tools/virtualization/xe-guest-utilities/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation (rec {
     maintainers = with lib.maintainers; [ benwbooth ];
     platforms = lib.platforms.linux;
     license = [ lib.licenses.gpl2 lib.licenses.lgpl21 ];
+    # never built on aarch64-linux since first introduction in nixpkgs
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
   src = fetchurl {
     url = "https://sources.archlinux.org/other/community/xe-guest-utilities/xe-guest-utilities_${version}-1120.tar.gz";


### PR DESCRIPTION
###### Description of changes

This is the first result of work I'm doing towards the goal explained in https://github.com/NixOS/nixpkgs/issues/185049.

This seemed like the safest set to start with, since these never worked to begin with.

I can see some packages that might not have been marked with the right platforms (when they were added to nixpkgs), but I wanted to start with this and also show that those things can be caught with this tool.

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I'm currently running `maintainers/scripts/rebuild-amount.sh` to see how much rebuilds this will cause, which hopefully will give some insight in which packages are removed (ofborg should help with that too, I guess).

Consider this a bit of an RFC as well. For packages that have not been broken forever, I still want to add some extra info in the commit message, but I wasn't sure how useful that'd be here. If you think it would really be useful to add here I could see what I can do, but I think this should be good enough for these types of packages.

Use the following links to check the build list of the packages:
- (for aarch64-darwin) https://hydra.nixos.org/job/nixpkgs/nixpkgs-unstable-aarch64-darwin/bazel_3.aarch64-darwin
- (for the other 3 platforms) https://hydra.nixos.org/job/nixpkgs/trunk/libstdcxx5.aarch64-linux

Fill in the attr and platform as you see fit in the above links.

