### PR TITLE
mdds: Get source archives from gitlab

### DIFF
--- a/pkgs/development/libraries/mdds/default.nix
+++ b/pkgs/development/libraries/mdds/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, fetchurl, boost, llvmPackages }:
+{ lib, stdenv, fetchFromGitLab, autoreconfHook, boost, llvmPackages }:
 
 stdenv.mkDerivation rec {
   pname = "mdds";
   version = "2.0.2";
 
-  src = fetchurl {
-    url = "https://kohei.us/files/${pname}/src/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-EyEfLy44fvO3TXOh3O5Soa1c4G34+OZkdnnfknijEWo=";
+  src = fetchFromGitLab {
+    owner = "mdds";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-jCzF0REocpnP56LfY42zlGTXyKyz4GPovDshhrh4jyo=";
   };
 
   postInstall = ''
@@ -15,6 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   checkInputs = [ boost ];
 

--- a/pkgs/development/libraries/mdds/default.nix
+++ b/pkgs/development/libraries/mdds/default.nix
@@ -16,15 +16,17 @@ stdenv.mkDerivation rec {
     cp "$out/share/pkgconfig/"* "$out/lib/pkgconfig"
   '';
 
-  buildInputs = lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
   nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
 
   checkInputs = [ boost ];
 
   meta = with lib; {
-    homepage = "https://gitlab.com/mdds/mdds";
     description = "A collection of multi-dimensional data structure and indexing algorithm";
-    platforms = platforms.all;
+    homepage = "https://gitlab.com/mdds/mdds";
+    maintainers = [];
     license = licenses.mit;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
As a stress test, I am trying to `nixos-rebuild` into nixos 22.11 without using any substituters, and fixing build failures along the way. 

###### Description of changes

mdds' release asset links in the gitlab releases point to the author's website, and are currently 404ing. Use the gitlab releases instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).