### PR TITLE
resholve: add usable (overridden) python27

### DIFF
--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -1,8 +1,19 @@
-{ callPackage
+{ lib
+, pkgsBuildHost
+, system
 , ...
 }:
 
 let
+  pkgs = import ../../../.. {
+    inherit system;
+    # Allow python27 with known security issues only for resholve,
+    # see issue #201859 for the reasoning
+    # In resholve case this should not be a security issue,
+    # since it will only be used during build, not runtime
+    config.permittedInsecurePackages = [ pkgsBuildHost.python27.name ];
+  };
+  callPackage = lib.callPackageWith pkgs;
   source = callPackage ./source.nix { };
   deps = callPackage ./deps.nix { };
 in

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -1,4 +1,5 @@
 { callPackage
+, python27
 , ...
 }:
 
@@ -14,5 +15,5 @@
 
 rec {
   # binlore = callPackage ./binlore.nix { };
-  oil = callPackage ./oildev.nix { };
+  oil = callPackage ./oildev.nix { inherit python27; };
 }

--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, python27Packages
+, python27
 , callPackage
 , fetchFromGitHub
 , makeWrapper
@@ -32,7 +32,7 @@ rec {
     '';
   };
 
-  py-yajl = python27Packages.buildPythonPackage rec {
+  py-yajl = python27.pkgs.buildPythonPackage rec {
     pname = "oil-pyyajl-unstable";
     version = "2019-12-05";
     src = fetchFromGitHub {
@@ -51,7 +51,7 @@ rec {
     (or accepting all of the patches we need to do so).
     This creates one without disturbing upstream too much.
   */
-  oildev = python27Packages.buildPythonPackage rec {
+  oildev = python27.pkgs.buildPythonPackage rec {
     pname = "oildev-unstable";
     version = "2021-07-14";
 
@@ -95,7 +95,7 @@ rec {
 
     nativeBuildInputs = [ re2c file makeWrapper ];
 
-    propagatedBuildInputs = with python27Packages; [ six typing ];
+    propagatedBuildInputs = with python27.pkgs; [ six typing ];
 
     doCheck = true;
 

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , callPackage
-, python27Packages
+, python27
 , installShellFiles
 , rSrc
 , version
@@ -10,7 +10,7 @@
 , resholve-utils
 }:
 
-python27Packages.buildPythonApplication {
+python27.pkgs.buildPythonApplication {
   pname = "resholve";
   inherit version;
   src = rSrc;
@@ -19,7 +19,7 @@ python27Packages.buildPythonApplication {
 
   propagatedBuildInputs = [
     oildev
-    python27Packages.configargparse
+    python27.pkgs.configargparse
   ];
 
   postPatch = ''
@@ -40,7 +40,7 @@ python27Packages.buildPythonApplication {
 
   passthru = {
     inherit (resholve-utils) mkDerivation phraseSolution writeScript writeScriptBin;
-    tests = callPackage ./test.nix { inherit rSrc binlore; };
+    tests = callPackage ./test.nix { inherit rSrc binlore python27; };
   };
 
   meta = with lib; {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1291,12 +1291,6 @@ mapAliases ({
   redis-desktop-manager = throw "'redis-desktop-manager' has been renamed to/replaced by 'resp-app'"; # Added 2022-11-10
   redshift-wlr = throw "redshift-wlr has been replaced by gammastep"; # Added 2021-12-25
   reicast = throw "reicast has been removed from nixpkgs as it is unmaintained, please use flycast instead"; # Added 2022-03-07
-
-  # 3 resholve aliases below added 2022-04-08; drop after 2022-11-30?
-  resholvePackage = throw "resholvePackage has been renamed to resholve.mkDerivation";
-  resholveScript = throw "resholveScript has been renamed to resholve.writeScript";
-  resholveScriptBin = throw "resholveScriptBin has been renamed to resholve.writeScriptBin";
-
   residualvm = throw "residualvm was merged to scummvm code in 2018-06-15; consider using scummvm"; # Added 2021-11-27
   retroArchCores = throw "retroArchCores has been removed. Please use overrides instead, e.g.: `retroarch.override { cores = with libretro; [ ... ]; }`"; # Added 2021-11-19
   retroshare06 = retroshare;


### PR DESCRIPTION
###### Description of changes

Minimum-viable-change to keep resholve (and all packages using resholve's Nix API) building after #201859.

I've also added an ~unrelated commit to clean up some old resholve aliases that just happen to be ripe for removal today.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
