### PR TITLE
xcodeenv: allow versions higher than specified

### DIFF
--- a/pkgs/development/mobile/xcodeenv/default.nix
+++ b/pkgs/development/mobile/xcodeenv/default.nix
@@ -1,15 +1,9 @@
-{ stdenv, lib }:
+{ callPackage }:
 
 rec {
-  composeXcodeWrapper = import ./compose-xcodewrapper.nix {
-    inherit stdenv;
-  };
+  composeXcodeWrapper = callPackage ./compose-xcodewrapper.nix { };
 
-  buildApp = import ./build-app.nix {
-    inherit stdenv lib composeXcodeWrapper;
-  };
+  buildApp = callPackage ./build-app.nix { inherit composeXcodeWrapper; };
 
-  simulateApp = import ./simulate-app.nix {
-    inherit stdenv lib composeXcodeWrapper;
-  };
+  simulateApp = callPackage ./simulate-app.nix { inherit composeXcodeWrapper; };
 }


### PR DESCRIPTION
###### Description of changes

Add `allowHigher` option to let higher versions of Xcode. This is useful when xcodeenv is used for `nix-shell` for developers and their xcode version might be a bit newer than required one.

We have been using this version of `xcodeenv` in our [status-mobile](https://github.com/status-im/status-mobile) project for over two years: https://github.com/status-im/status-mobile/commit/933c0f8f8cc8eaee6380a079cd95d054e1fa49c5

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).