### PR TITLE
kicad-unstable: 2022-09-18 -> 2022-12-19 and cleanup

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -33,6 +33,7 @@
 , dbus
 , at-spi2-core
 , libXtst
+, pcre2
 
 , swig4
 , python
@@ -66,6 +67,11 @@ stdenv.mkDerivation rec {
   version = if (stable) then kicadVersion else builtins.substring 0 10 src.rev;
 
   src = kicadSrc;
+
+  patches = [
+    # upstream issue 12941 (attempted to upstream, but appreciably unacceptable)
+    ./writable.patch
+  ];
 
   # tagged releases don't have "unknown"
   # kicad nightlies use git describe --dirty
@@ -114,6 +120,9 @@ stdenv.mkDerivation rec {
   ]
   ++ optionals (!withPCM && stable) [
     "-DKICAD_PCM=OFF"
+  ]
+  ++ optionals (!stable) [ # upstream issue 12491
+    "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_eeschema'"
   ];
 
   nativeBuildInputs = [
@@ -136,6 +145,7 @@ stdenv.mkDerivation rec {
     dbus
     at-spi2-core
     libXtst
+    pcre2
   ];
 
   buildInputs = [
@@ -162,14 +172,10 @@ stdenv.mkDerivation rec {
   ++ optional (withScripting) wxPython
   ++ optional (withNgspice) libngspice
   ++ optional (withOCC) opencascade-occt
-  ++ optional (debug) valgrind
-  ;
-
-  # started becoming necessary halfway into 2022, not sure what changed to break a test...
-  preInstallCheck = optionals (withNgspice) [ "export LD_LIBRARY_PATH=${libngspice}/lib" ];
+  ++ optional (debug) valgrind;
 
   # debug builds fail all but the python test
-  doInstallCheck = !(!stable || debug);
+  doInstallCheck = !(debug);
   installCheckTarget = "test";
 
   dontStrip = debug;

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation rec {
   preInstallCheck = optionals (withNgspice) [ "export LD_LIBRARY_PATH=${libngspice}/lib" ];
 
   # debug builds fail all but the python test
-  doInstallCheck = !debug;
+  doInstallCheck = !(!stable || debug);
   installCheckTarget = "test";
 
   dontStrip = debug;

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -138,8 +138,7 @@ stdenv.mkDerivation rec {
     ++ optionals (withScripting)
     [ python.pkgs.wrapPython ];
 
-  # We are emulating wrapGAppsHook, along with other variables to the
-  # wrapper
+  # We are emulating wrapGAppsHook, along with other variables to the wrapper
   makeWrapperArgs = with passthru.libraries; [
     "--prefix XDG_DATA_DIRS : ${base}/share"
     "--prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share"
@@ -231,5 +230,7 @@ stdenv.mkDerivation rec {
     # as long as the base and libraries (minus 3d) are build,
     # this wrapper does not need to get built
     # the kicad-*small "packages" cause this to happen
+
+    mainProgram = "kicad";
   };
 }

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -25,23 +25,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2022-09-18";
+      version =			"2022-12-19";
       src = {
-        rev =			"0efc1149afed2af5b81e4555de4623217ece650f";
-        sha256 =		"19fqy8yvvl45izg5ynhch9r4gl4ncx0bz9s6n1x98bgzxkdyc14q";
+        rev =			"a3a2e2e5b1981ebfbb60f1e8e40bd02625d33692";
+        sha256 =		"1584n2gn68vdyzlm9805ln1bdgzf831j5l4v29z08dkbi2sl3rg0";
       };
     };
     libVersion = {
-      version =			"2022-09-18";
+      version =			"2022-12-19";
       libSources = {
-        symbols.rev =		"879023fba005d23f285b6d052d9e6bcba1d754aa";
-        symbols.sha256 =	"1nxz8r3h3j62fs3s77lj27333fsj5c4i01n05lv0gqx36h28hqxk";
+        symbols.rev =		"2fa69d6d1dce065f8d0998733f66d2cd7db31b9e";
+        symbols.sha256 =	"1kp8v0q1pirpi4v485j5bg72jpnxglbpgxjxda6kvq8d2124pwlb";
         templates.rev =		"ae2b46f8756d79379b90fec01d4fdde1ccfd73c1";
         templates.sha256 =	"08zxh83fbygh1x2jhca8nrp3f9kihf7kmg65qmyp95wvps4p5h8v";
-        footprints.rev =	"b1dfe894de90b0063befc02b914dc9e2b47e3a62";
-        footprints.sha256 =	"06kn6c00wlnr33mks582xhadvkbbgmqhb4qc1wjfw264pavz7v7y";
-        packages3d.rev =	"45df600c5e3dd5113d62e6445115e7c37bdf362f";
-        packages3d.sha256 =	"0cnrg7mr3khpglviid1adk2ihs1qwj0r7l32z2vqsl8aidzbg9kr";
+        footprints.rev =	"24671f7754c74dfa528e6b62ebef33b161aa4ab6";
+        footprints.sha256 =	"1rs05n1wjb2w3x7xqkkijbdxyw3fj0fph8znvnsxp9bgwaaipd4h";
+        packages3d.rev =	"7aeaa02a2e7438fbbe94a00ca321366a39dc1267";
+        packages3d.sha256 =	"13wfcm7fgsgl3a0g00ra3v35c8wqw9yzgdiai54f1m77r2cr7bhp";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/writable.patch
+++ b/pkgs/applications/science/electronics/kicad/writable.patch
@@ -1,0 +1,49 @@
+commit 6a72fd032405515e468797be91b5a6ebcbbb5fd8
+Author: Evils <evils.devils@protonmail.com>
+Date:   Wed Nov 23 19:49:13 2022 +0100
+
+    ensure new projects are writable
+
+diff --git a/kicad/kicad_manager_frame.cpp b/kicad/kicad_manager_frame.cpp
+index 7ee8090858..391514519c 100644
+--- a/kicad/kicad_manager_frame.cpp
++++ b/kicad/kicad_manager_frame.cpp
+@@ -638,6 +638,12 @@ void KICAD_MANAGER_FRAME::CreateNewProject( const wxFileName& aProjectFileName,
+ 
+                 // wxFFile dtor will close the file
+             }
++
++            if( destFileName.IsOk() && !destFileName.IsFileWritable() )
++            {
++                destFileName.SetPermissions(0644);
++            }
++
+         }
+     }
+ 
+diff --git a/kicad/project_template.cpp b/kicad/project_template.cpp
+index bf951fcddb..2bef94326b 100644
+--- a/kicad/project_template.cpp
++++ b/kicad/project_template.cpp
+@@ -282,6 +282,21 @@ bool PROJECT_TEMPLATE::CreateProject( wxFileName& aNewProjectPath, wxString* aEr
+ 
+             result = false;
+         }
++	else if( !destFile.IsFileWritable() && !destFile.SetPermissions(0644) )
++        {
++            if( aErrorMsg )
++            {
++                if( !aErrorMsg->empty() )
++                    *aErrorMsg += "\n";
++
++                wxString msg;
++
++                msg.Printf( _( "Cannot make file writable: '%s'." ), destFile.GetFullPath() );
++                *aErrorMsg += msg;
++            }
++
++            result = false;
++	}
+     }
+ 
+     return result;


### PR DESCRIPTION
###### Description of changes

bunch of cleanup i've had around
mostly delayed due to wanting to resolve the qa_eeschema test [failure](https://gitlab.com/kicad/code/kicad/-/issues/12491) instead of disabling it
(there's an open MR to fix that issue, but it seems masked by another, as using the MR's patch doesn't resolve it)

update includes an upstream [fix](https://gitlab.com/kicad/code/kicad/-/merge_requests/1319) by one of our users
and a patch for a Nix specific [issue](https://gitlab.com/kicad/code/kicad/-/issues/12941) reported to me by a user

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).