### PR TITLE
mbedtls_3: init at 3.2.1

### DIFF
--- a/pkgs/applications/emulators/dolphin-emu/default.nix
+++ b/pkgs/applications/emulators/dolphin-emu/default.nix
@@ -24,7 +24,7 @@
 , wxGTK30
 , soundtouch
 , miniupnpc
-, mbedtls
+, mbedtls_2
 , curl
 , lzo
 , sfml
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
     wxGTK30
     soundtouch
     miniupnpc
-    mbedtls
+    mbedtls_2
     curl
     lzo
     sfml

--- a/pkgs/applications/emulators/dolphin-emu/master.nix
+++ b/pkgs/applications/emulators/dolphin-emu/master.nix
@@ -20,7 +20,7 @@
 , alsa-lib
 , miniupnpc
 , enet
-, mbedtls
+, mbedtls_2
 , soundtouch
 , sfml
 , xz
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
     hidapi
     miniupnpc
     enet
-    mbedtls
+    mbedtls_2
     soundtouch
     sfml
     xz

--- a/pkgs/applications/emulators/dolphin-emu/primehack.nix
+++ b/pkgs/applications/emulators/dolphin-emu/primehack.nix
@@ -29,7 +29,7 @@
 , alsa-lib
 , miniupnpc
 , enet
-, mbedtls
+, mbedtls_2
 , soundtouch
 , sfml
 , fmt
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     hidapi
     miniupnpc
     enet
-    mbedtls
+    mbedtls_2
     soundtouch
     sfml
     fmt

--- a/pkgs/applications/misc/lutris/fhsenv.nix
+++ b/pkgs/applications/misc/lutris/fhsenv.nix
@@ -30,7 +30,7 @@ in buildFHSUserEnv {
     # DGen // TODO: libarchive is broken
 
     # Dolphin
-    bluez ffmpeg gettext portaudio wxGTK30 miniupnpc mbedtls lzo sfml gsm
+    bluez ffmpeg gettext portaudio wxGTK30 miniupnpc mbedtls_2 lzo sfml gsm
     wavpack orc nettle gmp pcre vulkan-loader
 
     # DOSBox

--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitLab, qmake, libusb1, hidapi, pkg-config, coreutils, mbedtls }:
+{ lib, mkDerivation, fetchFromGitLab, qmake, libusb1, hidapi, pkg-config, coreutils, mbedtls_2 }:
 
 mkDerivation rec {
   pname = "openrgb";
@@ -12,7 +12,7 @@ mkDerivation rec {
   };
 
   nativeBuildInputs = [ qmake pkg-config ];
-  buildInputs = [ libusb1 hidapi mbedtls ];
+  buildInputs = [ libusb1 hidapi mbedtls_2 ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/networking/browsers/dillo/default.nix
+++ b/pkgs/applications/networking/browsers/dillo/default.nix
@@ -8,7 +8,7 @@
 , libXinerama
 , libjpeg
 , libpng
-, mbedtls
+, mbedtls_2
 , openssl
 , perl
 , pkg-config
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
     libXinerama
     libjpeg
     libpng
-    mbedtls
+    mbedtls_2
     openssl
     perl
   ];

--- a/pkgs/applications/networking/browsers/dillong/default.nix
+++ b/pkgs/applications/networking/browsers/dillong/default.nix
@@ -5,7 +5,7 @@
 , pkg-config
 , which
 , fltk
-, mbedtls
+, mbedtls_2
 }:
 
 stdenv.mkDerivation {
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     fltk
-    mbedtls
+    mbedtls_2
   ];
 
   # The start_page and home settings refer to /usr.

--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, coreutils, ocaml-ng, zlib, pcre, neko, mbedtls, Security }:
+{ lib, stdenv, fetchFromGitHub, coreutils, ocaml-ng, zlib, pcre, neko, mbedtls_2, Security }:
 
 let
   ocamlDependencies = version:
@@ -42,7 +42,7 @@ let
       inherit version;
 
       buildInputs = [ zlib pcre neko ]
-        ++ lib.optional (lib.versionAtLeast version "4.1") mbedtls
+        ++ lib.optional (lib.versionAtLeast version "4.1") mbedtls_2
         ++ lib.optional (lib.versionAtLeast version "4.1" && stdenv.isDarwin) Security
         ++ ocamlDependencies version;
 

