### PR TITLE
[22.11] pgadmin4: apply patch for CVE-2022-4223

### DIFF
--- a/pkgs/tools/admin/pgadmin/CVE-2022-4223.patch
+++ b/pkgs/tools/admin/pgadmin/CVE-2022-4223.patch
@@ -1,0 +1,56 @@
+From 9d30dd3857661d110ad8a50024b276148fd64cb6 Mon Sep 17 00:00:00 2001
+From: Akshay Joshi <akshay.joshi@enterprisedb.com>
+Date: Wed, 30 Nov 2022 12:02:45 +0530
+Subject: [PATCH] Ensure that only authorized and authenticated users can
+ validate binary paths (CVE-2022-4223). #5593
+
+(cherry picked from commit 461849c2763e680ed2296bb8a753ca7aef546595)
+---
+ web/pgadmin/misc/__init__.py | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/web/pgadmin/misc/__init__.py b/web/pgadmin/misc/__init__.py
+index 7f6a783fb..2fae3fc4e 100644
+--- a/web/pgadmin/misc/__init__.py
++++ b/web/pgadmin/misc/__init__.py
+@@ -10,8 +10,9 @@
+ """A blueprint module providing utility functions for the application."""
+ 
+ import pgadmin.utils.driver as driver
+-from flask import url_for, render_template, Response, request
++from flask import url_for, render_template, Response, request, current_app
+ from flask_babel import gettext
++from flask_security import login_required
+ from pgadmin.utils import PgAdminModule, replace_binary_path
+ from pgadmin.utils.csrf import pgCSRFProtect
+ from pgadmin.utils.session import cleanup_session_files
+@@ -192,13 +193,14 @@ def shutdown():
+ ##########################################################################
+ # A special URL used to validate the binary path
+ ##########################################################################
++@login_required
+ @blueprint.route("/validate_binary_path",
+                  endpoint="validate_binary_path",
+                  methods=["POST"])
+ def validate_binary_path():
+     """
+     This function is used to validate the specified utilities path by
+-    running the utilities with there versions.
++    running the utilities with their versions.
+     """
+     data = None
+     if hasattr(request.data, 'decode'):
+@@ -219,6 +221,10 @@ def validate_binary_path():
+                               (utility + '.exe'))))
+ 
+             try:
++                # if path doesn't exist raise exception
++                if not os.path.exists(binary_path):
++                    current_app.logger.warning('Invalid binary path.')
++                    raise Exception()
+                 # Get the output of the '--version' command
+                 version_string = \
+                     subprocess.getoutput('"{0}" --version'.format(full_path))
+-- 
+2.38.1
+

--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -110,6 +110,7 @@ pythonPackages.buildPythonApplication rec {
   patches = [
     # Expose setup.py for later use
     ./expose-setup.py.patch
+    ./CVE-2022-4223.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

[Version 6.16 seems quite large in term of changes](https://www.pgadmin.org/docs/pgadmin4/development/release_notes_6_16.html) so I preferred to only backport the security fix.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
