### PR TITLE
storcli: 7.2106.00 -> 7.2309.00, perccli: 7.1910.00 -> 7.2110.00

### DIFF
--- a/pkgs/tools/misc/perccli/default.nix
+++ b/pkgs/tools/misc/perccli/default.nix
@@ -3,13 +3,16 @@
 , fetchurl
 , rpmextract
 }:
+
 stdenvNoCC.mkDerivation rec {
   pname = "perccli";
-  version = "7.1910.00";
+  version = "7.2110.00";
 
   src = fetchurl {
-    url = "https://dl.dell.com/FOLDER07815522M/1/PERCCLI_${version}_A12_Linux.tar.gz";
-    sha256 = "sha256-Gt/kr5schR/IzFmnhXO57gjZpOJ9NSnPX/Sj7zo8Qjk=";
+    # On pkg update: manually adjust the version in the URL because of the different format.
+    url = "https://dl.dell.com/FOLDER09074160M/1/PERCCLI_7.211.0_Linux.tar.gz";
+    sha256 = "sha256-FQasejMVm80uliXOg/riGGwcsK0fSDGh1KYz9r34wBQ=";
+
     # Dell seems to block "uncommon" user-agents, such as Nixpkgs's custom one.
     # Sending no user-agent at all seems to be fine though.
     curlOptsList = [ "--user-agent" "" ];
@@ -19,7 +22,7 @@ stdenvNoCC.mkDerivation rec {
 
   buildCommand = ''
     tar xf $src
-    rpmextract PERCCLI_*_Linux/perccli-*.noarch.rpm
+    rpmextract perccli-00${version}00.0000-1.noarch.rpm
     install -D ./opt/MegaRAID/perccli/perccli64 $out/bin/perccli64
     ln -s perccli64 $out/bin/perccli
 

--- a/pkgs/tools/misc/perccli/default.nix
+++ b/pkgs/tools/misc/perccli/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenvNoCC
-, fetchurl
+, fetchzip
 , rpmextract
 }:
 
@@ -8,10 +8,10 @@ stdenvNoCC.mkDerivation rec {
   pname = "perccli";
   version = "7.2110.00";
 
-  src = fetchurl {
+  src = fetchzip {
     # On pkg update: manually adjust the version in the URL because of the different format.
     url = "https://dl.dell.com/FOLDER09074160M/1/PERCCLI_7.211.0_Linux.tar.gz";
-    sha256 = "sha256-FQasejMVm80uliXOg/riGGwcsK0fSDGh1KYz9r34wBQ=";
+    sha256 = "sha256-8gk+0CrgeisfN2hNpaO1oFey57y7KuNy2i6PWTikDls=";
 
     # Dell seems to block "uncommon" user-agents, such as Nixpkgs's custom one.
     # Sending no user-agent at all seems to be fine though.
@@ -20,21 +20,32 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ rpmextract ];
 
-  buildCommand = ''
-    tar xf $src
-    rpmextract perccli-00${version}00.0000-1.noarch.rpm
-    install -D ./opt/MegaRAID/perccli/perccli64 $out/bin/perccli64
-    ln -s perccli64 $out/bin/perccli
-
-    # Not needed because the binary is statically linked
-    #eval fixupPhase
+  unpackPhase = ''
+    rpmextract $src/perccli-00${version}00.0000-1.noarch.rpm
   '';
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = let
+    inherit (stdenvNoCC.hostPlatform) system;
+    platforms = {
+      x86_64-linux = ''
+        install -D ./opt/MegaRAID/perccli/perccli64 $out/bin/perccli64
+        ln -s perccli64 $out/bin/perccli
+      '';
+    };
+  in platforms.${system} or (throw "unsupported system: ${system}");
+
+  # Not needed because the binary is statically linked
+  dontFixup = true;
 
   meta = with lib; {
     description = "Perccli Support for PERC RAID controllers";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ panicgh ];
-    platforms = with platforms; intersectLists x86_64 linux;
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/tools/misc/storcli/default.nix
+++ b/pkgs/tools/misc/storcli/default.nix
@@ -4,13 +4,14 @@
 , rpmextract
 , unzip
 }:
+
 stdenvNoCC.mkDerivation rec {
   pname = "storcli";
-  version = "7.2106.00";
+  version = "7.2309.00";
 
   src = fetchurl {
-    url = "https://docs.broadcom.com/docs-and-downloads/raid-controllers/raid-controllers-common-files/00${version}00.0000_Unified_StorCLI.zip";
-    sha256 = "sha256-sRMpNXCdcysliVQwRE/1yAeU/cp+y0f2F8BPiWyotxQ=";
+    url = "https://docs.broadcom.com/docs-and-downloads/raid-controllers/raid-controllers-common-files/Unified_storcli_all_os_${version}00.0000.zip";
+    sha256 = "sha256-b98+drI83ddXMOpo6HnTDf75jr83JVIpAwEGjLesmVo=";
   };
 
   nativeBuildInputs = [ rpmextract unzip ];

--- a/pkgs/tools/misc/storcli/default.nix
+++ b/pkgs/tools/misc/storcli/default.nix
@@ -1,36 +1,52 @@
 { lib
 , stdenvNoCC
-, fetchurl
+, fetchzip
 , rpmextract
-, unzip
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "storcli";
   version = "7.2309.00";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://docs.broadcom.com/docs-and-downloads/raid-controllers/raid-controllers-common-files/Unified_storcli_all_os_${version}00.0000.zip";
-    sha256 = "sha256-b98+drI83ddXMOpo6HnTDf75jr83JVIpAwEGjLesmVo=";
+    sha256 = "sha256-n2MzT2LHLHWMWhshWXJ/Q28w9EnLrW6t7hLNveltxLo=";
   };
 
-  nativeBuildInputs = [ rpmextract unzip ];
+  nativeBuildInputs = [ rpmextract ];
 
-  buildCommand = ''
-    unzip $src
-    rpmextract Unified_storcli_all_os/Linux/storcli-*.noarch.rpm
-    install -D ./opt/MegaRAID/storcli/storcli64 $out/bin/storcli64
-    ln -s storcli64 $out/bin/storcli
-
-    # Not needed because the binary is statically linked
-    #eval fixupPhase
+  unpackPhase = let
+    inherit (stdenvNoCC.hostPlatform) system;
+    platforms = {
+      x86_64-linux = "Linux";
+      aarch64-linux = "ARM/Linux";
+    };
+    platform = platforms.${system} or (throw "unsupported system: ${system}");
+  in ''
+    rpmextract $src/${platform}/storcli-00${version}00.0000-1.*.rpm
   '';
 
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -D ./opt/MegaRAID/storcli/storcli64 $out/bin/storcli64
+    ln -s storcli64 $out/bin/storcli
+  '';
+
+  # Not needed because the binary is statically linked
+  dontFixup = true;
+
   meta = with lib; {
+    # Unfortunately there is no better page for this.
+    # Filter for downloads, set 100 items per page. Sort by newest does not work.
+    # Then search manually for the latest version.
+    homepage = "https://www.broadcom.com/site-search?q=storcli";
     description = "Storage Command Line Tool";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ panicgh ];
-    platforms = with platforms; intersectLists x86_64 linux;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Stylistic rewrites, add support for storcli on aarch64-linux.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
    <details>
      <summary>2 packages built:</summary>
      <ul>
        <li>perccli</li>
        <li>storcli</li>
      </ul>
    </details>
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
```console
$ export NIXPKGS_ALLOW_UNFREE=1
$ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1
$ nix-build -A perccli
$ ./result/bin/perccli show
CLI Version = 007.2110.0000.0000 Sep 27, 2022
Operating system = Linux 5.15.80
Status Code = 0
Status = Success
Description = None

Number of Controllers = 0
Host Name = XXX
Operating System  = Linux 5.15.80

$ nix-build -A storcli
$ ./result/bin/storcli show
CLI Version = 007.2309.0000.0000 Sep 16, 2022
Operating system = Linux 5.15.80
Status Code = 0
Status = Success
Description = None

Number of Controllers = 0
Host Name = XXX
Operating System  = Linux 5.15.80

$ nix-build -A pkgsCross.aarch64-multiplatform.storcli
$ file -L result/bin/storcli
result/bin/storcli: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), statically linked, for GNU/Linux 3.7.0, BuildID[sha1]=016964ce7937e7b8baf387acb587213bda3cff09, stripped
$ nix-shell -p qemu --run "qemu-aarch64 result/bin/storcli show"
CLI Version = 007.2309.0000.0000 Sep 16, 2022
Operating system = Linux 5.15.80
Status Code = 0
Status = Success
Description = None

Number of Controllers = 0
Host Name = XXX
Operating System  = Linux 5.15.80
```
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
