### PR TITLE
hyperion-ng: 2.0.12 -> 2.0.14, unbreak on aarch64-linux

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7248,6 +7248,12 @@
     githubId = 1047859;
     name = "Kaz Wesley";
   };
+  kazenyuk = {
+    email = "kazenyuk@pm.me";
+    github = "nvmd";
+    githubId = 524492;
+    name = "Sergey Kazenyuk";
+  };
   kcalvinalvin = {
     email = "calvin@kcalvinalvin.info";
     github = "kcalvinalvin";

--- a/pkgs/applications/video/hyperion-ng/default.nix
+++ b/pkgs/applications/video/hyperion-ng/default.nix
@@ -1,51 +1,73 @@
-{ stdenv, avahi-compat, cmake, fetchFromGitHub, flatbuffers, hidapi, lib, libcec
-, libusb1, libX11, libxcb, libXrandr, mbedtls, mkDerivation, protobuf, python3
-, qtbase, qtserialport, qtsvg, qtx11extras, wrapQtAppsHook }:
+{ stdenv, lib, fetchFromGitHub
+, cmake, wrapQtAppsHook, perl
+, flatbuffers, protobuf, mbedtls
+, hidapi, libcec, libusb1
+, libX11, libxcb, libXrandr, python3
+, qtbase, qtserialport, qtsvg, qtx11extras
+, withRPiDispmanx ? false, libraspberrypi
+}:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "hyperion.ng";
-  version = "2.0.12";
+  version = "2.0.14";
 
   src = fetchFromGitHub {
     owner = "hyperion-project";
     repo = pname;
     rev = version;
-    sha256 = "sha256-J31QaWwGNhIpnZmWN9lZEI6fC0VheY5X8fGchQqtAlQ=";
+    sha256 = "sha256-Y1PZ+YyPMZEX4fBpMG6IVT1gtXR9ZHlavJMCQ4KAenc=";
+    # needed for `dependencies/external/`:
+    # * rpi_ws281x` - not possible to use as a "system" lib
+    # * qmdnsengine - not in nixpkgs yet
+    fetchSubmodules = true;
   };
 
   buildInputs = [
-    avahi-compat
-    flatbuffers
     hidapi
-    libcec
     libusb1
     libX11
     libxcb
     libXrandr
-    mbedtls
+    flatbuffers
     protobuf
+    mbedtls
     python3
     qtbase
     qtserialport
     qtsvg
     qtx11extras
-  ];
+  ] ++ lib.optional stdenv.isLinux libcec
+    ++ lib.optional withRPiDispmanx libraspberrypi;
 
-  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+  nativeBuildInputs = [
+    cmake wrapQtAppsHook
+  ] ++ lib.optional stdenv.isDarwin perl; # for macos bundle
+
+  patchPhase =  ''
+    patchShebangs test/testrunner.sh
+    patchShebangs src/hyperiond/CMakeLists.txt
+  '' ;
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
-    "-DUSE_SYSTEM_MBEDTLS_LIBS=ON"
+    "-DENABLE_DEPLOY_DEPENDENCIES=OFF"
     "-DUSE_SYSTEM_FLATBUFFERS_LIBS=ON"
     "-DUSE_SYSTEM_PROTO_LIBS=ON"
-  ];
+    "-DUSE_SYSTEM_MBEDTLS_LIBS=ON"
+    # "-DUSE_SYSTEM_QMDNS_LIBS=ON"  # qmdnsengine not in nixpkgs yet
+    "-DENABLE_TESTS=ON"
+  ] ++ lib.optional (withRPiDispmanx == false) "-DENABLE_DISPMANX=OFF";
+
+  doCheck = true;
+  checkPhase = ''
+    cd ../ && ./test/testrunner.sh && cd -
+  '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
-    description = "Open Source Ambilight solution";
+    description = "An opensource Bias or Ambient Lighting implementation";
     homepage = "https://github.com/hyperion-project/hyperion.ng";
     license = licenses.mit;
-    maintainers = with maintainers; [ algram ];
+    maintainers = with maintainers; [ algram kazenyuk ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updating package to version 2.0.14 with lots of upstream changes ([Release notes](https://github.com/hyperion-project/hyperion.ng/releases/tag/2.0.14)), unbreaking for `aarch64-linux` (previosly marked as broken in #173671).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
