### PR TITLE
glib: always include docbook_xsl and libxslt in nativeBuildInputs

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -165,12 +165,12 @@ stdenv.mkDerivation (finalAttrs: {
     perl
     python3
     gettext
+    docbook_xsl
+    libxslt
   ] ++ lib.optionals buildDocs [
     gtk-doc
-    docbook_xsl
     docbook_xml_dtd_45
     libxml2
-    libxslt
   ];
 
   propagatedBuildInputs = [ zlib libffi gettext libiconv ];


### PR DESCRIPTION
###### Description of changes

This fixes static and cross compilation of glib. The two packages are needed for the build to success, even when not building the docs. For instance cross compiling for riscv64 from x86_64 fails with:

```
error: builder for '/nix/store/h20ljlkwgz5cc8zs1sg4clm5wyrsbiz2-glib-riscv64-unknown-linux-gnu-2.74.1.drv' failed with exit code 1;
       last 10 log lines:
       > Program msgfmt found: YES (/nix/store/ahb1jl345mpn3v8my8aj77df294q59ij-gettext-0.21/bin/msgfmt)
       > Program msginit found: YES (/nix/store/ahb1jl345mpn3v8my8aj77df294q59ij-gettext-0.21/bin/msginit)
       > Program msgmerge found: YES (/nix/store/ahb1jl345mpn3v8my8aj77df294q59ij-gettext-0.21/bin/msgmerge)
       > Program xgettext found: YES (/nix/store/ahb1jl345mpn3v8my8aj77df294q59ij-gettext-0.21/bin/xgettext)
       > Configuring config.h using configuration
       > Program xsltproc found: NO
       >
       > meson.build:2413:2: ERROR: Program 'xsltproc' not found or not executable
       >
       > A full log can be found at /build/glib-2.74.1/build/meson-logs/meson-log.txt

```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] x86_64-linux (static)
  - [X] riscv64-linux (cross)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
