### PR TITLE
fcitx5-with-addons: fix not found liblua.so

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
@@ -1,13 +1,12 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , cmake
 , extra-cmake-modules
 , fcitx5
-, lua5_3
-, luaPackage ? lua5_3
+, lua
 , gettext
 }:
-
 stdenv.mkDerivation rec {
   pname = "fcitx5-lua";
   version = "5.0.10";
@@ -19,16 +18,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-0ESgQv8kyc+zv/tDZtBZ+QhFFswD80ApwswFlJs8tOU=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    extra-cmake-modules
-  ];
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
 
-  buildInputs = [
-    fcitx5
-    luaPackage
-    gettext
-  ];
+  buildInputs = [ fcitx5 lua gettext ];
+
+  passthru = {
+    extraLdLibraries = [ lua ];
+  };
 
   meta = with lib; {
     description = "Lua support for Fcitx 5";

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -1,9 +1,11 @@
-{ symlinkJoin, makeWrapper, fcitx5, fcitx5-lua, fcitx5-configtool, fcitx5-qt, fcitx5-gtk, addons ? [] }:
+{ lib, symlinkJoin, makeWrapper, fcitx5, fcitx5-lua, fcitx5-configtool, fcitx5-qt, fcitx5-gtk, addons ? [ ] }:
+
+with lib;
 
 symlinkJoin {
   name = "fcitx5-with-addons-${fcitx5.version}";
 
-  paths = [ fcitx5 fcitx5-configtool fcitx5-lua fcitx5-qt fcitx5-gtk ] ++ addons;
+  paths = [ fcitx5 fcitx5-configtool fcitx5-qt fcitx5-lua fcitx5-gtk ] ++ addons;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -11,7 +13,8 @@ symlinkJoin {
     wrapProgram $out/bin/fcitx5 \
       --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5" \
       --suffix XDG_DATA_DIRS : "$out/share" \
-      --suffix PATH : "$out/bin"
+      --suffix PATH : "$out/bin" \
+      --suffix LD_LIBRARY_PATH : ${makeLibraryPath fcitx5-lua.extraLdLibraries};
 
     desktop=share/applications/org.fcitx.Fcitx5.desktop
     autostart=etc/xdg/autostart/org.fcitx.Fcitx5.desktop

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -1,11 +1,11 @@
-{ lib, symlinkJoin, makeWrapper, fcitx5, fcitx5-lua, fcitx5-configtool, fcitx5-qt, fcitx5-gtk, addons ? [ ] }:
+{ lib, symlinkJoin, makeWrapper, fcitx5, fcitx5-configtool, fcitx5-qt, fcitx5-gtk, addons ? [ ] }:
 
 with lib;
 
 symlinkJoin {
   name = "fcitx5-with-addons-${fcitx5.version}";
 
-  paths = [ fcitx5 fcitx5-configtool fcitx5-qt fcitx5-lua fcitx5-gtk ] ++ addons;
+  paths = [ fcitx5 fcitx5-configtool fcitx5-qt fcitx5-gtk ] ++ addons;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -14,7 +14,7 @@ symlinkJoin {
       --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5" \
       --suffix XDG_DATA_DIRS : "$out/share" \
       --suffix PATH : "$out/bin" \
-      --suffix LD_LIBRARY_PATH : ${makeLibraryPath fcitx5-lua.extraLdLibraries};
+      --suffix LD_LIBRARY_PATH : ${makeLibraryPath (flatten (map (x: x.extraLdLibraries or []) addons))}
 
     desktop=share/applications/org.fcitx.Fcitx5.desktop
     autostart=etc/xdg/autostart/org.fcitx.Fcitx5.desktop

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6979,7 +6979,7 @@ with pkgs;
 
   fcitx5-chewing = callPackage ../tools/inputmethods/fcitx5/fcitx5-chewing.nix { };
 
-  fcitx5-lua = callPackage ../tools/inputmethods/fcitx5/fcitx5-lua.nix { };
+  fcitx5-lua = callPackage ../tools/inputmethods/fcitx5/fcitx5-lua.nix { lua = lua5_3; };
 
   fcitx5-m17n = callPackage ../tools/inputmethods/fcitx5/fcitx5-m17n.nix { };
 


### PR DESCRIPTION
Signed-off-by: ercao <vip@ercao.cn>

###### Description of changes

fix: when start fcitx5-daemon.service show the not found liblua.so.5.3
```text
E2022-12-05 22:13:53.805405 luaaddonloader.cpp:21] Failed to load lua library: liblua.so.5.3: cannot open shared object file: No such file or directory
E2022-12-05 22:13:53.805440 addonloader.cpp:61] Failed to create addon: luaaddonloader Failed to resolve lua functions.
I2022-12-05 22:13:53.805449 addonmanager.cpp:188] Could not load addon luaaddonloader
``` 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
