### PR TITLE
libredwg: 0.12.4 -> 0.12.5

### DIFF
--- a/pkgs/development/libraries/libredwg/default.nix
+++ b/pkgs/development/libraries/libredwg/default.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
     cp ${printVersion} build-aux/git-version-gen
   '';
 
+  preConfigure = lib.optionalString (stdenv.isDarwin && enablePython) ''
+    # prevent configure picking up stack_size from distutils.sysconfig
+    export PYTHON_EXTRA_LDFLAGS=" "
+  '';
+
   nativeBuildInputs = [ autoreconfHook pkg-config texinfo ]
     ++ lib.optional enablePython swig;
 

--- a/pkgs/development/libraries/libredwg/default.nix
+++ b/pkgs/development/libraries/libredwg/default.nix
@@ -1,20 +1,40 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, texinfo, pcre2
-, enablePython ? false, python ? null, swig, libxml2, ncurses
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, writeShellScript
+, pkg-config
+, texinfo
+, pcre2
+, swig
+, libxml2
+, ncurses
+, enablePython ? false
+, python ? null
 }:
 let
   isPython3 = enablePython && python.pythonAtLeast "3";
 in
 stdenv.mkDerivation rec {
   pname = "libredwg";
-  version = "0.12.4";
+  version = "0.12.5";
 
   src = fetchFromGitHub {
     owner = "LibreDWG";
     repo = pname;
     rev = version;
-    sha256 = "sha256-CZZ5/uCls2tY3PKmD+hBBvp7d7KX8nZuCPf03sa4iXc=";
+    sha256 = "sha256-s9aiOKSM7+3LJNE+jRrEMcL1QKRWrlTKbwO7oL9VhuE=";
     fetchSubmodules = true;
   };
+
+  postPatch = let
+    printVersion = writeShellScript "print-version" ''
+      echo ${lib.escapeShellArg version}
+    '';
+  in ''
+    # avoid git dependency
+    cp ${printVersion} build-aux/git-version-gen
+  '';
 
   nativeBuildInputs = [ autoreconfHook pkg-config texinfo ]
     ++ lib.optional enablePython swig;


### PR DESCRIPTION
###### Description of changes

Marking this as a security fix, though not with any specific CVEs: the NEWS file for this release (https://github.com/LibreDWG/libredwg/blob/0.12.5/NEWS#L5) lists many "minor" fuzzing fixes (which include double frees and "bounds checks", neither of which sound very minor to me) and makes a significant safety improvement in restricting the set of accepted DXF classes.

Note there are two CVEs currently out on libredwg, _neither of which_ this fixes:

 - CVE-2022-35164 doesn't seem to have a working fix yet
 - CVE-2022-45332 is only for a version of DXF that had support added _after_ 0.12.5. Trying the supplied PoC with 0.12.5 didn't exhibit a vulnerability.

Edit: have also added a commit to fix `python3Packages.libredwg` building on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
