### PR TITLE
skawarePackages: refactor

### DIFF
--- a/pkgs/development/skaware-packages/default.nix
+++ b/pkgs/development/skaware-packages/default.nix
@@ -1,0 +1,33 @@
+{ lib, pkgs }:
+
+lib.makeScope pkgs.newScope (self:
+  let
+    inherit (self) callPackage;
+  in {
+  buildManPages = callPackage ./build-skaware-man-pages.nix { };
+  buildPackage = callPackage ./build-skaware-package.nix { };
+  cleanPackaging = callPackage ./clean-packaging.nix { };
+
+  execline = callPackage ./execline { };
+  execline-man-pages = callPackage ./execline-man-pages { };
+
+  mdevd = callPackage ./mdevd { };
+  nsss = callPackage ./nsss { };
+  sdnotify-wrapper = callPackage ./sdnotify-wrapper { };
+  utmps = callPackage ./utmps { };
+
+  skalibs = callPackage ./skalibs { };
+  skalibs_2_10 = callPackage ./skalibs/2_10.nix { };
+
+  s6 = callPackage ./s6 { };
+  s6-dns = callPackage ./s6-dns { };
+  s6-linux-init = callPackage ./s6-linux-init { };
+  s6-linux-utils = callPackage ./s6-linux-utils { };
+  s6-networking = callPackage ./s6-networking { };
+  s6-portable-utils = callPackage ./s6-portable-utils { };
+  s6-rc = callPackage ./s6-rc { };
+
+  s6-man-pages = callPackage ./s6-man-pages { };
+  s6-networking-man-pages = callPackage ./s6-networking-man-pages { };
+  s6-portable-utils-man-pages = callPackage ./s6-portable-utils-man-pages { };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22490,44 +22490,7 @@ with pkgs;
 
   skjold = callPackage ../development/tools/skjold { };
 
-  skawarePackages = recurseIntoAttrs rec {
-    buildManPages = callPackage ../development/skaware-packages/build-skaware-man-pages.nix { };
-    buildPackage = callPackage ../development/skaware-packages/build-skaware-package.nix {
-      inherit cleanPackaging;
-    };
-    cleanPackaging = callPackage ../development/skaware-packages/clean-packaging.nix { };
-
-    execline = callPackage ../development/skaware-packages/execline { };
-    execline-man-pages = callPackage ../development/skaware-packages/execline-man-pages {
-      inherit buildManPages;
-    };
-
-    mdevd = callPackage ../development/skaware-packages/mdevd { };
-    nsss = callPackage ../development/skaware-packages/nsss { };
-    sdnotify-wrapper = callPackage ../development/skaware-packages/sdnotify-wrapper { };
-    utmps = callPackage ../development/skaware-packages/utmps { };
-
-    skalibs = callPackage ../development/skaware-packages/skalibs { };
-    skalibs_2_10 = callPackage ../development/skaware-packages/skalibs/2_10.nix { };
-
-    s6 = callPackage ../development/skaware-packages/s6 { };
-    s6-dns = callPackage ../development/skaware-packages/s6-dns { };
-    s6-linux-init = callPackage ../development/skaware-packages/s6-linux-init { };
-    s6-linux-utils = callPackage ../development/skaware-packages/s6-linux-utils { };
-    s6-networking = callPackage ../development/skaware-packages/s6-networking { };
-    s6-portable-utils = callPackage ../development/skaware-packages/s6-portable-utils { };
-    s6-rc = callPackage ../development/skaware-packages/s6-rc { };
-
-    s6-man-pages = callPackage ../development/skaware-packages/s6-man-pages {
-      inherit buildManPages;
-    };
-    s6-networking-man-pages = callPackage ../development/skaware-packages/s6-networking-man-pages {
-      inherit buildManPages;
-    };
-    s6-portable-utils-man-pages = callPackage ../development/skaware-packages/s6-portable-utils-man-pages {
-      inherit buildManPages;
-    };
-  };
+  skawarePackages = recurseIntoAttrs (callPackage ../development/skaware-packages { });
 
   inherit (skawarePackages)
     execline


### PR DESCRIPTION
This way, the skawarePackages live inside its own directory, with a huge `inherit` to bring them to top-level.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
