### PR TITLE
mdbook-admonish: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/tools/text/mdbook-admonish/default.nix
+++ b/pkgs/tools/text/mdbook-admonish/default.nix
@@ -2,25 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook-admonish";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "tommilligan";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-AGOq05NevkRU8qHsJIWd2WfZ4i7w/wexf6c0fUAaoLg=";
+    hash = "sha256-jo5kR1fzSRQq8fvblJaK3IEHfxeN7h0ZdT6vvPBXTXM=";
   };
 
-  cargoPatches = [
-    # https://github.com/tommilligan/mdbook-admonish/pull/33
-    (fetchpatch {
-      name = "update-mdbook-for-rust-1.64.patch";
-      url = "https://github.com/tommilligan/mdbook-admonish/commit/650123645b18a3f8ed170738c7c1813315095ed9.patch";
-      hash = "sha256-8LMk+Dgz9k0g9fbGGC0X2byyJtfDDgvdGxO06mD6GDI=";
-    })
-  ];
-
-  cargoHash = "sha256-5PWfze00/mWmzYqP5M1pAPt+SuknpU9dc0B7RSikuTE=";
+  cargoHash = "sha256-N0zkdaVWas9jK9IXn9T85s18mNTjoEl8OUF2HA2CuHg=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
 

--- a/pkgs/tools/text/mdbook-admonish/default.nix
+++ b/pkgs/tools/text/mdbook-admonish/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "A preprocessor for mdbook to add Material Design admonishments";
     license = licenses.mit;
-    maintainers = with maintainers; [ jmgilman ];
+    maintainers = with maintainers; [ jmgilman Frostman ];
     homepage = "https://github.com/tommilligan/mdbook-admonish";
   };
 }

--- a/pkgs/tools/text/mdbook-admonish/default.nix
+++ b/pkgs/tools/text/mdbook-admonish/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, rustPlatform, CoreServices }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, CoreServices }:
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook-admonish";


### PR DESCRIPTION
###### Description of changes

Bumps of dependencies, minor changes
https://github.com/tommilligan/mdbook-admonish/releases/tag/v1.8.0
https://github.com/tommilligan/mdbook-admonish/compare/v1.7.0...v1.8.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
