### PR TITLE
lemmy-help: 0.9.0 -> 0.10.0, add figsoda as a maintainer

### DIFF
--- a/pkgs/tools/misc/lemmy-help/default.nix
+++ b/pkgs/tools/misc/lemmy-help/default.nix
@@ -2,18 +2,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lemmy-help";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "numToStr";
     repo = "lemmy-help";
     rev = "v${version}";
-    sha256 = "sha256-VY8sGxS8wwrezTe4ht9xdr4iE2n9fNSNhfCeGDJL5Lo=";
+    sha256 = "sha256-gsYVrqPcabLCMYN3Gmr6CXTCKKFAy2rDCxmcRwR1Iic=";
   };
 
   buildFeatures = [ "cli" ];
 
-  cargoSha256 = "sha256-yj14kg41EqOco0gx79n8xhf8cyotZ1Mxj2AbNV9TImU=";
+  cargoSha256 = "sha256-iyMEzxCTxJ/CP3UEnLc4SN5zhIjCLGUl4OOk0u0bCJc=";
 
   meta = with lib; {
     description = "A CLI for generating vim help docs from emmylua comments";
@@ -21,6 +21,8 @@ rustPlatform.buildRustPackage rec {
       `lemmy-help` is an emmylua parser as well as a CLI which takes that parsed tree and converts it into vim help docs.
     '';
     homepage = "https://github.com/numToStr/lemmy-help";
+    changelog = "https://github.com/numToStr/lemmy-help/releases/tag/v${version}";
     license = with licenses; [ mit ];
+    maintainers = with maintainers; [ figsoda ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/numToStr/lemmy-help/compare/v0.9.0...v0.10.0

Changelog: https://github.com/numToStr/lemmy-help/releases/tag/v0.10.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
