### PR TITLE
nodePackages."@azure/static-web-apps-cli": init at 1.0.3

### DIFF
--- a/pkgs/development/node-packages/main-programs.nix
+++ b/pkgs/development/node-packages/main-programs.nix
@@ -15,6 +15,7 @@
   "@angular/cli" = "ng";
   "@antora/cli" = "antora";
   "@astrojs/language-server" = "astro-ls";
+  "@azure/static-web-apps-cli" = "swa";
   "@bitwarden/cli" = "bw";
   "@commitlint/cli" = "commitlint";
   "@forge/cli" = "forge";

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -5,6 +5,7 @@
 , "@antora/cli"
 , "@antora/site-generator-default"
 , "@astrojs/language-server"
+, "@azure/static-web-apps-cli"
 , "@bitwarden/cli"
 , "@commitlint/cli"
 , "@commitlint/config-conventional"

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -81,6 +81,22 @@ final: prev: {
     meta = oldAttrs.meta // { platforms = lib.platforms.linux; };
   });
 
+  "@azure/static-web-apps-cli" = prev."@azure/static-web-apps-cli".override (oldAttrs: {
+    buildInputs = with pkgs; [
+      buildPackages.makeWrapper
+      libsecret
+      pkg-config
+      final.node-gyp-build
+    ];
+    postFixup = ''
+      wrapProgram "$out/bin/swa" \
+        --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+        --prefix PATH : "$out/bin"
+      substituteInPlace $out/lib/node_modules/@azure/static-web-apps-cli/node_modules/spawn-command/lib/spawn-command.js \
+        --replace "/bin/sh" "${pkgs.bash}/bin/bash"
+    '';
+  });
+
   balanceofsatoshis = prev.balanceofsatoshis.override {
     nativeBuildInputs = [ pkgs.installShellFiles ];
     postInstall = ''


### PR DESCRIPTION
###### Description of changes
Add the static-web-apps-cli to deploy static web apps to the Microsoft Azure cloud
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
