### PR TITLE
python310Packages.spsdk: 1.6.3 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/click-command-tree/default.nix
+++ b/pkgs/development/python-modules/click-command-tree/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, click
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "click-command-tree";
+  version = "1.1.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "whwright";
+    repo = pname;
+    rev = version;
+    hash = "sha256-vFOcn+ibyLZnhU3OQMtnHI04UqAY2/CCvhq4EEU4XFo=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "remove-setup-downloading-flake8.patch";
+      url = "https://github.com/whwright/click-command-tree/commit/1ecfcfa29bf01e1131e6ec712bd7338ac1283dc8.patch";
+      hash = "sha256-u5jsNfEo1+XNlkVGPCM/rsDPnYko6cr2z2si9nq+sLA=";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    click
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tests.py"
+  ];
+
+  pythonImportsCheck = [ "click_command_tree" ];
+
+  meta = with lib; {
+    description = "click plugin to show the command tree of your CLI";
+    homepage = "https://github.com/whwright/click-command-tree";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tjni ];
+  };
+}

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , dos2unix
 , pythonRelaxDepsHook
 , asn1crypto
@@ -9,6 +8,7 @@
 , bincopy
 , bitstring
 , click
+, click-command-tree
 , click-option-group
 , cmsis-pack-manager
 , commentjson
@@ -33,42 +33,32 @@
 
 buildPythonPackage rec {
   pname = "spsdk";
-  version = "1.6.3";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "NXPmicro";
     repo = pname;
     rev = version;
-    sha256 = "sha256-JMhd2XdbjEN6SUzFgcBHd/dStiuYeXXis6pfijSfUso=";
+    hash = "sha256-yCmkOrUe5XqbuHeo7F84j1gmdzpdpCRWdD9V74U64c4=";
   };
 
-  patches = [
-    # https://github.com/NXPmicro/spsdk/pull/43
-    (fetchpatch {
-      name = "cryptography-37-compat.patch";
-      url = "https://github.com/NXPmicro/spsdk/commit/a85b854de1093de593d27fa64de442224ab2e0fd.patch";
-      sha256 = "sha256-4pXV/8RaNuGl7KNdoGD/8YnPQ2ZmUQOjXWA/Yy0Kxu8=";
-    })
-    # https://github.com/NXPmicro/spsdk/pull/41
-    (fetchpatch {
-      name = "blhost-click-8-1-compat.patch";
-      url = "https://github.com/NXPmicro/spsdk/commit/5112b1b69aa681d265035475e73d28ea0c8cb6ab.patch";
-      sha256 = "sha256-Okz6Er6OVuAA5IlB5IabSa/gUSLa+E2Ltd+J3uoIg6o=";
-    })
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
   ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = [
     "bincopy"
     "bitstring"
     "cmsis-pack-manager"
-    "cryptography"
     "deepmerge"
     "jinja2"
     "pylink-square"
     "pyocd"
   ];
-  pythonRemoveDeps = [ "pyocd-pemicro" ];
+
+  pythonRemoveDeps = [
+    "pyocd-pemicro"
+  ];
 
   propagatedBuildInputs = [
     asn1crypto
@@ -76,6 +66,7 @@ buildPythonPackage rec {
     bincopy
     bitstring
     click
+    click-command-tree
     click-option-group
     cmsis-pack-manager
     commentjson
@@ -99,12 +90,6 @@ buildPythonPackage rec {
   checkInputs = [
     pytestCheckHook
     voluptuous
-  ];
-
-  disabledTests = [
-    # tests also fail on debian, so presumable they are broken
-    "test_elftosb_mbi_signed"
-    "test_elftosb_sb31"
   ];
 
   pythonImportsCheck = [ "spsdk" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1750,6 +1750,8 @@ self: super: with self; {
 
   clickclick = callPackage ../development/python-modules/clickclick { };
 
+  click-command-tree = callPackage ../development/python-modules/click-command-tree { };
+
   click-completion = callPackage ../development/python-modules/click-completion { };
 
   click-configfile = callPackage ../development/python-modules/click-configfile { };


### PR DESCRIPTION
###### Description of changes

https://github.com/NXPmicro/spsdk/blob/master/docs/release_notes.rst

I can't test this on hardware myself, but because I spent some time understanding this package recently, I'd like to update it so that the next person who touches it starts from what currently is available upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
