### PR TITLE
python3Packages.azure-storage-queue: 2.1.0 -> 12.5.0

### DIFF
--- a/pkgs/development/python-modules/azure-storage-queue/default.nix
+++ b/pkgs/development/python-modules/azure-storage-queue/default.nix
@@ -3,20 +3,23 @@
 , fetchPypi
 , azure-common
 , azure-storage-common
+, msrest
 }:
 
 buildPythonPackage rec {
   pname = "azure-storage-queue";
-  version = "2.1.0";
+  version = "12.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "14e82d3691f1bbd23f2aff143a6c17af3c297164f6e597d223b65a67051ba278";
+    sha256 = "sha256-OzdEJK9y0y2v+Lr5tkYwB0w6iz/VMypFIWs7yWvHsXI=";
+    extension = "zip";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-storage-common
+    msrest
   ];
 
   # has no tests


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2022-30187

https://github.com/Azure/azure-sdk-for-python/blob/azure-storage-queue_12.5.0/sdk/storage/azure-storage-queue/CHANGELOG.md

Security fix is not directly referenced in the CVE information but the related change seems to be this:

> 12.4.0b1 (2022-06-15)
> Features Added
> Introduced version 2.0 of client-side encryption for Queue messages which utilizes AES-GCM-256 encryption. Version 1.0 is now deprecated and no longer considered secure. If you are using client-side encryption, it is highly recommended that you update to version 2.0. The encryption version can be specified on any client constructor via the encryption_version keyword (i.e. encryption_version='2.0').

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>python310Packages.azure-storage-queue</li>
    <li>python39Packages.azure-storage-queue</li>
  </ul>
</details>