### PR TITLE
phlare: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2287,6 +2287,12 @@
     githubId = 5394722;
     name = "Spencer Baugh";
   };
+  cathalmullan = {
+    email = "contact@cathal.dev";
+    github = "CathalMullan";
+    githubId = 37139470;
+    name = "Cathal Mullan";
+  };
   catouc = {
     email = "catouc@philipp.boeschen.me";
     github = "catouc";

--- a/pkgs/servers/monitoring/phlare/default.nix
+++ b/pkgs/servers/monitoring/phlare/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "phlare";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "phlare";
+    sha256 = "sha256-z1PT5chkpHQJPziY7bGf6W1X5uezL6E2GUV6w/NlyFk=";
+  };
+
+  proxyVendor = true;
+  vendorSha256 = "sha256-KJbh+M9jYxUW9akVBHZoB/mtOHWpMPtlwIgC9fu+NYY=";
+
+  ldflags = let
+    prefix = "github.com/grafana/phlare/pkg/util/build";
+  in [
+    "-s" "-w"
+    # https://github.com/grafana/phlare/blob/v0.3.0/Makefile#L32
+    "-X ${prefix}.Version=${version}"
+    "-X ${prefix}.Branch=v${version}"
+    "-X ${prefix}.Revision=v${version}"
+    "-X ${prefix}.BuildUser=nix"
+    "-X ${prefix}.BuildDate=1980-01-01T00:00:00Z"
+  ];
+
+  subPackages = [
+    "cmd/phlare"
+    "cmd/profilecli"
+  ];
+
+  meta = with lib; {
+    description = "Grafana Phlare is an open source database that provides fast, scalable, highly available, and efficient storage and querying of profiling data.";
+    license = licenses.agpl3;
+    homepage = "https://grafana.com/oss/phlare";
+    maintainers = with maintainers; [ cathalmullan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23831,6 +23831,8 @@ with pkgs;
 
   mimir = callPackage ../servers/monitoring/mimir { };
 
+  phlare = callPackage ../servers/monitoring/phlare { };
+
   grafana_reporter = callPackage ../servers/monitoring/grafana-reporter { };
 
   grafana-image-renderer = callPackage ../servers/monitoring/grafana-image-renderer { };


### PR DESCRIPTION
###### Description of changes

Grafana Phlare: An open source database that provides fast, scalable, highly available, and efficient storage and querying of profiling data.

https://grafana.com/oss/phlare

Resolves #204869

###### Things done

[Successfully hooked up Phlare to the Grafana UI](https://i.imgur.com/mCvDfo9.png).

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
