### PR TITLE
openjdk*: disable openjfx by default; openjfx*: add with{Media,Webkit} options

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -250,6 +250,16 @@
       </listitem>
       <listitem>
         <para>
+          <literal>openjdk</literal> from version 11 and above is not
+          build with <literal>openjfx</literal> (i.e.: JavaFX) support
+          by default anymore. You can re-enable it by overriding with
+          <literal>enableJavaFX</literal> set to
+          <literal>true</literal>, e.g.:
+          <literal>openjdk11.override { enableJavaFX = true; };</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           A new <literal>virtualisation.rosetta</literal> module was
           added to allow running <literal>x86_64</literal> binaries
           through

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -74,6 +74,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `mastodon` now supports connection to a remote `PostgreSQL` database.
 
+- `openjdk` from version 11 and above is not build with `openjfx` (i.e.: JavaFX) support by default anymore. You can re-enable it by overriding with `enableJavaFX` set to `true`, e.g.: `openjdk11.override { enableJavaFX = true; };`.
+
 - A new `virtualisation.rosetta` module was added to allow running `x86_64` binaries through [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) inside virtualised NixOS guests on Apple silicon. This feature works by default with the [UTM](https://docs.getutm.app/) virtualisation [package](https://search.nixos.org/packages?channel=unstable&show=utm&from=0&size=1&sort=relevance&type=packages&query=utm).
 
 - The new option `users.motdFile` allows configuring a Message Of The Day that can be updated dynamically.

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk11-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/12.nix
+++ b/pkgs/development/compilers/openjdk/12.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk11, fetchpatch
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/13.nix
+++ b/pkgs/development/compilers/openjdk/13.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk13-bootstrap, fetchpatch
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/14.nix
+++ b/pkgs/development/compilers/openjdk/14.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk14-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/15.nix
+++ b/pkgs/development/compilers/openjdk/15.nix
@@ -4,7 +4,7 @@
 , libXcursor, libXrandr, fontconfig, openjdk15-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/16.nix
+++ b/pkgs/development/compilers/openjdk/16.nix
@@ -4,7 +4,7 @@
 , libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk16-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -4,7 +4,7 @@
 , libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk17-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/18.nix
+++ b/pkgs/development/compilers/openjdk/18.nix
@@ -4,7 +4,7 @@
 , libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk18-bootstrap
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/19.nix
+++ b/pkgs/development/compilers/openjdk/19.nix
@@ -5,7 +5,7 @@
 , ensureNewerSourcesForZipFilesHook
 , setJavaClassPath
 , headless ? false
-, enableJavaFX ? openjfx.meta.available, openjfx
+, enableJavaFX ? false, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, fetchFromGitHub, writeText, gradle_7, pkg-config, perl, cmake
 , gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python3, ruby, icu68
-, openjdk11-bootstrap }:
+, openjdk11-bootstrap
+, withMedia ? true
+, withWebKit ? false }:
 
 let
   major = "11";
@@ -10,16 +12,6 @@ let
   gradle_ = (gradle_7.override {
     java = openjdk11-bootstrap;
   });
-
-  NIX_CFLAGS_COMPILE = [
-    # avoids errors about deprecation of GTypeDebugFlags, GTimeVal, etc.
-    "-DGLIB_DISABLE_DEPRECATION_WARNINGS"
-    # glib-2.62 deprecations
-    # -fcommon: gstreamer workaround for -fno-common toolchains:
-    #   ld: gsttypefindelement.o:(.bss._gst_disable_registry_cache+0x0): multiple definition of
-    #     `_gst_disable_registry_cache'; gst.o:(.bss._gst_disable_registry_cache+0x0): first defined here
-    "-fcommon"
-  ];
 
   makePackage = args: stdenv.mkDerivation ({
     version = "${major}${update}-${build}";
@@ -81,8 +73,8 @@ in makePackage {
   pname = "openjfx-modular-sdk";
 
   gradleProperties = ''
-    COMPILE_MEDIA = true
-    COMPILE_WEBKIT = false
+    COMPILE_MEDIA = ${if withMedia then "true" else "false"}
+    COMPILE_WEBKIT = ${if withWebKit then "true" else "false"}
   '';
 
   preBuild = ''

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, writeText, gradle_7, pkg-config, perl, cmake
-, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python3, ruby, icu68
+, gperf, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python3, ruby, icu68
 , openjdk11-bootstrap
 , withMedia ? true
 , withWebKit ? false }:
@@ -23,7 +23,7 @@ let
       sha256 = "sha256-uKb6k+tIFdwy1BYiHWeGmKNz82X4CZjFlGYqLDpSFY0=";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];
+    buildInputs = [ gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradle_6
-, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
+, pkg-config, perl, cmake, gperf, gtk3, libXtst, libXxf86vm, glib, alsa-lib
 , ffmpeg_4-headless, python3, ruby
 , withMedia ? true
 , withWebKit ? false }:
@@ -23,7 +23,7 @@ let
       sha256 = "019glq8rhn6amy3n5jc17vi2wpf1pxpmmywvyz1ga8n09w7xscq1";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];
