### PR TITLE
vim-full: rename from vim_configurable

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -10,12 +10,21 @@ At the moment we support two different methods for managing plugins:
 - Vim packages (*recommended*)
 - vim-plug (vim only)
 
+Right now two Vim packages are available: `vim` which has most features that require extra
+dependencies disabled and `vim-full` which has them configurable and enabled by default.
+
+::: {.note}
+`vim_configurable` is a deprecated alias for `vim-full` and refers to the fact that its
+build-time features are configurable. It has nothing to do with user configuration,
+and both the `vim` and `vim-full` packages can be customized as explained in the next section.
+:::
+
 ## Custom configuration {#custom-configuration}
 
 Adding custom .vimrc lines can be done using the following code:
 
 ```nix
-vim_configurable.customize {
+vim-full.customize {
   # `name` optionally specifies the name of the executable and package
   name = "vim-with-plugins";
 
@@ -62,7 +71,7 @@ neovim-qt.override {
 To store your plugins in Vim packages (the native Vim plugin manager, see `:help packages`) the following example can be used:
 
 ```nix
-vim_configurable.customize {
+vim-full.customize {
   vimrcConfig.packages.myVimPackage = with pkgs.vimPlugins; {
     # loaded on launch
     start = [ youcompleteme fugitive ];
@@ -101,7 +110,7 @@ The resulting package can be added to `packageOverrides` in `~/.nixpkgs/config.n
 ```nix
 {
   packageOverrides = pkgs: with pkgs; {
-    myVim = vim_configurable.customize {
+    myVim = vim-full.customize {
       # `name` specifies the name of the executable and package
       name = "vim-with-plugins";
       # add here code from the example section
@@ -190,7 +199,7 @@ To use [vim-plug](https://github.com/junegunn/vim-plug) to manage your Vim
 plugins the following example can be used:
 
 ```nix
-vim_configurable.customize {
+vim-full.customize {
   vimrcConfig.packages.myVimPackage = with pkgs.vimPlugins; {
     # loaded on launch
     plug.plugins = [ youcompleteme fugitive phpCompletion elm-vim ];

--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -160,6 +160,17 @@
     <itemizedlist>
       <listitem>
         <para>
+          <literal>vim_configurable</literal> has been renamed to
+          <literal>vim-full</literal> to avoid confusion:
+          <literal>vim-full</literal>’s build-time features are
+          configurable, but both <literal>vim</literal> and
+          <literal>vim-full</literal> are
+          <emphasis>customizable</emphasis> (in the sense of user
+          configuration, like vimrc).
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The module for the application firewall
           <literal>opensnitch</literal> got the ability to configure
           rules. Available as

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -49,6 +49,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `vim_configurable` has been renamed to `vim-full` to avoid confusion: `vim-full`'s build-time features are configurable, but both `vim` and `vim-full` are *customizable* (in the sense of user configuration, like vimrc).
+
 - The module for the application firewall `opensnitch` got the ability to configure rules. Available as [services.opensnitch.rules](#opt-services.opensnitch.rules)
 
 - `services.mastodon` gained a tootctl wrapped named `mastodon-tootctl` similar to `nextcloud-occ` which can be executed from any user and switches to the configured mastodon user with sudo and sources the environment variables.

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -1,5 +1,5 @@
 # run tests by building `neovim.tests`
-{ vimUtils, vim_configurable, writeText, neovim, vimPlugins
+{ vimUtils, writeText, neovim, vimPlugins
 , lib, fetchFromGitHub, neovimUtils, wrapNeovimUnstable
 , neovim-unwrapped
 , fetchFromGitLab

--- a/pkgs/applications/editors/spacevim/default.nix
+++ b/pkgs/applications/editors/spacevim/default.nix
@@ -2,7 +2,7 @@
 , git
 , fzf
 , makeWrapper
-, vim_configurable
+, vim-full
 , vimPlugins
 , fetchFromGitHub
 , lib
@@ -14,7 +14,7 @@
 
 let
   format = formats.toml { };
-  vim-customized = vim_configurable.customize {
+  vim-customized = vim-full.customize {
     name = "vim";
     # Not clear at the moment how to import plugins such that
     # SpaceVim finds them and does not auto download them to

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -63,7 +63,7 @@ let
 
 in stdenv.mkDerivation rec {
 
-  pname = "vim_configurable";
+  pname = "vim-full";
 
   inherit (common) version postPatch hardeningDisable enableParallelBuilding meta;
 

--- a/pkgs/applications/editors/vim/macvim-configurable.nix
+++ b/pkgs/applications/editors/vim/macvim-configurable.nix
@@ -6,9 +6,9 @@ let
   makeCustomizable = macvim: macvim // {
     # configure expects the same args as vimUtils.vimrcFile.
     # This is the same as the value given to neovim.override { configure = … }
-    # or the value of vim_configurable.customize { vimrcConfig = … }
+    # or the value of vim-full.customize { vimrcConfig = … }
     #
-    # Note: Like neovim and vim_configurable, configuring macvim disables the
+    # Note: Like neovim and vim-full, configuring macvim disables the
     # sourcing of the user's vimrc. Use `customRC = "source $HOME/.vim/vimrc"`
     # if you want to preserve that behavior.
     configure = let

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -14,7 +14,7 @@ USAGE EXAMPLE
 Install Vim like this eg using nixos option environment.systemPackages which will provide
 vim-with-plugins in PATH:
 
-  vim_configurable.customize {
+  vim-full.customize {
     name = "vim-with-plugins"; # optional
 
     # add custom .vimrc lines like this:
@@ -105,7 +105,7 @@ fitting the vimrcConfig.vam.pluginDictionaries option.
 Thus the most simple usage would be:
 
   vim_with_plugins =
-    let vim = vim_configurable;
+    let vim = vim-full;
         inherit (vimUtil.override {inherit vim}) rtpPath addRtp buildVimPlugin vimHelpTags;
         vimPlugins = [
           # the derivation list from the buffer created by nix#ExportPluginsForNix

--- a/pkgs/applications/editors/vim/vimacs.nix
+++ b/pkgs/applications/editors/vim/vimacs.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, config, vim_configurable, macvim, vimPlugins
+{ lib, stdenv, config, vim-full, macvim, vimPlugins
 , useMacvim ? stdenv.isDarwin && (config.vimacs.macvim or true)
 , vimacsExtraArgs ? "" }:
 
 stdenv.mkDerivation rec {
   pname = "vimacs";
   version = lib.getVersion vimPackage;
-  vimPackage = if useMacvim then macvim else vim_configurable;
+  vimPackage = if useMacvim then macvim else vim-full;
 
   buildInputs = [ vimPackage vimPlugins.vimacs ];
 

--- a/pkgs/test/vim/default.nix
+++ b/pkgs/test/vim/default.nix
@@ -1,4 +1,4 @@
-{ vimUtils, vim_configurable, writeText, vimPlugins
+{ vimUtils, vim-full, writeText, vimPlugins
 , lib, fetchFromGitHub
 , pkgs
 }:
@@ -14,12 +14,12 @@ in
   ### vim tests
   ##################
 
-  test_vim_with_vim_nix_using_plug = vim_configurable.customize {
+  test_vim_with_vim_nix_using_plug = vim-full.customize {
     name = "vim-with-vim-addon-nix-using-plug";
     vimrcConfig.plug.plugins = with vimPlugins; [ vim-nix ];
   };
 
-  test_vim_with_vim_nix = vim_configurable.customize {
+  test_vim_with_vim_nix = vim-full.customize {
     name = "vim-with-vim-addon-nix";
     vimrcConfig.packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1559,6 +1559,8 @@ mapAliases ({
   vdirsyncerStable  = vdirsyncer; # Added 2020-11-08, see https://github.com/NixOS/nixpkgs/issues/103026#issuecomment-723428168
   venus = throw "venus has been removed from nixpkgs, as it's unmaintained"; # Added 2021-02-05
   vgo2nix = throw "vgo2nix has been removed, because it was deprecated. Consider using gomod2nix instead"; # added 2022-08-24
+  vimHugeX = vim-full; # Added 2022-12-04
+  vim_configurable = vim-full; # Added 2022-12-04
   vimbWrapper = throw "'vimbWrapper' has been renamed to/replaced by 'vimb'"; # Converted to throw 2022-02-22
   virtinst = throw "virtinst has been removed, as it's included in virt-manager"; # Added 2021-07-21
   virtuoso = throw "virtuoso has been removed, because it was unmaintained in nixpkgs"; # added 2021-12-15

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27532,7 +27532,7 @@ with pkgs;
   assign-lb-ip = callPackage ../applications/networking/cluster/assign-lb-ip { };
 
   astroid = callPackage ../applications/networking/mailreaders/astroid {
-    vim = vim_configurable.override { features = "normal"; };
+    vim = vim-full.override { features = "normal"; };
   };
 
   aucatctl = callPackage ../applications/audio/aucatctl { };
@@ -32738,14 +32738,12 @@ with pkgs;
 
   macvim = callPackage ../applications/editors/vim/macvim-configurable.nix { stdenv = clangStdenv; };
 
-  vimHugeX = vim_configurable;
-
-  vim_configurable = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
+  vim-full = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices Cocoa Foundation CoreData;
     inherit (darwin) libobjc;
   });
 
-  vim-darwin = (vim_configurable.override {
+  vim-darwin = (vim-full.override {
     config = {
       vim = {
         gui = "none";


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/145351.

The word "configurable" has [proven](https://github.com/NixOS/nixpkgs/pull/201380#discussion_r1038241962) to be confusing because it suggests user configuration, not build configuration. I think this is enough to warrant a rename.

Makes `vim_configurable` and `vimHugeX` aliases to `vim-full`.