### PR TITLE
[22.05] vlc: 3.0.17.3 -> 3.0.18

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -82,11 +82,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "${optionalString onlyLibVLC "lib"}vlc";
-  version = "3.0.17.3";
+  version = "3.0.18";
 
   src = fetchurl {
     url = "http://get.videolan.org/vlc/${version}/vlc-${version}.tar.xz";
-    sha256 = "sha256-b36Q74lz0x2W3mTbgXFz40UVCClxepQISxu4MhzeIBQ=";
+    sha256 = "sha256-VwlEOcNl2KqLm0H6MIDMDu8r7+YCW7XO9yKszGJa7ew=";
   };
 
   # VLC uses a *ton* of libraries for various pieces of functionality, many of
@@ -187,12 +187,8 @@ stdenv.mkDerivation rec {
   BUILDCC = "${stdenv.cc}/bin/gcc";
 
   patches = [
-    # patches to build with recent live555
+    # patch to build with recent live555
     # upstream issue: https://code.videolan.org/videolan/vlc/-/issues/25473
-    (fetchpatch {
-      url = "https://code.videolan.org/videolan/vlc/uploads/3c84ea58d7b94d7a8d354eaffe4b7d55/0001-Get-addr-by-ref.-from-getConnectionEndpointAddress.patch";
-      sha256 = "171d3qjl9a4dm13sqig3ra8s2zcr76wfnqz4ba4asg139cyc1axd";
-    })
     (fetchpatch {
       url = "https://code.videolan.org/videolan/vlc/uploads/eb1c313d2d499b8a777314f789794f9d/0001-Add-lssl-and-lcrypto-to-liblive555_plugin_la_LIBADD.patch";
       sha256 = "0kyi8q2zn2ww148ngbia9c7qjgdrijf4jlvxyxgrj29cb5iy1kda";

--- a/pkgs/development/libraries/live555/default.nix
+++ b/pkgs/development/libraries/live555/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "live555";
-  version = "2022.06.16";
+  version = "2022.07.14";
 
   src = fetchurl {
     urls = [
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       "https://download.videolan.org/contrib/live555/live.${version}.tar.gz"
       "mirror://sourceforge/slackbuildsdirectlinks/live.${version}.tar.gz"
     ];
-    sha256 = "sha256-84OUQw++RNqH3sAY4S6yXRJXZY+5T0VdTIUqELuVdV0=";
+    sha256 = "sha256-VrWkBmLdP0MYfiFit3Mtkv7Ti8dWPmrndrbKo+BpRCA=";
   };
 
   nativeBuildInputs = lib.optional stdenv.isDarwin darwin.cctools;

--- a/pkgs/development/libraries/live555/default.nix
+++ b/pkgs/development/libraries/live555/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "live555";
-  version = "2022.07.14";
+  version = "2022.12.01";
 
   src = fetchurl {
     urls = [
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       "https://download.videolan.org/contrib/live555/live.${version}.tar.gz"
       "mirror://sourceforge/slackbuildsdirectlinks/live.${version}.tar.gz"
     ];
-    sha256 = "sha256-VrWkBmLdP0MYfiFit3Mtkv7Ti8dWPmrndrbKo+BpRCA=";
+    sha256 = "sha256-BXwdPcJMJrM+FMTcNZKIWt8iBAOh4SVeihAeIzxpwQg=";
   };
 
   nativeBuildInputs = lib.optional stdenv.isDarwin darwin.cctools;


### PR DESCRIPTION
###### Description of changes

https://code.videolan.org/videolan/vlc/-/raw/3.0.18/NEWS

Fixes CVE-2022-41325.
https://www.videolan.org/security/sb-vlc3018.html

See #204058

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 205195` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages marked as broken and skipped:</summary>
  <ul>
    <li>elisa</li>
    <li>libsForQt512.elisa</li>
    <li>libsForQt512.phonon-backend-vlc</li>
    <li>libsForQt514.elisa</li>
    <li>libsForQt514.phonon-backend-vlc</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>obs-studio-plugins.obs-ndi</li>
  </ul>
</details>
<details>
  <summary>31 packages built:</summary>
  <ul>
    <li>arcan.all-wrapped</li>
    <li>arcan.arcan</li>
    <li>arcan.arcan-wrapped</li>
    <li>arcan.durden-wrapped</li>
    <li>arcan.pipeworld-wrapped</li>
    <li>arcan.prio-wrapped</li>
    <li>arcan.xarcan</li>
    <li>kaffeine</li>
    <li>libsForQt5.elisa</li>
    <li>libsForQt5.phonon-backend-vlc</li>
    <li>libvlc</li>
    <li>live555</li>
    <li>megaglest</li>
    <li>minitube</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-pipewire-audio-capture</li>
    <li>obs-studio-plugins.obs-vkcapture</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>openlpFull</li>
    <li>pympress</li>
    <li>python310Packages.python-vlc</li>
    <li>python39Packages.python-vlc</li>
    <li>reaper</li>
    <li>strawberry</li>
    <li>vlc</li>
  </ul>
</details>