### PR TITLE
neovide: drop python2, clean up

### DIFF
--- a/pkgs/applications/editors/neovim/neovide/default.nix
+++ b/pkgs/applications/editors/neovim/neovide/default.nix
@@ -1,40 +1,34 @@
-{ rustPlatform
-, runCommand
-, lib
+{ lib
+, rustPlatform
+, clangStdenv
 , fetchFromGitHub
+, linkFarm
 , fetchgit
-, fetchurl
+, runCommand
+, gn
+, ninja
 , makeWrapper
 , pkg-config
-, python2
 , python3
-, openssl
+, removeReferencesTo
+, xcbuild
 , SDL2
 , fontconfig
-, freetype
-, ninja
-, gn
-, llvmPackages
-, makeFontsConf
+, xorg
+, stdenv
+, darwin
 , libglvnd
 , libxkbcommon
-, stdenv
 , enableWayland ? stdenv.isLinux
 , wayland
-, xorg
-, xcbuild
-, Security
-, ApplicationServices
-, AppKit
-, Carbon
-, removeReferencesTo
 }:
-rustPlatform.buildRustPackage rec {
+
+rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } rec {
   pname = "neovide";
   version = "0.10.3";
 
   src = fetchFromGitHub {
-    owner = "Kethku";
+    owner = "neovide";
     repo = "neovide";
     rev = version;
     sha256 = "sha256-CcBiCcfOJzuq0DnokTUHpMdo7Ry29ugQ+N7Hk0R+cQE=";
@@ -52,35 +46,24 @@ rustPlatform.buildRustPackage rec {
         sha256 = "sha256-w5dw/lGm40gKkHPR1ji/L82Oa808Kuh8qaCeiqBLkLw=";
       };
       # The externals for skia are taken from skia/DEPS
-      externals = lib.mapAttrs (n: fetchgit) (lib.importJSON ./skia-externals.json);
+      externals = linkFarm "skia-externals" (lib.mapAttrsToList
+        (name: value: { inherit name; path = fetchgit value; })
+        (lib.importJSON ./skia-externals.json));
     in
-      runCommand "source" {} (
-        ''
-          cp -R ${repo} $out
-          chmod -R +w $out
+    runCommand "source" { } ''
+      cp -R ${repo} $out
+      chmod -R +w $out
+      ln -s ${externals} $out/third_party/externals
+    ''
+  ;
 
-          mkdir -p $out/third_party/externals
-          cd $out/third_party/externals
-        '' + (builtins.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "cp -ra ${value} ${name}") externals))
-      );
-
-  SKIA_NINJA_COMMAND = "${ninja}/bin/ninja";
   SKIA_GN_COMMAND = "${gn}/bin/gn";
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-
-  preConfigure = ''
-    unset CC CXX
-  '';
-
-  # test needs a valid fontconfig file
-  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+  SKIA_NINJA_COMMAND = "${ninja}/bin/ninja";
 
   nativeBuildInputs = [
-    pkg-config
     makeWrapper
-    python2 # skia-bindings
-    python3 # rust-xcb
-    llvmPackages.clang # skia
+    pkg-config
+    python3 # skia
     removeReferencesTo
   ] ++ lib.optionals stdenv.isDarwin [ xcbuild ];
 
@@ -91,21 +74,12 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   buildInputs = [
-    openssl
     SDL2
-    (fontconfig.overrideAttrs (old: {
-      propagatedBuildInputs = [
-        # skia is not compatible with freetype 2.11.0
-        (freetype.overrideAttrs (old: rec {
-          version = "2.10.4";
-          src = fetchurl {
-            url = "mirror://savannah/${old.pname}/${old.pname}-${version}.tar.xz";
-            sha256 = "112pyy215chg7f7fmp2l9374chhhpihbh8wgpj5nj6avj3c59a46";
-          };
-        }))
-      ];
-    }))
-  ] ++ lib.optionals stdenv.isDarwin [ Security ApplicationServices Carbon AppKit ];
+    fontconfig
+    rustPlatform.bindgenHook
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.AppKit
+  ];
 
   postFixup = let
     libPath = lib.makeLibraryPath ([
@@ -138,10 +112,9 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "This is a simple graphical user interface for Neovim.";
-    homepage = "https://github.com/Kethku/neovide";
+    homepage = "https://github.com/neovide/neovide";
+    changelog = "https://github.com/neovide/neovide/releases/tag/${version}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ ck3d ];
-    platforms = platforms.all;
-    mainProgram = "neovide";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32782,9 +32782,7 @@ with pkgs;
 
   gnvim = callPackage ../applications/editors/neovim/gnvim/wrapper.nix { };
 
-  neovide = callPackage ../applications/editors/neovim/neovide {
-    inherit (darwin.apple_sdk.frameworks) Security ApplicationServices Carbon AppKit;
-  };
+  neovide = callPackage ../applications/editors/neovim/neovide { };
 
   neovim-remote = callPackage ../applications/editors/neovim/neovim-remote.nix { };
 


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/pull/201859

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
