### PR TITLE
emulationstation-de: init at 1.2.6

### DIFF
--- a/pkgs/applications/emulators/emulationstation-de/default.nix
+++ b/pkgs/applications/emulators/emulationstation-de/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitLab, cmake, SDL2, curl, ffmpeg, pugixml, pkgconf, freetype, freeimage, alsa-lib }:
+
+stdenv.mkDerivation rec{
+  pname = "emulationstation-de";
+  version = "1.2.6";
+
+  src = fetchFromGitLab {
+    owner  = "es-de";
+    repo   = "emulationstation-de";
+    rev    = "v${version}";
+    sha256 = "BiQnHtcKheEhwp0KKy9BCDIuZuAjmS8tWNyNw4nl5Fk=";
+  };
+
+  patches = [ ./es-find-rules.patch ];
+
+  nativeBuildInputs = [ cmake pkgconf ];
+
+  buildInputs = [ SDL2 curl ffmpeg pugixml freetype freeimage alsa-lib ];
+
+  meta = with lib; {
+    description = "A frontend for browsing and launching games from your multi-platform game collection.";
+    homepage    = "https://es-de.org/";
+    license = licenses.mit;
+    platforms   = lib.platforms.linux;
+    maintainers = with maintainers; [ baduhai ];
+    changelog = "https://gitlab.com/es-de/emulationstation-de/-/tags/v${version}";
+  };
+}

--- a/pkgs/applications/emulators/emulationstation-de/es-find-rules.patch
+++ b/pkgs/applications/emulators/emulationstation-de/es-find-rules.patch
@@ -1,0 +1,20 @@
+diff --git a/resources/systems/unix/es_find_rules.xml b/resources/systems/unix/es_find_rules.xml
+index 3616bb79..bd08a931 100644
+--- a/resources/systems/unix/es_find_rules.xml
++++ b/resources/systems/unix/es_find_rules.xml
+@@ -40,6 +40,8 @@
+             <entry>/usr/local/lib/libretro</entry>
+             <!-- NetBSD repository -->
+             <entry>/usr/pkg/lib/libretro</entry>
++            <!-- NixOS and nixpkgs repository -->
++            <entry>/run/current-system/sw/lib/retroarch/cores</entry>
+         </rule>
+     </core>
+     <emulator name="ATARI800">
+@@ -554,4 +556,4 @@
+             <entry>~/bin/yuzu*.AppImage</entry>
+         </rule>
+     </emulator>
+-</ruleList>
+\ No newline at end of file
++</ruleList>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1975,6 +1975,8 @@ with pkgs;
 
   emulationstation = callPackage ../applications/emulators/emulationstation { };
 
+  emulationstation-de = callPackage ../applications/emulators/emulationstation-de { };
+
   fceux = callPackage ../applications/emulators/fceux {
     lua = lua5_1;
     inherit (libsForQt5) wrapQtAppsHook;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added emulationstation-de package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