+    buildInputs = [ gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradle_6
 , pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
-, ffmpeg_4-headless, python3, ruby }:
+, ffmpeg_4-headless, python3, ruby
+, withMedia ? true
+, withWebKit ? false }:
 
 let
   major = "15";
@@ -76,8 +78,8 @@ in makePackage {
   pname = "openjfx-modular-sdk";
 
   gradleProperties = ''
-    COMPILE_MEDIA = true
-    COMPILE_WEBKIT = false
+    COMPILE_MEDIA = ${if withMedia then "true" else "false"}
+    COMPILE_WEBKIT = ${if withWebKit then "true" else "false"}
   '';
 
   preBuild = ''

--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless, gradle_7
 , pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
-, ffmpeg_4-headless, python3, ruby, icu68 }:
+, ffmpeg_4-headless, python3, ruby, icu68
+, withMedia ? true
+, withWebKit ? false }:
 
 let
   major = "17";
@@ -66,8 +68,8 @@ in makePackage {
   pname = "openjfx-modular-sdk";
 
   gradleProperties = ''
-    COMPILE_MEDIA = true
-    COMPILE_WEBKIT = false
+    COMPILE_MEDIA = ${if withMedia then "true" else "false"}
+    COMPILE_WEBKIT = ${if withWebKit then "true" else "false"}
   '';
 
   preBuild = ''

--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless, gradle_7
-, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
+, pkg-config, perl, cmake, gperf, gtk3, libXtst, libXxf86vm, glib, alsa-lib
 , ffmpeg_4-headless, python3, ruby, icu68
 , withMedia ? true
 , withWebKit ? false }:
@@ -23,7 +23,7 @@ let
       sha256 = "sha256-jzLOlWuhkUS0/4+nXtjd1/IYbAHHnJrusFRTh7aPt8U=";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];
+    buildInputs = [ gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;

--- a/pkgs/development/compilers/openjdk/openjfx/19.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/19.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, writeText, openjdk17_headless
-, openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
+, openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk3, libXtst
 , libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, icu68
 , withMedia ? true
 , withWebKit ? false }:
@@ -37,7 +37,7 @@ let
       })
     ];
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 icu68 ];
+    buildInputs = [ gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 icu68 ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;

--- a/pkgs/development/compilers/openjdk/openjfx/19.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/19.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, writeText, openjdk17_headless
 , openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
-, libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, icu68 }:
+, libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, icu68
+, withMedia ? true
+, withWebKit ? false }:
 
 let
   major = "19";
@@ -83,8 +85,8 @@ in makePackage {
   pname = "openjfx-modular-sdk";
 
   gradleProperties = ''
-    COMPILE_MEDIA = true
-    COMPILE_WEBKIT = false
+    COMPILE_MEDIA = ${if withMedia then "true" else "false"}
+    COMPILE_WEBKIT = ${if withWebKit then "true" else "false"}
   '';
 
   preBuild = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31078,7 +31078,9 @@ with pkgs;
 
   pdfdiff = callPackage ../applications/misc/pdfdiff { };
 
-  pdfsam-basic = callPackage ../applications/misc/pdfsam-basic { };
+  pdfsam-basic = callPackage ../applications/misc/pdfsam-basic {
+    jdk11 = openjdk11.override { enableJavaFX = true; };
+  };
 
   mupdf = callPackage ../applications/misc/mupdf { };
   mupdf_1_17 = callPackage ../applications/misc/mupdf/1.17.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2803,7 +2803,9 @@ with pkgs;
 
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
 
-  bisq-desktop = callPackage ../applications/blockchains/bisq-desktop { };
+  bisq-desktop = callPackage ../applications/blockchains/bisq-desktop {
+    openjdk11 = openjdk11.override { enableJavaFX = true; };
+  };
 
   bic = callPackage ../development/interpreters/bic { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Considering that `openjfx` is an optional component of Java since the version 11 and it is also probably one of the main causes of security issues, since it bundles its own copy of WebKit and ffmpeg, let's disable it by default. We can still enable it manually for the few derivations that need it.

Even when enabling it, disable WebKit by default. This is by far the largest cause of security issues in `openjfx`, and also causes the build times to be really long. Without it, the build times are reasonable. Again, if some derivation needs it, we can still enable manually. This also makes all our `openjfx` derivations more consistent since the newest versions of `openjfx` were not enabling it anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
