### PR TITLE
openjdk/openjfx: bumps

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -11,8 +11,8 @@
 let
   major = "11";
   minor = "0";
-  update = "15";
-  build = "10";
+  update = "17";
+  build = "8";
 
   openjdk = stdenv.mkDerivation rec {
     pname = "openjdk" + lib.optionalString headless "-headless";
@@ -22,7 +22,7 @@ let
       owner = "openjdk";
       repo = "jdk${major}u";
       rev = "jdk-${version}";
-      sha256 = "le2JDxPJPSuga4JxLJNRZwCaodptSb2kh4TsJXumTXs=";
+      sha256 = "sha256-kvgLYqQZPqyuigVyzbDHc3TMff0clvzM8IdzYLYcxPU=";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -20,7 +20,7 @@ let
     powerpc64le-linux = "ppc64le";
   }.${stdenv.system} or (throw "Unsupported platform ${stdenv.system}");
 
-  update = "322";
+  update = "352";
   build = "ga";
 
   openjdk8 = stdenv.mkDerivation rec {
@@ -31,7 +31,7 @@ let
       owner = "openjdk";
       repo = "jdk8u";
       rev = "jdk${version}";
-      sha256 = "sha256-e39Yv+NDQG7z6fGmpKEnkKd5MoHZ50SXlq/Q7lzWcDA=";
+      sha256 = "sha256-xDiiALDjStD9IPhbBr997rm/v2Q/WdS10cILBCmdJIQ=";
     };
     outputs = [ "out" "jre" ];
 

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -120,6 +120,9 @@ in makePackage {
     license = licenses.gpl2;
     description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
+    knownVulnerabilities = [
+      "This OpenJFX version has reached its end of life."
+    ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradle_5
+{ stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradle_6
 , pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
 , ffmpeg_4-headless, python3, ruby }:
 
@@ -7,7 +7,7 @@ let
   update = ".0.1";
   build = "+1";
   repover = "${major}${update}${build}";
-  gradle_ = (gradle_5.override {
+  gradle_ = (gradle_6.override {
     java = openjdk11_headless;
   });
 
@@ -69,10 +69,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    # Downloaded AWT jars differ by platform.
-    outputHash = {
-      x86_64-linux = "0hmyr5nnjgwyw3fcwqf0crqg9lny27jfirycg3xmkzbcrwqd6qkw";
-    }.${stdenv.system} or (throw "Unsupported platform");
+    outputHash = "sha256-fGLTMM9s/Vn7eMzn6OQR3tL0cGbAYc7c4J4/aW3JvkI=";
   };
 
 in makePackage {
@@ -80,7 +77,7 @@ in makePackage {
 
   gradleProperties = ''
     COMPILE_MEDIA = true
-    COMPILE_WEBKIT = true
+    COMPILE_WEBKIT = false
   '';
 
   preBuild = ''

--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -4,7 +4,7 @@
 
 let
   major = "17";
-  update = ".0.0.1";
+  update = ".0.5";
   build = "+1";
   repover = "${major}${update}${build}";
   gradle_ = (gradle_7.override {
@@ -16,9 +16,9 @@ let
 
     src = fetchFromGitHub {
       owner = "openjdk";
-      repo = "jfx";
+      repo = "jfx${major}u";
       rev = repover;
-      sha256 = "sha256-PSiE9KbF/4u9VyBl9PAMLGzKyGFB86/XByeh7vhL6Kw=";
+      sha256 = "sha256-jzLOlWuhkUS0/4+nXtjd1/IYbAHHnJrusFRTh7aPt8U=";
     };
 
     buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See: https://github.com/NixOS/nixpkgs/issues/204997

This PR should bring `openjdk` and `openjfx` to all their current GA builds. Since for `openjfx` there is no proper GA tag, I am using this site as reference: https://gluonhq.com/products/javafx/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
