### PR TITLE
nixos/installer/cd-dvd: use filtered nixpkgs source

### DIFF
--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -6,6 +6,12 @@
 with lib;
 
 let
+  # This is copied into the installer image, so it's important that it is filtered
+  # to avoid including a large .git directory.
+  # We also want the source name to be normalised to "source" to avoid depending on the
+  # location of nixpkgs.
+  # In the future we might want to expose the ISO image from the flake and use
+  # `self.outPath` directly instead.
   nixpkgs = lib.cleanSource pkgs.path;
 
   # We need a copy of the Nix expressions for Nixpkgs and NixOS on the
@@ -31,7 +37,14 @@ let
 in
 
 {
-  nix.registry.nixpkgs.flake.outPath = builtins.path { name = "source"; path = pkgs.path; };
+  # Pin the nixpkgs flake in the installer to our cleaned up nixpkgs source.
+  # FIXME: this might be surprising and is really only needed for offline installations,
+  # see discussion in https://github.com/NixOS/nixpkgs/pull/204178#issuecomment-1336289021
+  nix.registry.nixpkgs.to = {
+    type = "path";
+    path = nixpkgs;
+  };
+
   # Provide the NixOS/Nixpkgs sources in /etc/nixos.  This is required
   # for nixos-install.
   boot.postBootCommands = mkAfter


### PR DESCRIPTION
I was quite surprised when building the minimal ISO image resulted in a 3.8 GiB image (instead of ~800 MiB). This was because the `nixpkgs` registry entry pinned in `channel.nix` copies the entire `pkgs.path` directory, including `.git`.

Let's use the already available clean nixpkgs source instead.

This is still not great reproducibility-wise since *untracked* files will still be included. The next step would be to build the ISO using the flake, but it is not exposed in `flake.nix` currently. I'll look into this in a later PR.

Tested on a VPS.