### PR TITLE
lib2geom: fix tests on i686

### DIFF
--- a/pkgs/development/libraries/lib2geom/default.nix
+++ b/pkgs/development/libraries/lib2geom/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, fetchpatch
 , fetchFromGitLab
 , cmake
 , ninja
@@ -24,6 +25,16 @@ stdenv.mkDerivation rec {
     rev = "refs/tags/${version}";
     sha256 = "sha256-SNo5YT7o29zdxkHLuy9MT88qBg/U1Wwa3BWShF5ACTc=";
   };
+
+  patches = [
+    # Fixed upstream, remove when the new version releases:
+    # https://gitlab.com/inkscape/lib2geom/-/issues/49
+    (fetchpatch {
+      name = "expect-double-eq-in-choose-test.patch";
+      url = "https://gitlab.com/inkscape/lib2geom/-/commit/5b7c75dd3841cb415f163f0a81f556c57d3e0a83.patch";
+      sha256 = "RMgwJkylrGFTTrqBzqs5j2LMSLsHhcE/UT1pKBZnU50=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
###### Description of changes
ZHF #200691

Lib2geom tests fail on i686 due to what seems to be an integer precision issue. I have reported the issue upstream [here](https://gitlab.com/inkscape/lib2geom/-/issues/49) and it got fixed there.

This imports and uses the patch from upstream to fix it here for the time being.

This library is a dependency of the Cinnamon desktop, so ideally I want this backported onto the 22.11 release branch too.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] i686-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
