### PR TITLE
cargo-about: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/development/tools/rust/cargo-about/default.nix
+++ b/pkgs/development/tools/rust/cargo-about/default.nix
@@ -9,13 +9,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-about";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = "cargo-about";
     rev = version;
-    sha256 = "sha256-T8Hhody0jMmZb6/xMkSvKCv4STZPbcrf/UB3APspYDM=";
+    sha256 = "sha256-8476jJK1oiXVX9G09NSL+xvXZdZ+h7grCHC6R0XXewo=";
   };
 
   cargoPatches = [
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     ./zstd-pkg-config.patch
   ];
 
-  cargoSha256 = "sha256-2Reqj+WP6OoaB/3Z5llZP4c5ToVmMNX0Fe0IqDwcg2E=";
+  cargoSha256 = "sha256-EFpkBWQSWYyMrUa9Dh+n9kDNmXL/2yuEmFN3DcPeE7U=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-about/zstd-pkg-config.patch
+++ b/pkgs/development/tools/rust/cargo-about/zstd-pkg-config.patch
@@ -1,6 +1,6 @@
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -183,6 +183,7 @@ dependencies = [
+@@ -207,6 +207,7 @@ dependencies = [
   "toml_edit",
   "twox-hash",
   "url",
@@ -8,32 +8,33 @@
  ]
  
  [[package]]
-@@ -1039,6 +1040,12 @@ version = "0.1.0"
+@@ -1093,6 +1094,12 @@ version = "0.1.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
  
 +[[package]]
 +name = "pkg-config"
-+version = "0.3.22"
++version = "0.3.26"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
++checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 +
  [[package]]
  name = "ppv-lite86"
- version = "0.2.15"
-@@ -1902,4 +1909,5 @@ checksum = "2141bed8922b427761470e6bbfeff255da94fa20b0bbeab0d9297fcaf71e3aa7"
+ version = "0.2.16"
+@@ -2045,4 +2052,5 @@ checksum = "2141bed8922b427761470e6bbfeff255da94fa20b0bbeab0d9297fcaf71e3aa7"
  dependencies = [
   "cc",
   "libc",
 + "pkg-config",
  ]
-diff --git a/Cargo.toml b/Cargo.toml
-index bf2a896..35cbf7c 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -80,3 +80,5 @@ toml_edit = "0.9"
+@@ -80,6 +80,8 @@ toml_edit = "0.15"
  twox-hash = "1.6"
  # Url parsing
  url = "2.2"
-+
++# Use pkg-config feature of zstd
 +zstd = { version = "*", features = ["pkg-config"] }
+ 
+ [dev-dependencies]
+ # Filesystems - Filesystem fixtures and assertions for testing


### PR DESCRIPTION
Diff: https://github.com/EmbarkStudios/cargo-about/compare/0.5.1...0.5.2

Changelog: https://github.com/EmbarkStudios/cargo-about/blob/0.5.2/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
