### PR TITLE
adguardhome: 0.107.19 -> 0.107.20

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,23 +1,23 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-R9Ggjl9Qw1F2n2U7uGcLqgjwrLoUjlO8KUsI4sQf/JU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.19/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-pCyMhfDl371zzc3oXo+n09qNcxMtDQEqaqVW+YIrx28=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.20/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-MStBeDsqHK+m91DBTIAzaleIL0GNhqdslIvPOmtOaDQ=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.19/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-O2UTzaWaYTkeR3z/O8U/Btigjp/8gns4Y/D9yoX2Hns=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.20/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-bkUSxifnSfDZk2kmp23n6KBlqa70CrBIKuCF+EEHTwk=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.19/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-ao/uebGho3CafFEcCfcS+awsC9lO/6z1UL57Yvr/q14=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.20/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-dHj91ZYhHTA8XoZ8oUhDQzu6Fpg0n/CBqDZux0QnwXI=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.19/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-KJIogRRlZFPy3jBb9JeEA7xgZkl9/97cA13rBK6/1fI=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.20/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-f5nXnLkL6yvkE9kUnHdsD+MQhUjbkQGmVj7Nr/znBrw=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.19/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-r8gqUa9dULAYPUB64X4aqyaNf0CpckUNIsWl+VylhaM=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.20/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.19";
+  version = "0.107.20";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

