### PR TITLE
ogdf: 2020.02 -> 2022.02

### DIFF
--- a/pkgs/development/libraries/ogdf/default.nix
+++ b/pkgs/development/libraries/ogdf/default.nix
@@ -2,31 +2,25 @@
 
 stdenv.mkDerivation rec {
   pname = "ogdf";
-  version = "2020.02";
+  version = "2022.02";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "catalpa-202002";
-    sha256 = "0drrs8zh1097i5c60z9g658vs9k1iinkav8crlwk722ihfm1vxqd";
+    rev = "dogwood-202202";
+    sha256 = "sha256-zkQ6sS0EUmiigv3T7To+tG3XbFbR3XEbFo15oQ0bWf0=";
   };
 
   nativeBuildInputs = [ cmake doxygen ];
 
   cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-fPIC" ];
 
-  # Without disabling hardening for format, the build fails with
-  # the following error.
-  #> /build/source/src/coin/CoinUtils/CoinMessageHandler.cpp:766:35: error: format not a string literal and no format arguments [-Werror=format-security]
-  #> 766 |      sprintf(messageOut_,format_+2);
-  hardeningDisable = [ "format" ];
-
   meta = with lib; {
     description = "Open Graph Drawing Framework/Open Graph algorithms and Data structure Framework";
     homepage = "http://www.ogdf.net";
     license = licenses.gpl2;
     maintainers = [ maintainers.ianwookim ];
-    platforms = platforms.i686 ++ platforms.x86_64;
+    platforms = platforms.all;
     longDescription = ''
       OGDF stands both for Open Graph Drawing Framework (the original name) and
       Open Graph algorithms and Data structures Framework.

--- a/pkgs/development/libraries/ogdf/default.nix
+++ b/pkgs/development/libraries/ogdf/default.nix
@@ -13,7 +13,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake doxygen ];
 
-  cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-fPIC" ];
+  cmakeFlags = [
+    "-DCMAKE_CXX_FLAGS=-fPIC"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DOGDF_WARNING_ERRORS=OFF"
+  ];
 
   meta = with lib; {
     description = "Open Graph Drawing Framework/Open Graph algorithms and Data structure Framework";


### PR DESCRIPTION
###### Description of changes

Upgrade version and  removed unnecessary hardening customization.
Tested locally on x86_64-linux, x86_64-darwin and aarch64-darwin.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
