### PR TITLE
ocamlPackages.sha: 1.15.1 → 1.15.2

### DIFF
--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -11,7 +11,7 @@ let
       ptmap
       camlp5
       sha
-      dune_2
+      dune_3
       luv
       extlib
     ] else if lib.versionAtLeast version "4.0"
@@ -23,7 +23,7 @@ let
       ptmap
       camlp5
       sha
-      dune_2
+      dune_3
       luv
       extlib-1-7-7
     ] else with ocaml-ng.ocamlPackages_4_05; [

--- a/pkgs/development/ocaml-modules/plotkicadsch/default.nix
+++ b/pkgs/development/ocaml-modules/plotkicadsch/default.nix
@@ -17,6 +17,7 @@
 
 buildDunePackage rec {
   pname = "plotkicadsch";
+  duneVersion = "3";
 
   inherit (kicadsch) src version;
 

--- a/pkgs/development/ocaml-modules/sha/default.nix
+++ b/pkgs/development/ocaml-modules/sha/default.nix
@@ -1,17 +1,14 @@
-{ lib, fetchurl, buildDunePackage, stdlib-shims, dune-configurator, ounit }:
+{ lib, fetchurl, buildDunePackage, stdlib-shims, ounit2 }:
 
 buildDunePackage rec {
   pname = "sha";
-  version = "1.15.1";
+  version = "1.15.2";
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/djs55/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "sha256-cRtjydvwgXgimi6F3C48j7LrWgfMO6m9UJKjKlxvp0Q=";
+    url = "https://github.com/djs55/ocaml-${pname}/releases/download/${version}/${pname}-${version}.tbz";
+    hash = "sha256-P71Xs5p8QAaOtBrh7MuhQJOL6144BqTLvXlZOyGD/7c=";
   };
-
-  useDune2 = true;
-
-  buildInputs = [ dune-configurator ];
 
   propagatedBuildInputs = [
     stdlib-shims
@@ -19,7 +16,7 @@ buildDunePackage rec {
 
   doCheck = true;
   checkInputs = [
-    ounit
+    ounit2
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
