### PR TITLE
imgbrd-grabber: fix build

### DIFF
--- a/pkgs/applications/graphics/imgbrd-grabber/default.nix
+++ b/pkgs/applications/graphics/imgbrd-grabber/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , cmake
 , fetchFromGitHub
+, fetchpatch
 , wrapQtAppsHook
 , qtmultimedia
 , qttools
@@ -48,6 +49,16 @@ stdenv.mkDerivation rec {
 
   extraOutputsToLink = [ "doc" ];
 
+  patches = [
+    # fix a compilation error that was added in a recent version of TypeScript
+    # remove after updating to the next release
+    (fetchpatch {
+      url = "https://github.com/Bionus/imgbrd-grabber/commit/21a06657831fa4026a5ac7bbd879dc7ac13cb278.patch";
+      sha256 = "sha256-DAMk9Uvx7sqwTWLqb4Ghuh4JlLJloqrGnefMoVf5msQ=";
+      stripLen = 1;
+    })
+  ];
+
   postPatch = ''
     # the package.sh script provides some install helpers
     # using this might make it easier to maintain/less likely for the
@@ -69,6 +80,10 @@ stdenv.mkDerivation rec {
     ln -sf ${catch2.src} tests/src/vendor/catch
 
     sed "s|strict\": true|strict\": false|g" -i ./sites/tsconfig.json
+  '';
+
+  preBuild = ''
+    export HOME=$TMPDIR
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

TypeScript v7.9.3 ([updated in this commit](https://github.com/NixOS/nixpkgs/commit/3a5e1d626cea9459a8e4ce65ef1ba77bbeef61e9)) seems to have introduced a new compilation error, causing the build to fail. This patch is a simple workaround until it is updated upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
