### PR TITLE
mailmap: cleanup shortlog stats for nixos-22.11 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,14 @@
+ajs124 <git@ajs124.de> <ajs124@users.noreply.github.com>
+Anderson Torres <torres.anderson.85@protonmail.com>
 Daniel Løvbrøtte Olsen <me@dandellion.xyz> <daniel.olsen99@gmail.com>
+Fabian Affolter <mail@fabian-affolter.ch> <fabian@affolter-engineering.ch>
+Janne Heß <janne@hess.ooo> <dasJ@users.noreply.github.com>
+Jörg Thalheim <joerg@thalheim.io> <Mic92@users.noreply.github.com>
+Martin Weinelt <hexa@darmstadt.ccc.de> <mweinelt@users.noreply.github.com>
 R. RyanTM <ryantm-bot@ryantm.com>
-Sandro <sandro.jaeckel@gmail.com>
+Robert Hensing <robert@roberthensing.nl> <roberth@users.noreply.github.com>
+Sandro Jäckel <sandro.jaeckel@gmail.com>
+Sandro Jäckel <sandro.jaeckel@gmail.com> <sandro.jaeckel@sap.com>
+superherointj <5861043+superherointj@users.noreply.github.com>
+Vladimír Čunát <v@cunat.cz> <vcunat@gmail.com>
+Vladimír Čunát <v@cunat.cz> <vladimir.cunat@nic.cz>


### PR DESCRIPTION
Only cleanups the shortlog stats for contributors that appeared before the changes in the top 30 and commiter names had more than 10 commits in an effort to attribute them correct
$ git shortlog -se nixos-22.05..nixos-22.11 | sort -nr | nl | head -n30

@ajs124 @AndersonTorres @fabaff @dasJ @Mic92 @mweinelt @roberth @superherointj @vcunat 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
