### PR TITLE
vsce: init at 2.15.0

### DIFF
--- a/pkgs/development/tools/vsce/default.nix
+++ b/pkgs/development/tools/vsce/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, buildNpmPackage
+, fetchFromGitHub
+, pkg-config
+, libsecret
+, python3
+, testers
+, vsce
+}:
+
+buildNpmPackage rec {
+  pname = "vsce";
+  version = "2.15.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vscode-vsce";
+    rev = "v${version}";
+    hash = "sha256-WDKOHQV6J22l0ELmXwl5BC5x7MsI6TAMeU3oBFpwqx4=";
+  };
+
+  npmDepsHash = "sha256-i2LpQ/4MwkUGTUhih0ybLv5np45j7m4kCx9IOBIgtXo=";
+
+  postPatch = ''
+    substituteInPlace package.json --replace '"version": "0.0.0"' '"version": "${version}"'
+  '';
+
+  nativeBuildInputs = [ pkg-config python3 ];
+
+  buildInputs = [ libsecret ];
+
+  makeCacheWritable = true;
+  npmFlags = [ "--legacy-peer-deps" ];
+
+  passthru.tests.version = testers.testVersion {
+    package = vsce;
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/microsoft/vscode-vsce";
+    description = "Visual Studio Code Extension Manager";
+    maintainers = with maintainers; [ aaronjheng ];
+    license = licenses.mit;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32936,6 +32936,8 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
+  vsce = callPackage ../development/tools/vsce { };
+
   vscode = callPackage ../applications/editors/vscode/vscode.nix { };
   vscode-fhs = vscode.fhs;
   vscode-fhsWithPackages = vscode.fhsWithPackages;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
