### PR TITLE
mypy-boto3-*: init at 1.26.0.post1

### DIFF
--- a/pkgs/development/python-modules/mypy-boto3-batch/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-batch/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-batch";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mx68bjs2f1bf63ddsa6bpkd2ygdxx8w8mhwshwkpxn4iq74mc1g";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_batch"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.batch";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-dynamodb/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-dynamodb/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-dynamodb";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qz69cz49rqzyfpnbs3h01d5gf2fsqk2d8580dvbfcr0jvzl24bk";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_dynamodb"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.dynamodb";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-events/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-events/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-events";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08nf6sy5br1v72kyfvdmrb061g62zvx6z2bf8csiblf4mqz4la2d";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_events"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.events";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-lambda/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-lambda/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-lambda";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1g5f74xhz0w04pid1csrhr38q1li7z4mc7bjwrcgq4xab7wysv9y";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_lambda"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.lambda";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-s3control/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-s3control/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-s3control";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1f64wgk38hwkwiqqs8k11g7mqcp2pfly7y5wxyff78p9362akxqv";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_s3control"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.s3control";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-sns/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-sns/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-sns";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10l5xrlrrr91i02ysjjqr2g9v05gqixf87rqhvka8ak40vqx8fq8";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_sns"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.sns";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-sqs/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-sqs/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-sqs";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0436fvbqpa1c283arvqcka907pzr10gamvnzxdp9bi3aj16avbkc";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_sqs"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.sqs";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-ssm/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-ssm/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-ssm";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hc7gq0lkwn1x8y9w208sja0c3q792vpm10pllcxblja713p4ilb";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_ssm"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.ssm";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-stepfunctions/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-stepfunctions/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-stepfunctions";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1i6bg7rvzixnid5wa4pk8ps179h8219ksx8p4i6yjlbxbpd5ymlk";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_stepfunctions"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.stepfunctions";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mypy-boto3-sts/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3-sts/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, boto3
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "mypy-boto3-sts";
+  version = "1.26.0.post1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07pgr0cr9zx5nsf44q1aid5kalq4sm3frh3dyslg5lh5bgf8cr5k";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+    typing-extensions
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "mypy_boto3_sts"
+  ];
+
+  meta = with lib; {
+    description = "Type annotations for boto3.sts";
+    homepage = "https://github.com/youtype/mypy_boto3_builder";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6006,9 +6006,29 @@ self: super: with self; {
 
   mypy = callPackage ../development/python-modules/mypy { };
 
+  mypy-boto3-batch = callPackage ../development/python-modules/mypy-boto3-batch { };
+
   mypy-boto3-builder = callPackage ../development/python-modules/mypy-boto3-builder { };
 
+  mypy-boto3-dynamodb = callPackage ../development/python-modules/mypy-boto3-dynamodb { };
+
+  mypy-boto3-events = callPackage ../development/python-modules/mypy-boto3-events { };
+
+  mypy-boto3-lambda = callPackage ../development/python-modules/mypy-boto3-lambda { };
+
   mypy-boto3-s3 = callPackage ../development/python-modules/mypy-boto3-s3 { };
+
+  mypy-boto3-s3control = callPackage ../development/python-modules/mypy-boto3-s3control { };
+
+  mypy-boto3-sns = callPackage ../development/python-modules/mypy-boto3-sns { };
+
+  mypy-boto3-sqs = callPackage ../development/python-modules/mypy-boto3-sqs { };
+
+  mypy-boto3-ssm = callPackage ../development/python-modules/mypy-boto3-ssm { };
+
+  mypy-boto3-stepfunctions = callPackage ../development/python-modules/mypy-boto3-stepfunctions { };
+
+  mypy-boto3-sts = callPackage ../development/python-modules/mypy-boto3-sts { };
 
   mypy-extensions = callPackage ../development/python-modules/mypy/extensions.nix { };
 


### PR DESCRIPTION
###### Description of changes

Motivation: #205083. Includes the following new packages:

<details>

- mypy-boto3-batch
- mypy-boto3-dynamodb
- mypy-boto3-events
- mypy-boto3-lambda
- mypy-boto3-s3control
- mypy-boto3-sns
- mypy-boto3-sqs
- mypy-boto3-ssm
- mypy-boto3-stepfunctions
- mypy-boto3-sts

</details>

@fabaff Are you OK to be listed as the maintainer of these, or should I instead add myself?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (`nix-build nixos --attr pkgs.python39Packages.mypy-boto3-accessanalyzer --attr pkgs.python39Packages.mypy-boto3-account …`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).