### PR TITLE
haskellPackages.cryptonite: fix compilation with avx

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -182,4 +182,12 @@ self: super: {
 
   # Needs OneTuple for ghc < 9.2
   binary-orphans = addBuildDepends [ self.OneTuple ] super.binary-orphans;
+
+  # fix build with avx, see https://github.com/haskell-crypto/cryptonite/issues/347
+  # https://github.com/haskell-crypto/cryptonite/pull/373
+  cryptonite = appendPatch (pkgs.fetchpatch {
+    url = "https://github.com/haskell-crypto/cryptonite/commit/1da7efd7ffac8b8b3ea325da79cd73a2e4a39085.patch";
+    excludes = [ "cbits/decaf/tools/generate.sh" ];
+    sha256 = "sha256-fgu8D9z3lFfVNz5GJqsbWApG+T2PPZyXJ+AkFXArwH0=";
+  }) (doDistribute super.cryptonite);
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -52,6 +52,14 @@ self: super: {
   # weeder == 2.5.* requires GHC 9.4
   weeder = doDistribute self.weeder_2_4_1;
 
+  # fix build with avx, see https://github.com/haskell-crypto/cryptonite/issues/347
+  # https://github.com/haskell-crypto/cryptonite/pull/373
+  cryptonite = appendPatch (pkgs.fetchpatch {
+    url = "https://github.com/haskell-crypto/cryptonite/commit/1da7efd7ffac8b8b3ea325da79cd73a2e4a39085.patch";
+    excludes = [ "cbits/decaf/tools/generate.sh" ];
+    sha256 = "sha256-fgu8D9z3lFfVNz5GJqsbWApG+T2PPZyXJ+AkFXArwH0=";
+  }) super.cryptonite;
+
   # Jailbreaks & Version Updates
   hashable-time = doJailbreak super.hashable-time;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -55,6 +55,14 @@ in {
   # still the case when updating: https://gitlab.haskell.org/ghc/ghc/-/blob/0198841877f6f04269d6050892b98b5c3807ce4c/ghc.mk#L463
   xhtml = if self.ghc.hasHaddock or true then null else self.xhtml_3000_2_2_1;
 
+  # fix build with avx, see https://github.com/haskell-crypto/cryptonite/issues/347
+  # https://github.com/haskell-crypto/cryptonite/pull/373
+  cryptonite = appendPatch (pkgs.fetchpatch {
+    url = "https://github.com/haskell-crypto/cryptonite/commit/1da7efd7ffac8b8b3ea325da79cd73a2e4a39085.patch";
+    excludes = [ "cbits/decaf/tools/generate.sh" ];
+    sha256 = "sha256-fgu8D9z3lFfVNz5GJqsbWApG+T2PPZyXJ+AkFXArwH0=";
+  }) super.cryptonite;
+
   # Tests fail because of typechecking changes
   conduit = dontCheck super.conduit;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -85,4 +85,12 @@ self: super: {
   inline-c-cpp =
     (if isDarwin then appendConfigureFlags ["--ghc-option=-fcompact-unwind"] else x: x)
     super.inline-c-cpp;
+
+  # fix build with avx, see https://github.com/haskell-crypto/cryptonite/issues/347
+  # https://github.com/haskell-crypto/cryptonite/pull/373
+  cryptonite = appendPatch (pkgs.fetchpatch {
+    url = "https://github.com/haskell-crypto/cryptonite/commit/1da7efd7ffac8b8b3ea325da79cd73a2e4a39085.patch";
+    excludes = [ "cbits/decaf/tools/generate.sh" ];
+    sha256 = "sha256-fgu8D9z3lFfVNz5GJqsbWApG+T2PPZyXJ+AkFXArwH0=";
+  }) (doDistribute super.cryptonite);
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
