### PR TITLE
lexend: bump version, install variable fonts

### DIFF
--- a/pkgs/data/fonts/lexend/default.nix
+++ b/pkgs/data/fonts/lexend/default.nix
@@ -5,13 +5,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "lexend";
-  version = "0.pre+date=2022-01-27";
+  version = "0.pre+date=2022-09-22";
 
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = pname;
-    rev = "57e6c14e2a9b457e8376044a31525c2100297e9c";
-    sha256 = "sha256-+tPggQIO50a8kOSnOVN/MR9ZwX5xZqYVNZO79eog9QA=";
+    rev = "cd26b9c2538d758138c20c3d2f10362ed613854b";
+    sha256 = "ZKogntyJ/44GBZmFwbtw5Ujw5Gnvv0tVB59ciKqR4c8=";
   };
 
   installPhase = ''
@@ -19,8 +19,8 @@ stdenvNoCC.mkDerivation rec {
 
     cd fonts
     for f in *; do
-      mkdir -p $out/share/fonts/truetype/lexend/$f
-      install $f/ttf/* $out/share/fonts/truetype/lexend/$f/
+      install -D -t $out/share/fonts/truetype/lexend/$f $f/ttf/*
+      install -D -t $out/share/fonts/variable/lexend/$f $f/variable/*
     done
 
     runHook postInstall


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
