### PR TITLE
testers.testBuildFailure: Read last log line without final newline

### DIFF
--- a/pkgs/build-support/testers/expect-failure.sh
+++ b/pkgs/build-support/testers/expect-failure.sh
@@ -21,7 +21,7 @@ set -eu
 echo "testBuildFailure: Expecting non-zero exit from builder and args: ${*@Q}"
 
 ("$@" 2>&1) | @coreutils@/bin/tee $TMPDIR/testBuildFailure.log \
-  | while read ln; do
+  | while IFS= read -r ln; do
     echo "original builder: $ln"
   done
 

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -29,15 +29,24 @@ lib.recurseIntoAttrs {
     happy = runCommand "testBuildFailure-happy" {
       failed = testers.testBuildFailure (runCommand "fail" {} ''
         echo ok-ish >$out
+
         echo failing though
         echo also stderr 1>&2
+        echo 'line\nwith-\bbackslashes'
+        printf "incomplete line - no newline"
+
         exit 3
       '');
     } ''
+      grep -F 'ok-ish' $failed/result
+
       grep -F 'failing though' $failed/testBuildFailure.log
       grep -F 'also stderr' $failed/testBuildFailure.log
-      grep -F 'ok-ish' $failed/result
+      grep -F 'line\nwith-\bbackslashes' $failed/testBuildFailure.log
+      grep -F 'incomplete line - no newline' $failed/testBuildFailure.log
+
       [[ 3 = $(cat $failed/testBuildFailure.exit) ]]
+
       touch $out
     '';
 


### PR DESCRIPTION
###### Description of changes

Read last log line despite missing final newline

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
