### PR TITLE
[release-22.05] botan2: Fix CVE-2022-43705

### DIFF
--- a/pkgs/development/libraries/botan/2.0.nix
+++ b/pkgs/development/libraries/botan/2.0.nix
@@ -15,5 +15,46 @@ callPackage ./generic.nix (args // {
       # our source tarball doesn't include the tests
       excludes = [ "src/tests/*" ];
     })
+    # https://github.com/randombit/botan/security/advisories/GHSA-4v9w-qvcq-6q7w
+    (fetchpatch {
+      name = "CVE-2022-43705-1.patch";
+      url = "https://github.com/randombit/botan/commit/fd83d9e262f63fb673e4c13ca37e5b768e41e812.patch";
+      hash = "sha256-f0vZGXalao1jqtaONlZna4alzpyLF4BbZwirQN+MPs0=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-43705-2.patch";
+      url = "https://github.com/randombit/botan/commit/4e35073ff356e37c3adcf1ff3522e9d0d48c765f.patch";
+      hash = "sha256-BBoIMuI1ayesI0rhYbdlO6rphZE1C4LCYI7bwHd8bUw=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-43705-3.patch";
+      url = "https://github.com/randombit/botan/commit/c2faa88b0281e5017be72e1c85d0c41f686e1928.patch";
+      hash = "sha256-n88gRLrxQG5/cundLyajd1IEi7x4aS5Ou3a1BudTrXI=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-43705-4.patch";
+      url = "https://github.com/randombit/botan/commit/5d8d9fbf75c8b814ea609161bee525d520f5cb57.patch";
+      hash = "sha256-gqm9mG1NUyYfzMA3vjUjdU4aWOyHU4hiptpXGCR+HqM=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-43705-5.patch";
+      url = "https://github.com/randombit/botan/commit/1829ef9d89614da1eacdf511356bdf98a970f5f5.patch";
+      hash = "sha256-Whi4GOT6CPmV8qE2Q9ktJ11aozR8xvDV8h6bIRgxMPA=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-43705-6.patch";
+      url = "https://github.com/randombit/botan/commit/991b0159282781f2d5c06ff42a9ff00ee563e96b.patch";
+      hash = "sha256-vEgfAlE5Pl5V0kVsjFtxm51ODubs9nRi52l50AiaTsM=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-43705-7.patch";
+      url = "https://github.com/randombit/botan/commit/a33689613127f319c0047fb96f092de16e7cb350.patch";
+      hash = "sha256-3/l6RjPZDXTGPGwYVNDL/G213hCEIn0RV0JmNxOt4UI=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-43705-8.patch";
+      url = "https://github.com/randombit/botan/commit/909c62717855402e04dbaf8ffc085f444d547aae.patch";
+      hash = "sha256-AAsmNgwN8887nE84/BgJOcb6IuLK11HZoMJOhyeqDpI=";
+    })
   ];
 })


### PR DESCRIPTION
Backports security patches and regression tests. A complete fix would require an API change that is scheduled for the 3.0 release, which is out of scope.

https://github.com/randombit/botan/security/advisories/GHSA-4v9w-qvcq-6q7w

Fixes: CVE-2022-43705

List of patches via https://security-tracker.debian.org/tracker/CVE-2022-43705

cc #204194 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
