### PR TITLE
dictdDBs.wiktionary, dictdDBs.wordnet: make independent of CPython2

### DIFF
--- a/pkgs/servers/dict/dictd-wordnet.nix
+++ b/pkgs/servers/dict/dictd-wordnet.nix
@@ -1,5 +1,6 @@
-{lib, stdenv, python2, wordnet, writeScript}:
+{lib, stdenv, pypy2, wordnet, writeScript}:
 
+let python2 = pypy2; in
 stdenv.mkDerivation rec {
   version = "542";
   pname = "dict-db-wordnet";
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
       DATA="$DATA `echo $i | sed -e s,data,index,` $i";
     done
 
-    python ${convert} $DATA
+    ${python2.interpreter} ${convert} $DATA
     echo en_US.UTF-8 > locale
   '';
 

--- a/pkgs/servers/dict/wiktionary/default.nix
+++ b/pkgs/servers/dict/wiktionary/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, fetchurl, python2, dict, glibcLocales }:
+{ lib, stdenv, fetchurl, pypy2, dict, glibcLocales }:
 
+let python2 = pypy2; in
 stdenv.mkDerivation rec {
   pname = "dict-db-wiktionary";
   version = "20220420";


### PR DESCRIPTION
###### Description of changes

Trivial change, will self-merge eventually

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
