### PR TITLE
Issue template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,6 +26,7 @@ If applicable, add screenshots to help explain your problem.
 Add any other context about the problem here.
 
 ### Notify maintainers
+
 <!--
 Please @ people who are in the `meta.maintainers` list of the offending package or module.
 If in doubt, check `git blame` for whoever last touched something.

--- a/.github/ISSUE_TEMPLATE/build_failure.md
+++ b/.github/ISSUE_TEMPLATE/build_failure.md
@@ -1,31 +1,36 @@
 ---
 name: Build failure
 about: Create a report to help us improve
-title: ''
+title: 'Build failure: PACKAGENAME'
 labels: '0.kind: build failure'
 assignees: ''
 
 ---
 
 ### Steps To Reproduce
+
 Steps to reproduce the behavior:
 1. build *X*
 
 ### Build log
+
 ```
 log here if short otherwise a link to a gist
 ```
 
 ### Additional context
+
 Add any other context about the problem here.
 
 ### Notify maintainers
+
 <!--
 Please @ people who are in the `meta.maintainers` list of the offending package or module.
 If in doubt, check `git blame` for whoever last touched something.
 -->
 
 ### Metadata
+
 Please run `nix-shell -p nix-info --run "nix-info -m"` and paste the result.
 
 ```console

--- a/.github/ISSUE_TEMPLATE/missing_documentation.md
+++ b/.github/ISSUE_TEMPLATE/missing_documentation.md
@@ -1,7 +1,7 @@
 ---
 name: Missing or incorrect documentation
 about: Help us improve the Nixpkgs and NixOS reference manuals
-title: ''
+title: 'Documentation request: '
 labels: '9.needs: documentation'
 assignees: ''
 
@@ -10,6 +10,10 @@ assignees: ''
 ## Problem
 
 <!-- describe your problem -->
+
+## Proposal
+
+<!-- propose a solution (optional) -->
 
 ## Checklist
 
@@ -25,8 +29,4 @@ assignees: ''
 [nixos-source]: https://github.com/NixOS/nixpkgs/tree/master/nixos/doc/manual
 [open documentation issues]: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+label%3A%229.needs%3A+documentation%22
 [open documentation pull requests]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+is%3Apr+label%3A%228.has%3A+documentation%22%2C%226.topic%3A+documentation%22
-
-## Proposal
-
-<!-- propose a solution -->
 

--- a/.github/ISSUE_TEMPLATE/missing_documentation.md
+++ b/.github/ISSUE_TEMPLATE/missing_documentation.md
@@ -1,7 +1,7 @@
 ---
 name: Missing or incorrect documentation
 about: Help us improve the Nixpkgs and NixOS reference manuals
-title: 'Documentation request: '
+title: 'Documentation: '
 labels: '9.needs: documentation'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
+++ b/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
@@ -1,24 +1,29 @@
 ---
 name: Out-of-date package reports
 about: For packages that are out-of-date
-title: ''
+title: 'Update request: PACKAGENAME OLDVERSION → NEWVERSION'
 labels: '9.needs: package (update)'
 assignees: ''
 
 ---
 
+##### Package details
+
+- Package name:
+<!--
+Search your package here: https://search.nixos.org/packages?channel=unstable
+
+If there already is an open PR for the package, take this version as the current one and link to the PR
+-->
+- Current version:
+- Desired version:
+
+<!-- If this is a backporting request, fill in this section, otherwise remove it -->
+- [ ] This is a backporting request.
+- Current stable version:
 
 ###### Checklist
 
-<!-- Note that these are hard requirements -->
-
-<!--
-You can use the "Go to file" functionality on GitHub to find the package
-Then you can go to the history for this package
-Find the latest "package_name: old_version -> new_version" commit
-The "new_version" is the current version of the package
--->
-- [ ] Checked the [nixpkgs master branch](https://github.com/NixOS/nixpkgs)
 <!--
 Type the name of your package and try to find an open pull request for the package
 If you find an open pull request, you can review it!
@@ -26,20 +31,9 @@ There's a high chance that you'll have the new version right away while helping 
 -->
 - [ ] Checked the [nixpkgs pull requests](https://github.com/NixOS/nixpkgs/pulls)
 
-###### Project name
-`nix search` name:
-<!--
-The current version can be found easily with the same process as above for checking the master branch
-If an open PR is present for the package, take this version as the current one and link to the PR
--->
-current version:
-desired version:
+##### Notify maintainers
 
-###### Notify maintainers
-<!--
-Search your package here: https://search.nixos.org/packages?channel=unstable
-If no maintainer is listed for your package, tag the person that last updated the package
--->
+<!-- If the search.nixos.org result shows no maintainers, tag the person that last updated the package -->
 
 maintainers:
 

--- a/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
+++ b/.github/ISSUE_TEMPLATE/out_of_date_package_report.md
@@ -7,23 +7,11 @@ assignees: ''
 
 ---
 
-##### Package details
-
 - Package name:
-<!--
-Search your package here: https://search.nixos.org/packages?channel=unstable
-
-If there already is an open PR for the package, take this version as the current one and link to the PR
--->
-- Current version:
-- Desired version:
-
-<!-- If this is a backporting request, fill in this section, otherwise remove it -->
-- [ ] This is a backporting request.
-- Current stable version:
-
-###### Checklist
-
+- Latest released version:
+<!-- Search your package here: https://search.nixos.org/packages?channel=unstable -->
+- Current version on the unstable channel:
+- Current version on the stable/release channel:
 <!--
 Type the name of your package and try to find an open pull request for the package
 If you find an open pull request, you can review it!
@@ -31,12 +19,10 @@ There's a high chance that you'll have the new version right away while helping 
 -->
 - [ ] Checked the [nixpkgs pull requests](https://github.com/NixOS/nixpkgs/pulls)
 
-##### Notify maintainers
+**Notify maintainers**
 
-<!-- If the search.nixos.org result shows no maintainers, tag the person that last updated the package -->
+<!-- If the search.nixos.org result shows no maintainers, tag the person that last updated the package. -->
 
-maintainers:
+-----
 
-###### Note for maintainers
-
-Please tag this issue in your PR.
+Note for maintainers: Please tag this issue in your PR.

--- a/.github/ISSUE_TEMPLATE/packaging_request.md
+++ b/.github/ISSUE_TEMPLATE/packaging_request.md
@@ -1,14 +1,15 @@
 ---
 name: Packaging requests
 about: For packages that are missing
-title: ''
+title: 'Package request: PACKAGENAME'
 labels: '0.kind: packaging request'
 assignees: ''
 
 ---
 
 **Project description**
-_describe the project a little_
+
+<!-- Describe the project a little: -->
 
 **Metadata**
 


### PR DESCRIPTION
###### Description of changes

Improves the issue templates, inspired by #203004

- Also fill in issue titles as part of the template
- Fixed some wording, tried to make them friendlier overall
- Changed some section ordering, slight improvements to consistency

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @Krutonium, @NixOS/documentation-team 