### PR TITLE
Cinnamon updates 2022-12-02

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -74,6 +74,10 @@ in
           name = mkDefault "Mint-X-Dark";
           package = mkDefault pkgs.cinnamon.mint-x-icons;
         };
+        cursorTheme = mkIf (notExcluded pkgs.cinnamon.mint-cursor-themes) {
+          name = mkDefault "Bibata-Modern-Classic";
+          package = mkDefault pkgs.cinnamon.mint-cursor-themes;
+        };
       };
       services.xserver.displayManager.sessionCommands = ''
         if test "$XDG_CURRENT_DESKTOP" = "Cinnamon"; then

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/slick.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/slick.nix
@@ -11,6 +11,7 @@ let
   theme = cfg.theme.package;
   icons = cfg.iconTheme.package;
   font = cfg.font.package;
+  cursors = cfg.cursorTheme.package;
 
   slickGreeterConf = writeText "slick-greeter.conf" ''
     [Greeter]
@@ -18,6 +19,8 @@ let
     theme-name=${cfg.theme.name}
     icon-theme-name=${cfg.iconTheme.name}
     font-name=${cfg.font.name}
+    cursor-theme-name=${cfg.cursorTheme.name}
+    cursor-theme-size=${toString cfg.cursorTheme.size}
     draw-user-backgrounds=${boolToString cfg.draw-user-backgrounds}
     ${cfg.extraConfig}
   '';
@@ -84,6 +87,33 @@ in
         };
       };
 
+      cursorTheme = {
+        package = mkOption {
+          type = types.package;
+          default = pkgs.gnome.adwaita-icon-theme;
+          defaultText = literalExpression "pkgs.gnome.adwaita-icon-theme";
+          description = lib.mdDoc ''
+            The package path that contains the cursor theme given in the name option.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "Adwaita";
+          description = lib.mdDoc ''
+            Name of the cursor theme to use for the lightdm-slick-greeter.
+          '';
+        };
+
+        size = mkOption {
+          type = types.int;
+          default = 24;
+          description = lib.mdDoc ''
+            Size of the cursor theme to use for the lightdm-slick-greeter.
+          '';
+        };
+      };
+
       draw-user-backgrounds = mkEnableOption (lib.mdDoc "draw user backgrounds");
 
       extraConfig = mkOption {
@@ -107,6 +137,7 @@ in
     };
 
     environment.systemPackages = [
+      cursors
       icons
       theme
     ];

--- a/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-slick-greeter/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "1.5.9";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    sha256 = "sha256-UEzidH4ZWggcOWHHuAclHbbgATDBdogL99Ze0PlwRoc=";
+    sha256 = "sha256-XoGha0DyrtrGXW72Zvnk1FrvULPMYc0FvQj4JFSKxXo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/sticky/default.nix
+++ b/pkgs/applications/misc/sticky/default.nix
@@ -12,14 +12,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "sticky";
-  version = "1.12";
+  version = "1.13";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-kAO8Qz4bTn3+YeIXAvPZ1SpKgn+g+rBgi9+TaqL1vOY=";
+    hash = "sha256-oirTDIbvG9/iAkYrquX+ciujAnLUmubkBVvTyaiz2g8=";
   };
 
   postPatch = ''

--- a/pkgs/applications/video/hypnotix/default.nix
+++ b/pkgs/applications/video/hypnotix/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hypnotix";
-  version = "3.0";
+  version = "3.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "hypnotix";
     rev = version;
-    hash = "sha256-ZSHChUkd1yXVGNUotzyZ9eB7s3apwvRmEJcO5J0vsZQ=";
+    hash = "sha256-hCVItxvYTE0G5inI/A4w4FYfSfrACINBSaKXhA1mh4A=";
   };
 
   patches = [

--- a/pkgs/desktops/cinnamon/bulky/default.nix
+++ b/pkgs/desktops/cinnamon/bulky/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bulky";
-  version = "2.5";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "bulky";
     rev = version;
-    hash = "sha256-WgpB/oMA3w7KO7KmkGXsl92siFGQo3Y4mLvMLTi54k8=";
+    hash = "sha256-OI7sIPMZOTmVoWj4Y7kEH0mxay4DwO5kPjclgRDVMus=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-screensaver/default.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cinnamon-screensaver";
-  version = "5.6.1";
+  version = "5.6.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-dnfUvRlmsdUXfjAxPv+i/uJ8kr0LQ/i7ClUMtjjIWMo=";
+    hash = "sha256-xsxNGDFiBzVtoCV94iUuia45FRJGyGO522u6p1AIR6g=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/mint-artwork/default.nix
+++ b/pkgs/desktops/cinnamon/mint-artwork/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mint-artwork";
-  version = "1.7.0";
+  version = "1.7.2";
 
   src = fetchurl {
     urls = [
       "http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz"
-      "https://web.archive.org/web/20221130011545/http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz"
+      "https://web.archive.org/web/20221203023403/http://packages.linuxmint.com/pool/main/m/mint-artwork/mint-artwork_${version}.tar.xz"
     ];
-    hash = "sha256-1dBLsN9nTzrqitlwoobYnjh1qKXR6UOaDsTkBMfnX1k=";
+    hash = "sha256-I8gLWwwuXZkgc5zZ9QVkSarugcNWLFIz2mU1d4QqJRU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/warpinator/default.nix
+++ b/pkgs/desktops/cinnamon/warpinator/default.nix
@@ -15,7 +15,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "warpinator";
-  version = "1.4.1";
+  version = "1.4.2";
 
   format = "other";
 
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication rec  {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-gZ19WVolm8uoDZcX3OgLGkB8nFUPZIwCmKGQop9/xJ8=";
+    hash = "sha256-aiHlBeWGYqSaqvRtwL7smqt4iueIKzQoDawdFSCn6eg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/cinnamon/xapp/default.nix
+++ b/pkgs/desktops/cinnamon/xapp/default.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xapp";
-  version = "2.4.1";
+  version = "2.4.2";
 
   outputs = [ "out" "dev" ];
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = pname;
     rev = version;
-    hash = "sha256-c86n3aYSS3Klm2HtN8dIN5UvL6Jxz9y1fMF1QAefCIg=";
+    hash = "sha256-etB+q7FIwbApTUk8RohAy3kHX8Vb4cSY/qkvhj94yTM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Slick greeter now supports cursor theme settings because mint want to set its own cursor in mint-artwork.
Other updates here are basically translation updates.

Previous one: https://github.com/NixOS/nixpkgs/pull/203589

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
