### PR TITLE
cups-brother-hll2375dw: init at 4.0.0-1

### DIFF
--- a/pkgs/misc/cups/drivers/brother/hll2375dw/default.nix
+++ b/pkgs/misc/cups/drivers/brother/hll2375dw/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, perl
+, gnused
+, ghostscript
+, file
+, coreutils
+, gnugrep
+, which
+}:
+
+let
+  arches = [ "x86_64" "i686" "armv7l" ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-hll2375dw";
+  version = "4.0.0-1";
+
+  nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook ];
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  src = fetchurl {
+    url = "download.brother.com/welcome/dlf103535//hll2375dwpdrv-${version}.i386.deb";
+    hash = "sha256-N5VCBZLFrfw29QjjzlSvQ12urvyaf7ez/RJ08UwqHdk=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    dpkg-deb -x $src $out
+    # delete unnecessary files for the current architecture
+  '' + lib.concatMapStrings (arch: ''
+    echo Deleting files for ${arch}
+    rm -r "$out/opt/brother/Printers/HLL2375DW/lpd/${arch}"
+  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches) + ''
+      # bundled scripts don't understand the arch subdirectories for some reason
+      ln -s \
+        "$out/opt/brother/Printers/HLL2375DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+        "$out/opt/brother/Printers/HLL2375DW/lpd/"
+      # Fix global references and replace auto discovery mechanism with hardcoded values
+      substituteInPlace $out/opt/brother/Printers/HLL2375DW/lpd/lpdfilter \
+        --replace /opt "$out/opt" \
+        --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/HLL2375DW\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"HLL2375DW\"; #"
+      # Make sure all executables have the necessary runtime dependencies available
+      find "$out" -executable -and -type f | while read file; do
+        wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+      done
+      # Symlink filter and ppd into a location where CUPS will discover it
+      mkdir -p $out/lib/cups/filter
+      mkdir -p $out/share/cups/model
+      ln -s \
+        $out/opt/brother/Printers/HLL2375DW/lpd/lpdfilter \
+        $out/lib/cups/filter/brother_lpdwrapper_HLL2375DW
+      ln -s \
+        $out/opt/brother/Printers/HLL2375DW/cupswrapper/brother-HLL2375DW-cups-en.ppd \
+        $out/share/cups/model/
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    homepage = "http://www.brother.com/";
+    description = "Brother HLL2375DW printer driver";
+    license = licenses.unfree;
+    platforms = builtins.map (arch: "${arch}-linux") arches;
+    maintainers = [ maintainers.gador ];
+  };
+}

--- a/pkgs/misc/cups/drivers/brother/hll2375dw/default.nix
+++ b/pkgs/misc/cups/drivers/brother/hll2375dw/default.nix
@@ -33,46 +33,66 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook ];
   buildInputs = [ perl ];
 
-  dontUnpack = true;
-
   src = fetchurl {
-    url = "download.brother.com/welcome/dlf103535//hll2375dwpdrv-${version}.i386.deb";
+    url = "https://download.brother.com/welcome/dlf103535//hll2375dwpdrv-${version}.i386.deb";
     hash = "sha256-N5VCBZLFrfw29QjjzlSvQ12urvyaf7ez/RJ08UwqHdk=";
   };
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  patches = [
+    # The brother lpdwrapper uses a temporary file to convey the printer settings.
+    # The original settings file will be copied with "400" permissions and the "brprintconflsr3"
+    # binary cannot alter the temporary file later on. This fixes the permissions so the can be modified.
+    # Since this is all in briefly in the temporary directory of systemd-cups and not accessible by others,
+    # it shouldn't be a security concern.
+    ./fix-perm.patch
+  ];
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out
-    dpkg-deb -x $src $out
+    cp -ar opt $out/opt
     # delete unnecessary files for the current architecture
