### PR TITLE
mkshell: refactor Bash snippet

### DIFF
--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -44,12 +44,13 @@ stdenv.mkDerivation ({
   phases = [ "buildPhase" ];
 
   buildPhase = ''
-    echo "------------------------------------------------------------" >>$out
-    echo " WARNING: the existence of this path is not guaranteed." >>$out
-    echo " It is an internal implementation detail for pkgs.mkShell."   >>$out
-    echo "------------------------------------------------------------" >>$out
-    echo >> $out
-    # Record all build inputs as runtime dependencies
-    export >> $out
+    { echo "------------------------------------------------------------";
+      echo " WARNING: the existence of this path is not guaranteed.";
+      echo " It is an internal implementation detail for pkgs.mkShell.";
+      echo "------------------------------------------------------------";
+      echo;
+      # Record all build inputs as runtime dependencies
+      export;
+    } >> "$out"
   '';
 } // rest)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I’ve been using https://github.com/Fuuzetsu/shellcheck-nix-attributes on most of my derivations, and attaching it to one derived from `mkShell` resulted in

```
shellcheck_buildPhase

In /nix/store/8774inwznc87dwhac90winc9b5k6gmkb-nix-shell_shellcheck_buildPhase line 1:
echo "------------------------------------------------------------" >>$out
^-- SC2129 (style): Consider using { cmd1; cmd2; } >> file instead of individual redirects.
                                                                      ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo "------------------------------------------------------------" >>"$out"

In /nix/store/8774inwznc87dwhac90winc9b5k6gmkb-nix-shell_shellcheck_buildPhase line 2:
echo " WARNING: the existence of this path is not guaranteed." >>$out
                                                                 ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo " WARNING: the existence of this path is not guaranteed." >>"$out"

In /nix/store/8774inwznc87dwhac90winc9b5k6gmkb-nix-shell_shellcheck_buildPhase line 3:
echo " It is an internal implementation detail for pkgs.mkShell."   >>$out
                                                                      ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo " It is an internal implementation detail for pkgs.mkShell."   >>"$out"

In /nix/store/8774inwznc87dwhac90winc9b5k6gmkb-nix-shell_shellcheck_buildPhase line 4:
echo "------------------------------------------------------------" >>$out
                                                                      ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo "------------------------------------------------------------" >>"$out"

In /nix/store/8774inwznc87dwhac90winc9b5k6gmkb-nix-shell_shellcheck_buildPhase line 5:
echo >> $out
        ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo >> "$out"

In /nix/store/8774inwznc87dwhac90winc9b5k6gmkb-nix-shell_shellcheck_buildPhase line 7:
export >> $out
          ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
export >> "$out"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2129 -- Consider using { cmd1; cmd2; } >>...
```
——— https://garnix.io/build/qgxbameB

This addresses the shellcheck complaints.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
