### PR TITLE
linuxPackages.hyperv-daemons: add path conditions for kvp and vss

### DIFF
--- a/nixos/modules/virtualisation/hyperv-guest.nix
+++ b/nixos/modules/virtualisation/hyperv-guest.nix
@@ -56,8 +56,6 @@ in {
     systemd = {
       packages = [ config.boot.kernelPackages.hyperv-daemons.lib ];
 
-      services.hv-vss.unitConfig.ConditionPathExists = [ "/dev/vmbus/hv_vss" ];
-
       targets.hyperv-daemons = {
         wantedBy = [ "multi-user.target" ];
       };

--- a/pkgs/os-specific/linux/hyperv-daemons/default.nix
+++ b/pkgs/os-specific/linux/hyperv-daemons/default.nix
@@ -73,9 +73,9 @@ in stdenv.mkDerivation {
   buildCommand = ''
     system=$lib/lib/systemd/system
 
-    install -Dm444 ${service "fcopy" "file copy (FCOPY)" "hv_fcopy" } $system/hv-fcopy.service
-    install -Dm444 ${service "kvp"   "key-value pair (KVP)"     ""  } $system/hv-kvp.service
-    install -Dm444 ${service "vss"   "volume shadow copy (VSS)" ""  } $system/hv-vss.service
+    install -Dm444 ${service "fcopy" "file copy (FCOPY)"        "hv_fcopy" } $system/hv-fcopy.service
+    install -Dm444 ${service "kvp"   "key-value pair (KVP)"     "hv_kvp"   } $system/hv-kvp.service
+    install -Dm444 ${service "vss"   "volume shadow copy (VSS)" "hv_vss"   } $system/hv-vss.service
 
     cat > $system/hyperv-daemons.target <<EOF
     [Unit]


### PR DESCRIPTION
Same spirit as https://github.com/NixOS/nixpkgs/pull/120835

I ran into this because Vultr's virtualisation is now detected as HyperV instead of QEMU, but `/dev/vmbus` doesn't exist so this service failed.