### PR TITLE
headscale: 0.16.4 -> 0.17.0

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -188,6 +188,15 @@ in
         };
       };
 
+      logFormat = mkOption {
+        type = types.str;
+        default = "text";
+        description = lib.mdDoc ''
+          'text' or 'json'
+        '';
+        example = "json";
+      };
+
       logLevel = mkOption {
         type = types.str;
         default = "info";
@@ -369,8 +378,11 @@ in
       db_type = mkDefault cfg.database.type;
       db_path = mkDefault cfg.database.path;
 
-      log_level = mkDefault cfg.logLevel;
-
+      log {
+        format = mkDefault cfg.logFormat;
+        level = mkDefault cfg.logLevel;
+      };
+      
       dns_config = {
         nameservers = mkDefault cfg.dns.nameservers;
         domains = mkDefault cfg.dns.domains;

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -378,7 +378,7 @@ in
       listen_addr = mkDefault "${cfg.address}:${toString cfg.port}";
 
       private_key_path = mkDefault cfg.privateKeyFile;
-      
+
       noise = {
         private_key_path = mkDefault cfg.NoiseprivateKeyFile;
       };
@@ -403,7 +403,7 @@ in
         format = mkDefault cfg.logFormat;
         level = mkDefault cfg.logLevel;
       };
-      
+
       dns_config = {
         nameservers = mkDefault cfg.dns.nameservers;
         override_local_dns = mkDefault cfg.dns.overrideLocalDns;

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -215,6 +215,15 @@ in
           '';
         };
 
+        overrideLocalDns = mkOption {
+          type = types.bool;
+          default = false;
+          description = lib.mdDoc ''
+            Whether to use [Override local DNS](https://tailscale.com/kb/1054/dns/).
+          '';
+          example = true;
+        };
+
         domains = mkOption {
           type = types.listOf types.str;
           default = [ ];
@@ -385,6 +394,7 @@ in
       
       dns_config = {
         nameservers = mkDefault cfg.dns.nameservers;
+        override_local_dns = mkDefault cfg.dns.overrideLocalDns;
         domains = mkDefault cfg.dns.domains;
         magic_dns = mkDefault cfg.dns.magicDns;
         base_domain = mkDefault cfg.dns.baseDomain;

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -387,7 +387,7 @@ in
       db_type = mkDefault cfg.database.type;
       db_path = mkDefault cfg.database.path;
 
-      log {
+      log = {
         format = mkDefault cfg.logFormat;
         level = mkDefault cfg.logLevel;
       };

--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -86,6 +86,14 @@ in
         '';
       };
 
+      NoisePrivateKeyFile = mkOption {
+        type = types.path;
+        default = "${dataDir}/noise_private.key";
+        description = lib.mdDoc ''
+          Path to Noise private key file, generated automatically if it does not exist.
+        '';
+      };
+
       derp = {
         urls = mkOption {
           type = types.listOf types.str;
@@ -370,6 +378,10 @@ in
       listen_addr = mkDefault "${cfg.address}:${toString cfg.port}";
 
       private_key_path = mkDefault cfg.privateKeyFile;
+      
+      noise = {
+        private_key_path = mkDefault cfg.NoiseprivateKeyFile;
+      };
 
       derp = {
         urls = mkDefault cfg.derp.urls;

--- a/pkgs/servers/headscale/default.nix
+++ b/pkgs/servers/headscale/default.nix
@@ -44,6 +44,6 @@ buildGoModule rec {
       Headscale implements this coordination server.
     '';
     license = licenses.bsd3;
-    maintainers = with maintainers; [ nkje jk kradalby ];
+    maintainers = with maintainers; [ nkje jk kradalby ghuntley ];
   };
 }

--- a/pkgs/servers/headscale/default.nix
+++ b/pkgs/servers/headscale/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "headscale";
-  version = "0.16.4";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "juanfont";


### PR DESCRIPTION
###### Description of changes

nb: I made these changes in the GitHub web editor and have not tested (go go GitHub Actions + Integration tests) so please adjust as need be in my branch. 

1. Version bump https://github.com/juanfont/headscale to https://github.com/juanfont/headscale/releases/tag/v0.17.0
2. Implements breaking change `noise.private_key_path has been added and is required for the new noise protocol.`
3. Implements breaking change https://github.com/juanfont/headscale/pull/768
4. Implements https://github.com/juanfont/headscale/pull/905
5. Contains security fix https://github.com/juanfont/headscale/pull/823


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
