### PR TITLE
python3Packages.btrfsutil: build separately from btrfs-progs

### DIFF
--- a/pkgs/development/python-modules/btrfsutil/default.nix
+++ b/pkgs/development/python-modules/btrfsutil/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, btrfs-progs
+}:
+buildPythonPackage {
+  pname = "btrfsutil";
+  inherit (btrfs-progs) version src;
+  format = "setuptools";
+
+  buildInputs = [ btrfs-progs ];
+
+  preConfigure = ''
+    cd libbtrfsutil/python
+  '';
+
+  # No tests
+  doCheck = false;
+  pythonImportsCheck = [ "btrfsutil" ];
+
+  meta = with lib; {
+    description = "Library for managing Btrfs filesystems";
+    homepage = "https://btrfs.wiki.kernel.org/";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ raskin lopsided98 ];
+  };
+}

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -1,11 +1,10 @@
 { lib, stdenv, fetchurl
-, pkg-config, python3, sphinx
+, pkg-config, sphinx
 , zstd
 , acl, attr, e2fsprogs, libuuid, lzo, udev, zlib
 , runCommand, btrfs-progs
 , gitUpdater
 , udevSupport ? true
-, enablePython ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -19,13 +18,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-  ] ++ lib.optionals enablePython [
-    python3 python3.pkgs.setuptools
   ] ++ [
     sphinx
   ];
 
-  buildInputs = [ acl attr e2fsprogs libuuid lzo python3 udev zlib zstd ];
+  buildInputs = [ acl attr e2fsprogs libuuid lzo udev zlib zstd ];
 
   # gcc bug with -O1 on ARM with gcc 4.8
   # This should be fine on all platforms so apply universally
@@ -35,17 +32,16 @@ stdenv.mkDerivation rec {
     install -v -m 444 -D btrfs-completion $out/share/bash-completion/completions/btrfs
   '';
 
-  configureFlags = lib.optionals stdenv.hostPlatform.isMusl [
-    "--disable-backtrace"
-  ] ++ lib.optionals (!enablePython) [
+  configureFlags = [
+    # Built separately, see python3Packages.btrfsutil
     "--disable-python"
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+    "--disable-backtrace"
   ] ++ lib.optionals (!udevSupport) [
     "--disable-libudev"
   ];
 
   makeFlags = [ "udevruledir=$(out)/lib/udev/rules.d" ];
-
-  installFlags = lib.optionals enablePython [ "install_python" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1430,7 +1430,7 @@ self: super: with self; {
 
   btrfs = callPackage ../development/python-modules/btrfs { };
 
-  btrfsutil = toPythonModule (pkgs.btrfs-progs.override { python3 = self.python; });
+  btrfsutil = callPackage ../development/python-modules/btrfsutil { };
 
   btsocket = callPackage ../development/python-modules/btsocket { };
 


### PR DESCRIPTION
###### Description of changes

btrfs-progs was installing its Python bindings as an egg, which doesn't work with Nix. It turns out that there is no real benefit to building the Python bindings as part of the btrfs-progs package. Instead, we can just package them separately, and use nixpkgs' normal Python packaging support to install them as a wheel. This fixes the bindings and reduces closure sizes.

Fixes #204672 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
