### PR TITLE
shadow: 4.11.1 -> 4.13

### DIFF
--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -10,22 +10,17 @@ let
     then glibcCross
     else assert stdenv.hostPlatform.libc == "glibc"; stdenv.cc.libc;
 
-  dots_in_usernames = fetchpatch {
-    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-apps/shadow/files/shadow-4.1.3-dots-in-usernames.patch";
-    sha256 = "1fj3rg6x3jppm5jvi9y7fhd2djbi4nc5pgwisw00xlh4qapgz692";
-  };
-
 in
 
 stdenv.mkDerivation rec {
   pname = "shadow";
-  version = "4.11.1";
+  version = "4.13";
 
   src = fetchFromGitHub {
     owner = "shadow-maint";
-    repo = "shadow";
-    rev = "v${version}";
-    sha256 = "sha256-PxLX5V0t18JftT5wT41krNv18Ew7Kz3MfZkOi/80ODA=";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-L54DhdBYthfB9436t/XWXiqKhW7rfd0GLS7pYGB32rA=";
   };
 
   buildInputs = [ libxcrypt ]
@@ -34,13 +29,17 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_45 docbook_xsl flex bison itstool
     ];
 
-  patches =
-    [ ./keep-path.patch
-      # Obtain XML resources from XML catalog (patch adapted from gtk-doc)
-      ./respect-xml-catalog-files-var.patch
-      dots_in_usernames
-      ./runtime-shell.patch
-    ];
+  patches = [
+    ./keep-path.patch
+    # Obtain XML resources from XML catalog (patch adapted from gtk-doc)
+    ./respect-xml-catalog-files-var.patch
+    ./runtime-shell.patch
+    # Fix HAVE_SHADOWGRP configure check
+    (fetchpatch {
+      url = "https://github.com/shadow-maint/shadow/commit/a281f241b592aec636d1b93a99e764499d68c7ef.patch";
+      sha256 = "sha256-GJWg/8ggTnrbIgjI+HYa26DdVbjTHTk/IHhy7GU9G5w=";
+    })
+  ];
 
   RUNTIME_SHELL = runtimeShell;
 
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
     ''sed 's/^\(s[ug]idperms\) = [0-9]755/\1 = 0755/' -i src/Makefile.am
     '';
 
-  outputs = [ "out" "su" "man" ];
+  outputs = [ "out" "su" "dev" "man" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes
Update shadow to version 4.13.
Removed patch shadow-4.1.3-dots-in-usernames. This change included in this PR - https://github.com/shadow-maint/shadow/pull/551
Added `dev` outputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
