### PR TITLE
jna: init at 4.5.2

### DIFF
--- a/pkgs/applications/networking/p2p/freenet/default.nix
+++ b/pkgs/applications/networking/p2p/freenet/default.nix
@@ -1,15 +1,7 @@
-{ lib, stdenv, fetchurl, jdk, bash, coreutils, substituteAll, nixosTests }:
+{ lib, stdenv, fetchurl, jdk, bash, coreutils, substituteAll, nixosTests, jna }:
 
 let
   version = "build01494";
-  jna = fetchurl {
-    url = "https://github.com/freenet/fred/releases/download/${version}/jna-4.5.2.jar";
-    sha256 = "sha256-DI63rPZyYWVteQBRkd66ujtr9d1gpDc1okVCk4Hb7P8=";
-  };
-  jna_platform = fetchurl {
-    url = "https://github.com/freenet/fred/releases/download/${version}/jna-platform-4.5.2.jar";
-    sha256 = "sha256-8dAMFn2JIcbiPGJu+fHDrgvkc8lcaP+gErx65VqH4tY=";
-  };
   freenet_ext = fetchurl {
     url = "https://github.com/freenet/fred/releases/download/${version}/freenet-ext.jar";
     sha256 = "sha256-MvKz1r7t9UE36i+aPr72dmbXafCWawjNF/19tZuk158=";
@@ -38,8 +30,8 @@ let
       mkdir -p $out/share/freenet
       ln -s ${bcprov} $out/share/freenet/bcprov.jar
       ln -s ${freenet_ext} $out/share/freenet/freenet-ext.jar
-      ln -s ${jna_platform} $out/share/freenet/jna_platform.jar
-      ln -s ${jna} $out/share/freenet/jna.jar
+      ln -s ${jna}/share/java/jna-platform.jar $out/share/freenet/jna_platform.jar
+      ln -s ${jna}/share/java/jna.jar $out/share/freenet/jna.jar
       ln -s $src $out/share/freenet/freenet.jar
     '';
   };
@@ -71,5 +63,6 @@ in stdenv.mkDerivation {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ nagy ];
     platforms = with lib.platforms; linux;
+    changelog = "https://github.com/freenet/fred/blob/build${version}/NEWS.md";
   };
 }

--- a/pkgs/development/java-modules/jna/default.nix
+++ b/pkgs/development/java-modules/jna/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitHub, ant, jdk8 }:
+
+stdenv.mkDerivation rec {
+  pname = "jna";
+  version = "4.5.2";
+
+  src = fetchFromGitHub {
+    owner = "java-native-access";
+    repo = pname;
+    rev = version;
+    hash = "sha256-FJXYej49soHPa+kAUeLZYzbw+NnFoag2LdKrTihPWvE=";
+  };
+
+  nativeBuildInputs = [ ant jdk8 ];
+
+  buildPhase = ''
+    runHook preBuild
+    rm -r dist # remove prebuilt files
+    ant dist
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 -t $out/share/java dist/jna{,-platform}.jar
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "Java Native Access";
+    license = with licenses; [ lgpl21 asl20 ];
+    maintainers = with maintainers; [ nagy ];
+    platforms = platforms.linux;
+    changelog = "https://github.com/java-native-access/jna/blob/${version}/CHANGES.md";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14696,6 +14696,8 @@ with pkgs;
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
 
+  jna = callPackage ../development/java-modules/jna { };
+
   javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };
 
   juniper = callPackage ../development/compilers/juniper { };


### PR DESCRIPTION
###### Description of changes



###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).