### PR TITLE
ceph: use lua5_3_compat

### DIFF
--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -15,7 +15,7 @@
 , nixosTests
 , cryptsetup
 , sqlite
-, lua
+, lua5_3_compat
 , icu
 , bzip2
 , doxygen
@@ -168,7 +168,7 @@ in rec {
       boost ceph-python-env libxml2 optYasm optLibatomic_ops optLibs3
       malloc zlib openldap lttng-ust babeltrace gperf gtest cunit
       snappy lz4 oath-toolkit leveldb libnl libcap_ng rdkafka
-      cryptsetup sqlite lua icu bzip2
+      cryptsetup sqlite lua5_3_compat icu bzip2
     ] ++ lib.optionals stdenv.isLinux [
       linuxHeaders util-linux libuuid udev keyutils liburing optLibaio optLibxfs optZfs
       # ceph 14


### PR DESCRIPTION
###### Description of changes

As per [this investigation](https://github.com/NixOS/nixpkgs/issues/203298), Ceph needs lua 5.3 or higher. The original `.nix` file included `lua` which was version 5.2.4 so the change is to move it to the minimum using `lua5_3_compat` which is v5.3.6.

The relevant error that identified this is:

```
-- Performing Test HAS_VTA                                                                                                             
-- Performing Test HAS_VTA - Success
Cmake Error at /nix/store/rxb9zl1mdx9f2n3z0nyv9zhngj3f2pw0-cmake-3.24.3/share/cmake-3.24/Modules/FindPackageHandleStandardArgs.cmake:23    0 (message):
  Could NOT find Lua (missing: LUA_INCLUDE_DIR) (Required is at least version
  "5.3")
Call Stack (most recent call first):
  /nix/store/rxb9zl1mdx9f2n3z0nyv9zhngj3f2pw0-cmake-3.24.3/share/cmake-3.24/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAI    LURE_MESSAGE)
  /nix/store/rxb9zl1mdx9f2n3z0nyv9zhngj3f2pw0-cmake-3.24.3/share/cmake-3.24/Modules/FindLua.cmake:236 (FIND_PACKAGE_HANDLE_STANDARD_ARG    S)
  src/CMakeLists.txt:580 (find_package)
```
###### Things done

Bumped up the requirements to use the minimum version.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).