### PR TITLE
usbmuxd2: init at unstable-2022-02-07

### DIFF
--- a/pkgs/tools/misc/usbmuxd2/default.nix
+++ b/pkgs/tools/misc/usbmuxd2/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, clangStdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libimobiledevice
+, libusb1
+, avahi
+, clang
+}: let
+
+  libgeneral = clangStdenv.mkDerivation rec {
+    pname = "libgeneral";
+    version = "unstable-2021-12-12";
+    src = fetchFromGitHub {
+      owner = "tihmstar";
+      repo = pname;
+      rev = "017d71edb0a12ff4fa01a39d12cd297d8b3d8d34";
+      sha256 = "sha256-NrSl/BeKe3wahiYTHGRVSq3PLgQfu76kHCC5ziY7cgQ=";
+    };
+    postPatch = ''
+      # Set package version so we don't require git
+      sed -i '/AC_INIT/s/m4_esyscmd.*/${version})/' configure.ac
+    '';
+    nativeBuildInputs = [
+      autoreconfHook
+      pkg-config
+    ];
+    meta = with lib; {
+      description = "Helper library used by usbmuxd2";
+      homepage = "https://github.com/tihmstar/libgeneral";
+      license = licenses.lgpl21;
+      platforms = platforms.all;
+    };
+  };
+
+in
+clangStdenv.mkDerivation rec {
+  pname = "usbmuxd2";
+  version = "unstable-2022-02-07";
+
+  src = fetchFromGitHub {
+    owner = "tihmstar";
+    repo = pname;
+    rev = "753b79eaf317c56df6c8b1fb6da5847cc54a0bb0";
+    hash = "sha256-T9bt3KOJwFpdPeFuXfBhkBZNaNzix3Q3D47vASR+fVg=";
+  };
+
+  postPatch = ''
+    # Set package version so we don't require git
+    sed -i '/AC_INIT/s/m4_esyscmd.*/${version})/' configure.ac
+    # Do not check libgeneral version
+    sed -i 's/libgeneral >= 39/libgeneral/' configure.ac
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    clang
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    avahi
+    libgeneral
+    libimobiledevice
+    libusb1
+  ];
+
+  configureFlags = [
+    "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ];
+
+  makeFlags = [
+    "sbindir=${placeholder "out"}/bin"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/tihmstar/usbmuxd2";
+    description = "A socket daemon to multiplex connections from and to iOS devices";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12550,6 +12550,8 @@ with pkgs;
 
   usbmuxd = callPackage ../tools/misc/usbmuxd {};
 
+  usbmuxd2 = callPackage ../tools/misc/usbmuxd2 {};
+
   ustreamer = callPackage ../applications/video/ustreamer { };
 
   usync = callPackage ../applications/misc/usync { };


### PR DESCRIPTION
###### Description of changes

[usbmuxd2](https://github.com/tihmstar/usbmuxd2) is a rewrite and alternative for the older and discontinued usbmuxd for tethering and pairing iOS devices.

usbmuxd has several issues, see the [article](https://nixos.wiki/wiki/IOS) in the NixOS wiki for example.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
