### PR TITLE
sosreport: 4.3 -> 4.4

### DIFF
--- a/pkgs/applications/logging/sosreport/default.nix
+++ b/pkgs/applications/logging/sosreport/default.nix
@@ -1,36 +1,33 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , gettext
+, magic
 , pexpect
+, pyyaml
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "sosreport";
-  version = "4.3";
+  version = "4.4";
 
   src = fetchFromGitHub {
     owner = "sosreport";
     repo = "sos";
     rev = version;
-    sha256 = "sha256-fLEYRRQap7xqSyUU9MAV8cxxYKydHjn8J147VTXSf78=";
+    sha256 = "sha256-xbL/4CmDnygiL/u3Jsa6fAkO4YfklDzuFMsxSGy1Ra4=";
   };
-
-  patches = [
-    (fetchpatch {
-      # fix sos --help
-      url = "https://github.com/sosreport/sos/commit/ac4eb48fa35c13b99ada41540831412480babf8d.patch";
-      sha256 = "sha256-6ZRoDDZN2KkHTXOKuHTAquB/HTIUppodmx83WxxYFP0=";
-    })
-  ];
 
   nativeBuildInputs = [
     gettext
   ];
 
   propagatedBuildInputs = [
+    magic
     pexpect
+    pyyaml
+    setuptools
   ];
 
   # requires avocado-framework 94.0, latest version as of writing is 96.0


### PR DESCRIPTION
###### Description of changes

Release notes: https://github.com/sosreport/sos/releases/tag/4.4

`sudo sos report` 4.3 didn't work for me, with:

```
Traceback (most recent call last):
  File "/nix/store/ylhmxwzggdcx36ypf8a3plfb0dx3zngp-python3.10-sosreport-4.3/bin/.sos-wrapped", line 23, in <module>
    sos.execute()
  File "/nix/store/ylhmxwzggdcx36ypf8a3plfb0dx3zngp-python3.10-sosreport-4.3/lib/python3.10/site-packages/sos/__init__.py", line 188, in execute
    self._component.execute()
  File "/nix/store/ylhmxwzggdcx36ypf8a3plfb0dx3zngp-python3.10-sosreport-4.3/lib/python3.10/site-packages/sos/report/__init__.py", line 1587, in execute
    self.batch()
  File "/nix/store/ylhmxwzggdcx36ypf8a3plfb0dx3zngp-python3.10-sosreport-4.3/lib/python3.10/site-packages/sos/report/__init__.py", line 1002, in batch
    msg = self.policy.get_msg()
  File "/nix/store/ylhmxwzggdcx36ypf8a3plfb0dx3zngp-python3.10-sosreport-4.3/lib/python3.10/site-packages/sos/policies/__init__.py", line 608, in get_msg
    return self.msg % {'distro': self.system}
KeyError: 'vendor'
```

4.4 doesn't seem to have this issue.

I'm wondering if it would be nice to have a `sosreportFull` package, which would bring some of the used tools to sos' `$PATH`, since NixOS systems usually don't have a lot of system tools installed globally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
