### PR TITLE
github-runner: make `ldd` and `ldconfig` paths absolute on Linux

### DIFF
--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -7,6 +7,7 @@
 , fetchFromGitHub
 , fetchurl
 , git
+, glibc
 , icu
 , libkrb5
 , lib
@@ -259,7 +260,12 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/lib/run.sh    --replace '"$DIR"/bin' '"$DIR"/lib'
     substituteInPlace $out/lib/config.sh --replace './bin' $out'/lib' \
       --replace 'source ./env.sh' $out/bin/env.sh
-
+  '' + lib.optionalString stdenv.isLinux ''
+    # Make binary paths absolute
+    substituteInPlace $out/lib/config.sh \
+      --replace 'ldd' '${glibc}/bin/ldd' \
+      --replace '/sbin/ldconfig' '${glibc}/bin/ldconfig'
+  '' + ''
     # Remove uneeded copy for run-helper template
     substituteInPlace $out/lib/run.sh --replace 'cp -f "$DIR"/run-helper.sh.template "$DIR"/run-helper.sh' ' '
     substituteInPlace $out/lib/run-helper.sh --replace '"$DIR"/bin/' '"$DIR"/'


### PR DESCRIPTION
###### Description of changes

The `config.sh` script started to complain about a missing `ldd`. Apparently, until recently, `glibc` was implicitly in the derivations path. This PR patches the script to call `ldd` and `ldconfig` with an absolute path on Linux.

This PR should be backported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
