### PR TITLE
httplz: fix for rust 1.65

### DIFF
--- a/pkgs/tools/networking/httplz/default.nix
+++ b/pkgs/tools/networking/httplz/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchCrate
+, fetchpatch
 , installShellFiles
 , makeWrapper
 , pkg-config
@@ -20,6 +21,15 @@ rustPlatform.buildRustPackage rec {
     pname = "https";
     sha256 = "sha256-+nCqMTLrBYNQvoKo1PzkyzRCkKdlE88+NYoJcIlAJts=";
   };
+
+  patches = [
+    # https://github.com/thecoshman/http/pull/151
+    (fetchpatch {
+      name = "fix-rust-1.65-compile.patch";
+      url = "https://github.com/thecoshman/http/commit/6e4c8e97cce09d0d18d4936f90aa643659d813fc.patch";
+      hash = "sha256-mXclXfp2Nzq6Pr9VFmxiOzECGZEQRNOAcXoKhiOyuFs=";
+    })
+  ];
 
   cargoSha256 = "sha256-odiVIfNJPpagoASnYvdOosHXa37gbQM8Zmvtnao0pAs=";
 


### PR DESCRIPTION
###### Description of changes

This broke when Rust upgraded in https://github.com/NixOS/nixpkgs/pull/199664. Rust has added a new default lint in https://github.com/rust-lang/rust/pull/97739 that requires code changes upstream.

We can pull in https://github.com/thecoshman/http/pull/151, which I submitted upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
