### PR TITLE
[22.05] capnproto: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/development/libraries/capnproto/default.nix
+++ b/pkgs/development/libraries/capnproto/default.nix
@@ -6,14 +6,14 @@
 
 stdenv.mkDerivation rec {
   pname = "capnproto";
-  version = "0.9.1";
+  version = "0.9.2";
 
   # release tarballs are missing some ekam rules
   src = fetchFromGitHub {
     owner = "capnproto";
     repo = "capnproto";
     rev = "v${version}";
-    sha256 = "0cbiwkmd29abih8rjjm35dfkrkr8c6axbzq3fkryay6jyvpi42c5";
+    sha256 = "sha256-BspWOPZcP5nCTvmsDE62Zutox+aY5pw42d6hpH3v4cM=";
   };
 
   nativeBuildInputs = [ cmake ]


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2022-46149.

https://github.com/capnproto/capnproto/blob/b2fdf71399accdf4ab93d38421a3225440b1d108/security-advisories/2022-11-30-0-pointer-list-bounds.md

Also see #204059
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


Result of `nixpkgs-review pr 204339` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>sonic-lineup</li>
  </ul>
</details>
<details>
  <summary>19 packages built:</summary>
  <ul>
    <li>brise</li>
    <li>capnproto</li>
    <li>capnproto-java</li>
    <li>cargo-rr</li>
    <li>clickhouse</li>
    <li>ekam</li>
    <li>fcitx-engines.rime</li>
    <li>fcitx5-rime</li>
    <li>ibus-engines.rime</li>
    <li>laminar</li>
    <li>librime</li>
    <li>python310Packages.pycapnp</li>
    <li>python310Packages.sequoia</li>
    <li>python39Packages.pycapnp</li>
    <li>sequoia (python39Packages.sequoia)</li>
    <li>rime-data</li>
    <li>rr</li>
    <li>rr-unstable</li>
    <li>sonic-visualiser</li>
  </ul>
</details>

`sonic-lineup` failure is not caused by this change, it is already broken https://hydra.nixos.org/build/199796723