### PR TITLE
vcv-rack: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -115,7 +115,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "VCV-Rack";
-  version = "2.2.0";
+  version = "2.2.1";
 
   desktopItems = [
     (makeDesktopItem {
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
     owner = "VCVRack";
     repo = "Rack";
     rev = "v${version}";
-    sha256 = "1ag1syjxdzxx13pdcfga9ksc6a5hw9bcdfhbry8qd2pxs9lmv2q6";
+    sha256 = "079alr6y0101k92v5lrnycljcbifh0hsvklbf4w5ax2zrxnyplq8";
   };
 
   patches = [
@@ -203,11 +203,9 @@ stdenv.mkDerivation rec {
     zstd
   ];
 
-  makeFlags = [
-    ( if stdenv.hostPlatform.system == "aarch64-linux"
-      then "MACHINE=arm64-linux"
-      else "MACHINE=${stdenv.hostPlatform.config}"
-    )
+  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ] ++ [
     "all"
     "plugins"
   ];

--- a/pkgs/applications/audio/vcv-rack/rack-minimize-vendoring.patch
+++ b/pkgs/applications/audio/vcv-rack/rack-minimize-vendoring.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index e1be07d1..309b3b0b 100644
+index fc7c3af1..c3672c6a 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -34,7 +34,7 @@ ifdef ARCH_LIN


### PR DESCRIPTION
This is a very minor update to VCV Rack, but the upstream Makefiles now recognize `aarch64` in platform strings and accepts a CROSS_COMPILE environment variable for cross-compiling plugins for a given target. This commit updates the `makeFlags` accordingly.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstream changelog for VCV Rack v2.2.1: https://github.com/VCVRack/Rack/blob/v2.2.1/CHANGELOG.md#221-2022-12-07

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
