### PR TITLE
ocaml-ng.ocamlPackages_5_0: 5.0.0-β2 → 5.0.0-rc1

### DIFF
--- a/pkgs/development/compilers/ocaml/5.0.nix
+++ b/pkgs/development/compilers/ocaml/5.0.nix
@@ -1,9 +1,9 @@
 import ./generic.nix {
   major_version = "5";
   minor_version = "0";
-  patch_version = "0-beta2";
+  patch_version = "0-rc1";
   src = fetchTarball {
-    url = "https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0~beta2.tar.xz";
-    sha256 = "sha256:1r76a3wadidca9306wkkcxdh5l0rk93pc6xmbs46cc1jfm6pgwas";
+    url = "https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0~rc1.tar.xz";
+    sha256 = "sha256:1ql9rmh2g9fhfv99vk9sdca1biiin32vi4idgdgl668n0vb8blw8";
   };
 }


### PR DESCRIPTION
###### Description of changes

Bug fixes: https://discuss.ocaml.org/t/first-release-candidate-for-ocaml-5-0-0/10922#bug-fixes-4

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
