### PR TITLE
ruff: 0.0.165 -> 0.0.169

### DIFF
--- a/pkgs/development/tools/ruff/default.nix
+++ b/pkgs/development/tools/ruff/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ruff";
-  version = "0.0.165";
+  version = "0.0.166";
 
   src = fetchFromGitHub {
     owner = "charliermarsh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-McbLVoYujMNFoZg4rOZW1GNzUYymZHEohNEntOnaP1M=";
+    sha256 = "sha256-APgYvtWw4v8oyir0BrqbJnBMbgBg8N9LBHDT+n/FyDY=";
   };
 
-  cargoSha256 = "sha256-2YczpduILH3gSXCEG2w2n1yG4bqox4MMViZJcEFNRtw=";
+  cargoSha256 = "sha256-KkTOs8eGiN3rSzxdoyAr6zMMVcm6pIujrJRoTHfStuI=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     CoreServices

--- a/pkgs/development/tools/ruff/default.nix
+++ b/pkgs/development/tools/ruff/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ruff";
-  version = "0.0.168";
+  version = "0.0.169";
 
   src = fetchFromGitHub {
     owner = "charliermarsh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-fQBtFhKngoIl4I2Wa7quFZrmNBhQhSCVp5gw3LTYIio=";
+    sha256 = "sha256-YPVI1SaaLSqrpTu/uFTSyWbPVSDeADNVv2OfgR9K4qI=";
   };
 
-  cargoSha256 = "sha256-kLdO+b04YfdMex1B5Mx+EzDD3kkx5EktCPwTVbxKZ+c=";
+  cargoSha256 = "sha256-bP6gn/UIv1reytd8atNdoXZxsFFJCt+axl3UiCayERo=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     CoreServices

--- a/pkgs/development/tools/ruff/default.nix
+++ b/pkgs/development/tools/ruff/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ruff";
-  version = "0.0.166";
+  version = "0.0.167";
 
   src = fetchFromGitHub {
     owner = "charliermarsh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-APgYvtWw4v8oyir0BrqbJnBMbgBg8N9LBHDT+n/FyDY=";
+    sha256 = "sha256-3PnqR6ARvUGrw1tv5laBteCLzDZWSZXfAED47vEqQGo=";
   };
 
-  cargoSha256 = "sha256-KkTOs8eGiN3rSzxdoyAr6zMMVcm6pIujrJRoTHfStuI=";
+  cargoSha256 = "sha256-ND86qiQqDuiBVoeb6a1hQrBVIf3KXM1ZfBCipQKby3s=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     CoreServices

--- a/pkgs/development/tools/ruff/default.nix
+++ b/pkgs/development/tools/ruff/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ruff";
-  version = "0.0.167";
+  version = "0.0.168";
 
   src = fetchFromGitHub {
     owner = "charliermarsh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-3PnqR6ARvUGrw1tv5laBteCLzDZWSZXfAED47vEqQGo=";
+    sha256 = "sha256-fQBtFhKngoIl4I2Wa7quFZrmNBhQhSCVp5gw3LTYIio=";
   };
 
-  cargoSha256 = "sha256-ND86qiQqDuiBVoeb6a1hQrBVIf3KXM1ZfBCipQKby3s=";
+  cargoSha256 = "sha256-kLdO+b04YfdMex1B5Mx+EzDD3kkx5EktCPwTVbxKZ+c=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     CoreServices


### PR DESCRIPTION
Diff: https://github.com/charliermarsh/ruff/compare/v0.0.165...v0.0.167

Changelog: https://github.com/charliermarsh/ruff/releases/tag/v0.0.169

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
