### PR TITLE
tailor: 0.9.35 -> 0.9.37

### DIFF
--- a/pkgs/applications/version-management/tailor/default.nix
+++ b/pkgs/applications/version-management/tailor/default.nix
@@ -1,19 +1,37 @@
-{ fetchurl, pypy2Packages }:
+{ lib
+, python3
+, fetchurl
+}:
 
-pypy2Packages.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "tailor";
-  version = "0.9.35";
+  version = "0.9.37";
 
   src = fetchurl {
-    urls = [
-      "http://darcs.arstecnica.it/tailor/tailor-${version}.tar.gz"
-      "https://src.fedoraproject.org/repo/pkgs/tailor/tailor-${version}.tar.gz/58a6bc1c1d922b0b1e4579c6440448d1/tailor-${version}.tar.gz"
-    ];
-    sha256 = "061acapxxn5ab3ipb5nd3nm8pk2xj67bi83jrfd6lqq3273fmdjh";
+    url = "https://gitlab.com/ports1/tailor/-/archive/0.937/tailor-0.937.tar.gz";
+    hash = "sha256-Bdf8ZCRsbCsFz1GRxyQxxndXSsm8oOL2738m9UxOTVc=";
   };
 
-  meta = {
-    description = "Version control tools integration tool";
+  propagatedBuildInputs = with python3.pkgs; [
+    future
+  ];
+
+  # AssertionError: Tailor Darcs repository not found!
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A tool to migrate changesets between various kinds of version control system.";
+    longDescription = ''
+      With its ability to "translate the history" from one VCS kind to another,
+      this tool makes it easier to keep the upstream changes merged in
+      a own branch of a product.
+
+      Tailor is able to fetch the history from Arch, Bazaar, CVS, Darcs, Monotone,
+      Perforce or Subversion and rewrite it over Aegis, Bazaar, CVS, Darcs, Git,
+      Mercurial, Monotone and Subversion.
+    '';
+    homepage = "https://gitlab.com/ports1/tailor";
+    license = licenses.gpl1Plus;
+    platforms = platforms.unix;
   };
 }
-


### PR DESCRIPTION
###### Description of changes

#201859

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
