### PR TITLE
chirp: 20220823 -> unstable-2022-12-07

### DIFF
--- a/pkgs/applications/radio/chirp/default.nix
+++ b/pkgs/applications/radio/chirp/default.nix
@@ -1,24 +1,39 @@
 { lib
-, fetchurl
-, python2
+, fetchFromGitHub
+, python3
+, unstableGitUpdater
 }:
-python2.pkgs.buildPythonApplication rec {
-  pname = "chirp-daily";
-  version = "20220823";
 
-  src = fetchurl {
-    url = "https://trac.chirp.danplanet.com/chirp_daily/daily-${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-V+8HQAYU2XjOYeku0XEHqkY4m0XjiUBxM61QcupnlVM=";
+python3.pkgs.buildPythonApplication rec {
+  pname = "chirp";
+  version = "unstable-2022-12-07";
+
+  src = fetchFromGitHub {
+    owner = "kk7ds";
+    repo = "chirp";
+    rev = "dc0c98d22423b496faf0a86296a6ec0bb3b3e11a";
+    hash = "sha256-z0xD11CB7Vt8k0dPXE+E5ZD9XAFwWNxjnUs25/Gd7zI=";
   };
 
-  propagatedBuildInputs = with python2.pkgs; [
-    pygtk pyserial libxml2 future
+  propagatedBuildInputs = with python3.pkgs; [
+    future
+    pyserial
+    requests
+    six
+    wxPython_4_2
   ];
+
+  # "running build_ext" fails with no output
+  doCheck = false;
+
+  passthru.updateScript = unstableGitUpdater {
+    branch = "py3";
+  };
 
   meta = with lib; {
     description = "A free, open-source tool for programming your amateur radio";
     homepage = "https://chirp.danplanet.com/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

Similar with #204489, but switching to the Python 3 branch instead.

#201859

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