-  '' + lib.concatMapStrings (arch: ''
-    echo Deleting files for ${arch}
-    rm -r "$out/opt/brother/Printers/HLL2375DW/lpd/${arch}"
-  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches) + ''
-      # bundled scripts don't understand the arch subdirectories for some reason
-      ln -s \
-        "$out/opt/brother/Printers/HLL2375DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
-        "$out/opt/brother/Printers/HLL2375DW/lpd/"
-      # Fix global references and replace auto discovery mechanism with hardcoded values
-      substituteInPlace $out/opt/brother/Printers/HLL2375DW/lpd/lpdfilter \
-        --replace /opt "$out/opt" \
-        --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/HLL2375DW\"; #" \
-        --replace "PRINTER =~" "PRINTER = \"HLL2375DW\"; #"
-      # Make sure all executables have the necessary runtime dependencies available
-      find "$out" -executable -and -type f | while read file; do
-        wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
-      done
-      # Symlink filter and ppd into a location where CUPS will discover it
-      mkdir -p $out/lib/cups/filter
-      mkdir -p $out/share/cups/model
-      ln -s \
-        $out/opt/brother/Printers/HLL2375DW/lpd/lpdfilter \
-        $out/lib/cups/filter/brother_lpdwrapper_HLL2375DW
-      ln -s \
-        $out/opt/brother/Printers/HLL2375DW/cupswrapper/brother-HLL2375DW-cups-en.ppd \
-        $out/share/cups/model/
-      runHook postInstall
-    '';
+  '' + lib.concatMapStrings
+    (arch: ''
+      echo Deleting files for ${arch}
+      rm -r "$out/opt/brother/Printers/HLL2375DW/lpd/${arch}"
+    '')
+    (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches) + ''
+    # bundled scripts don't understand the arch subdirectories for some reason
+    ln -s \
+      "$out/opt/brother/Printers/HLL2375DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+      "$out/opt/brother/Printers/HLL2375DW/lpd/"
+
+    # Fix global references and replace auto discovery mechanism with hardcoded values
+    substituteInPlace $out/opt/brother/Printers/HLL2375DW/lpd/lpdfilter \
+      --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/HLL2375DW\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"HLL2375DW\"; #"
+    substituteInPlace $out/opt/brother/Printers/HLL2375DW/cupswrapper/lpdwrapper \
+      --replace "my \$basedir = C" "my \$basedir = \"$out/opt/brother/Printers/HLL2375DW\" ; #" \
+      --replace "PRINTER =~" "PRINTER = \"HLL2375DW\"; #"
+
+    # Make sure all executables have the necessary runtime dependencies available
+    find "$out" -executable -and -type f | while read file; do
+      wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+    done
+
+    # Symlink filter and ppd into a location where CUPS will discover it
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+    mkdir -p $out/etc/opt/brother/Printers/HLL2375DW/inf
+
+    ln -s $out/opt/brother/Printers/HLL2375DW/inf/brHLL2375DWrc \
+          $out/etc/opt/brother/Printers/HLL2375DW/inf/brHLL2375DWrc
+    ln -s \
+      $out/opt/brother/Printers/HLL2375DW/cupswrapper/lpdwrapper \
+      $out/lib/cups/filter/brother_lpdwrapper_HLL2375DW
+    ln -s \
+      $out/opt/brother/Printers/HLL2375DW/cupswrapper/brother-HLL2375DW-cups-en.ppd \
+      $out/share/cups/model/
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://www.brother.com/";

--- a/pkgs/misc/cups/drivers/brother/hll2375dw/fix-perm.patch
+++ b/pkgs/misc/cups/drivers/brother/hll2375dw/fix-perm.patch
@@ -1,0 +1,10 @@
+--- a/opt/brother/Printers/HLL2375DW/cupswrapper/lpdwrapper  2022-12-07 18:32:29.950543083 +0100
++++ b/opt/brother/Printers/HLL2375DW/cupswrapper/lpdwrapper      2022-12-07 18:46:03.046989151 +0100
+@@ -379,6 +379,7 @@
+
+
+ `cp  $basedir/inf/br${PRINTER}rc  $TEMPRC`;
++`chmod 666  $TEMPRC`;
+ $ENV{BRPRINTERRCFILE} = $TEMPRC;
+
+ logprint( 0 , "TEMPRC    = $TEMPRC\n");

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37249,6 +37249,8 @@ with pkgs;
   mfcl3770cdwlpr = (callPackage ../misc/cups/drivers/brother/mfcl3770cdw { }).driver;
   mfcl3770cdwcupswrapper = (callPackage ../misc/cups/drivers/brother/mfcl3770cdw { }).cupswrapper;
 
+  cups-brother-hll2375dw = callPackage ../misc/cups/drivers/brother/hll2375dw { };
+
   mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
   mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
 


### PR DESCRIPTION
###### Description of changes

Init of cups driver for Brothers HL-L2375DW laser printer.
Heavily based on #165514 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
