### PR TITLE
nixVersion.nix_{2_6,2_7,2_8,2_9}: remove

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -859,14 +859,14 @@ self: super: builtins.intersectAttrs super {
     (overrideCabal { doCheck = pkgs.postgresql.doCheck; })
   ];
 
-  cachix = super.cachix.override { nix = pkgs.nixVersions.nix_2_9; };
+  cachix = super.cachix.override { nix = pkgs.nixVersions.nix_2_10; };
 
-  hercules-ci-agent = super.hercules-ci-agent.override { nix = pkgs.nixVersions.nix_2_9; };
+  hercules-ci-agent = super.hercules-ci-agent.override { nix = pkgs.nixVersions.nix_2_10; };
   hercules-ci-cnix-expr =
     addTestToolDepend pkgs.git (
-      super.hercules-ci-cnix-expr.override { nix = pkgs.nixVersions.nix_2_9; }
+      super.hercules-ci-cnix-expr.override { nix = pkgs.nixVersions.nix_2_10; }
     );
-  hercules-ci-cnix-store = super.hercules-ci-cnix-store.override { nix = pkgs.nixVersions.nix_2_9; };
+  hercules-ci-cnix-store = super.hercules-ci-cnix-store.override { nix = pkgs.nixVersions.nix_2_10; };
 
   # the testsuite fails because of not finding tsc without some help
   aeson-typescript = overrideCabal (drv: {

--- a/pkgs/development/tools/language-servers/rnix-lsp/default.nix
+++ b/pkgs/development/tools/language-servers/rnix-lsp/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rnix-lsp";
-  version = "0.2.5";
+  version = "unstable-2022-11-27";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "rnix-lsp";
-    rev = "v${version}";
-    sha256 = "sha256-WXpj2fgduYlF4t0QEvdfV1Eft8/nFXWF2zyEBKMUEIk=";
+    rev = "95d40673fe43642e2e1144341e86d0036abd95d9";
+    sha256 = "sha256-F0s0m62S5bHNVWNHLZD6SeHiLrsDx98VQbRjDyIu+qQ=";
   };
 
-  cargoSha256 = "sha256-LfbmOhZJVthsLm8lnzHvEt7Vy27y4w4wpPfrf/s3s84=";
+  cargoSha256 = "sha256-RKHBp+/bEH9FEPLcf1MKmTugk1A8rQU447mNm9Le3DE=";
 
   checkInputs = lib.optional (!stdenv.isDarwin) nix;
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -59,47 +59,13 @@ in lib.makeExtensible (self: {
 
   nix_2_5 = throw "nixVersions.nix_2_5 has been removed";
 
-  # This is the last version of nix where https://github.com/NixOS/nix/issues/6572
-  # is not an unsolved breaking bug. Please keep it until the issue is fixed
-  # and in latest stable nix.
-  nix_2_6 = common {
-    version = "2.6.1";
-    sha256 = "sha256-E9iQ7f+9Z6xFcUvvfksTEfn8LsDfzmwrcRBC//5B3V0=";
-  };
+  nix_2_6 = throw "nixVersions.nix_2_6 has been removed";
 
-  nix_2_7 = common {
-    version = "2.7.0";
-    sha256 = "sha256-m8tqCS6uHveDon5GSro5yZor9H+sHeh+v/veF1IGw24=";
-    patches = [
-      # remove when there's a 2.7.1 release
-      # https://github.com/NixOS/nix/pull/6297
-      # https://github.com/NixOS/nix/issues/6243
-      # https://github.com/NixOS/nixpkgs/issues/163374
-      (fetchpatch {
-        url = "https://github.com/NixOS/nix/commit/c9afca59e87afe7d716101e6a75565b4f4b631f7.patch";
-        sha256 = "sha256-xz7QnWVCI12lX1+K/Zr9UpB93b10t1HS9y/5n5FYf8Q=";
-      })
-    ];
-  };
+  nix_2_7 = throw "nixVersions.nix_2_7 has been removed";
 
-  nix_2_8 = common {
-    version = "2.8.1";
-    sha256 = "sha256-zldZ4SiwkISFXxrbY/UdwooIZ3Z/I6qKxtpc3zD0T/o=";
-  };
+  nix_2_8 = throw "nixVersions.nix_2_8 has been removed";
 
-  nix_2_9 = common {
-    version = "2.9.2";
-    sha256 = "sha256-uZCaBo9rdWRO/AlQMvVVjpAwzYijB2H5KKQqde6eHkg=";
-    patches = [
-      (fetchpatch {
-        # https://github.com/NixOS/nix/pull/7283
-        name = "fix-requires-non-existing-output.patch";
-        url = "https://github.com/NixOS/nix/commit/3ade5f5d6026b825a80bdcc221058c4f14e10a27.patch";
-        sha256 = "sha256-s1ybRFCjQaSGj7LKu0Z5g7UiHqdJGeD+iPoQL0vaiS0=";
-      })
-      patch-sqlite-exception
-    ];
-  };
+  nix_2_9 = throw "nixVersions.nix_2_9 has been removed";
 
   nix_2_10 = common {
     version = "2.10.3";

--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -10,7 +10,6 @@
 , gobject-introspection
 , vala
 , gtk-doc
-, nix
 , boost
 , meson
 , ninja
@@ -48,7 +47,6 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-base
     gtk3
     sqlite
-    nix
     boost
   ] ++ lib.optional enableSystemd systemd
   ++ lib.optional enableBashCompletion bash-completion;
@@ -69,7 +67,10 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     (if enableSystemd then "-Dsystemd=true" else "-Dsystem=false")
-    "-Dpackaging_backend=nix"
+    # often fails to build with nix updates
+    # and remounts /nix/store as rw
+    # https://github.com/NixOS/nixpkgs/issues/177946
+    #"-Dpackaging_backend=nix"
     "-Ddbus_sys=${placeholder "out"}/share/dbus-1/system.d"
     "-Ddbus_services=${placeholder "out"}/share/dbus-1/system-services"
     "-Dsystemdsystemunitdir=${placeholder "out"}/lib/systemd/system"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16625,7 +16625,7 @@ with pkgs;
 
   nil = callPackage ../development/tools/language-servers/nil { };
 
-  rnix-lsp = callPackage ../development/tools/language-servers/rnix-lsp { nix = nixVersions.nix_2_9; };
+  rnix-lsp = callPackage ../development/tools/language-servers/rnix-lsp { };
 
   sumneko-lua-language-server = darwin.apple_sdk_11_0.callPackage ../development/tools/language-servers/sumneko-lua-language-server {
     inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation Foundation;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10390,7 +10390,7 @@ with pkgs;
 
   p7zip = callPackage ../tools/archivers/p7zip { };
 
-  packagekit = callPackage ../tools/package-management/packagekit { nix = nixVersions.nix_2_8; };
+  packagekit = callPackage ../tools/package-management/packagekit { };
 
   packetdrill = callPackage ../tools/networking/packetdrill { };
 


### PR DESCRIPTION
the comment from 2_6 does not apply anymore because the fix has been merged nix#7283
and the fix has been applied to 2_9+

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
