### PR TITLE
webcord: init at 4.1.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/webcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/webcord/default.nix
@@ -1,0 +1,81 @@
+{ lib, stdenv, buildNpmPackage, fetchFromGitHub, copyDesktopItems
+, python3, pipewire, libpulseaudio, xdg-utils, electron_22, makeDesktopItem }:
+
+buildNpmPackage rec {
+  name = "webcord";
+  version = "4.1.1";
+
+  src = fetchFromGitHub {
+    owner = "SpacingBat3";
+    repo = "WebCord";
+    rev = "v${version}";
+    sha256 = "sha256-Buu7eKmI0UGV/9Kfj+urmDcjBtR9HSwW+mlHaYhfUa4=";
+  };
+
+  npmDepsHash = "sha256-PeoOoEljbkHynjZwocCWCTyYvIvSE1gQiABUzIiXEdM=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    python3
+  ];
+
+  libPath = lib.makeLibraryPath [
+    pipewire
+    libpulseaudio
+  ];
+
+  binPath = lib.makeBinPath [
+    xdg-utils
+  ];
+
+  # npm install will error when electron tries to download its binary
+  # we don't need it anyways since we wrap the program with our nixpkgs electron
+  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  # remove husky commit hooks, errors and aren't needed for packaging
+  postPatch = ''
+    rm -rf .husky
+  '';
+
+  # override installPhase so we can copy the only folders that matter
+  installPhase = ''
+    runHook preInstall
+
+    # Remove dev deps that aren't necessary for running the app
+    npm prune --omit=dev
+
+    mkdir -p $out/lib/node_modules/webcord
+    cp -r app node_modules sources package.json $out/lib/node_modules/webcord/
+
+    install -Dm644 sources/assets/icons/app.png $out/share/icons/hicolor/256x256/apps/webcord.png
+
+    makeWrapper '${electron_22}/bin/electron' $out/bin/webcord \
+      --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/webcord \
+      --prefix PATH : "${binPath}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}" \
+      --add-flags $out/lib/node_modules/webcord/
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "webcord";
+      exec = "webcord";
+      icon = "webcord";
+      desktopName = "WebCord";
+      comment = meta.description;
+      categories = [ "Network" "InstantMessaging" ];
+    })
+  ];
+
+  meta = with lib; {
+    description = "A Discord and Fosscord electron-based client implemented without Discord API";
+    homepage = "https://github.com/SpacingBat3/WebCord";
+    downloadPage = "https://github.com/SpacingBat3/WebCord/releases";
+    changelog = "https://github.com/SpacingBat3/WebCord/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ huantian ];
+    platforms = electron_22.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33006,6 +33006,8 @@ with pkgs;
 
   webcamoid = libsForQt5.callPackage ../applications/video/webcamoid { };
 
+  webcord = callPackage ../applications/networking/instant-messengers/webcord {};
+
   webex = callPackage ../applications/networking/instant-messengers/webex {};
 
   webmacs = libsForQt5.callPackage ../applications/networking/browsers/webmacs {};


### PR DESCRIPTION
###### Description of changes
Resolves #183061

[WebCord](https://github.com/SpacingBat3/WebCord) is a Discord and [Fosscord](https://fosscord.com/) client implemented directly without [Discord API](https://discord.com/developers/docs/reference). Made with the [Electron](https://www.electronjs.org/) framework.

Note WebCord has ARM and Darwin support; however, I have not done any testing on those platforms as I don't have any devices available to test with. Any help would be appreciated!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
