### PR TITLE
python3Packages.twisted: disable failing test on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -109,6 +109,11 @@ buildPythonPackage rec {
   '' + lib.optionalString (stdenv.isAarch64 && stdenv.isDarwin) ''
     echo 'AbortConnectionTests_AsyncioSelectorReactorTests.test_fullWriteBufferAfterByteExchange.skip = "Timeout after 120 seconds"' >> src/twisted/internet/test/test_tcp.py
     echo 'AbortConnectionTests_AsyncioSelectorReactorTests.test_resumeProducingAbort.skip = "Timeout after 120 seconds"' >> src/twisted/internet/test/test_tcp.py
+
+    echo 'PosixReactorBaseTests.test_removeAllSkipsInternalReaders.skip = "Fails due to unclosed event loop"' >> src/twisted/internet/test/test_posixbase.py
+    echo 'PosixReactorBaseTests.test_wakerIsInternalReader.skip = "Fails due to unclosed event loop"' >> src/twisted/internet/test/test_posixbase.py
+
+    echo 'TCPPortTests.test_connectionLostFailed.skip = "Fails due to unclosed event loop"' >> src/twisted/internet/test/test_posixbase.py
   '';
 
   # Generate Twisted's plug-in cache. Twisted users must do it as well. See


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/201130#issuecomment-1336348692

```
[ERROR]
Traceback (most recent call last):
  File "/nix/store/xz6krlmwsc15z96p7hgcvssmx848hvq0-python3.10-twisted-22.10.0/lib/python3.10/site-packages/twisted/internet/test/test_posixbase.py", line 55, in tearDown
    self.assertEqual(
  File "/nix/store/xz6krlmwsc15z96p7hgcvssmx848hvq0-python3.10-twisted-22.10.0/lib/python3.10/site-packages/twisted/trial/_synctest.py", line 441, in assertEqual
    super().assertEqual(first, second, msg)
  File "/nix/store/70c1n7i4c90dn4iys0myy30yfxmlsza7-python3-3.10.8/lib/python3.10/unittest/case.py", line 845, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/nix/store/70c1n7i4c90dn4iys0myy30yfxmlsza7-python3-3.10.8/lib/python3.10/unittest/case.py", line 838, in _baseAssertEqual
    raise self.failureException(msg)
twisted.trial.unittest.FailTest: 3 != 0 : Warnings found at the end of the test:
[{'message': 'unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>', 'category': <class 'ResourceWarning'>, 'filename': '/nix/store/70c1n7i4c90dn4iys0myy30yfxmlsza7-python3-3.10.8/lib/python3.10/asyncio/base_events.py', 'lineno': 688}, {'message': 'unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>', 'category': <class 'ResourceWarning'>, 'filename': '/nix/store/70c1n7i4c90dn4iys0myy30yfxmlsza7-python3-3.10.8/lib/python3.10/asyncio/base_events.py', 'lineno': 688}, {'message': 'unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>', 'category': <class 'ResourceWarning'>, 'filename': '/nix/store/70c1n7i4c90dn4iys0myy30yfxmlsza7-python3-3.10.8/lib/python3.10/asyncio/base_events.py', 'lineno': 688}]

twisted.internet.test.test_posixbase.PosixReactorBaseTests.test_removeAllSkipsInternalReaders
```



###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
