### PR TITLE
gitlab: 15.6.1 -> 15.6.2

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "15.6.1",
-  "repo_hash": "sha256-cdwfljmJvApU2q0pmWSmcMnHkQH4hfN7+cld5oP880g=",
+  "version": "15.6.2",
+  "repo_hash": "sha256-WMDst9BHjqK5UIYKzqJJnhrLPHxV0PmW+r8FGBueBs8=",
   "yarn_hash": "0lgl8rs9mlrwpzq75rywdbjbiib17wxvzlv1jibnx66iw1ym2rvh",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v15.6.1-ee",
+  "rev": "v15.6.2-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "15.6.1",
+    "GITALY_SERVER_VERSION": "15.6.2",
     "GITLAB_PAGES_VERSION": "1.63.0",
     "GITLAB_SHELL_VERSION": "14.13.0",
-    "GITLAB_WORKHORSE_VERSION": "15.6.1"
+    "GITLAB_WORKHORSE_VERSION": "15.6.2"
   },
   "vendored_gems": [
     "bundler-checksum",

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "15.6.1";
+  version = "15.6.2";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -22,7 +22,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      sha256 = "sha256-mzX+6kMXqdrxqMaUwN2tG5kJgKSRv0/tNN8ibHqBbzU=";
+      sha256 = "sha256-or5Z96BCLFUC4r9bAZf9ytUOt4WozqwwuWGFuX2ix9k=";
     };
 
     vendorSha256 = "sha256-SEPfso27PHHpvnQwdeMQYECw/CZIa/NdpMBSTRJEwIo=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "15.6.1";
+  version = "15.6.2";
 
   src = fetchFromGitLab {
     owner = data.owner;

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
@@ -336,8 +336,7 @@ gem 'pg_query', '~> 2.2'
 
 gem 'premailer-rails', '~> 1.10.3'
 
-# LabKit: Tracing and Correlation
-gem 'gitlab-labkit', '~> 0.28.0'
+gem 'gitlab-labkit', '~> 0.29.0'
 gem 'thrift', '>= 0.16.0'
 
 # I18n

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
@@ -575,7 +575,7 @@ GEM
       fog-json (~> 1.2.0)
       mime-types
       ms_rest_azure (~> 0.12.0)
-    gitlab-labkit (0.28.0)
+    gitlab-labkit (0.29.0)
       actionpack (>= 5.0.0, < 8.0.0)
       activesupport (>= 5.0.0, < 8.0.0)
       grpc (>= 1.37)
@@ -1668,7 +1668,7 @@ DEPENDENCIES
   gitlab-dangerfiles (~> 3.6.2)
   gitlab-experiment (~> 0.7.1)
   gitlab-fog-azure-rm (~> 1.4.0)
-  gitlab-labkit (~> 0.28.0)
+  gitlab-labkit (~> 0.29.0)
   gitlab-license (~> 2.2.1)
   gitlab-mail_room (~> 0.0.9)
   gitlab-markup (~> 1.8.0)

--- a/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
@@ -290,6 +290,9 @@
     };
     version = "0.2.0";
   };
+  attr_encrypted = {
+    dependencies = ["encryptor"];
+  };
   attr_required = {
     groups = ["default"];
     platforms = [];
@@ -1093,7 +1096,7 @@
     version = "4.8.1";
   };
   devise-two-factor = {
-    dependencies = ["activesupport" "devise" "railties" "rotp"];
+    dependencies = ["activesupport" "attr_encrypted" "devise" "railties" "rotp"];
     groups = ["default"];
     platforms = [];
     source = {
@@ -2084,10 +2087,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0m2n5lvnm5nxn7bc6bqm3ycwk47kck6nl1c0s83pcvsn6qizbsx7";
+      sha256 = "09xlv72nbys9a5iqvhxfzdr7vy3s3m2a6ixqb9vq71k925faq6gb";
       type = "gem";
     };
-    version = "0.28.0";
+    version = "0.29.0";
   };
   gitlab-license = {
     groups = ["default"];

--- a/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
@@ -290,9 +290,6 @@
     };
     version = "0.2.0";
   };
-  attr_encrypted = {
-    dependencies = ["encryptor"];
-  };
   attr_required = {
     groups = ["default"];
     platforms = [];
@@ -1096,7 +1093,7 @@
     version = "4.8.1";
   };
   devise-two-factor = {
-    dependencies = ["activesupport" "attr_encrypted" "devise" "railties" "rotp"];
+    dependencies = ["activesupport" "devise" "railties" "rotp"];
     groups = ["default"];
     platforms = [];
     source = {


### PR DESCRIPTION
###### Description of changes

https://gitlab.com/gitlab-org/gitlab/-/commit/07b960f293254a3368bf98c9d2f4f203faff9e18

Also removed the Ruby Gem that is failing mentioned previously: 
https://github.com/NixOS/nixpkgs/pull/197470#pullrequestreview-1152775835
https://github.com/NixOS/nixpkgs/pull/203868#issuecomment-1333168768
https://github.com/NixOS/nixpkgs/pull/203868/commits/4ac49afb5bbdf7f46df83a4cc775df68cc903ca6

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
