### PR TITLE
vdirsyncer: 0.18.0->0.19.0

### DIFF
--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -17,6 +17,8 @@
 , pytest-asyncio
 , trustme
 , aioresponses
+, vdirsyncer
+, testers
 }:
 
 buildPythonPackage rec {
@@ -71,6 +73,8 @@ buildPythonPackage rec {
     "test_request_ssl"
     "test_verbosity"
   ];
+
+  passthru.tests.version = testers.testVersion { package = vdirsyncer; };
 
   meta = with lib; {
     homepage = "https://github.com/pimutils/vdirsyncer";

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -7,25 +7,28 @@
 , click-threading
 , requests-toolbelt
 , requests
-, requests-oauthlib
 , atomicwrites
 , hypothesis
 , pytestCheckHook
-, pytest-localserver
 , pytest-subtesthack
 , setuptools-scm
+, aiostream
+, aiohttp
+, pytest-asyncio
+, trustme
+, aioresponses
 }:
 
 buildPythonPackage rec {
   pname = "vdirsyncer";
-  version = "0.18.0";
+  version = "0.19.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-J7w+1R93STX7ujkpFcjI1M9jmuUaRLZ0aGtJoQJfwgE=";
+    hash = "sha256:0995bavlv8s9j0127ncq3yzy5p72lam9qgpswyjfanc6l01q87lf";
   };
 
   postPatch = ''
@@ -41,8 +44,9 @@ buildPythonPackage rec {
     click-log
     click-threading
     requests
-    requests-oauthlib
     requests-toolbelt
+    aiostream
+    aiohttp
   ];
 
   nativeBuildInputs = [
@@ -52,8 +56,10 @@ buildPythonPackage rec {
   checkInputs = [
     hypothesis
     pytestCheckHook
-    pytest-localserver
     pytest-subtesthack
+    pytest-asyncio
+    trustme
+    aioresponses
   ];
 
   preCheck = ''


### PR DESCRIPTION
###### Description of changes

https://github.com/pimutils/vdirsyncer/blob/main/CHANGELOG.rst#version-0190

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
