### PR TITLE
[22.11] subsurface: 5.0.2 -> 5.0.10 and unbreak build

### DIFF
--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -1,17 +1,38 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, cmake, wrapQtAppsHook, pkg-config, qmake
-, curl, grantlee, libgit2, libusb-compat-0_1, libssh2, libxml2, libxslt, libzip, zlib
-, qtbase, qtconnectivity, qtlocation, qtsvg, qttools, qtwebkit, libXcomposite
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, writeShellScriptBin
+, cmake
+, wrapQtAppsHook
+, pkg-config
+, qmake
+, curl
+, grantlee
+, libgit2
+, libssh2
+, libxml2
+, libxslt
+, libzip
+, zlib
+, qtbase
+, qtconnectivity
+, qtlocation
+, qtsvg
+, qttools
+, qtwebengine
+, libXcomposite
 , bluez
 }:
 
 let
-  version = "5.0.2";
+  version = "5.0.10";
 
   subsurfaceSrc = (fetchFromGitHub {
     owner = "Subsurface";
     repo = "subsurface";
     rev = "v${version}";
-    sha256 = "1yay06m8p9qp2ghrg8dxavdq55y09apcgdnb7rihgs3hq86k539n";
+    hash = "sha256-KzUBhFGvocaS1VrVT2stvKrj3uVxYka+dyYZUfkIoNs=";
     fetchSubmodules = true;
   });
 
@@ -21,7 +42,7 @@ let
 
     src = subsurfaceSrc;
 
-    prePatch = "cd libdivecomputer";
+    sourceRoot = "source/libdivecomputer";
 
     nativeBuildInputs = [ autoreconfHook ];
 
@@ -30,7 +51,7 @@ let
     enableParallelBuilding = true;
 
     meta = with lib; {
-      homepage = "http://www.libdivecomputer.org";
+      homepage = "https://www.libdivecomputer.org";
       description = "A cross-platform and open source library for communication with dive computers from various manufacturers";
       maintainers = with maintainers; [ mguentner ];
       license = licenses.lgpl21;
@@ -40,14 +61,13 @@ let
 
   googlemaps = stdenv.mkDerivation rec {
     pname = "googlemaps";
-
-    version = "2021-03-19";
+    version = "0.0.0.2";
 
     src = fetchFromGitHub {
       owner = "vladest";
       repo = "googlemaps";
-      rev = "8f7def10c203fd3faa5ef96c5010a7294dca0759";
-      sha256 = "1irz398g45hk6xizwzd07qcx1ln8f7l6bhjh15f56yc20waqpx1x";
+      rev = "v.${version}";
+      hash = "sha256-PfSLFQeCeVNcCVDCZehxyNLQGT6gff5jNxMW8lAaP8c=";
     };
 
     nativeBuildInputs = [ qmake ];
@@ -74,17 +94,37 @@ let
     };
   };
 
-in stdenv.mkDerivation {
+  get-version = writeShellScriptBin "get-version" ''
+    echo -n ${version}
+  '';
+
+in
+stdenv.mkDerivation {
   pname = "subsurface";
   inherit version;
 
   src = subsurfaceSrc;
 
+  postPatch = ''
+    install -m555 -t scripts ${lib.getExe get-version}
+  '';
+
   buildInputs = [
-    libdc googlemaps
-    curl grantlee libgit2 libssh2 libusb-compat-0_1 libxml2 libxslt libzip
-    qtbase qtconnectivity qtsvg qttools qtwebkit
     bluez
+    curl
+    googlemaps
+    grantlee
+    libdc
+    libgit2
+    libssh2
+    libxml2
+    libxslt
+    libzip
+    qtbase
+    qtconnectivity
+    qtsvg
+    qttools
+    qtwebengine
   ];
 
   nativeBuildInputs = [ cmake wrapQtAppsHook pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11694,7 +11694,7 @@ with pkgs;
 
   subgit = callPackage ../applications/version-management/git-and-tools/subgit { };
 
-  subsurface = libsForQt514.callPackage ../applications/misc/subsurface { };
+  subsurface = libsForQt5.callPackage ../applications/misc/subsurface { };
 
   sudo = callPackage ../tools/security/sudo { };
 


### PR DESCRIPTION
###### Description of changes

backport of #202145

Necessary in 22.11, as it removes the dependency on the broken qtwebkit (#201028) and replaces it by qtwebengine.

The build result of this PR could even be substituted from the binary cache, indicating it is equivalent with the state of master at some point.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
