### PR TITLE
fetchdarcs: support fetching by commit hash

### DIFF
--- a/pkgs/build-support/fetchdarcs/builder.sh
+++ b/pkgs/build-support/fetchdarcs/builder.sh
@@ -2,11 +2,15 @@ source $stdenv/setup
 
 tagtext=""
 tagflags=""
-if test -n "$rev"; then
-    tagtext="(tag $rev) "
+# Darcs hashes are sha1 (120 bits, 40-character hex)
+if [[ "$rev" =~ [a-fA-F0-9]{40} ]]; then
+    tagtext="(hash $rev)"
+    tagflags="--to-hash=$rev"
+elif test -n "$rev"; then
+    tagtext="(tag $rev)"
     tagflags="--tag=$rev"
 elif test -n "$context"; then
-    tagtext="(context) "
+    tagtext="(context)"
     tagflags="--context=$context"
 fi
 

--- a/pkgs/build-support/fetchdarcs/default.nix
+++ b/pkgs/build-support/fetchdarcs/default.nix
@@ -1,12 +1,17 @@
 {stdenvNoCC, darcs, cacert}:
 
-{url, rev ? null, context ? null, md5 ? "", sha256 ? ""}:
+{ url
+, rev ? null
+, context ? null
+, md5 ? ""
+, sha256 ? ""
+, name ? "fetchdarcs"
+}:
 
 if md5 != "" then
   throw "fetchdarcs does not support md5 anymore, please use sha256"
 else
 stdenvNoCC.mkDerivation {
-  name = "fetchdarcs";
   builder = ./builder.sh;
   nativeBuildInputs = [cacert darcs];
 
@@ -14,5 +19,5 @@ stdenvNoCC.mkDerivation {
   outputHashMode = "recursive";
   outputHash = sha256;
 
-  inherit url rev context;
+  inherit url rev context name;
 }


### PR DESCRIPTION
###### Description of changes

Allow fetching Darcs repository by hash in addition to tag or branch.

This mirrors the behavior of the git fetcher.

Feels like something you should merge into staging, but the reality seems to be that... literally zero packages depend on this? Is that right? In that case this can go into master, correct?

Also adds optional arg `name` with same default value, as the previously hard-coded value.
###### Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
