### PR TITLE
topiary: init at unstable-2022-12-02

### DIFF
--- a/pkgs/development/tools/misc/topiary/default.nix
+++ b/pkgs/development/tools/misc/topiary/default.nix
@@ -1,0 +1,28 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "topiary";
+  version = "unstable-2022-12-02";
+
+  src = fetchFromGitHub {
+    owner = "tweag";
+    repo = pname;
+    rev = "ae861a30097bd6297f553eb0ea2597f86f16d156";
+    sha256 = "sha256-WVrl+LxWSbHkbFGbkUhmw4Klwg6CzfnLAz8F0mF0kb8=";
+  };
+
+  cargoSha256 = "sha256-qoCOcYp1NYz/YhIBP6AkCCudVLpqhztRehc2xZoYp9A=";
+
+  postInstall = ''
+    install -Dm444 languages/* -t $out/share/languages
+  '';
+
+  TOPIARY_LANGUAGE_DIR = "${placeholder "out"}/share/languages";
+
+  meta = with lib; {
+    description = "A uniform formatter for simple languages, as part of the Tree-sitter ecosystem";
+    homepage = "https://github.com/tweag/topiary";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12246,6 +12246,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Foundation;
   };
 
+  topiary = callPackage ../development/tools/misc/topiary { };
+
   todo = callPackage ../tools/misc/todo { };
 
   tor = callPackage ../tools/security/tor { };


### PR DESCRIPTION
###### Description of changes

https://github.com/tweag/topiary
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
