### PR TITLE
emanote: patch out erroneous runtime deps due to cabal _Path module

### DIFF
--- a/pkgs/applications/misc/emanote/default.nix
+++ b/pkgs/applications/misc/emanote/default.nix
@@ -1,0 +1,11 @@
+{ lib, haskellPackages, haskell, removeReferencesTo}:
+
+let
+  static = haskell.lib.compose.justStaticExecutables haskellPackages.emanote;
+in
+  (haskell.lib.overrideCabal static (drv: {
+    buildTools = (drv.buildTools or []) ++ [ removeReferencesTo ];
+  })).overrideAttrs (drv: rec {
+    disallowedReferences = [ haskellPackages.pandoc haskellPackages.pandoc-types haskellPackages.warp];
+    postInstall = lib.concatStrings (map (e: "remove-references-to -t ${e} $out/bin/emanote\n") disallowedReferences);
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18909,7 +18909,7 @@ with pkgs;
 
   elfio = callPackage ../development/libraries/elfio { };
 
-  emanote = haskell.lib.compose.justStaticExecutables haskellPackages.emanote;
+  emanote = callPackage ../applications/misc/emanote { };
 
   enchant1 = callPackage ../development/libraries/enchant/1.x.nix { };
 


### PR DESCRIPTION
Patch emanote static binary's dependencies to remove erroneous references due to Cabal *_Path modules.

Reduces closure size for static executable reported by `nix path-info -S ./result` from 5643632280
 to 570510096

- Follow-up to https://github.com/NixOS/nixpkgs/pull/199442

## What I did:

- Duplicated https://github.com/NixOS/nixpkgs/pull/86194 but for emanote
- Added extra deps shown by `nix-tree ./result` to the list of disallowed packages (pandoc, warp).
- Noted smaller closure size
- Removed overrides until the closure got big again.
 
![b7e](https://user-images.githubusercontent.com/14615/205730268-76dff269-a2a6-493a-801b-98d5b32a738f.jpg)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

