### PR TITLE
patsh: 0.1.3 -> 0.2.0

### DIFF
--- a/pkgs/development/tools/misc/patsh/default.nix
+++ b/pkgs/development/tools/misc/patsh/default.nix
@@ -1,30 +1,41 @@
 { lib
+, runCommand
 , rustPlatform
 , fetchFromGitHub
 , stdenv
-, runCommand
-, tree-sitter
+, coreutils
 }:
+
+let
+  custom = runCommand "custom" { } ''
+    mkdir -p $out/bin
+    touch $out/bin/{'foo$','foo"`'}
+    chmod +x $out/bin/{'foo$','foo"`'}
+  '';
+in
 
 rustPlatform.buildRustPackage rec {
   pname = "patsh";
-  version = "0.1.3";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-KmQVZwZC7KHlzNnL2IKQ76wHUDNUZKz/aFaY4ujvBo4=";
+    sha256 = "sha256-7HXJspebluQeejKYmVA7sy/F3dtU1gc4eAbKiPexMMA=";
   };
 
-  cargoSha256 = "sha256-vozQKBxAVELdqTnqBpgHX0Wyk18EZAtpiRsKjwz8xKE=";
+  cargoSha256 = "sha256-R6ScpLYbEJAu7+CyJsMdljtXq7wsMojHK5O1lH+E/E8=";
 
-  # tests fail on darwin due to rpath issues
-  doCheck = !stdenv.isDarwin;
+  checkInputs = [ custom ];
 
-  TREE_SITTER_BASH = runCommand "tree-sitter-bash" { } ''
-    mkdir $out
-    ln -s ${tree-sitter.builtGrammars.tree-sitter-bash}/parser $out/libtree-sitter-bash.a
+  postPatch = ''
+    for file in tests/fixtures/*-expected.sh; do
+      substituteInPlace $file \
+        --subst-var-by cc ${stdenv.cc} \
+        --subst-var-by coreutils ${coreutils} \
+        --subst-var-by custom ${custom}
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/nix-community/patsh/compare/v0.1.3...v0.2.0

Changelog: https://github.com/nix-community/patsh/blob/v0.2.0/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
