### PR TITLE
gonic: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/servers/gonic/default.nix
+++ b/pkgs/servers/gonic/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, buildGoModule, fetchFromGitHub
-, pkg-config, taglib, alsa-lib
-, zlib, AudioToolbox, AppKit
+, pkg-config, taglib, zlib
 
 # Disable on-the-fly transcoding,
 # removing the dependency on ffmpeg.
@@ -8,32 +7,37 @@
 # to the original file, but if transcoding is configured
 # that takes a while. So best to disable all transcoding
 # in the configuration if you disable transcodingSupport.
-, transcodingSupport ? true, ffmpeg }:
+, transcodingSupport ? true, ffmpeg
+, mpv }:
 
 buildGoModule rec {
   pname = "gonic";
-  version = "0.14.0";
+  version = "0.15.0";
   src = fetchFromGitHub {
     owner = "sentriz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-wX97HtvHgHpKTDwZl/wHQRpiyDJ7U38CpdzWu/CYizQ=";
+    sha256 = "sha256-sTvdMLa7rwrTRDH5DR5nJCzzbtXM9y8mq63CNR1lVfI=";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ taglib zlib ]
-    ++ lib.optionals stdenv.isLinux [ alsa-lib ]
-    ++ lib.optionals stdenv.isDarwin [ AudioToolbox AppKit ];
-  vendorSha256 = "sha256-oTuaA5ZsZ7zMcjzGh37zO/1XyOfj6xjfNr6A7ecrOiA=";
+  buildInputs = [ taglib zlib ];
+  vendorSha256 = "sha256-B9qzhh7FKkZPfuylxlyNP0blU5sjGwM6bLsw+vFkkb4=";
 
   # TODO(Profpatsch): write a test for transcoding support,
   # since it is prone to break
   postPatch = lib.optionalString transcodingSupport ''
     substituteInPlace \
-      server/encode/encode.go \
+      transcode/transcode.go \
       --replace \
-        '"ffmpeg"' \
-        '"${lib.getBin ffmpeg}/bin/ffmpeg"'
+        '`ffmpeg' \
+        '`${lib.getBin ffmpeg}/bin/ffmpeg'
+  '' + ''
+    substituteInPlace \
+      jukebox/jukebox.go \
+      --replace \
+        '"mpv"' \
+        '"${lib.getBin mpv}/bin/mpv"'
   '';
 
   meta = {
@@ -41,5 +45,6 @@ buildGoModule rec {
     description = "Music streaming server / subsonic server API implementation";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ Profpatsch ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29141,9 +29141,7 @@ with pkgs;
 
   gollum = callPackage ../applications/misc/gollum { };
 
-  gonic = callPackage ../servers/gonic {
-    inherit (darwin.apple_sdk.frameworks) AppKit AudioToolbox;
-  };
+  gonic = callPackage ../servers/gonic { };
 
   goodvibes = callPackage ../applications/audio/goodvibes { };
 


### PR DESCRIPTION
###### Description of changes

[Changelog](https://github.com/sentriz/gonic/releases/tag/v0.15.0)

The structure of the code saw significant changes, so I had to update the `ffmpeg` patch. I don't use transcoding myself so don't know if it works properly.

The *jukebox* feature now requires `mpv` which also needs patching. Again, haven't tried it, but the built-in tests would not pass without the patch. They do pass afterwards, so I hope it works?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
