### PR TITLE
azure-static-sites-client: init at 1.0.021731

### DIFF
--- a/pkgs/development/tools/azure-static-sites-client/default.nix
+++ b/pkgs/development/tools/azure-static-sites-client/default.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, curl
+, icu70
+, libkrb5
+, lttng-ust
+, openssl_1_1
+, zlib
+, azure-static-sites-client
+  # "latest", "stable" or "backup"
+, versionFlavor ? "stable"
+}:
+let
+  versions = lib.importJSON ./versions.json;
+  flavor = with lib; head (filter (x: x.version == versionFlavor) versions);
+  fetchBinary = runtimeId: fetchurl {
+    url = flavor.files.${runtimeId}.url;
+    sha256 = flavor.files.${runtimeId}.sha;
+  };
+  sources = {
+    "x86_64-linux" = fetchBinary "linux-x64";
+    "x86_64-darwin" = fetchBinary "macOS";
+  };
+in
+stdenv.mkDerivation {
+  pname = "StaticSitesClient-${versionFlavor}";
+  version = flavor.buildId;
+
+  src = sources.${stdenv.targetPlatform.system} or (throw "Unsupported platform");
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    curl
+    icu70
+    openssl_1_1
+    libkrb5
+    lttng-ust
+    stdenv.cc.cc.lib
+    zlib
+  ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m755 "$src" -D "$out/bin/StaticSitesClient"
+
+    for icu_lib in 'icui18n' 'icuuc' 'icudata'; do
+      patchelf --add-needed "lib''${icu_lib}.so.${with lib; head (splitVersion (getVersion icu70.name))}" "$out/bin/StaticSitesClient"
+    done
+
+    patchelf --add-needed 'libgssapi_krb5.so' \
+             --add-needed 'liblttng-ust.so'   \
+             --add-needed 'libssl.so.1.1'     \
+             "$out/bin/StaticSitesClient"
+
+    runHook postInstall
+  '';
+
+  # Stripping kills the binary
+  dontStrip = true;
+
+  # Just make sure the binary executes sucessfully
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/StaticSitesClient version
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    # Create tests for all flavors
+    tests = with lib; genAttrs (map (x: x.version) versions) (versionFlavor:
+      azure-static-sites-client.override { inherit versionFlavor; }
+    );
+    updateScript = ./update.sh;
+  };
+
+  meta = with lib; {
+    description = "Azure static sites client";
+    homepage = "https://github.com/Azure/static-web-apps-cli";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    mainProgram = "StaticSitesClient";
+    maintainers = with maintainers; [ veehaitch ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/azure-static-sites-client/update.sh
+++ b/pkgs/development/tools/azure-static-sites-client/update.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl
+
+set -euo pipefail
+
+dirname="$(dirname "$0")"
+
+curl -O --silent --output-dir "$dirname" 'https://swalocaldeploy.azureedge.net/downloads/versions.json'
+echo "" >> "$dirname/versions.json"

--- a/pkgs/development/tools/azure-static-sites-client/versions.json
+++ b/pkgs/development/tools/azure-static-sites-client/versions.json
@@ -1,0 +1,59 @@
+[
+  {
+    "version": "latest",
+    "buildId": "1.0.021731",
+    "publishDate": "2022-12-14T02:22:20.0230853Z",
+    "files": {
+      "linux-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021731/linux/StaticSitesClient",
+        "sha": "d2f88cf8b855169534c7e330dd95385b993b1c0f83331306e685faa8468a82b5"
+      },
+      "win-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021731/windows/StaticSitesClient.exe",
+        "sha": "525d13ebffd79ea9663a15a4bd2e6d49bca72d20aa44838aa4b83133943d450c"
+      },
+      "osx-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021731/macOS/StaticSitesClient",
+        "sha": "5de3ac4b205d3871e7a8ff3b5869f2a57002277ac7fa6317032239d114e25ab8"
+      }
+    }
+  },
+  {
+    "version": "stable",
+    "buildId": "1.0.021731",
+    "publishDate": "2022-12-14T02:22:20.0230853Z",
+    "files": {
+      "linux-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021731/linux/StaticSitesClient",
+        "sha": "d2f88cf8b855169534c7e330dd95385b993b1c0f83331306e685faa8468a82b5"
+      },
+      "win-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021731/windows/StaticSitesClient.exe",
+        "sha": "525d13ebffd79ea9663a15a4bd2e6d49bca72d20aa44838aa4b83133943d450c"
+      },
+      "osx-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021731/macOS/StaticSitesClient",
+        "sha": "5de3ac4b205d3871e7a8ff3b5869f2a57002277ac7fa6317032239d114e25ab8"
+      }
+    }
+  },
+  {
+    "version": "backup",
+    "buildId": "1.0.021671",
+    "publishDate": "2022-12-08T00:34:47.6310685Z",
+    "files": {
+      "linux-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021671/linux/StaticSitesClient",
+        "sha": "306c2d24cbc6461cdf1fe29e9206ccb9d452ba3514ee9d67a1d7e0f8edbc036f"
+      },
+      "win-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021671/windows/StaticSitesClient.exe",
+        "sha": "ee868ca5e73a6ad8758698c168bb01d07b66288d353813fefe41d441f82b9f1f"
+      },
+      "osx-x64": {
+        "url": "https://swalocaldeploy.azureedge.net/downloads/1.0.021671/macOS/StaticSitesClient",
+        "sha": "5ef513530a45d4b8e135e272f7e7112e900fbb8c8137c19e645a694e71b98c74"
+      }
+    }
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2667,6 +2667,8 @@ with pkgs;
 
   azure-functions-core-tools = callPackage ../development/tools/azure-functions-core-tools { };
 
+  azure-static-sites-client = callPackage ../development/tools/azure-static-sites-client { };
+
   azure-storage-azcopy = callPackage ../development/tools/azcopy { };
 
   bashblog = callPackage ../tools/text/bashblog { };


### PR DESCRIPTION
###### Description of changes

Binary for Azure static web apps. More information [here](https://github.com/Azure/static-web-apps-cli/blob/2cd0e980ea4bf604df10fd5d63149b20b292e916/docs/www/docs/contribute/99-troubleshooting.md#unable-to-download-staticsitesclient-binary-file-not-found-404---403).

In theory, should work for `x86_64-darwin` as well but this PR only introduces support for `x86-64-linux`.

Tested deployment with `./StaticSitesClient upload`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
