### PR TITLE
or-tools: enable cross-compilation

### DIFF
--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -41,6 +41,8 @@ buildPythonPackage {
     fi
   '';
 
+  outputs = [ "out" "dev" ];
+
   buildInputs = [ protobuf ];
 
   propagatedNativeBuildInputs = [

--- a/pkgs/development/python-modules/pybind11/setup-hook.sh
+++ b/pkgs/development/python-modules/pybind11/setup-hook.sh
@@ -1,0 +1,12 @@
+# Tell the pybind11 CMake module where to find host platform Python. This is
+# required when cross-compiling.
+pybind11CMakeFlags () {
+  cmakeFlagsArray+=(
+    '-DPYBIND11_PYTHONLIBS_OVERWRITE=OFF'
+    '-DPYTHON_EXECUTABLE=@pythonInterpreter@'
+    '-DPYTHON_INCLUDE_DIR=@pythonIncludeDir@'
+    '-DPYTHON_SITE_PACKAGES=@pythonSitePackages@'
+  )
+}
+
+preConfigureHooks+=(pybind11CMakeFlags)


### PR DESCRIPTION
###### Description of changes

This PR enables cross-compiling Google OR-Tools. This required changes to pybind11 and protobuf as well.

pybind11 needed a setup hook to allow it's CMake module to find the proper Python headers and libraries for the host platform. This is basically the return of #200772 in setup hook form. This setup hook should help cross-compile other packages that use pybind11, but I haven't done much testing of this.

Each change is explained in more detail in the commit messages.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv6l-linux (cross)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
