### PR TITLE
[22.11] nixos/profiles/base: install vim w/nix-syntax plugin

### DIFF
--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -20,7 +20,13 @@
     pkgs.mkpasswd # for generating password files
 
     # Some text editors.
-    pkgs.vim
+    (pkgs.vim.customize {
+      name = "vim";
+      vimrcConfig.packages.default = {
+        start = [ pkgs.vimPlugins.vim-nix ];
+      };
+      vimrcConfig.customRC = "syntax on";
+    })
 
     # Some networking tools.
     pkgs.fuse


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/201380 to 22.11. No ISO size increase. Tested the image, works fine.