### PR TITLE
openjfx11: 11.0.3+1 -> 11.0.11+1, openjdk{11,12,13,14}: enableJavaFX by default

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -4,8 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk11-bootstrap
 , setJavaClassPath
 , headless ? false
-# disabled by default since openjfx11 depends on python2 (EOL)
-, enableJavaFX ? false, openjfx
+, enableJavaFX ? openjfx.meta.available, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/12.nix
+++ b/pkgs/development/compilers/openjdk/12.nix
@@ -4,8 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk11, fetchpatch
 , setJavaClassPath
 , headless ? false
-# disabled by default since openjfx11 depends on python2 (EOL)
-, enableJavaFX ? false, openjfx
+, enableJavaFX ? openjfx.meta.available, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/13.nix
+++ b/pkgs/development/compilers/openjdk/13.nix
@@ -4,8 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk13-bootstrap, fetchpatch
 , setJavaClassPath
 , headless ? false
-# disabled by default since openjfx11 depends on python2 (EOL)
-, enableJavaFX ? false, openjfx
+, enableJavaFX ? openjfx.meta.available, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/14.nix
+++ b/pkgs/development/compilers/openjdk/14.nix
@@ -4,8 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk14-bootstrap
 , setJavaClassPath
 , headless ? false
-# disabled by default since openjfx11 depends on python2 (EOL)
-, enableJavaFX ? false, openjfx
+, enableJavaFX ? openjfx.meta.available, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,26 +1,36 @@
 { stdenv, lib, fetchurl, writeText, gradle_4, pkg-config, perl, cmake
-, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python2, ruby
+, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python3, ruby
 , openjdk11-bootstrap }:
 
 let
   major = "11";
-  update = ".0.3";
+  update = ".0.11";
   build = "1";
   repover = "${major}${update}+${build}";
   gradle_ = (gradle_4.override {
     java = openjdk11-bootstrap;
   });
 
+  NIX_CFLAGS_COMPILE = [
+    # avoids errors about deprecation of GTypeDebugFlags, GTimeVal, etc.
+    "-DGLIB_DISABLE_DEPRECATION_WARNINGS"
+    # glib-2.62 deprecations
+    # -fcommon: gstreamer workaround for -fno-common toolchains:
+    #   ld: gsttypefindelement.o:(.bss._gst_disable_registry_cache+0x0): multiple definition of
+    #     `_gst_disable_registry_cache'; gst.o:(.bss._gst_disable_registry_cache+0x0): first defined here
+    "-fcommon"
+  ];
+
   makePackage = args: stdenv.mkDerivation ({
     version = "${major}${update}-${build}";
 
     src = fetchurl {
-      url = "https://hg.openjdk.java.net/openjfx/${major}/rt/archive/${repover}.tar.gz";
-      sha256 = "1h7qsylr7rnwnbimqjyn3whszp9kv4h3gpicsrb3mradxc9yv194";
+      url = "https://hg.openjdk.java.net/openjfx/${major}-dev/rt/archive/${repover}.tar.gz";
+      sha256 = "sha256-mbEALUxuwbtlGeZ2Xsm3m3aNDdthLYWd6QHmdkAILxc=";
     };
 
     buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];
-    nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python2 ruby ];
+    nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;
 
@@ -34,8 +44,7 @@ let
       JDK_HOME = ${openjdk11-bootstrap.home}
     '' + args.gradleProperties or "");
 
-    #avoids errors about deprecation of GTypeDebugFlags, GTimeVal, etc.
-    NIX_CFLAGS_COMPILE = [ "-DGLIB_DISABLE_DEPRECATION_WARNINGS" ];
+    inherit NIX_CFLAGS_COMPILE;
 
     buildPhase = ''
       runHook preBuild
@@ -67,8 +76,7 @@ let
     outputHashMode = "recursive";
     # Downloaded AWT jars differ by platform.
     outputHash = {
-      i686-linux = "0mjlyf6jvbis7nrm5d394sjv4hjw6k3753hr1nwdxk8skwc3ry08";
-      x86_64-linux = "0d4msxswdav1xsfkpr0qd3xgqkcbxzf47v1zdy5jmg5w4bs6a78a";
+      x86_64-linux = "sha256-syceJMUEknBDCHK8eGs6rUU3IQn+HnQfURfCrDxYPa8=";
     }.${stdenv.system} or (throw "Unsupported platform");
   };
 
@@ -91,11 +99,7 @@ in makePackage {
     cp -r build/modular-sdk $out
   '';
 
-  # glib-2.62 deprecations
-  # -fcommon: gstreamer workaround for -fno-common toolchains:
-  #   ld: gsttypefindelement.o:(.bss._gst_disable_registry_cache+0x0): multiple definition of
-  #     `_gst_disable_registry_cache'; gst.o:(.bss._gst_disable_registry_cache+0x0): first defined here
-  NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS -fcommon";
+  inherit NIX_CFLAGS_COMPILE;
 
   stripDebugList = [ "." ];
 
@@ -105,6 +109,9 @@ in makePackage {
       new_refs="$(patchelf --print-rpath "$lib" | sed -E 's,:?${openjdk11-bootstrap}[^:]*,,')"
       patchelf --set-rpath "$new_refs" "$lib"
     done
+
+    # Remove licenses, otherwise they may conflict with the ones included in the openjdk
+    rm -rf $out/modules_legal/*
   '';
 
   disallowedReferences = [ openjdk11-bootstrap ];
@@ -119,6 +126,6 @@ in makePackage {
     license = licenses.gpl2;
     description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -72,7 +72,6 @@ let
     # Downloaded AWT jars differ by platform.
     outputHash = {
       x86_64-linux = "0hmyr5nnjgwyw3fcwqf0crqg9lny27jfirycg3xmkzbcrwqd6qkw";
-      i686-linux = "0hx69p2z96p7jbyq4r20jykkb8gx6r8q2cj7m30pldlsw3650bqx";
     }.${stdenv.system} or (throw "Unsupported platform");
   };
 
@@ -121,6 +120,6 @@ in makePackage {
     license = licenses.gpl2;
     description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2788,9 +2788,7 @@ with pkgs;
 
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
 
-  bisq-desktop = callPackage ../applications/blockchains/bisq-desktop {
-    openjdk11 = openjdk11.override { enableJavaFX = true; };
-  };
+  bisq-desktop = callPackage ../applications/blockchains/bisq-desktop { };
 
   bic = callPackage ../development/interpreters/bic { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Continuation of https://github.com/NixOS/nixpkgs/pull/203958.

Upgrading `openjfx11` to the latest version available seems to allow WebKit to be build with `python3`. Since now it works again, we can re-enable `openjfx11` in all `openjdk` versions that depend on it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
