### PR TITLE
ipmitool: package the iana enterprise numbers

### DIFF
--- a/pkgs/tools/system/ipmitool/default.nix
+++ b/pkgs/tools/system/ipmitool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, openssl, readline }:
+{ stdenv, lib, fetchFromGitHub, fetchurl, autoreconfHook, openssl, readline }:
 
 stdenv.mkDerivation rec {
   pname = "ipmitool";
@@ -11,12 +11,24 @@ stdenv.mkDerivation rec {
     hash = "sha256-VVYvuldRIHhaIUibed9cLX8Avfy760fdBLNO8MoUKCk=";
   };
 
+  # IANA list of enterprise numbers
+  # Public domain, see: https://www.iana.org/help/licensing-terms
+  enterprise_numbers = fetchurl {
+    url = "https://www.iana.org/assignments/enterprise-numbers.txt";
+    hash = "sha256-aA7FPF3kLDDzeq7lc3n1dnLBaPKY6sdZXf5B7A6/ArI=";
+  };
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ openssl readline ];
 
   postPatch = ''
     substituteInPlace configure.ac \
       --replace 'AC_MSG_WARN([** Neither wget nor curl could be found.])' 'AM_CONDITIONAL([DOWNLOAD], [false])'
+  '';
+
+  # Install the IANA enterprise numbers
+  postInstall = ''
+    install -D ${enterprise_numbers} $out/share/misc/enterprise-numbers
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Packages the IANA enterprise numbers to stop a warning. This fixes #204926.

I am unsure if the CC-0 for the private enterprise numbers should be added to licenses or not as it is public domain. For now it is only stated in the comment over the `fetchurl`.

###### Things done
Tested and verified working on an IPMI-enabled Supermicro server running NixOS.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
