### PR TITLE
[Backport staging-22.11]: zfs: 2.1.6 -> 2.1.7

### DIFF
--- a/nixos/tests/alps.nix
+++ b/nixos/tests/alps.nix
@@ -4,6 +4,9 @@ let
 in
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "alps";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ hmenke ];
+  };
 
   nodes = {
     server = {

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -235,10 +235,10 @@ in {
     # IMPORTANT: Always use a tagged release candidate or commits from the
     # zfs-<version>-staging branch, because this is tested by the OpenZFS
     # maintainers.
-    version = "2.1.7-staging-2022-10-27";
-    rev = "04f1983aab16d378be376768275856bc38be48bd";
+    version = "2.1.7-staging-2022-11-08";
+    rev = "0f4ee295ba94803e5833f57481cfdbee5d1160d4";
 
-    sha256 = "sha256-6s9Qcw6Qqq7+JU9UPa8DDu2yzhD1OV3piLlYsgEoIhg=";
+    sha256 = "sha256-AixYjnr8MgST/VxEPY4NdcAvpoKiJ3zrvOai5bJjC/U=";
 
     isUnstable = true;
   };

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -16,7 +16,6 @@
 , enablePython ? true
 
 # for determining the latest compatible linuxPackages
-, linuxPackages_5_15 ? pkgs.linuxKernel.packages.linux_5_15
 , linuxPackages_6_0 ? pkgs.linuxKernel.packages.linux_6_0
 }:
 
@@ -217,13 +216,13 @@ in {
   # to be adapted
   zfsStable = common {
     # check the release notes for compatible kernels
-    kernelCompatible = kernel.kernelOlder "5.20";
-    latestCompatibleLinuxPackages = linuxPackages_5_15;
+    kernelCompatible = kernel.kernelOlder "6.1";
+    latestCompatibleLinuxPackages = linuxPackages_6_0;
 
     # this package should point to the latest release.
-    version = "2.1.6";
+    version = "2.1.7";
 
-    sha256 = "sha256-gd5WlNtnoSiVj4sKUGf0WhR7Z1GPebwu3Z1mkNsoC/I=";
+    sha256 = "sha256-vLm6RE11nqOCoYXne79JU3nUQnVEUNbwrULwFfghWcI=";
   };
 
   zfsUnstable = common {
@@ -235,10 +234,10 @@ in {
     # IMPORTANT: Always use a tagged release candidate or commits from the
     # zfs-<version>-staging branch, because this is tested by the OpenZFS
     # maintainers.
-    version = "2.1.7-staging-2022-11-08";
-    rev = "0f4ee295ba94803e5833f57481cfdbee5d1160d4";
+    version = "2.1.8-staging-2022-12-01";
+    rev = "21bd7661334cd865d17934bebbcaf8d3356279ee";
 
-    sha256 = "sha256-AixYjnr8MgST/VxEPY4NdcAvpoKiJ3zrvOai5bJjC/U=";
+    sha256 = "sha256-vLm6RE11nqOCoYXne79JU3nUQnVEUNbwrULwFfghWcI=";
 
     isUnstable = true;
   };

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -203,7 +203,7 @@ let
         changelog = "https://github.com/openzfs/zfs/releases/tag/zfs-${version}";
         license = lib.licenses.cddl;
         platforms = lib.platforms.linux;
-        maintainers = with lib.maintainers; [ hmenke jcumming jonringer wizeman globin ];
+        maintainers = with lib.maintainers; [ jcumming jonringer wizeman globin ];
         mainProgram = "zfs";
         # If your Linux kernel version is not yet supported by zfs, try zfsUnstable.
         # On NixOS set the option boot.zfs.enableUnstable.

--- a/pkgs/servers/alps/default.nix
+++ b/pkgs/servers/alps/default.nix
@@ -45,6 +45,6 @@ buildGoModule rec {
     description = "A simple and extensible webmail.";
     homepage = "https://git.sr.ht/~migadu/alps";
     license = licenses.mit;
-    maintainers = with maintainers; [ gordias booklearner madonius ];
+    maintainers = with maintainers; [ gordias booklearner madonius hmenke ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Backport all changes so far to `pkgs/os-specific/linux/zfs/` (most importantly "zfs: 2.1.6 -> 2.1.7"). The list of changes was obtained with this command:

```sh
➤ git log --no-merges --oneline staging-22.11..master -- pkgs/os-specific/linux/zfs/
da053d008fb maintainers: remove and add hmenke
782d97768bc zfs: 2.1.6 -> 2.1.7
4236d385f98 zfsUnstable: 2.1.7-2022-10-27 → 2.1.7-2022-11-08
```

These changes were merged in the following PRs:

* #199291
* #204043
* #204262

I've run the following commands to build:

```sh
➤ nix-build -A zfs .

➤ nix-build -A linuxKernel.packages.linux_5_10.zfs .
➤ nix-build -A linuxKernel.packages.linux_5_15.zfs .
➤ nix-build -A linuxKernel.packages.linux_6_0.zfs .

➤ nix run nixpkgs#nixpkgs-review pr 204659
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
