### PR TITLE
mitmproxy: 8.1.1 -> 9.0.1

### DIFF
--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
 , buildPythonPackage
 , pythonOlder
   # Mitmproxy requirements
@@ -8,7 +7,6 @@
 , blinker
 , brotli
 , certifi
-, click
 , cryptography
 , flask
 , h11
@@ -16,6 +14,7 @@
 , hyperframe
 , kaitaistruct
 , ldap3
+, mitmproxy-wireguard
 , msgpack
 , passlib
 , protobuf
@@ -42,23 +41,15 @@
 
 buildPythonPackage rec {
   pname = "mitmproxy";
-  version = "8.1.1";
-  disabled = pythonOlder "3.8";
+  version = "9.0.1";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "mitmproxy";
+    repo = "mitmproxy";
     rev = "refs/tags/v${version}";
     sha256 = "sha256-nW/WfiY6uF67qNa95tvNvSv/alP2WmzTk34LEBma/04=";
   };
-
-  patches = [
-    # Fix onboarding addon tests failing with Flask >= v2.2
-    (fetchpatch {
-      url = "https://github.com/mitmproxy/mitmproxy/commit/bc370276a19c1d1039e7a45ecdc23c362626c81a.patch";
-      hash = "sha256-Cp7RnYpZEuRhlWYOk8BOnAKBAUa7Vy296UmQi3/ufes=";
-    })
-  ];
 
   propagatedBuildInputs = [
     setuptools
@@ -67,7 +58,6 @@ buildPythonPackage rec {
     blinker
     brotli
     certifi
-    click
     cryptography
     flask
     h11
@@ -75,11 +65,12 @@ buildPythonPackage rec {
     hyperframe
     kaitaistruct
     ldap3
+    mitmproxy-wireguard
     msgpack
     passlib
     protobuf
-    publicsuffix2
     pyopenssl
+    publicsuffix2
     pyparsing
     pyperclip
     ruamel-yaml
@@ -120,6 +111,12 @@ buildPythonPackage rec {
     # ValueError: Exceeds the limit (4300) for integer string conversion
     "test_roundtrip_big_integer"
   ];
+
+  disabledTestPaths = [
+    # teardown of half the tests broken
+    "test/mitmproxy/addons/test_onboarding.py"
+  ];
+
   dontUsePytestXdist = true;
 
   pythonImportsCheck = [ "mitmproxy" ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
