### PR TITLE
nodejs-{16,18,19}_x: backport `npm pack` fixes from npm v9

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -175,9 +175,10 @@ buildNpmPackage rec {
     hash = "sha256-BR+ZGkBBfd0dSQqAvujsbgsEPFYw/ThrylxUbOksYxM=";
   };
 
-  patches = [ ./remove-prepack-script.patch ];
-
   npmDepsHash = "sha256-tuEfyePwlOy2/mOPdXbqJskO6IowvAP4DWg8xSZwbJw=";
+
+  # The prepack script runs the build script, which we'd rather do in the build phase.
+  npmPackFlags = [ "--ignore-scripts" ];
 
   NODE_OPTIONS = "--openssl-legacy-provider";
 

--- a/pkgs/development/tools/ansible-language-server/default.nix
+++ b/pkgs/development/tools/ansible-language-server/default.nix
@@ -18,7 +18,7 @@ buildNpmPackage rec {
   npmDepsHash = "sha256-8FP6hF85w1Zbhiwi2V350ZWFAykAfvsXRGL8bvGk1XE=";
   npmBuildScript = "compile";
 
-  # We remove the prepare and prepack scripts because they run the
+  # We remove/ignore the prepare and prepack scripts because they run the
   # build script, and therefore are redundant.
   #
   # Additionally, the prepack script runs npm ci in addition to the
@@ -27,8 +27,9 @@ buildNpmPackage rec {
   # wiping out node_modules, which causes a mysterious error stating that tsc isn't installed.
   postPatch = ''
     sed -i '/"prepare"/d' package.json
-    sed -i '/"prepack"/d' package.json
   '';
+
+  npmPackFlags = [ "--ignore-scripts" ];
 
   passthru.updateScript = nix-update-script {
     attrPath = pname;

--- a/pkgs/development/web/nodejs/npm-patches.nix
+++ b/pkgs/development/web/nodejs/npm-patches.nix
@@ -1,0 +1,23 @@
+{ fetchpatch }:
+
+[
+  # Makes `npm pack` obey `--foreground-scripts`
+  (fetchpatch {
+    name = "libnpmpack-obey-foreground-scripts.patch";
+    url = "https://github.com/npm/cli/commit/e4e8ae20aef9e27e57282e87e8757d5b364abb39.patch";
+    hash = "sha256-NQ8CZBfRqAOMe0Ysg3cq1FiferWKTzXC1QXgzX+f8OU=";
+    stripLen = 2;
+    extraPrefix = "deps/npm/node_modules/";
+    includes = [ "deps/npm/node_modules/libnpmpack/lib/index.js" ];
+  })
+
+  # Makes `npm pack` obey `--ignore-scripts`
+  (fetchpatch {
+    name = "libnpmpack-obey-ignore-scripts.patch";
+    url = "https://github.com/npm/cli/commit/a990c3c9a0e67f0a8b6454213675e159fe49432d.patch";
+    hash = "sha256-eA5YST9RxMMjk5FCwEbl1HQUpXZuwWZkx5WC4yJium8=";
+    stripLen = 2;
+    extraPrefix = "deps/npm/node_modules/";
+    includes = [ "deps/npm/node_modules/libnpmpack/lib/index.js" ];
+  })
+]

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -5,6 +5,8 @@ let
     inherit openssl;
     python = python3;
   };
+
+  npmPatches = callPackage ./npm-patches.nix { };
 in
   buildNodejs {
     inherit enableNpm;
@@ -13,5 +15,5 @@ in
     patches = [
       ./disable-darwin-v8-system-instrumentation.patch
       ./bypass-darwin-xcrun-node16.patch
-    ];
+    ] ++ npmPatches;
   }

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -5,6 +5,8 @@ let
     inherit openssl;
     python = python3;
   };
+
+  npmPatches = callPackage ./npm-patches.nix { };
 in
 buildNodejs {
   inherit enableNpm;
@@ -21,5 +23,5 @@ buildNodejs {
 
     ./disable-darwin-v8-system-instrumentation.patch
     ./bypass-darwin-xcrun-node16.patch
-  ];
+  ] ++ npmPatches;
 }

--- a/pkgs/development/web/nodejs/v19.nix
+++ b/pkgs/development/web/nodejs/v19.nix
@@ -5,6 +5,8 @@ let
     inherit openssl;
     python = python3;
   };
+
+  npmPatches = callPackage ./npm-patches.nix { };
 in
 buildNodejs {
   inherit enableNpm;
@@ -14,5 +16,5 @@ buildNodejs {
     ./revert-arm64-pointer-auth.patch
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
-  ];
+  ] ++ npmPatches;
 }


### PR DESCRIPTION
###### Description of changes

This backports my fixes to npm bugs that were discovered when writing `buildNpmPackage`.

The first patch fixes a bug that resulted in the install phase unconditionally failing if the package had {pre,post}pack scripts, while the second makes `npm pack` respect `--ignore-scripts` in the first place -- allowing us to stop running these without patching them out of the `package.json`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
