### PR TITLE
ucblogo: init at 6.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16024,4 +16024,10 @@
     github = "ziguana";
     githubId = 45833444;
   };
+  hllizi = {
+    name = "David Lahm";
+    email = "david@klinger-lahm.de";
+    github = "hllizi";
+    githubId = 35627697;
+  };
 }

--- a/pkgs/development/interpreters/ucblogo/default.nix
+++ b/pkgs/development/interpreters/ucblogo/default.nix
@@ -13,9 +13,10 @@
 stdenv.mkDerivation {
   pname = "ucblogo";
   version = "6.2.2";
-  src = fetchTarball {
-    url = "https://github.com/jrincayc/ucblogo-code/archive/refs/tags/version_6.2.2.zip";
-    sha256 = "0vzzic9x1kclc2pn57cjwpb2q71h5pvn8cy2ancwww9l8i8qsb0p";
+  src = builtins.fetchGit {
+    rev = "0ba6ad1629f94a89f98e2bf884c1388c6ee78b6d";
+    ref = "master";
+    url = "https://github.com/jrincayc/ucblogo-code.git";
   };
   nativeBuildInputs = [
         autoreconfHook

--- a/pkgs/development/interpreters/ucblogo/default.nix
+++ b/pkgs/development/interpreters/ucblogo/default.nix
@@ -1,0 +1,34 @@
+{
+        wxGTK32
+,       wrapGAppsHook
+,       autoreconfHook
+,       autoconf-archive
+,       texinfo
+,       tetex
+,       stdenv
+,       fetchFromGitHub
+,       gtk3
+,       lib
+}:
+stdenv.mkDerivation {
+  name = "ucb-logo";
+  version = "6.2.2";
+  src = fetchTarball {
+    url = "https://github.com/jrincayc/ucblogo-code/archive/refs/tags/version_6.2.2.zip";
+    sha256 = "0vzzic9x1kclc2pn57cjwpb2q71h5pvn8cy2ancwww9l8i8qsb0p";
+  };
+  nativeBuildInputs = [
+        autoreconfHook
+        texinfo
+        tetex
+        autoconf-archive
+  ];
+  buildInputs = [
+        gtk3
+        wxGTK32
+        wrapGAppsHook
+      ];
+  meta = with lib; {
+      maintainers = with maintainers; [hllizi];
+    };
+}

--- a/pkgs/development/interpreters/ucblogo/default.nix
+++ b/pkgs/development/interpreters/ucblogo/default.nix
@@ -11,7 +11,7 @@
 ,       lib
 }:
 stdenv.mkDerivation {
-  name = "ucb-logo";
+  name = "ucblogo";
   version = "6.2.2";
   src = fetchTarball {
     url = "https://github.com/jrincayc/ucblogo-code/archive/refs/tags/version_6.2.2.zip";

--- a/pkgs/development/interpreters/ucblogo/default.nix
+++ b/pkgs/development/interpreters/ucblogo/default.nix
@@ -13,7 +13,7 @@
 stdenv.mkDerivation {
   pname = "ucblogo";
   version = "6.2.2";
-  src = builtins.fetchGit {
+  src = builtins.fetchgit {
     rev = "0ba6ad1629f94a89f98e2bf884c1388c6ee78b6d";
     ref = "master";
     url = "https://github.com/jrincayc/ucblogo-code.git";

--- a/pkgs/development/interpreters/ucblogo/default.nix
+++ b/pkgs/development/interpreters/ucblogo/default.nix
@@ -11,7 +11,7 @@
 ,       lib
 }:
 stdenv.mkDerivation {
-  name = "ucblogo";
+  pname = "ucblogo";
   version = "6.2.2";
   src = fetchTarball {
     url = "https://github.com/jrincayc/ucblogo-code/archive/refs/tags/version_6.2.2.zip";
@@ -29,6 +29,10 @@ stdenv.mkDerivation {
         wrapGAppsHook
       ];
   meta = with lib; {
+      description = "Berkeley Logo interpreter";
       maintainers = with maintainers; [hllizi];
+      license = lib.licenses.gpl3 ;
+      platforms = lib.platforms.linux;
+      homepage = "https://people.eecs.berkeley.edu/~bh/logo.html";
     };
 }

--- a/pkgs/development/interpreters/ucblogo/default.nix
+++ b/pkgs/development/interpreters/ucblogo/default.nix
@@ -1,39 +1,39 @@
-{
-        wxGTK32
-,       wrapGAppsHook
-,       autoreconfHook
-,       autoconf-archive
-,       texinfo
-,       tetex
-,       stdenv
-,       fetchFromGitHub
-,       gtk3
-,       lib
+{ wxGTK32
+, wrapGAppsHook
+, autoreconfHook
+, autoconf-archive
+, texinfo
+, tetex
+, stdenv
+, fetchFromGitHub
+, gtk3
+, lib
 }:
 stdenv.mkDerivation {
   pname = "ucblogo";
   version = "6.2.2";
-  src = builtins.fetchgit {
+  src = fetchFromGitHub {
     rev = "0ba6ad1629f94a89f98e2bf884c1388c6ee78b6d";
-    ref = "master";
-    url = "https://github.com/jrincayc/ucblogo-code.git";
+    sha256 = "FyyNUUQ0cc6ZVcIzZPctMBws1uWSnWKvYJTN0BOL/28=";
+    owner = "jrincayc";
+    repo = "ucblogo-code";
   };
   nativeBuildInputs = [
-        autoreconfHook
-        texinfo
-        tetex
-        autoconf-archive
+    autoreconfHook
+    texinfo
+    tetex
+    autoconf-archive
   ];
   buildInputs = [
-        gtk3
-        wxGTK32
-        wrapGAppsHook
-      ];
+    gtk3
+    wxGTK32
+    wrapGAppsHook
+  ];
   meta = with lib; {
-      description = "Berkeley Logo interpreter";
-      maintainers = with maintainers; [hllizi];
-      license = lib.licenses.gpl3 ;
-      platforms = lib.platforms.linux;
-      homepage = "https://people.eecs.berkeley.edu/~bh/logo.html";
-    };
+    description = "Berkeley Logo interpreter";
+    maintainers = with maintainers; [ hllizi ];
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    homepage = "https://people.eecs.berkeley.edu/~bh/logo.html";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38152,4 +38152,6 @@ with pkgs;
   aitrack = libsForQt5.callPackage ../applications/misc/aitrack { };
 
   widevine-cdm = callPackage ../applications/networking/browsers/misc/widevine-cdm.nix { };
+
+  ucblogo = callPackage ../development/interpreters/ucblogo { };
 }


### PR DESCRIPTION
###### Description of changes

As I couldn't find any working Logo interpreter in the nixpkgs I tried to build ucblogo. This was very unproblematic to do and I thought I might just turn it into a package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
