### PR TITLE
zee: fix for rust 1.65

### DIFF
--- a/pkgs/applications/editors/zee/default.nix
+++ b/pkgs/applications/editors/zee/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, stdenv, Security }:
+{ lib, rustPlatform, fetchFromGitHub, fetchpatch, pkg-config, openssl, stdenv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "zee";
@@ -11,6 +11,11 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-/9SogKOaXdFDB+e0//lrenTTbfmXqNFGr23L+6Pnm8w=";
   };
 
+  cargoPatches = [
+    # fixed upstream but unreleased
+    ./update-ropey-for-rust-1.65.diff
+  ];
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
@@ -20,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   # see https://github.com/zee-editor/zee#syntax-highlighting
   ZEE_DISABLE_GRAMMAR_BUILD=1;
 
-  cargoSha256 = "sha256-mbqI1csnU95VWgax4GjIxB+nhMtmpaeJ8QQ3qb0hY4c=";
+  cargoHash = "sha256-fBBjtjM7AnyAL6EOFstL4h6yS+UoLgxck6Mc0tJcXaI=";
 
   meta = with lib; {
     description = "A modern text editor for the terminal written in Rust";

--- a/pkgs/applications/editors/zee/update-ropey-for-rust-1.65.diff
+++ b/pkgs/applications/editors/zee/update-ropey-for-rust-1.65.diff
@@ -1,0 +1,28 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 7159c28..0fa43c2 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1248,9 +1248,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ropey"
+-version = "1.4.1"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa0dd9b26e2a102b33d400b7b7d196c81a4014eb96eda90b1c5b48d7215d9633"
++checksum = "bbd22239fafefc42138ca5da064f3c17726a80d2379d817a3521240e78dd0064"
+ dependencies = [
+  "smallvec",
+  "str_indices",
+@@ -1408,9 +1408,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+ 
+ [[package]]
+ name = "str_indices"
+-version = "0.3.2"
++version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "adfad63a1b47951101cd667a85b2959a62910cf03f814fff25df89c460b873f8"
++checksum = "9d9199fa80c817e074620be84374a520062ebac833f358d74b37060ce4a0f2c0"
+ 
+ [[package]]
+ name = "strsim"


### PR DESCRIPTION
###### Description of changes

This broke when Rust upgraded in https://github.com/NixOS/nixpkgs/pull/199664. This was fixed upstream in https://github.com/zee-editor/zee/commit/a1d69136b6800df4aec2a84e94e1acbf2b8e3569 by updating ropey, but that patch leads to merge conflicts and cannot be pulled directly. New release is requested in https://github.com/zee-editor/zee/issues/92, but, in the meantime, I've created a patch locally that updates just ropey and str_indices.

For more context, the issue was reported in https://github.com/cessen/ropey/issues/56 and due to a change introduced in https://github.com/rust-lang/rust/pull/94075.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
