### PR TITLE
klibc: 2.0.10 -> 2.0.11

### DIFF
--- a/pkgs/os-specific/linux/klibc/default.nix
+++ b/pkgs/os-specific/linux/klibc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, buildPackages, linuxHeaders, perl }:
+{ lib, stdenv, fetchurl, buildPackages, linuxHeaders, perl, nixosTests }:
 
 let
   commonMakeFlags = [
@@ -42,6 +42,11 @@ stdenv.mkDerivation rec {
       ln -sv $file $out/lib/klibc/include
     done
   '';
+
+  passthru.tests = {
+    # uses klibc's ipconfig
+    inherit (nixosTests) initrd-network-ssh;
+  };
 
   meta = {
     description = "Minimalistic libc subset for initramfs usage";

--- a/pkgs/os-specific/linux/klibc/default.nix
+++ b/pkgs/os-specific/linux/klibc/default.nix
@@ -9,11 +9,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "klibc";
-  version = "2.0.10";
+  version = "2.0.11";
 
   src = fetchurl {
     url = "mirror://kernel/linux/libs/klibc/2.0/klibc-${version}.tar.xz";
-    sha256 = "sha256-ZidT2oiJ50TfwNtutAIcM3fufvjtZtfVd2X4yeJZOc0=";
+    hash = "sha256-XrMOXh7HPcTjhMYLuUOvicUxdMgvh3Ev3TTdMoZNX2A=";
   };
 
   patches = [ ./no-reinstall-kernel-headers.patch ];

--- a/pkgs/os-specific/linux/klibc/no-reinstall-kernel-headers.patch
+++ b/pkgs/os-specific/linux/klibc/no-reinstall-kernel-headers.patch
@@ -1,11 +1,12 @@
-diff -Naur klibc-2.0.3-orig/scripts/Kbuild.install klibc-2.0.3/scripts/Kbuild.install
---- klibc-2.0.3-orig/scripts/Kbuild.install	2013-12-03 13:53:46.000000000 -0500
-+++ klibc-2.0.3/scripts/Kbuild.install	2014-01-04 18:17:09.342609021 -0500
-@@ -95,7 +95,6 @@
+diff --git a/scripts/Kbuild.install b/scripts/Kbuild.install
+index 0788637f..6708e19f 100644
+--- a/scripts/Kbuild.install
++++ b/scripts/Kbuild.install
+@@ -102,7 +102,6 @@ header:
  	$(Q)mkdir -p $(INSTALLROOT)$(INSTALLDIR)/$(KCROSS)include
  	$(Q)mkdir -p $(INSTALLROOT)$(INSTALLDIR)/$(KCROSS)lib
  	$(Q)mkdir -p $(INSTALLROOT)$(INSTALLDIR)/$(KCROSS)bin
 -	$(Q)cp -rfL $(KLIBCKERNELSRC)/include/. $(INSTALLROOT)$(INSTALLDIR)/$(KCROSS)include/.
- 	$(Q)cp -rf usr/include/. $(INSTALLROOT)$(INSTALLDIR)/$(KCROSS)include/.
- 	$(Q)chmod -R a+rX $(INSTALLROOT)$(INSTALLDIR)/$(KCROSS)include
- 	$(Q)$(install-data) $(srctree)/klcc/klcc.1 $(INSTALLROOT)$(mandir)/man1/$(KCROSS)klcc.1
+ ifneq ($(srctree),$(objtree))
+ 	$(Q)cp -rf $(srctree)/usr/include/. $(INSTALLROOT)$(INSTALLDIR)/$(KCROSS)include/.
+ endif


### PR DESCRIPTION
###### Description of changes

Changelog: https://lists.zytor.com/archives/klibc/2022-October/004689.html

Had to rebase the no-reinstall-kernel-headers.patch

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) - nixos/tests/initrd-network-ssh
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 204080` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.hardkernel_4_14.v86d</li>
    <li>linuxPackages_hardkernel_latest.v86d</li>
  </ul>
</details>
<details>
  <summary>20 packages built:</summary>
  <ul>
    <li>klibc</li>
    <li>klibcShrunk</li>
    <li>linuxKernel.packages.linux_4_14.v86d</li>
    <li>linuxPackages_4_14_hardened.v86d (linuxKernel.packages.linux_4_14_hardened.v86d)</li>
    <li>linuxKernel.packages.linux_4_19.v86d</li>
    <li>linuxPackages_4_19_hardened.v86d (linuxKernel.packages.linux_4_19_hardened.v86d)</li>
    <li>linuxKernel.packages.linux_5_10.v86d</li>
    <li>linuxPackages_5_10_hardened.v86d (linuxKernel.packages.linux_5_10_hardened.v86d)</li>
    <li>linuxPackages.v86d (linuxKernel.packages.linux_5_15.v86d)</li>
    <li>linuxPackages_hardened.v86d (linuxPackages_5_15_hardened.v86d)</li>
    <li>linuxKernel.packages.linux_5_4.v86d</li>
    <li>linuxPackages_latest.v86d (linuxKernel.packages.linux_6_0.v86d)</li>
    <li>linuxKernel.packages.linux_6_0_hardened.v86d</li>
    <li>linuxPackages_latest-libre.v86d (linuxKernel.packages.linux_latest_libre.v86d)</li>
    <li>linuxPackages-libre.v86d (linuxKernel.packages.linux_libre.v86d)</li>
    <li>linuxPackages_lqx.v86d (linuxKernel.packages.linux_lqx.v86d)</li>
    <li>linuxPackages_testing_bcachefs.v86d (linuxKernel.packages.linux_testing_bcachefs.v86d)</li>
    <li>linuxPackages_xanmod.v86d (linuxKernel.packages.linux_xanmod.v86d)</li>
    <li>linuxPackages_xanmod_latest.v86d (linuxKernel.packages.linux_xanmod_latest.v86d ,linuxPackages_xanmod_stable.v86d)</li>
    <li>linuxPackages_zen.v86d (linuxKernel.packages.linux_zen.v86d)</li>
  </ul>
</details>
