### PR TITLE
python3.pkgs.pygls: 0.13.0 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/lsprotocol/default.nix
+++ b/pkgs/development/python-modules/lsprotocol/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, cattrs
+, attrs
+, nox
+, pytest
+, pyhamcrest
+, jsonschema
+}:
+
+buildPythonPackage rec {
+  pname = "lsprotocol";
+  version = "2022.0.0a9";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = pname;
+    rev = version;
+    hash = "sha256-6XecPKuBhwtkmZrGozzO+VEryI5wwy9hlvWE1oV6ajk=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+    nox
+  ];
+
+  propagatedBuildInputs = [
+    cattrs
+    attrs
+  ];
+
+  checkInputs = [
+    pytest
+    pyhamcrest
+    jsonschema
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    sed -i "/^    _install_requirements/d" noxfile.py
+    nox --session tests
+
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "lsprotocol" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/microsoft/lsprotocol";
+    description = "Python implementation of the Language Server Protocol.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/nox/default.nix
+++ b/pkgs/development/python-modules/nox/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, argcomplete
+, colorlog
+, packaging
+, virtualenv
+, pytestCheckHook
+, pytest-cov
+, jinja2
+, tox
+}:
+
+buildPythonPackage rec {
+  pname = "nox";
+  version = "2022.11.21";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "wntrblm";
+    repo = pname;
+    rev = version;
+    hash = "sha256-N70yBZyrtdQvgaJzkskG3goHit8eH0di9jHycuAwzfU=";
+  };
+
+  nativeBuildInputs = [
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  propagatedBuildInputs = [
+    argcomplete
+    colorlog
+    packaging
+    virtualenv
+  ];
+
+  checkInputs = [
+    jinja2
+    tox
+  ];
+
+  meta = with lib; {
+    homepage = "https://nox.thea.codes/";
+    description = "Flexible test automation for Python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -3,7 +3,7 @@
 , pythonOlder
 , fetchFromGitHub
 , setuptools-scm
-, pydantic
+, lsprotocol
 , toml
 , typeguard
 , mock
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "pygls";
-  version = "0.13.0";
+  version = "1.0.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "openlawlibrary";
     repo = "pygls";
     rev = "v${version}";
-    hash = "sha256-guwOnB4EEUpucfprNLLr49Yn8EdOpRzzG+cT4NCn0rA=";
+    hash = "sha256-31J4+giK1RDBS52Q/Ia3Y/Zak7fp7gRVTQ7US/eFjtM=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    pydantic
+    lsprotocol
     typeguard
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6039,6 +6039,8 @@ self: super: with self; {
 
   nomadnet = callPackage ../development/python-modules/nomadnet { };
 
+  nox = callPackage ../development/python-modules/nox { };
+
   nanomsg-python = callPackage ../development/python-modules/nanomsg-python {
     inherit (pkgs) nanomsg;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5434,6 +5434,8 @@ self: super: with self; {
 
   lsassy = callPackage ../development/python-modules/lsassy { };
 
+  lsprotocol = callPackage ../development/python-modules/lsprotocol { };
+
   luddite = callPackage ../development/python-modules/luddite { };
 
   ludios_wpull = callPackage ../development/python-modules/ludios_wpull { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
