### PR TITLE
vscode, vscodium: 1.73.1 -> 1.74.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -5,6 +5,8 @@ let
     src,
     # Same as "Unique Identifier" on the extension's web page.
     # For the moment, only serve as unique extension dir.
+    vscodeExtPublisher,
+    vscodeExtName,
     vscodeExtUniqueId,
     configurePhase ? ''
       runHook preConfigure
@@ -23,7 +25,10 @@ let
 
     name = "vscode-extension-${name}";
 
-    inherit vscodeExtUniqueId;
+    passthru = {
+      inherit vscodeExtPublisher vscodeExtName vscodeExtUniqueId;
+    };
+    
     inherit configurePhase buildPhase dontPatchELF dontStrip;
 
     installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
@@ -54,9 +59,12 @@ let
   }: assert "" == name; assert null == src;
   buildVscodeExtension ((removeAttrs a [ "mktplcRef" "vsix" ]) // {
     name = "${mktplcRef.publisher}-${mktplcRef.name}-${mktplcRef.version}";
+    version = mktplcRef.version;
     src = if (vsix != null)
       then vsix
       else fetchVsixFromVscodeMarketplace mktplcRef;
+    vscodeExtPublisher = mktplcRef.publisher;
+    vscodeExtName = mktplcRef.name;
     vscodeExtUniqueId = "${mktplcRef.publisher}.${mktplcRef.name}";
   });
 

--- a/pkgs/applications/editors/vscode/with-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-extensions.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, runCommand, buildEnv, vscode, makeWrapper
+{ lib, stdenv, runCommand, buildEnv, vscode, makeWrapper, writeText
 , vscodeExtensions ? [] }:
 
 /*
@@ -46,12 +46,48 @@ let
   wrappedPkgVersion = lib.getVersion vscode;
   wrappedPkgName = lib.removeSuffix "-${wrappedPkgVersion}" vscode.name;
 
-  combinedExtensionsDrv = buildEnv {
-    name = "vscode-extensions";
-    paths = vscodeExtensions;
+  toExtensionJsonEntry = drv: rec {
+    identifier = {
+      id = "${drv.vscodeExtPublisher}.${drv.vscodeExtName}";
+      uuid = "";
+    };
+
+    version = drv.version;
+
+    location = {
+      "$mid" = 1;
+      fsPath = drv.outPath + "/share/vscode/extensions/${drv.vscodeExtUniqueId}";
+      path = location.fsPath;
+      scheme = "file";
+    };
+
+    metadata = {
+      id = identifier.uuid;
+      publisherId = "";
+      publisherDisplayName = drv.vscodeExtPublisher;
+      targetPlatform = "undefined";
+      isApplicationScoped = false;
+      updated = false;
+      isPreReleaseVersion = false;
+      installedTimestamp = 0;
+      preRelease = false;
+    };
   };
 
-  extensionsFlag = lib.optionalString (vscodeExtensions != []) ''
+  extensionJson = builtins.toJSON(map toExtensionJsonEntry vscodeExtensions);
+  extensionJsonFile = writeText "extensions.json" extensionJson;
+  extensionJsonOutput = runCommand "vscode-extensions-json" {} ''
+    mkdir -p $out/share/vscode/extensions
+    cp ${extensionJsonFile} $out/share/vscode/extensions/extensions.json
+  '';
+
+  combinedExtensionsDrv = buildEnv {
+    name = "vscode-extensions";
+    paths = vscodeExtensions ++ [extensionJsonOutput];
+  };
+
+  # extensionsFlag = lib.optionalString (vscodeExtensions != []) ''
+  extensionsFlag = ''
     --add-flags "--extensions-dir ${combinedExtensionsDrv}/share/vscode/extensions"
   '';
 in


### PR DESCRIPTION
###### Description of changes

Has been broken on insiders for probably around a month now. Finally got annoyed enough to spend some time to fix.

- Closes #205042
- Closes #205074
- Closes #205672
- Closes #205661

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
