### PR TITLE
Add linux-rt-5.15

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
@@ -1,0 +1,45 @@
+{ lib, buildLinux, fetchurl
+, kernelPatches ? [ ]
+, structuredExtraConfig ? {}
+, extraMeta ? {}
+, argsOverride ? {}
+, ... } @ args:
+
+let
+  version = "5.15.79-rt54"; # updated by ./update-rt.sh
+  branch = lib.versions.majorMinor version;
+  kversion = builtins.elemAt (lib.splitString "-" version) 0;
+in buildLinux (args // {
+  inherit version;
+
+  # modDirVersion needs a patch number, change X.Y-rtZ to X.Y.0-rtZ.
+  modDirVersion = if (builtins.match "[^.]*[.][^.]*-.*" version) == null then version
+    else lib.replaceStrings ["-"] [".0-"] version;
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
+    sha256 = "0m61k7k6lj24z9a266q08wzghggjik2wizcabdwd1vn0vcqr18yb";
+  };
+
+  kernelPatches = let rt-patch = {
+    name = "rt";
+    patch = fetchurl {
+      url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
+      sha256 = "098dml58d2nf7qhwn1pznqk7wvsh83rh85gsw7nmn2dym08510p9";
+    };
+  }; in [ rt-patch ] ++ kernelPatches;
+
+  structuredExtraConfig = with lib.kernel; {
+    PREEMPT_RT = yes;
+    # Fix error: unused option: PREEMPT_RT.
+    EXPERT = yes; # PREEMPT_RT depends on it (in kernel/Kconfig.preempt)
+    # Fix error: option not set correctly: PREEMPT_VOLUNTARY (wanted 'y', got 'n').
+    PREEMPT_VOLUNTARY = lib.mkForce no; # PREEMPT_RT deselects it.
+    # Fix error: unused option: RT_GROUP_SCHED.
+    RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
+  } // structuredExtraConfig;
+
+  extraMeta = extraMeta // {
+    inherit branch;
+  };
+} // argsOverride)

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "5.15.79-rt54"; # updated by ./update-rt.sh
+  version = "5.15.86-rt56"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -18,14 +18,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-    sha256 = "0m61k7k6lj24z9a266q08wzghggjik2wizcabdwd1vn0vcqr18yb";
+    sha256 = "1vpjnmwqsx6akph2nvbsv2jl7pp8b7xns3vmwbljsl23lkpxkz40";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "098dml58d2nf7qhwn1pznqk7wvsh83rh85gsw7nmn2dym08510p9";
+      sha256 = "0y7pkzacxh1fsvnbmjq0ljfb4zjw6dq9br6rl8kr3w4dj56fmaxs";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -822,6 +822,7 @@ mapAliases ({
 
   # Linux kernels
   linux-rt_5_10 = linuxKernel.kernels.linux_rt_5_10;
+  linux-rt_5_15 = linuxKernel.kernels.linux_rt_5_15;
   linux-rt_5_4 = linuxKernel.kernels.linux_rt_5_4;
   linuxPackages_4_14 = linuxKernel.packages.linux_4_14;
   linuxPackages_4_19 = linuxKernel.packages.linux_4_19;
@@ -841,6 +842,7 @@ mapAliases ({
   linuxPackages_rpi3 = linuxKernel.packages.linux_rpi3;
   linuxPackages_rpi4 = linuxKernel.packages.linux_rpi4;
   linuxPackages_rt_5_10 = linuxKernel.packages.linux_rt_5_10;
+  linuxPackages_rt_5_15 = linuxKernel.packages.linux_rt_5_15;
   linuxPackages_rt_5_4 = linuxKernel.packages.linux_rt_5_4;
   linux_4_14 = linuxKernel.kernels.linux_4_14;
   linux_4_19 = linuxKernel.kernels.linux_4_19;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -151,6 +151,14 @@ in {
       ];
     };
 
+    linux_rt_5_15 = callPackage ../os-specific/linux/kernel/linux-rt-5.15.nix {
+      kernelPatches = [
+        kernelPatches.bridge_stp_helper
+        kernelPatches.request_key_helper
+        kernelPatches.export-rt-sched-migrate
+      ];
+    };
+
     linux_5_17 = throw "linux 5.17 was removed because it has reached its end of life upstream";
 
     linux_5_18 = throw "linux 5.18 was removed because it has reached its end of life upstream";
@@ -526,6 +534,7 @@ in {
      # realtime kernel packages
      linux_rt_5_4 = packagesFor kernels.linux_rt_5_4;
      linux_rt_5_10 = packagesFor kernels.linux_rt_5_10;
+     linux_rt_5_15 = packagesFor kernels.linux_rt_5_15;
   };
 
   rpiPackages = {


### PR DESCRIPTION
5.15 is the current stable rt kernel[^1]. I've defined it but I didn't change `stable` or `latest` since I assumed we'd want a testing period. I didn't see a pre-existing `next` or `testing` type label to use.

[^1]: https://wiki.linuxfoundation.org/realtime/start

###### Description of changes

Ran `./update-rt.sh ./linux-rt-5.15.nix` and then updated `top-level` references.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
