### PR TITLE
android-tools: Avoid installing avbtool twice and update the description

### DIFF
--- a/pkgs/tools/misc/android-tools/default.nix
+++ b/pkgs/tools/misc/android-tools/default.nix
@@ -35,10 +35,6 @@ stdenv.mkDerivation rec {
     export GOCACHE=$TMPDIR/go-cache
   '';
 
-  postInstall = ''
-    install -Dm755 ../vendor/avb/avbtool.py -t $out/bin
-  '';
-
   meta = with lib; {
     description = "Android SDK platform tools";
     longDescription = ''
@@ -53,7 +49,8 @@ stdenv.mkDerivation rec {
       - mke2fs.android (required by fastboot)
       - simg2img, img2simg, append2simg
       - lpdump, lpmake, lpadd, lpflash, lpunpack
-      - mkbootimg, unpack_bootimg, repack_bootimg
+      - mkbootimg, unpack_bootimg, repack_bootimg, avbtool
+      - mkdtboimg
     '';
     # https://developer.android.com/studio/command-line#tools-platform
     # https://developer.android.com/studio/releases/platform-tools


### PR DESCRIPTION
The last release (version 33.0.3p1 [0], added in 28609af5c71) started to include avbtool and mkdtboimg [1].
This is just a minor fixup to update the package description and stop installing avbtool twice:
```
$ sha256sum /nix/store/f2ld3hjbxnafi3jw299nq4mc94xpcmx6-android-tools-33.0.3p1/bin/avbtool*
d4357c43798d6aa6d5cea3b8f3ad39e54244a1105db8048dc673c44119835e1c  /nix/store/f2ld3hjbxnafi3jw299nq4mc94xpcmx6-android-tools-33.0.3p1/bin/avbtool 
d4357c43798d6aa6d5cea3b8f3ad39e54244a1105db8048dc673c44119835e1c  /nix/store/f2ld3hjbxnafi3jw299nq4mc94xpcmx6-android-tools-33.0.3p1/bin/avbtool.py
```

[0]: https://github.com/nmeum/android-tools/releases/tag/33.0.3p1
[1]: https://github.com/nmeum/android-tools/commit/0652cba5f426591706ffc187e7089943421c38f9

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
