### PR TITLE
nixos/manual: document kernel backporting policy and implications of it

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -17,6 +17,16 @@ you may want to use one of the unversioned `pkgs.linuxPackages_*` aliases
 such as `pkgs.linuxPackages_latest`, that are kept up to date with new
 versions.
 
+Please note that the current convention in NixOS is to only keep actively
+maintained kernel versions on both unstable and the currently supported stable
+release(s) of NixOS. This means that a non-longterm kernel will be removed after it's
+abandoned by the kernel developers, even on stable NixOS versions. If you
+pin your kernel onto a non-longterm version, expect your evaluation to fail as
+soon as the version is out of maintenance.
+
+Longterm versions of kernels will be removed before the next stable NixOS that will
+exceed the maintenance period of the kernel version.
+
 The default Linux kernel configuration should be fine for most users.
 You can see the configuration of your current kernel with the following
 command:
@@ -138,3 +148,23 @@ $ cd linux-*
 $ make -C $dev/lib/modules/*/build M=$(pwd)/drivers/net/ethernet/mellanox modules
 # insmod ./drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko
 ```
+
+## ZFS {#sec-linux-zfs}
+
+It's a common issue that the latest stable version of ZFS doesn't support the latest
+available Linux kernel. It's possible to pin the system to the latest available kernel
+version *that is supported by ZFS* like this:
+
+```nix
+{
+  boot.kernelPackages = pkgs.zfs.latestCompatibleLinuxPackages;
+}
+```
+
+Please note that the version this attribute points to isn't monotonic because the latest kernel
+version only refers to kernel versions supported by the Linux developers. In other words,
+the latest kernel version that ZFS is compatible with may decrease over time.
+
+An example: the latest version ZFS is compatible with is 5.19 which is a non-longterm version. When 5.19
+is out of maintenance, the latest supported kernel version is 5.15 because it's longterm and the versions
+5.16, 5.17 and 5.18 are already out of maintenance because they're non-longterm.

--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -152,7 +152,10 @@ $ make -C $dev/lib/modules/*/build M=$(pwd)/drivers/net/ethernet/mellanox module
 ## ZFS {#sec-linux-zfs}
 
 It's a common issue that the latest stable version of ZFS doesn't support the latest
-available Linux kernel. It's possible to pin the system to the latest available kernel
+available Linux kernel. It is recommended to use the latest available LTS that's compatible
+with ZFS. Usually this is the default kernel provided by nixpkgs (i.e. `pkgs.linuxPackages`).
+
+Alternatively, it's possible to pin the system to the latest available kernel
 version *that is supported by ZFS* like this:
 
 ```nix

--- a/nixos/doc/manual/from_md/configuration/linux-kernel.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/linux-kernel.chapter.xml
@@ -171,9 +171,15 @@ $ make -C $dev/lib/modules/*/build M=$(pwd)/drivers/net/ethernet/mellanox module
     <title>ZFS</title>
     <para>
       It’s a common issue that the latest stable version of ZFS doesn’t
-      support the latest available Linux kernel. It’s possible to pin
-      the system to the latest available kernel version <emphasis>that
-      is supported by ZFS</emphasis> like this:
+      support the latest available Linux kernel. It is recommended to
+      use the latest available LTS that’s compatible with ZFS. Usually
+      this is the default kernel provided by nixpkgs (i.e.
+      <literal>pkgs.linuxPackages</literal>).
+    </para>
+    <para>
+      Alternatively, it’s possible to pin the system to the latest
+      available kernel version <emphasis>that is supported by
+      ZFS</emphasis> like this:
     </para>
     <programlisting language="bash">
 {

--- a/nixos/doc/manual/from_md/configuration/linux-kernel.chapter.xml
+++ b/nixos/doc/manual/from_md/configuration/linux-kernel.chapter.xml
@@ -22,6 +22,19 @@ boot.kernelPackages = pkgs.linuxKernel.packages.linux_3_10;
     date with new versions.
   </para>
   <para>
+    Please note that the current convention in NixOS is to only keep
+    actively maintained kernel versions on both unstable and the
+    currently supported stable release(s) of NixOS. This means that a
+    non-longterm kernel will be removed after it’s abandoned by the
+    kernel developers, even on stable NixOS versions. If you pin your
+    kernel onto a non-longterm version, expect your evaluation to fail
+    as soon as the version is out of maintenance.
+  </para>
+  <para>
+    Longterm versions of kernels will be removed before the next stable
+    NixOS that will exceed the maintenance period of the kernel version.
+  </para>
+  <para>
     The default Linux kernel configuration should be fine for most
     users. You can see the configuration of your current kernel with the
     following command:
@@ -153,5 +166,33 @@ $ cd linux-*
 $ make -C $dev/lib/modules/*/build M=$(pwd)/drivers/net/ethernet/mellanox modules
 # insmod ./drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko
 </programlisting>
+  </section>
+  <section xml:id="sec-linux-zfs">
+    <title>ZFS</title>
+    <para>
+      It’s a common issue that the latest stable version of ZFS doesn’t
+      support the latest available Linux kernel. It’s possible to pin
+      the system to the latest available kernel version <emphasis>that
+      is supported by ZFS</emphasis> like this:
+    </para>
+    <programlisting language="bash">
+{
+  boot.kernelPackages = pkgs.zfs.latestCompatibleLinuxPackages;
+}
+</programlisting>
+    <para>
+      Please note that the version this attribute points to isn’t
+      monotonic because the latest kernel version only refers to kernel
+      versions supported by the Linux developers. In other words, the
+      latest kernel version that ZFS is compatible with may decrease
+      over time.
+    </para>
+    <para>
+      An example: the latest version ZFS is compatible with is 5.19
+      which is a non-longterm version. When 5.19 is out of maintenance,
+      the latest supported kernel version is 5.15 because it’s longterm
+      and the versions 5.16, 5.17 and 5.18 are already out of
+      maintenance because they’re non-longterm.
+    </para>
   </section>
 </chapter>

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -62,6 +62,11 @@ in
         configuration.  For instance, if you use the NVIDIA X driver,
         then it also needs to contain an attribute
         {var}`nvidia_x11`.
+
+        Please note that we strictly support kernel versions that are
+        maintained by the Linux developers only. More information on the
+        availability of kernel versions is documented
+        [in the Linux section of the manual](https://nixos.org/manual/nixos/unstable/index.html#sec-kernel-config).
       '';
     };
 


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
I'm well aware that this issue is currently under discussion[1] and that these things may change. Also, please don't misinterpret this as an attempt to end the discussion.

This topic made it obvious that people are surprised by the way this issue is handled and only finding out about this unwritten rule because of asking is not a good state IMHO, so I decided to document the following things:

* Right now we drop kernels as soon as they get out of maintenance (LTS kernels even before the next stable NixOS that will exceed their lifespan).
* The `latestCompatibleLinuxPackages` attribute from ZFS isn't monotonic since latest only refers to the latest supported kernel.
* In fact `latestCompatibleLinuxPackages` doesn't seem to be documented at all in the manual, so I also did that.

[1] https://discourse.nixos.org/t/aggressive-kernel-removal-on-eol-in-nixos/23097

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
