### PR TITLE
unifi-protect-backup: 0.7.3 -> 0.8.3

### DIFF
--- a/pkgs/applications/backup/unifi-protect-backup/default.nix
+++ b/pkgs/applications/backup/unifi-protect-backup/default.nix
@@ -2,7 +2,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "unifi-protect-backup";
-  version = "0.7.4";
+  version = "0.8.3";
 
   format = "pyproject";
 
@@ -10,12 +10,14 @@ python3.pkgs.buildPythonApplication rec {
     owner = "ep1cman";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-4Kpz89yqKmxHmnaPYpvJ2hx46yfcaCYjOioyya+38vE=";
+    hash = "sha256-3iOaJZAvkhjiWLKI1m2hmVkWLaNtq74nQZYIm/XCgeA=";
   };
 
   preBuild = ''
     sed -i 's_click = "8.0.1"_click = "^8"_' pyproject.toml
     sed -i 's_pyunifiprotect = .*_pyunifiprotect = "*"_' pyproject.toml
+    sed -i 's_aiorun = .*_aiorun = "*"_' pyproject.toml
+    sed -i '/pylint/d' pyproject.toml
   '';
 
   nativeBuildInputs = with python3.pkgs; [
@@ -24,6 +26,8 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     aiocron
+    aiorun
+    aiosqlite
     click
     pyunifiprotect
   ];


### PR DESCRIPTION
###### Description of changes
https://github.com/ep1cman/unifi-protect-backup/blob/main/CHANGELOG.md#083---2022-12-08 https://github.com/ep1cman/unifi-protect-backup/blob/main/CHANGELOG.md#082---2022-12-05 https://github.com/ep1cman/unifi-protect-backup/blob/main/CHANGELOG.md#081---2022-12-04 https://github.com/ep1cman/unifi-protect-backup/blob/main/CHANGELOG.md#080---2022-12-03 https://github.com/ep1cman/unifi-protect-backup/blob/main/CHANGELOG.md#074---2022-08-21

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).