### PR TITLE
nailgun: split into client and server

### DIFF
--- a/pkgs/development/tools/nailgun/default.nix
+++ b/pkgs/development/tools/nailgun/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchMavenArtifact, fetchFromGitHub, jre, makeWrapper }:
+{ lib, stdenv, stdenvNoCC, fetchMavenArtifact, fetchFromGitHub, jre, makeWrapper, symlinkJoin }:
 
 let
   version = "1.0.0";
@@ -8,33 +8,62 @@ let
     inherit version;
     sha256 = "1mk8pv0g2xg9m0gsb96plbh6mc24xrlyrmnqac5mlbl4637l4q95";
   };
-in
-stdenv.mkDerivation {
-  pname = "nailgun";
-  inherit version;
 
-  src = fetchFromGitHub {
-    owner = "facebook";
-    repo = "nailgun";
-    rev = "nailgun-all-v${version}";
-    sha256 = "1syyk4ss5vq1zf0ma00svn56lal53ffpikgqgzngzbwyksnfdlh6";
+  commonMeta = {
+    license = lib.licenses.asl20;
+    homepage = "http://www.martiansoftware.com/nailgun/";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ];
   };
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  server = stdenvNoCC.mkDerivation {
+    pname = "nailgun-server";
+    inherit version;
 
-  nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [ makeWrapper ];
 
-  postInstall = ''
-    makeWrapper ${jre}/bin/java $out/bin/ng-server \
-      --add-flags '-classpath ${nailgun-server.jar}:$CLASSPATH com.facebook.nailgun.NGServer'
-  '';
+    dontUnpack = true;
+    installPhase = ''
+      runHook preInstall
 
-  meta = with lib; {
+      makeWrapper ${jre}/bin/java $out/bin/ng-server \
+        --add-flags '-classpath ${nailgun-server.jar}:$CLASSPATH com.facebook.nailgun.NGServer'
+
+      runHook postInstall
+    '';
+
+    meta = commonMeta // {
+      description = "Server for running Java programs from the command line without incurring the JVM startup overhead";
+      sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    };
+  };
+
+  client = stdenv.mkDerivation {
+    pname = "nailgun-client";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "facebook";
+      repo = "nailgun";
+      rev = "nailgun-all-v${version}";
+      sha256 = "1syyk4ss5vq1zf0ma00svn56lal53ffpikgqgzngzbwyksnfdlh6";
+    };
+
+    makeFlags = [ "PREFIX=$(out)" ];
+
+    meta = commonMeta // {
+      description = "Client for running Java programs from the command line without incurring the JVM startup overhead";
+    };
+  };
+in
+symlinkJoin rec {
+  pname = "nailgun";
+  inherit client server version;
+
+  name = "${pname}-${version}";
+  paths = [ client server ];
+
+  meta = commonMeta // {
     description = "Client, protocol, and server for running Java programs from the command line without incurring the JVM startup overhead";
-    homepage = "http://www.martiansoftware.com/nailgun/";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.asl20;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This makes it possible to use the extremely small nailgun client without downloading 500 MB of JDK.

The `nailgun` attribute path still contains symlinks to both client and server; the new attribute paths `nailgun.client` and `nailgun.server` can be used to be more selective.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
