### PR TITLE
prometheus-smartctl-exporter: unstable-2020-11-14 -> 0.9.1

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/smartctl.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/smartctl.nix
@@ -46,15 +46,11 @@ in {
         "CAP_SYS_ADMIN"
       ];
       DevicePolicy = "closed";
-      DeviceAllow = lib.mkOverride 50 (
-        if cfg.devices != [] then
-          cfg.devices
-        else [
-          "block-blkext rw"
-          "block-sd rw"
-          "char-nvme rw"
-        ]
-      );
+      DeviceAllow = lib.mkOverride 50 [
+        "block-blkext rw"
+        "block-sd rw"
+        "char-nvme rw"
+      ];
       ExecStart = ''
         ${pkgs.prometheus-smartctl-exporter}/bin/smartctl_exporter ${args}
       '';

--- a/nixos/modules/services/monitoring/prometheus/exporters/smartctl.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/smartctl.nix
@@ -4,16 +4,12 @@ with lib;
 
 let
   cfg = config.services.prometheus.exporters.smartctl;
-  format = pkgs.formats.yaml {};
-  configFile = format.generate "smartctl-exporter.yml" {
-    smartctl_exporter = {
-      bind_to = "${cfg.listenAddress}:${toString cfg.port}";
-      url_path = "/metrics";
-      smartctl_location = "${pkgs.smartmontools}/bin/smartctl";
-      collect_not_more_than_period = cfg.maxInterval;
-      devices = cfg.devices;
-    };
-  };
+  args = concatStrings [
+    "--web.listen-address=\"${cfg.listenAddress}:${toString cfg.port}\" "
+    "--smartctl.path=\"${pkgs.smartmontools}/bin/smartctl\" "
+    "--smartctl.interval=\"${cfg.maxInterval}\" "
+    "${concatMapStringsSep " " (device: "--smartctl.device=${device}") cfg.devices}"
+  ];
 in {
   port = 9633;
 
@@ -60,7 +56,7 @@ in {
         ]
       );
       ExecStart = ''
-        ${pkgs.prometheus-smartctl-exporter}/bin/smartctl_exporter -config ${configFile}
+        ${pkgs.prometheus-smartctl-exporter}/bin/smartctl_exporter ${args}
       '';
       PrivateDevices = lib.mkForce false;
       ProtectProc = "invisible";

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1086,13 +1086,8 @@ let
         ];
       };
       exporterTest = ''
-        wait_for_unit("prometheus-smartctl-exporter.service")
-        wait_for_open_port(9633)
         wait_until_succeeds(
-          "curl -sSf 'localhost:9633/metrics'"
-        )
-        wait_until_succeeds(
-            'journalctl -eu prometheus-smartctl-exporter.service -o cat | grep "/dev/vda: Unable to detect device type"'
+            'journalctl -eu prometheus-smartctl-exporter.service -o cat | grep "Device unavailable"'
         )
       '';
     };

--- a/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
@@ -16,6 +16,10 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-lQKuT5dzjDHFpRSmcXpKD1RJDlEv+0kcxENkv3mT4FU=";
 
+  ldflags = [
+    "-X github.com/prometheus/common/version.Version=${version}"
+  ];
+
   meta = with lib; {
     description = "Export smartctl statistics for Prometheus";
     homepage = "https://github.com/prometheus-community/smartctl_exporter";

--- a/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
@@ -1,36 +1,20 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
 , buildGoModule
 }:
 
 buildGoModule rec {
   pname = "smartctl_exporter";
-  version = "unstable-2020-11-14";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "prometheus-community";
     repo = pname;
-    rev = "e27581d56ad80340fb076d3ce22cef337ed76679";
-    sha256 = "sha256-iWaFDjVLBIAA9zGe0utbuvmEdA3R5lge0iCh3j2JfE8=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-fc1NZ5QwzR/jJkeaDm5PMT4wBFFlqZOXKTJMBJWKJJ8=";
   };
 
-  patches = [
-    # Fixes out of range panic (https://github.com/prometheus-community/smartctl_exporter/issues/19)
-    (fetchpatch {
-      url = "https://github.com/prometheus-community/smartctl_exporter/commit/15575301a8e2fe5802a8c066c6fa9765d50b8cfa.patch";
-      sha256 = "sha256-HLUrGXNz3uKpuQBUgQBSw6EGbGl23hQnimTGl64M5bQ=";
-    })
-    # Fix validation on empty smartctl response (https://github.com/prometheus-community/smartctl_exporter/pull/31)
-    (fetchpatch {
-      url = "https://github.com/prometheus-community/smartctl_exporter/commit/744b4e5f6a46e029d31d5aa46642e85f429c2cfa.patch";
-      sha256 = "sha256-MgLtYR1SpM6XrZQQ3AgQRmNF3OnaBCqXMJRV9BOzKPc=";
-    })
-    # Fixes missing metrics if outside of query interval (https://github.com/prometheus-community/smartctl_exporter/pull/18)
-    ./0001-Return-the-cached-value-if-it-s-not-time-to-scan-aga.patch
-  ];
-
-  vendorSha256 = "1xhrzkfm2p20k7prgdfax4408g4qpa4wbxigmcmfz7kjg2zi88ld";
+  vendorSha256 = "sha256-lQKuT5dzjDHFpRSmcXpKD1RJDlEv+0kcxENkv3mT4FU=";
 
   meta = with lib; {
     description = "Export smartctl statistics for Prometheus";

--- a/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
@@ -28,6 +28,6 @@ buildGoModule rec {
     homepage = "https://github.com/prometheus-community/smartctl_exporter";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ hexa ];
+    maintainers = with maintainers; [ hexa Frostman ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
+++ b/pkgs/servers/monitoring/prometheus/smartctl-exporter/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildGoModule
+, nixosTests
 }:
 
 buildGoModule rec {
@@ -19,6 +20,8 @@ buildGoModule rec {
   ldflags = [
     "-X github.com/prometheus/common/version.Version=${version}"
   ];
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) smartctl; };
 
   meta = with lib; {
     description = "Export smartctl statistics for Prometheus";


### PR DESCRIPTION
###### Description of changes

Big bump from the 2020 patched version to the recently released 0.9.1 - https://github.com/prometheus-community/smartctl_exporter/releases

Based on #199773. I've fully tested it on my env with and without the devices specified. As a followup to @mweinelt comment https://github.com/NixOS/nixpkgs/pull/199773#issuecomment-1306243317 - here is an upstream fix you've faced https://github.com/prometheus-community/smartctl_exporter/pull/93

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
