### PR TITLE
multiple: use lib.mesonEnable (really easy cases)

### DIFF
--- a/pkgs/applications/misc/wbg/default.nix
+++ b/pkgs/applications/misc/wbg/default.nix
@@ -16,12 +16,6 @@
 , libjpeg
 }:
 
-let
-  # Courtesy of sternenseemann and FRidh, commit c9a7fdfcfb420be8e0179214d0d91a34f5974c54
-  mesonFeatureFlag = feature: flag:
-    "-D${feature}=${if flag then "enabled" else "disabled"}";
-in
-
 stdenv.mkDerivation rec {
   pname = "wbg";
   version = "1.0.2";
@@ -52,8 +46,8 @@ stdenv.mkDerivation rec {
   mesonBuildType = "release";
 
   mesonFlags = [
-    (mesonFeatureFlag "png" enablePNG)
-    (mesonFeatureFlag "jpeg" enableJPEG)
+    (lib.mesonEnable "png" enablePNG)
+    (lib.mesonEnable "jpeg" enableJPEG)
   ];
 
   meta = with lib; {

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -99,21 +99,19 @@ in stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = lib.optionalString x11Support "-lX11 -lXext ";
 
-  mesonFlags = let
-    inherit (lib) mesonOption mesonBool mesonEnable;
-  in [
-    (mesonOption "default_library" "shared")
-    (mesonBool "libmpv" true)
-    (mesonEnable "libarchive" archiveSupport)
-    (mesonEnable "manpage-build" true)
-    (mesonEnable "cdda" cddaSupport)
-    (mesonEnable "dvbin" dvbinSupport)
-    (mesonEnable "dvdnav" dvdnavSupport)
-    (mesonEnable "openal" openalSupport)
-    (mesonEnable "sdl2" sdl2Support)
+  mesonFlags = [
+    (lib.mesonOption "default_library" "shared")
+    (lib.mesonBool "libmpv" true)
+    (lib.mesonEnable "libarchive" archiveSupport)
+    (lib.mesonEnable "manpage-build" true)
+    (lib.mesonEnable "cdda" cddaSupport)
+    (lib.mesonEnable "dvbin" dvbinSupport)
+    (lib.mesonEnable "dvdnav" dvdnavSupport)
+    (lib.mesonEnable "openal" openalSupport)
+    (lib.mesonEnable "sdl2" sdl2Support)
     # Disable whilst Swift isn't supported
-    (mesonEnable "swift-build" swiftSupport)
-    (mesonEnable "macos-cocoa-cb" swiftSupport)
+    (lib.mesonEnable "swift-build" swiftSupport)
+    (lib.mesonEnable "macos-cocoa-cb" swiftSupport)
   ];
 
   mesonAutoFeatures = "auto";

--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -13,10 +13,6 @@ let
     "grapheme"
     "run"
   ];
-
-  # Courtesy of sternenseemann and FRidh, commit c9a7fdfcfb420be8e0179214d0d91a34f5974c54
-  mesonFeatureFlag = feature: flag:
-    "-D${feature}=${if flag then "enabled" else "disabled"}";
 in
 
 stdenv.mkDerivation rec {
@@ -40,7 +36,7 @@ stdenv.mkDerivation rec {
 
   mesonBuildType = "release";
   mesonFlags = builtins.map (t:
-    mesonFeatureFlag "${t}-shaping" (lib.elem t withShapingTypes)
+    lib.mesonEnable "${t}-shaping" (lib.elem t withShapingTypes)
   ) availableShapingTypes;
 
   doCheck = true;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
