### PR TITLE
python3Packages.dependency-injector: 4.35.3 -> 4.40.0

### DIFF
--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -7,12 +7,13 @@
 , httpx
 , mypy-boto3-s3
 , numpy
-, scipy
 , pydantic
+, pytest-asyncio
 , pytestCheckHook
-, pyyaml
-, six
 , pythonOlder
+, pyyaml
+, scipy
+, six
 }:
 
 buildPythonPackage rec {
@@ -33,21 +34,42 @@ buildPythonPackage rec {
     six
   ];
 
+  passthru.optional-dependencies = {
+    aiohttp = [
+      aiohttp
+    ];
+    pydantic = [
+      pydantic
+    ];
+    flask = [
+      flask
+    ];
+    yaml = [
+      pyyaml
+    ];
+  };
+
   checkInputs = [
-    aiohttp
     fastapi
-    flask
     httpx
     mypy-boto3-s3
     numpy
-    pydantic
-    scipy
+    pytest-asyncio
     pytestCheckHook
-    pyyaml
-  ];
+    scipy
+  ] ++ passthru.optional-dependencies.aiohttp
+  ++ passthru.optional-dependencies.pydantic
+  ++ passthru.optional-dependencies.yaml
+  ++ passthru.optional-dependencies.flask;
 
   pythonImportsCheck = [
     "dependency_injector"
+  ];
+
+  disabledTestPaths = [
+    # Exclude tests for EOL Python releases
+    "tests/unit/ext/test_aiohttp_py35.py"
+    "tests/unit/wiring/test_*_py36.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -12,17 +12,21 @@
 , pytestCheckHook
 , pyyaml
 , six
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "dependency-injector";
   version = "4.40.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "ets-labs";
     repo = "python-dependency-injector";
     rev = version;
-    sha256 = "sha256-lcgPFdAgLmv7ILL2VVfqtGSw96aUfPv9oiOhksRtF3k=";
+    hash = "sha256-lcgPFdAgLmv7ILL2VVfqtGSw96aUfPv9oiOhksRtF3k=";
   };
 
   propagatedBuildInputs = [
@@ -42,11 +46,14 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  pythonImportsCheck = [ "dependency_injector" ];
+  pythonImportsCheck = [
+    "dependency_injector"
+  ];
 
   meta = with lib; {
     description = "Dependency injection microframework for Python";
     homepage = "https://github.com/ets-labs/python-dependency-injector";
+    changelog = "https://github.com/ets-labs/python-dependency-injector/blob/${version}/docs/main/changelog.rst";
     license = licenses.bsd3;
     maintainers = with maintainers; [ gerschtli ];
   };

--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "dependency-injector";
-  version = "4.35.3";
+  version = "4.40.0";
 
   src = fetchFromGitHub {
     owner = "ets-labs";
     repo = "python-dependency-injector";
     rev = version;
-    sha256 = "sha256-2qe4A2T3EagNCh1zSbPWblVN7p9NH8rNwQQVyESJTdk=";
+    sha256 = "sha256-lcgPFdAgLmv7ILL2VVfqtGSw96aUfPv9oiOhksRtF3k=";
   };
 
   propagatedBuildInputs = [
@@ -40,16 +40,6 @@ buildPythonPackage rec {
     scipy
     pytestCheckHook
     pyyaml
-  ];
-
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "six>=1.7.0,<=1.15.0" "six"
-  '';
-
-  disabledTestPaths = [
-    # There is no unique identifier to disable the one failing test
-    "tests/unit/ext/test_aiohttp_py35.py"
   ];
 
   pythonImportsCheck = [ "dependency_injector" ];


### PR DESCRIPTION
###### Description of changes
https://github.com/ets-labs/python-dependency-injector/releases/tag/4.40.0
https://github.com/ets-labs/python-dependency-injector/blob/master/docs/main/changelog.rst#4400

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
