### PR TITLE
qtsass: init at 0.4.0, eontimer: init at unstable-2020-05-22

### DIFF
--- a/pkgs/development/python-modules/qtsass/default.nix
+++ b/pkgs/development/python-modules/qtsass/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flaky
+, libsass
+, pytestCheckHook
+, pythonRelaxDepsHook
+}:
+
+buildPythonPackage rec {
+  pname = "qtsass";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "spyder-ide";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "LzLTI22rE/mrzAjBHMDgWfa2Cdm/KP76D8QJvxyMbeo=";
+  };
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  propagatedBuildInputs = [ libsass ];
+
+  checkInputs = [ pytestCheckHook flaky ];
+
+  pythonRelaxDeps = [ "libsass" ];
+
+  pytestFlagsArray = [ "tests/" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/spyder-ide/qtsass";
+    description = "Compile SASS files to Qt stylesheets";
+    license = licenses.mit;
+    maintainers = with maintainers; [ leo60228 ];
+  };
+}

--- a/pkgs/tools/games/eontimer/default.nix
+++ b/pkgs/tools/games/eontimer/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, copyDesktopItems
+, makeDesktopItem
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, sfml
+, qtbase
+, qttools
+, qtsass
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eontimer";
+  version = "unstable-2020-05-22";
+
+  src = fetchFromGitHub {
+    owner = "DasAmpharos";
+    repo = "EonTimer";
+    rev = "d53e42a508de4003b719791ce36e37a8f49dbfc9";
+    sha256 = "jelFKEaifMOtKWJIkJvDMoP+dsQOfNPkx9YjyK4HVj4=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/DasAmpharos/EonTimer/pull/95/commits/70685414d8f052394badd0f45daff4083018c788.patch";
+      sha256 = "AcExUornaHtvEgg3TzAkf9TCXAJ0kdgcV++yUTxX3NI=";
+    })
+    ./set-desktop-file-name.patch
+  ];
+
+  preConfigure = ''
+    qtsass -o resources/styles resources/styles
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D EonTimer $out/bin/EonTimer
+    install -Dm 644 $src/docs/icon.svg $out/share/pixmaps/EonTimer.svg
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ cmake qtsass wrapQtAppsHook copyDesktopItems ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "eontimer";
+      exec = "EonTimer";
+      icon = "EonTimer";
+      comment = "Timer designed for Pokémon RNG";
+      desktopName = "EonTimer";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  buildInputs = [ qtbase qttools sfml ];
+
+  meta = with lib; {
+    homepage = "https://github.com/DasAmpharos/EonTimer";
+    description = "Timer designed for Pokémon RNG";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ leo60228 ];
+  };
+}

--- a/pkgs/tools/games/eontimer/set-desktop-file-name.patch
+++ b/pkgs/tools/games/eontimer/set-desktop-file-name.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main.cpp b/src/main.cpp
+index 8ad1666..37cce71 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -8,6 +8,7 @@ int main(int argc, char **argv) {
+     QCoreApplication::setApplicationName(APP_NAME);
+     QCoreApplication::setOrganizationName("DylanMeadows");
+     QCoreApplication::setOrganizationDomain("io.github.dylmeadows");
++    QGuiApplication::setDesktopFileName("eontimer");
+     qRegisterMetaTypeStreamOperators<QList<int>>("QList<int>");
+ 
+     gui::ApplicationWindow window;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11927,6 +11927,8 @@ with pkgs;
 
   qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
+  qtsass = with python3.pkgs; toPythonApplication qtsass;
+
   qtspim = libsForQt5.callPackage ../development/tools/misc/qtspim { };
 
   quadrafuzz = callPackage ../applications/audio/quadrafuzz { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7535,6 +7535,8 @@ with pkgs;
 
   eot_utilities = callPackage ../tools/misc/eot-utilities { };
 
+  eontimer = libsForQt5.callPackage ../tools/games/eontimer { };
+
   eplot = callPackage ../tools/graphics/eplot { };
 
   epstool = callPackage ../tools/graphics/epstool { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10458,6 +10458,8 @@ self: super: with self; {
 
   qtpy = callPackage ../development/python-modules/qtpy { };
 
+  qtsass = callPackage ../development/python-modules/qtsass { };
+
   quadprog = callPackage ../development/python-modules/quadprog { };
 
   qualysclient = callPackage ../development/python-modules/qualysclient { };


### PR DESCRIPTION
###### Description of changes

EonTimer is a timer designed for manipulation of the RNG in Pokémon games.

qtsass is a tool to compile SASS stylesheets for Qt. EonTimer has a build dependency on it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
