### PR TITLE
gridtracker: init at 1.22.1226

### DIFF
--- a/pkgs/applications/radio/gridtracker/default.nix
+++ b/pkgs/applications/radio/gridtracker/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, nwjs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gridtracker";
+  version = "1.22.1226";
+
+  src = fetchFromGitLab {
+    owner = "gridtracker.org";
+    repo = "gridtracker";
+    rev = "v${version}";
+    sha256 = "sha256-/Noc2aqHBjphX6RDqxQBI/OOKZgEnOndn0daBt1edXM=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '$(DESTDIR)/usr' '$(DESTDIR)/'
+    substituteInPlace gridtracker.sh \
+      --replace "exec nw" "exec ${nwjs}/bin/nw" \
+      --replace "/usr/share/gridtracker" "$out/share/gridtracker"
+    substituteInPlace gridtracker.desktop \
+      --replace "/usr/share/gridtracker/gridview.png" "$out/share/gridtracker/gridview.png"
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" "NO_DIST_INSTALL=1" ];
+
+  meta = with lib; {
+    description = "An amateur radio companion to WSJT-X or JTDX";
+    longDescription = ''
+      GridTracker listens to traffic from WSJT-X/JTDX, displays it on a map,
+      and has a sophisticated alerting and filtering system for finding and
+      working interesting stations. It also will upload QSO records to multiple
+      logging frameworks including Logbook of the World.
+    '';
+    homepage = "https://gridtracker.org";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ melling ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7708,6 +7708,8 @@ with pkgs;
     libdevil = libdevil-nox;
   };
 
+  gridtracker = callPackage ../applications/radio/gridtracker { };
+
   grin = callPackage ../tools/text/grin { };
 
   gyb = callPackage ../tools/backup/gyb { };


### PR DESCRIPTION
###### Description of changes

GridTracker is a popular amateur radio application. Closes #201213.

> GridTracker listens to traffic from WSJT-X/JTDX, displays it on a map, and has a sophisticated alerting and filtering system for finding and working interesting stations. It also will upload QSO records to multiple logging frameworks including Logbook of the World.

Paging @Marc12O for testing. I've been using this for a little while in my own config and it works great.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
