### PR TITLE
erlang: fix build

### DIFF
--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -137,9 +137,6 @@ stdenv.mkDerivation ({
 
   postInstall = ''
     ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
-  '' + (lib.optionalString stdenv.isLinux ''
-    ln -s $out/lib/erlang/bin/escript $out/bin/escript
-  '') + ''
 
     ${postInstall}
   '';


### PR DESCRIPTION
Building Erlang (at nixpkgs master) fails for `x86_64-linux` with:

`ln: failed to create symbolic link '/nix/store/f766s9cfzi89wf1wwly2qs1yjg592nmr-erlang-24.3.4.5/bin/escript': File exists`

![image](https://user-images.githubusercontent.com/5861043/206451708-43e5ef03-ff74-4303-961f-4a4590ee024b.png)

Logs: [erlang.log](https://github.com/NixOS/nixpkgs/files/10185555/erlang.log)

By removing: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/erlang/generic-builder.nix#L140-L142
Just works.

I lack context on why this line is there. So I'm just proposing this change to know what you guys think. (And to fix Erlang build for master.)

Thanks in advance for the review.