### PR TITLE
hunspellDicts.pt-pt + hunspellDicts.pt-br: init at 6.3.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1514,7 +1514,8 @@
     email = "baduhai@pm.me";
     github = "baduhai";
     githubId = 31864305;
-    name = "William";
+    name = "William F A Hai";
+    matrix = "@baduhai:matrix.org";
   };
   baitinq = {
     email = "manuelpalenzuelamerino@gmail.com";

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -266,7 +266,7 @@ let
     , license
     , readmeFile ? "README_${dictFileName}.txt"
     , sourceRoot ? dictFileName
-    , maintainers ? with maintainers; [ vlaci ]
+    , maintainers ? with lib.maintainers; [ vlaci ]
     }:
     mkDict rec {
       pname = "hunspell-dict-${shortName}-libreoffice";
@@ -284,9 +284,8 @@ let
       meta = with lib; {
         homepage = "https://wiki.documentfoundation.org/Development/Dictionaries";
         description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
-        license = license;
-        maintainers = maintainers;
         platforms = platforms.all;
+        inherit license maintainers;
       };
     };
 

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -888,7 +888,7 @@ rec {
     readmeFile = "README_pt_PT.txt";
     shortDescription = "Portuguese (Portugal)";
     license = with lib.licenses; [ gpl2 lgpl21 mpl11 ];
-    maintainers = with maintainers; [ baduhai ];
+    maintainers = with lib.maintainers; [ baduhai ];
   };
 
   pt_BR = pt-br;
@@ -898,6 +898,6 @@ rec {
     readmeFile = "README_pt_BR.txt";
     shortDescription = "Brazilian Portuguese (Brazil)";
     license = with lib.licenses; [ lgpl3 ];
-    maintainers = with maintainers; [ baduhai ];
+    maintainers = with lib.maintainers; [ baduhai ];
   };
 }

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -266,6 +266,7 @@ let
     , license
     , readmeFile ? "README_${dictFileName}.txt"
     , sourceRoot ? dictFileName
+    , maintainers ? with maintainers; [ vlaci ]
     }:
     mkDict rec {
       pname = "hunspell-dict-${shortName}-libreoffice";
@@ -284,7 +285,7 @@ let
         homepage = "https://wiki.documentfoundation.org/Development/Dictionaries";
         description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
         license = license;
-        maintainers = with maintainers; [ vlaci ];
+        maintainers = maintainers;
         platforms = platforms.all;
       };
     };

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -878,4 +878,26 @@ rec {
     shortDescription = "Norwegian Nynorsk (Norway)";
     license = with lib.licenses; [ gpl2Only ];
   };
+
+  /* PORTUGUESE */
+
+  pt_PT = pt-pt;
+  pt-pt = mkDictFromLibreOffice {
+    shortName = "pt-pt";
+    dictFileName = "pt_PT";
+    readmeFile = "README_pt_PT.txt";
+    shortDescription = "Portuguese (Portugal)";
+    license = with lib.licenses; [ gpl2 lgpl21 mpl11 ];
+    maintainers = with maintainers; [ baduhai ];
+  };
+
+  pt_BR = pt-br;
+  pt-br = mkDictFromLibreOffice {
+    shortName = "pt-br";
+    dictFileName = "pt_BR";
+    readmeFile = "README_pt_BR.txt";
+    shortDescription = "Brazilian Portuguese (Brazil)";
+    license = with lib.licenses; [ lgpl3 ];
+    maintainers = with maintainers; [ baduhai ];
+  };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
