### PR TITLE
linuxPackages.apfs: unstable-2022-08-15 -> unstable-2022-10-20

### DIFF
--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "apfs";
-  version = "unstable-2022-08-15-${kernel.version}";
+  version = "unstable-2022-10-20-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "linux-apfs";
     repo = "linux-apfs-rw";
-    rev = "e4bf2d51d3fe8485ad2b28a89c157ada32ee3d77";
-    sha256 = "sha256-zvl1H9AIExgt6t2A2w7zDwXmRsmLY8y3P6EfbBuFdh8=";
+    rev = "e6eb67c92d425d395eac1c4403629391bdd5064d";
+    sha256 = "sha256-6rv5qZCjOqt0FaNFhA3tYg6/SdssvoT8kPVhalajgOo=";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , kernel
+, nixosTests
 }:
 
 stdenv.mkDerivation {
@@ -23,6 +24,8 @@ stdenv.mkDerivation {
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];
+
+  passthru.tests.test = nixosTests.apfs;
 
   meta = with lib; {
     description = "APFS module for linux";


### PR DESCRIPTION
###### Description of changes
This fixes a compatibility issue with Linux 6.0: https://github.com/linux-apfs/linux-apfs-rw/commit/e2ca36a76d35aea025e4b76f3ffb18401fa554bc.
I also added `passthru.tests`, so the test can be executed with `nix-build -A linuxPackages.apfs.tests`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).