--- a/pkgs/development/compilers/julia/1.8.nix
+++ b/pkgs/development/compilers/julia/1.8.nix
@@ -15,7 +15,7 @@
 , libgit2
 , curl
 , nghttp2
-, mbedtls
+, mbedtls_2
 , libssh2
 , gmp
 , mpfr
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     libgit2
     curl
     nghttp2
-    mbedtls
+    mbedtls_2
     libssh2
     gmp
     mpfr

--- a/pkgs/development/compilers/neko/default.nix
+++ b/pkgs/development/compilers/neko/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, boehmgc, zlib, sqlite, pcre, cmake, pkg-config
-, git, apacheHttpd, apr, aprutil, libmysqlclient, mbedtls, openssl, pkgs, gtk2, libpthreadstubs
+, git, apacheHttpd, apr, aprutil, libmysqlclient, mbedtls_2, openssl, pkgs, gtk2, libpthreadstubs
 }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config git ];
   buildInputs =
     [ boehmgc zlib sqlite pcre apacheHttpd apr aprutil
-      libmysqlclient mbedtls openssl libpthreadstubs ]
+      libmysqlclient mbedtls_2 openssl libpthreadstubs ]
       ++ lib.optional stdenv.isLinux gtk2
       ++ lib.optionals stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security
                                                 pkgs.darwin.apple_sdk.frameworks.Carbon];

--- a/pkgs/development/interpreters/hashlink/default.nix
+++ b/pkgs/development/interpreters/hashlink/default.nix
@@ -7,7 +7,7 @@
 , libjpeg_turbo
 , libuv
 , libvorbis
-, mbedtls
+, mbedtls_2
 , openal
 , pcre
 , SDL2
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     libpng
     libuv
     libvorbis
-    mbedtls
+    mbedtls_2
     openal
     pcre
     SDL2

--- a/pkgs/development/libraries/bctoolbox/default.nix
+++ b/pkgs/development/libraries/bctoolbox/default.nix
@@ -2,7 +2,7 @@
 , cmake
 , bc-decaf
 , fetchFromGitLab
-, mbedtls
+, mbedtls_2
 , lib
 , stdenv
 }:
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     # Vendored by BC
     bc-decaf
 
-    mbedtls
+    mbedtls_2
   ];
 
   src = fetchFromGitLab {

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitLab
 , lib
 , libantlr3c
-, mbedtls
+, mbedtls_2
 , stdenv
 , zlib
 }:
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     "-Wno-error=stringop-overflow"
   ];
 
-  propagatedBuildInputs = [ libantlr3c mbedtls bctoolbox belr ];
+  propagatedBuildInputs = [ libantlr3c mbedtls_2 bctoolbox belr ];
 
   meta = with lib; {
     homepage = "https://linphone.org/technical-corner/belle-sip";

--- a/pkgs/development/libraries/mbedtls/2.nix
+++ b/pkgs/development/libraries/mbedtls/2.nix
@@ -1,0 +1,6 @@
+{ callPackage }:
+
+callPackage ./generic.nix {
+  version = "2.28.1";
+  hash = "sha256-brbZB3fINDeVWXf50ct4bxYkoBVyD6bBBijZyFQSnyw=";
+}

--- a/pkgs/development/libraries/mbedtls/3.nix
+++ b/pkgs/development/libraries/mbedtls/3.nix
@@ -1,0 +1,6 @@
+{ callPackage }:
+
+callPackage ./generic.nix {
+  version = "3.2.1";
+  hash = "sha256-+M36NvFe4gw2PRbld/2JV3yBGrqK6soWcmrSEkUNcrc=";
+}

--- a/pkgs/development/libraries/mbedtls/generic.nix
+++ b/pkgs/development/libraries/mbedtls/generic.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv
+{ lib
+, stdenv
+, version
+, hash
 , fetchFromGitHub
 
 , cmake
@@ -11,17 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mbedtls";
-  # Auto updates are disabled due to repology listing dev releases as release
-  # versions. See
-  #  * https://github.com/NixOS/nixpkgs/pull/119838#issuecomment-822100428
-  #  * https://github.com/NixOS/nixpkgs/commit/0ee02a9d42b5fe1825b0f7cee7a9986bb4ba975d
-  version = "2.28.1"; # nixpkgs-update: no auto update
+  inherit version;
 
   src = fetchFromGitHub {
-    owner = "ARMmbed";
+    owner = "Mbed-TLS";
     repo = "mbedtls";
     rev = "${pname}-${version}";
-    sha256 = "sha256-brbZB3fINDeVWXf50ct4bxYkoBVyD6bBBijZyFQSnyw=";
+    inherit hash;
   };
 
   nativeBuildInputs = [ cmake ninja perl python3 ];
@@ -40,10 +39,11 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://tls.mbed.org/";
+    homepage = "https://www.trustedfirmware.org/projects/mbed-tls/";
+    changelog = "https://github.com/Mbed-TLS/mbedtls/blob/${pname}-${version}/ChangeLog";
     description = "Portable cryptographic and TLS library, formerly known as PolarSSL";
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ raphaelr ];
   };
 }

