### PR TITLE
qt6, python3Packages.pyqt6: unbreak on darwin

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -56,6 +56,7 @@ let
         inherit bison cups harfbuzz libGL dconf gtk3 developerBuild cmake;
         inherit (darwin.apple_sdk_11_0.frameworks) AGL AVFoundation AppKit GSS MetalKit;
         patches = [
+          ./patches/qtbase-qmake-mkspecs-mac.patch
           ./patches/qtbase-qmake-pkg-config.patch
           ./patches/qtbase-tzdir.patch
           # Remove symlink check causing build to bail out and fail.

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -225,6 +225,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     # build as a set of dynamic libraries
     "-DFEATURE_framework=OFF"
+    # error: 'path' is unavailable: introduced in macOS 10.15
+    "-DQT_FEATURE_cxx17_filesystem=OFF"
   ];
 
   NIX_LDFLAGS = toString (lib.optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -269,7 +269,7 @@ stdenv.mkDerivation rec {
     moveToOutput libexec "$dev"
 
     # fixup .pc file (where to find 'moc' etc.)
-    if [ -d "$dev/lib/pkgconfig" ]; then
+    if [ -f "$dev/lib/pkgconfig/Qt6Core.pc" ]; then
       sed -i "$dev/lib/pkgconfig/Qt6Core.pc" \
         -e "/^bindir=/ c bindir=$dev/bin"
     fi
@@ -277,7 +277,9 @@ stdenv.mkDerivation rec {
     patchShebangs $out $dev
 
     # QTEST_ASSERT and other macros keeps runtime reference to qtbase.dev
-    substituteInPlace "$dev/include/QtTest/qtestassert.h" --replace "__FILE__" "__BASE_FILE__"
+    if [ -f "$dev/include/QtTest/qtestassert.h" ]; then
+      substituteInPlace "$dev/include/QtTest/qtestassert.h" --replace "__FILE__" "__BASE_FILE__"
+    fi
   '';
 
   dontStrip = debugSymbols;

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -127,11 +127,10 @@ stdenv.mkDerivation rec {
     unixODBCDrivers.psql
     unixODBCDrivers.sqlite
     unixODBCDrivers.mariadb
-  ] ++ lib.optionals stdenv.isLinux [
-    util-linux
   ] ++ lib.optionals systemdSupport [
     systemd
-  ] ++ [
+  ] ++ lib.optionals stdenv.isLinux [
+    util-linux
     mtdev
     lksctp-tools
     libselinux
@@ -223,8 +222,6 @@ stdenv.mkDerivation rec {
     "-DQT_FEATURE_journald=${if systemdSupport then "ON" else "OFF"}"
     "-DQT_FEATURE_vulkan=ON"
   ] ++ lib.optionals stdenv.isDarwin [
-    # build as a set of dynamic libraries
-    "-DFEATURE_framework=OFF"
     # error: 'path' is unavailable: introduced in macOS 10.15
     "-DQT_FEATURE_cxx17_filesystem=OFF"
   ];
@@ -272,8 +269,10 @@ stdenv.mkDerivation rec {
     moveToOutput libexec "$dev"
 
     # fixup .pc file (where to find 'moc' etc.)
-    sed -i "$dev/lib/pkgconfig/Qt6Core.pc" \
-      -e "/^bindir=/ c bindir=$dev/bin"
+    if [ -d "$dev/lib/pkgconfig" ]; then
+      sed -i "$dev/lib/pkgconfig/Qt6Core.pc" \
+        -e "/^bindir=/ c bindir=$dev/bin"
+    fi
 
     patchShebangs $out $dev
 

--- a/pkgs/development/libraries/qt-6/patches/qtbase-qmake-mkspecs-mac.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtbase-qmake-mkspecs-mac.patch
@@ -1,0 +1,473 @@
+diff --git a/mkspecs/common/mac.conf b/mkspecs/common/mac.conf
+index 61bea952..9909dae7 100644
+--- a/mkspecs/common/mac.conf
++++ b/mkspecs/common/mac.conf
+@@ -23,7 +23,7 @@ QMAKE_INCDIR_OPENGL     = \
+ 
+ QMAKE_FIX_RPATH         = install_name_tool -id
+ 
+-QMAKE_LFLAGS_RPATH      = -Wl,-rpath,
++QMAKE_LFLAGS_RPATH      =
+ QMAKE_LFLAGS_GCSECTIONS = -Wl,-dead_strip
+ 
+ QMAKE_LFLAGS_REL_RPATH  =
+diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
+index 09db1764..aadfce87 100644
+--- a/mkspecs/features/mac/default_post.prf
++++ b/mkspecs/features/mac/default_post.prf
+@@ -1,9 +1,5 @@
+ load(default_post)
+ 
+-# Recompute SDK version in case the user set it explicitly
+-sdk_version = $$QMAKE_MAC_SDK_VERSION
+-QMAKE_MAC_SDK_VERSION = $$xcodeSDKInfo(SDKVersion)
+-
+ contains(TEMPLATE, .*app) {
+     !macx-xcode:if(isEmpty(BUILDS)|build_pass) {
+         # Detect changes to the platform SDK
+@@ -15,37 +11,6 @@ contains(TEMPLATE, .*app) {
+ 
+         QMAKE_EXTRA_INCLUDES += $$shell_quote($$PWD/sdk.mk)
+     }
+-
+-    # Detect incompatible SDK versions
+-
+-    isEmpty(QT_MAC_SDK_VERSION_MIN): \
+-        QT_MAC_SDK_VERSION_MIN = $$QT_MAC_SDK_VERSION
+-
+-    !versionAtLeast(QMAKE_MAC_SDK_VERSION, $$QT_MAC_SDK_VERSION_MIN): \
+-        warning("Qt requires at least version $$QT_MAC_SDK_VERSION_MIN of the platform SDK," \
+-              "you're building against version $${QMAKE_MAC_SDK_VERSION}. Please upgrade.")
+-
+-    !isEmpty(QT_MAC_SDK_VERSION_MAX) {
+-        # For Qt developers only
+-        !isEmpty($$list($$(QT_MAC_SDK_NO_VERSION_CHECK))): \
+-            CONFIG += sdk_no_version_check
+-
+-        QMAKE_MAC_SDK_MAJOR_VERSION = $$replace(QMAKE_MAC_SDK_VERSION, "(\\d+)(\\.\\d+)(\\.\\d+)?", \\1)
+-
+-        !sdk_no_version_check:!versionAtMost(QMAKE_MAC_SDK_MAJOR_VERSION, $$QT_MAC_SDK_VERSION_MAX) {
+-            warning("Qt has only been tested with version $$QT_MAC_SDK_VERSION_MAX"\
+-                    "of the platform SDK, you're using $${QMAKE_MAC_SDK_MAJOR_VERSION}.")
+-            warning("This is an unsupported configuration. You may experience build issues," \
+-                    "and by using")
+-            warning("the $$QMAKE_MAC_SDK_VERSION SDK you are opting in to new features" \
+-                    "that Qt has not been prepared for.")
+-
+-            warning("Please downgrade the SDK you use to build your app to version" \
+-                    "$$QT_MAC_SDK_VERSION_MAX, or configure")
+-            warning("with CONFIG+=sdk_no_version_check when running qmake" \
+-                    "to silence this warning.")
+-        }
+-    }
+ }
+ 
+ !no_objective_c:CONFIG += objective_c
+@@ -73,234 +38,6 @@ qt {
+     }
+ }
+ 
+-# Add the same default rpaths as Xcode does for new projects.
+-# This is especially important for iOS/tvOS/watchOS where no other option is possible.
+-!no_default_rpath {
+-    uikit: QMAKE_RPATHDIR += @executable_path/Frameworks
+-    else: QMAKE_RPATHDIR += @executable_path/../Frameworks
+-    equals(TEMPLATE, lib):!plugin:lib_bundle: QMAKE_RPATHDIR += @loader_path/Frameworks
+-}
+-
+-# Don't pass -headerpad_max_install_names when using Bitcode.
+-# In that case the linker emits a warning stating that the flag is ignored when
+-# used with bitcode, for reasons that cannot be determined (rdar://problem/20748962).
+-# Using this flag is also unnecessary in practice on UIKit platforms since they
+-# are sandboxed, and only UIKit platforms support bitcode to begin with.
+-!bitcode: QMAKE_LFLAGS += $$QMAKE_LFLAGS_HEADERPAD
+-
+-app_extension_api_only {
+-    QMAKE_CFLAGS              += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+-    QMAKE_CXXFLAGS            += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+-    QMAKE_CXXFLAGS_PRECOMPILE += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+-    QMAKE_LFLAGS              += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+-}
+-
+-macos {
+-    !isEmpty(QMAKE_APPLE_DEVICE_ARCHS) {
+-        # If the user has requested a specific set of architectures,
+-        # build all of those by default, but limited to only those.
+-        CONFIG -= only_active_arch
+-    } else {
+-        # Otherwise allow building all of the architectures available
+-        # in Qt, but only build the active arch (unless the user has
+-        # manually overridden this via CONFIG -= only_active_arch).
+-        QMAKE_APPLE_DEVICE_ARCHS = $$QT_ARCHS
+-    }
+-}
+-
+-macx-xcode {
+-    qmake_pkginfo_typeinfo.name = QMAKE_PKGINFO_TYPEINFO
+-    !isEmpty(QMAKE_PKGINFO_TYPEINFO): \
+-        qmake_pkginfo_typeinfo.value = $$QMAKE_PKGINFO_TYPEINFO
+-    else: \
+-        qmake_pkginfo_typeinfo.value = "????"
+-    QMAKE_MAC_XCODE_SETTINGS += qmake_pkginfo_typeinfo
+-
+-    bundle_version = $$VERSION
+-    isEmpty(bundle_version): bundle_version = 1.0.0
+-
+-    l = $$split(bundle_version, '.') 0 0  # make sure there are at least three
+-    VER_MAJ = $$member(l, 0, 0)
+-    VER_MIN = $$member(l, 1, 1)
+-    VER_PAT = $$member(l, 2, 2)
+-    unset(l)
+-
+-    qmake_full_version.name = QMAKE_FULL_VERSION
+-    qmake_full_version.value = $${VER_MAJ}.$${VER_MIN}.$${VER_PAT}
+-    QMAKE_MAC_XCODE_SETTINGS += qmake_full_version
+-
+-    qmake_short_version.name = QMAKE_SHORT_VERSION
+-    qmake_short_version.value = $${VER_MAJ}.$${VER_MIN}
+-    QMAKE_MAC_XCODE_SETTINGS += qmake_short_version
+-
+-    !isEmpty(QMAKE_XCODE_DEBUG_INFORMATION_FORMAT) {
+-        debug_information_format.name = DEBUG_INFORMATION_FORMAT
+-        debug_information_format.value = $$QMAKE_XCODE_DEBUG_INFORMATION_FORMAT
+-        debug_information_format.build = debug
+-        QMAKE_MAC_XCODE_SETTINGS += debug_information_format
+-    }
+-
+-    QMAKE_XCODE_ARCHS =
+-
+-    arch_device.name = "ARCHS[sdk=$${device.sdk}*]"
+-    arch_device.value = $$QMAKE_APPLE_DEVICE_ARCHS
+-    QMAKE_XCODE_ARCHS += $$QMAKE_APPLE_DEVICE_ARCHS
+-    QMAKE_MAC_XCODE_SETTINGS += arch_device
+-
+-    simulator {
+-        arch_simulator.name = "ARCHS[sdk=$${simulator.sdk}*]"
+-        arch_simulator.value = $$QMAKE_APPLE_SIMULATOR_ARCHS
+-        QMAKE_XCODE_ARCHS += $$QMAKE_APPLE_SIMULATOR_ARCHS
+-        QMAKE_MAC_XCODE_SETTINGS += arch_simulator
+-    }
+-
+-    only_active_arch.name = ONLY_ACTIVE_ARCH
+-    only_active_arch.value = YES
+-    only_active_arch.build = debug
+-    QMAKE_MAC_XCODE_SETTINGS += only_active_arch
+-} else {
+-    device|!simulator: VALID_DEVICE_ARCHS = $$QMAKE_APPLE_DEVICE_ARCHS
+-    simulator: VALID_SIMULATOR_ARCHS = $$QMAKE_APPLE_SIMULATOR_ARCHS
+-    VALID_ARCHS = $$VALID_DEVICE_ARCHS $$VALID_SIMULATOR_ARCHS
+-
+-    single_arch: VALID_ARCHS = $$first(VALID_ARCHS)
+-
+-    macos {
+-        only_active_arch: DEFAULT_ARCHS = $$system("uname -m")
+-        else: DEFAULT_ARCHS = $$VALID_ARCHS
+-    }
+-
+-    ARCHS = $(filter $(EXPORT_VALID_ARCHS), \
+-        $(if $(ARCHS), $(ARCHS), \
+-            $(if $(EXPORT_DEFAULT_ARCHS), $(EXPORT_DEFAULT_ARCHS), \
+-        $(EXPORT_VALID_ARCHS))))
+-    ARCH_ARGS = $(foreach arch, $(if $(EXPORT_ARCHS), $(EXPORT_ARCHS), $(EXPORT_VALID_ARCHS)), -arch $(arch))
+-
+-    QMAKE_EXTRA_VARIABLES += VALID_ARCHS DEFAULT_ARCHS ARCHS ARCH_ARGS
+-
+-    arch_flags = $(EXPORT_ARCH_ARGS)
+-
+-    QMAKE_CFLAGS += $$arch_flags
+-    QMAKE_CXXFLAGS += $$arch_flags
+-    QMAKE_LFLAGS += $$arch_flags
+-
+-    QMAKE_PCH_ARCHS = $$VALID_ARCHS
+-
+-    macos: deployment_target = $$QMAKE_MACOSX_DEPLOYMENT_TARGET
+-    ios: deployment_target = $$QMAKE_IOS_DEPLOYMENT_TARGET
+-    tvos: deployment_target = $$QMAKE_TVOS_DEPLOYMENT_TARGET
+-    watchos: deployment_target = $$QMAKE_WATCHOS_DEPLOYMENT_TARGET
+-
+-    # If we're doing a simulator and device build, device and simulator
+-    # architectures use different paths and flags for the sysroot and
+-    # deployment target switch, so we must multiplex them across multiple
+-    # architectures using -Xarch. Otherwise we fall back to the simple path.
+-    # This is not strictly necessary, but results in cleaner command lines
+-    # and makes it easier for people to override EXPORT_VALID_ARCHS to limit
+-    # individual rules to a different set of architecture(s) from the overall
+-    # build (such as machtest in QtCore).
+-    simulator:device {
+-        QMAKE_XARCH_CFLAGS =
+-        QMAKE_XARCH_LFLAGS =
+-        QMAKE_EXTRA_VARIABLES += QMAKE_XARCH_CFLAGS QMAKE_XARCH_LFLAGS
+-
+-        for (arch, VALID_ARCHS) {
+-            contains(VALID_SIMULATOR_ARCHS, $$arch) {
+-                sdk = $$simulator.sdk
+-                version_identifier = $$simulator.deployment_identifier
+-                platform_identifier = $$simulator.sdk
+-            } else {
+-                sdk = $$device.sdk
+-                version_identifier = $$device.deployment_identifier
+-                platform_identifier = $$device.sdk
+-            }
+-
+-            version_min_flags = \
+-                -Xarch_$${arch} \
+-                -m$${version_identifier}-version-min=$$deployment_target
+-            QMAKE_XARCH_CFLAGS_$${arch} = $$version_min_flags \
+-                -Xarch_$${arch} \
+-                -isysroot$$xcodeSDKInfo(Path, $$sdk)
+-            QMAKE_XARCH_LFLAGS_$${arch} = $$version_min_flags \
+-                -Xarch_$${arch} \
+-                -isysroot$$xcodeSDKInfo(Path, $$sdk)
+-
+-            QMAKE_XARCH_CFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS_$${arch})
+-            QMAKE_XARCH_LFLAGS += $(EXPORT_QMAKE_XARCH_LFLAGS_$${arch})
+-
+-            QMAKE_EXTRA_VARIABLES += \
+-                QMAKE_XARCH_CFLAGS_$${arch} \
+-                QMAKE_XARCH_LFLAGS_$${arch}
+-        }
+-
+-        QMAKE_CFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS)
+-        QMAKE_CXXFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS)
+-        QMAKE_LFLAGS += $(EXPORT_QMAKE_XARCH_LFLAGS)
+-    } else {
+-        simulator {
+-            version_identifier = $$simulator.deployment_identifier
+-            platform_identifier = $$simulator.sdk
+-            sysroot_path  = $$xcodeSDKInfo(Path, $$simulator.sdk)
+-        } else {
+-            version_identifier = $$device.deployment_identifier
+-            platform_identifier = $$device.sdk
+-            sysroot_path  = $$xcodeSDKInfo(Path, $$device.sdk)
+-        }
+-        version_min_flag = -m$${version_identifier}-version-min=$$deployment_target
+-        QMAKE_CFLAGS += -isysroot $$sysroot_path $$version_min_flag
+-        QMAKE_CXXFLAGS += -isysroot $$sysroot_path $$version_min_flag
+-        QMAKE_LFLAGS += -isysroot $$sysroot_path $$version_min_flag
+-    }
+-
+-    # Enable precompiled headers for multiple architectures
+-    QMAKE_CFLAGS_USE_PRECOMPILE =
+-    for (arch, VALID_ARCHS) {
+-        icc_pch_style: \
+-            use_flag = "-pch-use "
+-        else: \
+-            use_flag = -include
+-
+-        # Only use Xarch with multi-arch, as the option confuses ccache
+-        count(VALID_ARCHS, 1, greaterThan): \
+-            QMAKE_CFLAGS_USE_PRECOMPILE += \
+-                -Xarch_$${arch}
+-
+-        QMAKE_CFLAGS_USE_PRECOMPILE += \
+-            $${use_flag}${QMAKE_PCH_OUTPUT_$${arch}}
+-    }
+-    icc_pch_style {
+-        QMAKE_CXXFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE -include ${QMAKE_PCH_INPUT}
+-        QMAKE_CFLAGS_USE_PRECOMPILE =
+-    } else {
+-        QMAKE_CXXFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE
+-        QMAKE_OBJCFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE
+-        QMAKE_OBJCXXFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE
+-    }
+-
+-    QMAKE_PCH_OUTPUT_EXT = _${QMAKE_PCH_ARCH}$${QMAKE_PCH_OUTPUT_EXT}
+-}
+-
+-!equals(sdk_version, $$QMAKE_MAC_SDK_VERSION) {
+-    # Explicit SDK version has been set, respect that
+-    QMAKE_LFLAGS += -Wl,-sdk_version -Wl,$$sdk_version
+-}
+-
+-cache(QMAKE_XCODE_DEVELOPER_PATH, stash)
+-!isEmpty(QMAKE_XCODE_VERSION): \
+-    cache(QMAKE_XCODE_VERSION, stash)
+-
+-QMAKE_XCODE_LIBRARY_SUFFIX = $$qtPlatformTargetSuffix()
+-
+-xcode_product_bundle_identifier_setting.name = PRODUCT_BUNDLE_IDENTIFIER
+-xcode_product_bundle_identifier_setting.value = $$QMAKE_TARGET_BUNDLE_PREFIX
+-isEmpty(xcode_product_bundle_identifier_setting.value): \
+-    xcode_product_bundle_identifier_setting.value = "com.yourcompany"
+-xcode_product_bundle_target = $$QMAKE_BUNDLE
+-isEmpty(xcode_product_bundle_target): \
+-    xcode_product_bundle_target = ${PRODUCT_NAME:rfc1034identifier}
+-xcode_product_bundle_identifier_setting.value = "$${xcode_product_bundle_identifier_setting.value}.$${xcode_product_bundle_target}"
+-QMAKE_MAC_XCODE_SETTINGS += xcode_product_bundle_identifier_setting
+-
+ !macx-xcode {
+     generate_xcode_project.commands = @$(QMAKE) -spec macx-xcode \"$(EXPORT__PRO_FILE_)\" $$QMAKE_ARGS
+     generate_xcode_project.target = xcodeproj
+diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
+index e3534561..3b01424e 100644
+--- a/mkspecs/features/mac/default_pre.prf
++++ b/mkspecs/features/mac/default_pre.prf
+@@ -1,60 +1,2 @@
+ CONFIG = asset_catalogs rez $$CONFIG
+ load(default_pre)
+-
+-isEmpty(QMAKE_XCODE_DEVELOPER_PATH) {
+-    # Get path of Xcode's Developer directory
+-    QMAKE_XCODE_DEVELOPER_PATH = $$system("/usr/bin/xcode-select --print-path 2>/dev/null")
+-    isEmpty(QMAKE_XCODE_DEVELOPER_PATH): \
+-        error("Xcode path is not set. Please use xcode-select to choose Xcode installation path.")
+-
+-    # Make sure Xcode path is valid
+-    !exists($$QMAKE_XCODE_DEVELOPER_PATH): \
+-        error("Xcode is not installed in $${QMAKE_XCODE_DEVELOPER_PATH}. Please use xcode-select to choose Xcode installation path.")
+-}
+-
+-isEmpty(QMAKE_XCODEBUILD_PATH): \
+-    QMAKE_XCODEBUILD_PATH = $$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null")
+-
+-!isEmpty(QMAKE_XCODEBUILD_PATH) {
+-    # Make sure Xcode is set up properly
+-    !system("/usr/bin/xcrun xcodebuild -license check 2>/dev/null"): \
+-        error("Xcode not set up properly. You need to confirm the license agreement by running 'sudo xcrun xcodebuild -license accept'.")
+-
+-    isEmpty(QMAKE_XCODE_VERSION) {
+-        # Extract Xcode version using xcodebuild
+-        xcode_version = $$system("/usr/bin/xcrun xcodebuild -version")
+-        QMAKE_XCODE_VERSION = $$member(xcode_version, 1)
+-        isEmpty(QMAKE_XCODE_VERSION): error("Could not resolve Xcode version.")
+-        unset(xcode_version)
+-    }
+-}
+-
+-isEmpty(QMAKE_TARGET_BUNDLE_PREFIX) {
+-    QMAKE_XCODE_PREFERENCES_FILE = $$(HOME)/Library/Preferences/com.apple.dt.Xcode.plist
+-    exists($$QMAKE_XCODE_PREFERENCES_FILE): \
+-        QMAKE_TARGET_BUNDLE_PREFIX = $$system("/usr/libexec/PlistBuddy -c 'print IDETemplateOptions:bundleIdentifierPrefix' $$QMAKE_XCODE_PREFERENCES_FILE 2>/dev/null")
+-
+-    !isEmpty(_QMAKE_CACHE_):!isEmpty(QMAKE_TARGET_BUNDLE_PREFIX): \
+-        cache(QMAKE_TARGET_BUNDLE_PREFIX)
+-}
+-
+-QMAKE_ASSET_CATALOGS_APP_ICON = AppIcon
+-
+-# Make the default debug info format for static debug builds
+-# DWARF instead of DWARF with dSYM. This cuts down build times
+-# for application debug builds significantly, as Xcode doesn't
+-# have to pull out all the DWARF info from the Qt static libs
+-# and put it into a dSYM file. We don't need that dSYM file in
+-# the first place, since the information is available in the
+-# object files inside the archives (static libraries).
+-macx-xcode:qtConfig(static): \
+-    QMAKE_XCODE_DEBUG_INFORMATION_FORMAT = dwarf
+-
+-# This variable is used by the xcode_dynamic_library_suffix
+-# feature, which allows Xcode to choose the Qt libraries to link to
+-# at build time, depending on the current Xcode SDK and configuration.
+-QMAKE_XCODE_LIBRARY_SUFFIX_SETTING = QT_LIBRARY_SUFFIX
+-
+-xcode_copy_phase_strip_setting.name = COPY_PHASE_STRIP
+-xcode_copy_phase_strip_setting.value = NO
+-QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
+diff --git a/mkspecs/features/mac/sdk.mk b/mkspecs/features/mac/sdk.mk
+index a32ceacb..e69de29b 100644
+--- a/mkspecs/features/mac/sdk.mk
++++ b/mkspecs/features/mac/sdk.mk
+@@ -1,27 +0,0 @@
+-
+-ifeq ($(QT_MAC_SDK_NO_VERSION_CHECK),)
+-    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>/dev/null
+-    CURRENT_MAC_SDK_VERSION := $(shell DEVELOPER_DIR=$(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) $(CHECK_SDK_COMMAND))
+-    ifneq ($(CURRENT_MAC_SDK_VERSION),$(EXPORT_QMAKE_MAC_SDK_VERSION))
+-        # We don't want to complain about out of date SDK unless the target needs to be remade.
+-        # This covers use-cases such as running 'make check' after moving the build to a
+-        # computer without Xcode or with a different Xcode version.
+-        TARGET_UP_TO_DATE := $(shell QT_MAC_SDK_NO_VERSION_CHECK=1 $(MAKE) --question $(QMAKE_TARGET) && echo 1 || echo 0)
+-        ifeq ($(TARGET_UP_TO_DATE),0)
+-            ifneq ($(findstring missing DEVELOPER_DIR path,$(CURRENT_MAC_SDK_VERSION)),)
+-                $(info The developer dir $(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) is no longer valid.)
+-            else ifneq ($(findstring SDK "$(EXPORT_QMAKE_MAC_SDK)" cannot be located,$(CURRENT_MAC_SDK_VERSION)),)
+-                $(info The developer dir $(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) no longer contains the $(EXPORT_QMAKE_MAC_SDK_VERSION) platform SDK.)
+-            else ifneq ($(CURRENT_MAC_SDK_VERSION),)
+-                $(info The $(EXPORT_QMAKE_MAC_SDK) platform SDK has been changed from version $(EXPORT_QMAKE_MAC_SDK_VERSION) to version $(CURRENT_MAC_SDK_VERSION).)
+-            else
+-                $(info Unknown error resolving current platform SDK version.)
+-            endif
+-            $(info This requires a fresh build of your project. Please wipe the build directory)
+-            ifneq ($(EXPORT__QMAKE_STASH_),)
+-                $(info including the qmake cache in $(EXPORT__QMAKE_STASH_))
+-            endif
+-            $(error ^)
+-        endif
+-    endif
+-endif
+diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
+index 3a9c2778..e69de29b 100644
+--- a/mkspecs/features/mac/sdk.prf
++++ b/mkspecs/features/mac/sdk.prf
+@@ -1,61 +0,0 @@
+-
+-isEmpty(QMAKE_MAC_SDK): \
+-    error("QMAKE_MAC_SDK must be set when using CONFIG += sdk.")
+-
+-contains(QMAKE_MAC_SDK, .*/.*): \
+-    error("QMAKE_MAC_SDK can only contain short-form SDK names (eg. macosx, iphoneos)")
+-
+-defineReplace(xcodeSDKInfo) {
+-    info = $$1
+-    equals(info, "Path"): \
+-        infoarg = --show-sdk-path
+-    equals(info, "PlatformPath"): \
+-        infoarg = --show-sdk-platform-path
+-    equals(info, "SDKVersion"): \
+-        infoarg = --show-sdk-version
+-    sdk = $$2
+-    isEmpty(sdk): \
+-        sdk = $$QMAKE_MAC_SDK
+-
+-    isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}) {
+-        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcrun --sdk $$sdk $$infoarg 2>/dev/null")
+-        # --show-sdk-platform-path won't work for Command Line Tools; this is fine
+-        # only used by the XCTest backend to testlib
+-        isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}):if(!isEmpty(QMAKE_XCODEBUILD_PATH)|!equals(infoarg, "--show-sdk-platform-path")): \
+-            error("Could not resolve SDK $$info for \'$$sdk\' using $$infoarg")
+-        cache(QMAKE_MAC_SDK.$${sdk}.$${info}, set stash, QMAKE_MAC_SDK.$${sdk}.$${info})
+-    }
+-
+-    return($$eval(QMAKE_MAC_SDK.$${sdk}.$${info}))
+-}
+-
+-QMAKE_MAC_SDK_PATH = $$xcodeSDKInfo(Path)
+-QMAKE_MAC_SDK_PLATFORM_PATH = $$xcodeSDKInfo(PlatformPath)
+-QMAKE_MAC_SDK_VERSION = $$xcodeSDKInfo(SDKVersion)
+-
+-isEmpty(QMAKE_EXPORT_INCDIR_OPENGL) {
+-    QMAKE_EXPORT_INCDIR_OPENGL = $$QMAKE_INCDIR_OPENGL
+-    sysrootified =
+-    for(val, QMAKE_INCDIR_OPENGL): sysrootified += $${QMAKE_MAC_SDK_PATH}$$val
+-    QMAKE_INCDIR_OPENGL = $$sysrootified
+-}
+-
+-QMAKESPEC_NAME = $$basename(QMAKESPEC)
+-
+-# Resolve SDK version of various tools
+-for(tool, $$list(QMAKE_CC QMAKE_CXX QMAKE_FIX_RPATH QMAKE_AR QMAKE_RANLIB QMAKE_LINK QMAKE_LINK_SHLIB QMAKE_ACTOOL QMAKE_LINK_C QMAKE_LINK_C_SHLIB)) {
+-    tool_variable = QMAKE_MAC_SDK.$${QMAKESPEC_NAME}.$${QMAKE_MAC_SDK}.$${tool}
+-    !isEmpty($$tool_variable) {
+-        $$tool = $$eval($$tool_variable)
+-        next()
+-    }
+-
+-    value = $$eval($$tool)
+-    isEmpty(value): next()
+-
+-    sysrooted = $$system("/usr/bin/xcrun -sdk $$QMAKE_MAC_SDK -find $$first(value) 2>/dev/null")
+-    isEmpty(sysrooted): next()
+-
+-    $$tool = $$sysrooted $$member(value, 1, -1)
+-    cache($$tool_variable, set stash, $$tool)
+-}
+diff --git a/mkspecs/features/mac/toolchain.prf b/mkspecs/features/mac/toolchain.prf
+index df191eb1..e69de29b 100644
+--- a/mkspecs/features/mac/toolchain.prf
++++ b/mkspecs/features/mac/toolchain.prf
+@@ -1,5 +0,0 @@
+-# Ensure that we process sdk.prf first, as it will update QMAKE_CXX,
+-# which the default path determination uses.
+-sdk: load(sdk)
+-
+-load(toolchain)

--- a/pkgs/development/libraries/qtpbfimageplugin/default.nix
+++ b/pkgs/development/libraries/qtpbfimageplugin/default.nix
@@ -27,12 +27,6 @@ stdenv.mkDerivation rec {
       --replace '$$PROTOBUF/lib/libprotobuf-lite.a' '${protobuf}/lib/libprotobuf-lite.dylib'
   '';
 
-  # error: 'path' is unavailable: introduced in macOS 10.15
-  qmakeFlags = lib.optionals stdenv.isDarwin [
-    "CONFIG+=c++17"
-    "QMAKE_MACOSX_DEPLOYMENT_TARGET=10.15"
-  ];
-
   meta = with lib; {
     description = "Qt image plugin for displaying Mapbox vector tiles";
     longDescription = ''

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -135,7 +135,5 @@ buildPythonPackage rec {
     license = licenses.gpl3Only;
     platforms = platforms.mesaPlatforms;
     maintainers = with maintainers; [ LunNova ];
-    # python3Packages.pyqt-builder needs to be patched
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

The added qmake patch mimics [this](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch) in Qt 5.

Closes #210905.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
