### PR TITLE
carlito: Use stdenv.mkDerivation

### DIFF
--- a/pkgs/data/fonts/carlito/default.nix
+++ b/pkgs/data/fonts/carlito/default.nix
@@ -1,21 +1,20 @@
-{ lib, fetchzip }:
+{ lib, fetchzip, stdenvNoCC }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "carlito";
   version = "20130920";
-in fetchzip {
-  name = "carlito-${version}";
 
-  url = "https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/crosextrafonts-carlito-${version}.tar.gz";
+  src = fetchzip {
+    url = "https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/crosextrafonts-carlito-${version}.tar.gz";
+    sha256 = "sha256-OGDO5WoF7OmiRdLRRrIXMzg276Pgeq1L3Offcl0W2jg=";
+  };
 
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
+  installPhase = ''
     mkdir -p $out/etc/fonts/conf.d
     mkdir -p $out/share/fonts/truetype
-    cp -v *.ttf $out/share/fonts/truetype
+    cp -v $src/*.ttf $out/share/fonts/truetype
     cp -v ${./calibri-alias.conf} $out/etc/fonts/conf.d/30-calibri.conf
   '';
-
-  sha256 = "0d72zy6kdmxgpi63r3yvi3jh1hb7lvlgv8hgd4ag0x10dz18mbzv";
 
   meta = with lib; {
     # This font doesn't appear to have any official web site but this
@@ -25,7 +24,7 @@ in fetchzip {
     longDescription = ''
       Carlito is a free font that is metric-compatible with the
       Microsoft Calibri font. The font is designed by Łukasz Dziedzic
-      of the tyPoland foundry and based his Lato font.
+      of the tyPoland foundry and based upon his Lato font.
     '';
     license = licenses.ofl;
     platforms = platforms.all;


### PR DESCRIPTION
As a stress test (of myself, my workstation, and of nixpkgs), I am trying to `nixos-rebuild` into nixos 22.11 without using any substituters, and fixing build failures along the way. 

###### Description of changes

carlito used to call `fetchzip` directly, and the fact that it was a fixed-output derivation meant nobody noticed that:

1. the derivation no longer built from source (due to changes in `fetchzip`), and

2. the updated fontconfig xml never got used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
