### PR TITLE
suil: remove qt4 support

### DIFF
--- a/pkgs/development/libraries/audio/suil/default.nix
+++ b/pkgs/development/libraries/audio/suil/default.nix
@@ -1,16 +1,11 @@
 { stdenv, lib, fetchurl, gtk2, lv2, pkg-config, python3, serd, sord, sratom
 , wafHook
-, withQt4 ? true, qt4 ? null
-, withQt5 ? false, qt5 ? null }:
-
-# I haven't found an XOR operator in nix...
-assert withQt4 || withQt5;
-assert !(withQt4 && withQt5);
+, withQt5 ? true, qt5 ? null
+}:
 
 stdenv.mkDerivation rec {
   pname = "suil";
   version = "0.10.6";
-  name = "${pname}-qt${if withQt4 then "4" else "5"}-${version}";
 
   src = fetchurl {
     url = "https://download.drobilla.net/${pname}-${version}.tar.bz2";
@@ -19,8 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config wafHook python3 ];
   buildInputs = [ gtk2 lv2 serd sord sratom ]
-    ++ (lib.optionals withQt4 [ qt4 ])
-    ++ (lib.optionals withQt5 (with qt5; [ qtbase qttools ]));
+    ++ lib.optionals withQt5 (with qt5; [ qtbase qttools ]);
 
   dontWrapQtApps = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22786,15 +22786,6 @@ with pkgs;
 
   suil = callPackage ../development/libraries/audio/suil { };
 
-  suil-qt5 = suil.override {
-    withQt4 = false;
-    withQt5 = true;
-  };
-  suil-qt4 = suil.override {
-    withQt4 = true;
-    withQt5 = false;
-  };
-
   sundials = callPackage ../development/libraries/sundials {
     python = python3;
   };
@@ -27552,7 +27543,6 @@ with pkgs;
 
   audacity = callPackage ../applications/audio/audacity {
     inherit (darwin.apple_sdk.frameworks) AppKit AudioToolbox AudioUnit Carbon CoreAudio CoreAudioKit CoreServices;
-    suil = suil-qt5;
   };
 
   audio-recorder = callPackage ../applications/audio/audio-recorder { };


### PR DESCRIPTION
###### Description of changes

```
2 packages removed:
suil-qt4 (†0.10.6) suil-qt5 (†0.10.6)

Result of nixpkgs-review run on x86_64-linux 1

<details>
  <summary>8 packages built:</summary>
  <ul>
    <li>ardour</li>
    <li>ardour_6</li>
    <li>audacity</li>
    <li>ingen</li>
    <li>jalv</li>
    <li>qtractor</li>
    <li>suil</li>
    <li>tenacity</li>
  </ul>
</details>
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
