### PR TITLE
libwebsockets: use multiple outputs

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-why8LAcc4XN0JdTJ1JoNWijKENL5mOHBsi9K4wpYr2c=";
   };
 
+  outputs = [ "out" "dev" ];
+
   buildInputs = [ openssl zlib libuv ];
 
   nativeBuildInputs = [ cmake ];
@@ -34,7 +36,14 @@ stdenv.mkDerivation rec {
   ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON";
 
   postInstall = ''
-    rm -r ${placeholder "out"}/share/libwebsockets-test-server
+    # Fix path that will be incorrect on move to "dev" output.
+    substituteInPlace "$out/lib/cmake/libwebsockets/LibwebsocketsTargets-release.cmake" \
+      --replace "\''${_IMPORT_PREFIX}" "$out"
+
+    # The package builds a few test programs that are not usually necessary.
+    # Move those to the dev output.
+    moveToOutput "bin/libwebsockets-test-*" "$dev"
+    moveToOutput "share/libwebsockets-test-*" "$dev"
   '';
 
   # $out/share/libwebsockets-test-server/plugins/libprotocol_*.so refers to crtbeginS.o

--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -33,7 +33,13 @@ stdenv.mkDerivation rec {
     "-DDISABLE_WERROR=ON"
     "-DLWS_BUILD_HASH=no_hash"
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
-  ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON";
+  ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON"
+  ++ (
+    if stdenv.hostPlatform.isStatic then
+      [ "-DLWS_WITH_SHARED=OFF" ]
+    else
+      [ "-DLWS_WITH_STATIC=OFF" "-DLWS_LINK_TESTAPPS_DYNAMIC=ON" ]
+  );
 
   postInstall = ''
     # Fix path that will be incorrect on move to "dev" output.


### PR DESCRIPTION
###### Description of changes

This considerably lowers the closure size of packages that just need the libraries at runtime. The difference is roughly 60–70MiB.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).