--- a/pkgs/development/libraries/yojimbo/default.nix
+++ b/pkgs/development/libraries/yojimbo/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, premake5, doxygen, libsodium, mbedtls }:
+{ lib, stdenv, fetchFromGitHub, premake5, doxygen, libsodium, mbedtls_2 }:
 
 stdenv.mkDerivation {
   pname = "yojimbo";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ premake5 doxygen ];
-  propagatedBuildInputs = [ libsodium mbedtls ];
+  propagatedBuildInputs = [ libsodium mbedtls_2 ];
 
   postBuild = ''
     premake5 docs

--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -3,7 +3,7 @@
 
 , cmake
 , ninja
-, mbedtls
+, mbedtls_2
 , libxcrypt
 
 , enableCache     ? true     # Internal cache support.
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ mbedtls libxcrypt ] ++ lib.optionals enableXslt [ libxslt libxml2 ];
+  buildInputs = [ mbedtls_2 libxcrypt ] ++ lib.optionals enableXslt [ libxslt libxml2 ];
 
   prePatch = ''
     substituteInPlace CMakeLists.txt --replace SETUID ""

--- a/pkgs/tools/filesystems/dislocker/default.nix
+++ b/pkgs/tools/filesystems/dislocker/default.nix
@@ -3,7 +3,7 @@
 , fetchpatch
 , cmake
 , pkg-config
-, mbedtls
+, mbedtls_2
 , fuse
 }:
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ fuse mbedtls ];
+  buildInputs = [ fuse mbedtls_2 ];
 
   meta = with lib; {
     description = "Read BitLocker encrypted partitions in Linux";

--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake
-, libsodium, mbedtls, libev, c-ares, pcre
+, libsodium, mbedtls_2, libev, c-ares, pcre
 , asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, libxslt
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ libsodium mbedtls libev c-ares pcre ];
+  buildInputs = [ libsodium mbedtls_2 libev c-ares pcre ];
   nativeBuildInputs = [ cmake asciidoc xmlto docbook_xml_dtd_45
                         docbook_xsl libxslt ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21486,7 +21486,8 @@ with pkgs;
 
   maxflow = callPackage ../development/libraries/maxflow { };
 
-  mbedtls = callPackage ../development/libraries/mbedtls { };
+  mbedtls = callPackage ../development/libraries/mbedtls/2.nix { };
+  mbedtls_3 = callPackage ../development/libraries/mbedtls/3.nix { };
 
   mdctags = callPackage ../development/tools/misc/mdctags { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21486,8 +21486,8 @@ with pkgs;
 
   maxflow = callPackage ../development/libraries/maxflow { };
 
-  mbedtls = callPackage ../development/libraries/mbedtls/2.nix { };
-  mbedtls_3 = callPackage ../development/libraries/mbedtls/3.nix { };
+  mbedtls_2 = callPackage ../development/libraries/mbedtls/2.nix { };
+  mbedtls = callPackage ../development/libraries/mbedtls/3.nix { };
 
   mdctags = callPackage ../development/tools/misc/mdctags { };
 


### PR DESCRIPTION
###### Description of changes

mbedtls 3 is incompatible with mbedtls 2, so create a new package for version 3.

* Added mbedtls 3.2.1 at the attribute path `mbedtls`
* mbedtls 2 is now `mbedtls_2`
* Updated packages that don't build with the new mbedtls to explicitly use mbedtls_2
* Removed comment disabling nixpkgs-update, since the version information on Repology looks correct now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable: `selftest` executable
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
