### PR TITLE
lib/strings: simplify `splitString`

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -510,7 +510,7 @@ rec {
   toUpper = replaceChars lowerChars upperChars;
 
   /* Appends string context from another string.  This is an implementation
-     detail of Nix.
+     detail of Nix and should be used carefully.
 
      Strings in Nix carry an invisible `context` which is a list of strings
      representing store paths.  If the string is later used in a derivation
@@ -533,13 +533,11 @@ rec {
        splitString "/" "/usr/local/bin"
        => [ "" "usr" "local" "bin" ]
   */
-  splitString = _sep: _s:
+  splitString = sep: s:
     let
-      sep = builtins.unsafeDiscardStringContext _sep;
-      s = builtins.unsafeDiscardStringContext _s;
-      splits = builtins.filter builtins.isString (builtins.split (escapeRegex sep) s);
+      splits = builtins.filter builtins.isString (builtins.split (escapeRegex (toString sep)) (toString s));
     in
-      map (v: addContextFrom _sep (addContextFrom _s v)) splits;
+      map (addContextFrom s) splits;
 
   /* Return a string without the specified prefix, if the prefix matches.
 


### PR DESCRIPTION
There's no need to use `unsafeDiscardStringContext` since https://github.com/NixOS/nix/commit/ee7fe64c0ac00f2be11604a2a6509eb86dc19f0a (Nix 1.8).

Also the separator can't have a context since `builtins.split` would fail, so we can assume it doesn't.

See https://github.com/NixOS/nixpkgs/pull/2883#issuecomment-45606278