### PR TITLE
ocamlPackages.sedlex: 2.6 → 3.0

### DIFF
--- a/pkgs/development/ocaml-modules/piqi/default.nix
+++ b/pkgs/development/ocaml-modules/piqi/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  patches = [ ./no-ocamlpath-override.patch ];
+  patches = [ ./no-stream.patch ./no-ocamlpath-override.patch ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/piqi/no-stream.patch
+++ b/pkgs/development/ocaml-modules/piqi/no-stream.patch
@@ -1,0 +1,14 @@
+--- ./piqilib/piq_lexer.ml
++++ ./piqilib/piq_lexer.ml
+@@ -476,11 +476,6 @@ let init_from_string s =
+   make_buf lexbuf
+ 
+ 
+-let init_from_stream s =
+-  let lexbuf = Sedlexing.Utf8.from_stream s in
+-  make_buf lexbuf
+-
+-
+ let init_from_channel ch =
+   let lexbuf = Sedlexing.Utf8.from_channel ch in
+   make_buf lexbuf

--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -10,8 +10,8 @@
 
 let param =
   if lib.versionAtLeast ppxlib.version "0.26.0" then {
-    version = "2.6";
-    sha256 = "sha256-AU+dV+jTG9v3BXzip2Bnv04Ewyo3pyUglDDBFsOsFf0=";
+    version = "3.0";
+    sha256 = "sha256-+4ggynMznVfjviMBjXil8CXdMByq4kSmDz6P2PyEETA=";
   } else {
     version = "2.5";
     sha256 = "sha256:062a5dvrzvb81l3a9phljrhxfw9nlb61q341q0a6xn65hll3z2wy";


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
