### PR TITLE
dasel: 1.27.3 -> 2.0.2

### DIFF
--- a/pkgs/applications/misc/dasel/default.nix
+++ b/pkgs/applications/misc/dasel/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "dasel";
-  version = "1.27.3";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "TomWright";
     repo = "dasel";
     rev = "v${version}";
-    sha256 = "sha256-VrdjP9HlaBg8GY+2HPkQDwqJsoFtzTMz9QtQxhrUdxw=";
+    sha256 = "sha256-VdOXmhfgDzMyspoCFQl64obpQph14XZxR0Nas+crelA=";
   };
 
-  vendorSha256 = "sha256-zli9SEBU6n0JusAquqb9+O2W4yPZS7zmC5PCebVSeIA=";
+  vendorSha256 = "sha256-GO5Vg8zsXfjMBzRDC1/s/SYpviKUf59JB14vauKVFcE=";
 
   ldflags = [
     "-s" "-w" "-X github.com/tomwright/dasel/internal.Version=${version}"
@@ -22,13 +22,15 @@ buildGoModule rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    if [[ "$("$out/bin/${pname}" --version)" == "${pname} version ${version}" ]]; then
-      echo "" | $out/bin/dasel put object -p yaml -t string -t int "my.favourites" colour=red number=3 | grep -q red
-      echo '${pname} smoke check passed'
+    runHook preInstallCheck
+    if [[ $($out/bin/dasel --version) == "dasel version ${version}" ]]; then
+      echo '{ "my": { "favourites": { "colour": "blue" } } }' \
+        | $out/bin/dasel put -t json -r json -t string -v "red" "my.favourites.colour" \
+        | grep "red"
     else
-      echo '${pname} smoke check failed'
       return 1
     fi
+    runHook postInstallCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

https://github.com/TomWright/dasel/blob/4907b5c1ce63e5a76b14bf54fc959be104670b2f/CHANGELOG.md though it points to the main website [which has a specific section on the changes between v2 and v1](https://daseldocs.tomwright.me/#v1-to-v2-breaking-changes).

I also updated the install checks because of the breaking changes.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
