### PR TITLE
stgit: 1.5 -> 2.3.0

### DIFF
--- a/pkgs/applications/version-management/stgit/0001-fix-use-canonical-Message-ID-spelling.patch
+++ b/pkgs/applications/version-management/stgit/0001-fix-use-canonical-Message-ID-spelling.patch
@@ -1,0 +1,249 @@
+From c500ebe5a51da4eecba0c88d9a335e7a659e7ecb Mon Sep 17 00:00:00 2001
+From: Peter Grayson <pete@jpgrayson.net>
+Date: Sun, 18 Jun 2023 15:00:19 -0400
+Subject: fix: use canonical Message-ID spelling
+
+This change aligns with a change in git 2.41.0 to consistently spell
+"Message-ID" instead of "Message-Id".
+
+The test suite is updated to accommodate both spellings, since such headers
+are case insensitive.
+---
+ Documentation/stg.txt   |  2 +-
+ completion/stgit.zsh    |  2 +-
+ src/cmd/email/format.rs |  2 +-
+ src/cmd/email/send.rs   |  2 +-
+ src/cmd/import.rs       |  6 +++---
+ t/t1800-import.sh       |  2 +-
+ t/t1801-import-email.sh | 32 ++++++++++++++++----------------
+ 7 files changed, 24 insertions(+), 24 deletions(-)
+
+diff --git a/Documentation/stg.txt b/Documentation/stg.txt
+index fb4c08fb..20b75ce2 100644
+--- a/Documentation/stg.txt
++++ b/Documentation/stg.txt
+@@ -302,7 +302,7 @@ N.B. Set 'commit.gpgsign' to determine whether patch commits themselves are GPG
+ See linkgit:git-config[1] for more information about 'commit.gpgsign'.
+
+ stgit.import.message-id::
+-  When set to 'true', create 'Message-Id:' trailer in the patch description of patches
++  When set to 'true', create 'Message-ID:' trailer in the patch description of patches
+   imported from email using linkstg:import[].
+
+ stgit.keepoptimized::
+diff --git a/completion/stgit.zsh b/completion/stgit.zsh
+index 797d9044..de818242 100644
+--- a/completion/stgit.zsh
++++ b/completion/stgit.zsh
+@@ -717,7 +717,7 @@ _stg-import() {
+         '--replace[replace unapplied patches in series]'
+         '--reject[leave rejected hunks in .rej files]'
+         '--keep-cr[do not remove CR from email lines ending with CRLF]'
+-        '--message-id[create Message-Id trailer from email header]'
++        '--message-id[create Message-ID trailer from email header]'
+         '(-d --showdiff)'{-d,--showdiff}'[show patch content in editor buffer]'
+         ':file:_files'
+         + '(source)'
+diff --git a/src/cmd/email/format.rs b/src/cmd/email/format.rs
+index f385b48a..b30af9c0 100644
+--- a/src/cmd/email/format.rs
++++ b/src/cmd/email/format.rs
+@@ -323,7 +323,7 @@ fn message_options() -> Vec<Arg> {
+             .long_help(
+                 "Controls addition of `In-Reply-To` and `References` headers to make \
+                  the second and subsequent mails appear as replies to the first. Also \
+-                 controls generation of the `Message-Id` header to reference.\n\
++                 controls generation of the `Message-ID` header to reference.\n\
+                  \n\
+                  The optional <style> argument can be either `shallow` or `deep`. \
+                  `shallow` threading makes every mail a reply to the head of the \
+diff --git a/src/cmd/email/send.rs b/src/cmd/email/send.rs
+index 6904956f..af75f4b3 100644
+--- a/src/cmd/email/send.rs
++++ b/src/cmd/email/send.rs
+@@ -194,7 +194,7 @@ fn compose_options() -> Vec<Arg> {
+             .help("Specify the \"In-Reply-To:\" identifier")
+             .long_help(
+                 "Make the first mail (or all the mails with '--no-thread') appear as a \
+-                 reply to the given Message-Id, which avoids breaking threads to \
++                 reply to the given Message-ID, which avoids breaking threads to \
+                  provide a new patch series. The second and subsequent emails will be \
+                  sent as replies according to the '--[no-]chain-reply-to' setting.\n\
+                  \n\
+diff --git a/src/cmd/import.rs b/src/cmd/import.rs
+index d5477df7..2835aefa 100644
+--- a/src/cmd/import.rs
++++ b/src/cmd/import.rs
+@@ -210,9 +210,9 @@ fn make() -> clap::Command {
+         .arg(
+             Arg::new("message-id")
+                 .long("message-id")
+-                .help("Create Message-Id trailer from Message-ID header")
++                .help("Create Message-ID trailer from Message-ID header")
+                 .long_help(
+-                    "Create Message-Id trailer in patch description based on the \
++                    "Create Message-ID trailer in patch description based on the \
+                     Message-ID email header. This option is applicable when importing \
+                     with '--mail' or '--mbox'. This behavior may also be enabled via \
+                     the \"stgit.import.message-id\" configuration option.",
+@@ -500,7 +500,7 @@ fn import_file<'repo>(
+         if message.len() > 1 && &message[message.len() - 2..] != b"\n\n" {
+             message.push(b'\n');
+         }
+-        message.push_str("Message-Id: ");
++        message.push_str("Message-ID: ");
+         message.push_str(message_id);
+         message.push(b'\n');
+     }
+diff --git a/t/t1800-import.sh b/t/t1800-import.sh
+index ecf0020c..229269bf 100755
+--- a/t/t1800-import.sh
++++ b/t/t1800-import.sh
+@@ -43,7 +43,7 @@ test_expect_success 'Import patch with email headers' '
+     cat >expected <<-\EOF &&
+ 	body
+
+-	Message-Id: abc123
++	Message-ID: abc123
+
+ 	EOF
+     test_cmp expected body &&
+diff --git a/t/t1801-import-email.sh b/t/t1801-import-email.sh
+index dbd3f7da..0559e076 100755
+--- a/t/t1801-import-email.sh
++++ b/t/t1801-import-email.sh
+@@ -17,7 +17,7 @@ test_expect_success 'Apply a patch from an 8bit-encoded e-mail' '
+     [ $(git cat-file -p $(stg id) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id) \
+-        | grep -c "Message-Id: <20061111105814.23209.46952.stgit@localhost>") = 1 ] &&
++        | grep -c "Message-I[Dd]: <20061111105814.23209.46952.stgit@localhost>") = 1 ] &&
+     stg delete ..
+ '
+
+@@ -28,7 +28,7 @@ test_expect_success !MINGW,STG_IMPORT_URL 'Apply a patch from an 8bit-encoded e-
+     [ $(git cat-file -p $(stg id) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id) \
+-        | grep -c "Message-Id: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
+     stg delete ..
+ '
+
+@@ -40,7 +40,7 @@ test_expect_success 'Apply a patch from an 8bit-encoded e-mail with CRLF endings
+     [ $(git cat-file -p $(stg id) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id) \
+-        | grep -c "Message-Id: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
+     stg delete ..
+ '
+
+@@ -56,7 +56,7 @@ test_expect_success 'Apply e-mail with CRLF endings and --keep-cr' '
+     [ $(git cat-file -p $(stg id) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id) \
+-        | grep -c "Message-Id: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
+     stg delete ..
+ '
+
+@@ -68,7 +68,7 @@ test_expect_success 'Apply a patch from latin1-encoded email specifying utf-8 ch
+     [ $(git cat-file -p $(stg id) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id) \
+-        | grep -c "Message-Id: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
+     stg delete ..
+ '
+
+@@ -79,7 +79,7 @@ test_expect_success 'Apply a patch from email with quoted "From" header' '
+     [ $(git cat-file -p $(stg id) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id) \
+-        | grep -c "Message-Id: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
+     stg delete ..
+ '
+
+@@ -90,7 +90,7 @@ test_expect_success 'Apply a patch from a QP-encoded e-mail' '
+     [ $(git cat-file -p $(stg id) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id) \
+-        | grep -c "Message-Id: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111105814.23209.46952.stgit@localhost>") = 0 ] &&
+     stg delete ..
+ '
+
+@@ -102,19 +102,19 @@ test_expect_success 'Apply several patches from an mbox file' '
+     [ $(git cat-file -p $(stg id change-1) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-1) \
+-        | grep -c "Message-Id: <20061111114527.31778.12942.stgit@localhost>") = 1 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.12942.stgit@localhost>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+         | grep -c "tree e49dbce010ec7f441015a8c64bce0b99108af4cc") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+-        | grep -c "Message-Id: <20061111114527.31778.92851.stgit@localhost>") = 1 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.92851.stgit@localhost>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+         | grep -c "tree 166bbaf27a44aee21ba78c98822a741e6f7d78f5") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+-        | grep -c "Message-Id: <20061111114527.31778.45876.stgit@localhost>") = 1 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.45876.stgit@localhost>") = 1 ] &&
+     stg delete ..
+ '
+
+@@ -126,19 +126,19 @@ test_expect_success !MINGW,STG_IMPORT_URL 'Apply several patches from an mbox ur
+     [ $(git cat-file -p $(stg id change-1) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-1) \
+-        | grep -c "Message-Id: <20061111114527.31778.12942.stgit@localhost>") = 1 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.12942.stgit@localhost>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+         | grep -c "tree e49dbce010ec7f441015a8c64bce0b99108af4cc") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+-        | grep -c "Message-Id: <20061111114527.31778.92851.stgit@localhost>") = 1 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.92851.stgit@localhost>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+         | grep -c "tree 166bbaf27a44aee21ba78c98822a741e6f7d78f5") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+-        | grep -c "Message-Id: <20061111114527.31778.45876.stgit@localhost>") = 1 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.45876.stgit@localhost>") = 1 ] &&
+     stg delete ..
+ '
+
+@@ -156,19 +156,19 @@ test_expect_success 'Apply several patches from an mbox file from stdin' '
+     [ $(git cat-file -p $(stg id change-1) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-1) \
+-        | grep -c "Message-Id: <20061111114527.31778.12942.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.12942.stgit@localhost>") = 0 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+         | grep -c "tree e49dbce010ec7f441015a8c64bce0b99108af4cc") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-2) \
+-        | grep -c "Message-Id: <20061111114527.31778.92851.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.92851.stgit@localhost>") = 0 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+         | grep -c "tree 166bbaf27a44aee21ba78c98822a741e6f7d78f5") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+         | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+     [ $(git cat-file -p $(stg id change-3-colon) \
+-        | grep -c "Message-Id: <20061111114527.31778.45876.stgit@localhost>") = 0 ] &&
++        | grep -c "Message-I[Dd]: <20061111114527.31778.45876.stgit@localhost>") = 0 ] &&
+     stg delete ..
+ '
+
+--
+2.40.1
+

--- a/pkgs/applications/version-management/stgit/default.nix
+++ b/pkgs/applications/version-management/stgit/default.nix
@@ -1,32 +1,48 @@
 { stdenv
 , lib
+, rustPlatform
 , fetchFromGitHub
+, pkg-config
 , installShellFiles
-, python3Packages
+, makeWrapper
 , asciidoc
 , docbook_xsl
 , docbook_xml_dtd_45
+, xmlto
+, curl
 , git
 , perl
-, xmlto
+, darwin
 }:
 
-python3Packages.buildPythonApplication rec {
+rustPlatform.buildRustPackage rec {
   pname = "stgit";
-  version = "1.5";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "stacked-git";
     repo = "stgit";
     rev = "v${version}";
-    sha256 = "sha256-TsJr2Riygz/DZrn6UZMPvq1tTfvl3dFEZZNq2wVj1Nw=";
+    sha256 = "sha256-pGGLY/Hu62dT3KP9GH9YmPg6hePDoPdijJtmap5gpEA=";
   };
+  cargoHash = "sha256-f0MQvCkFYR7ErbBDJ3n0r9ZetKfcWg9twhc4r4EpPS4=";
 
-  nativeBuildInputs = [ installShellFiles asciidoc xmlto docbook_xsl docbook_xml_dtd_45 python3Packages.setuptools ];
+  nativeBuildInputs = [
+    pkg-config installShellFiles makeWrapper asciidoc xmlto docbook_xsl
+    docbook_xml_dtd_45 perl
+  ];
+  buildInputs = [ curl ];
 
-  format = "other";
+  nativeCheckInputs = [
+    git perl
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.system_cmds darwin.libiconv
+  ];
 
-  nativeCheckInputs = [ git perl ];
+  patches = [
+    # Fixes tests, can be removed when stgit 2.3.1 is released
+    ./0001-fix-use-canonical-Message-ID-spelling.patch
+  ];
 
   postPatch = ''
     for f in Documentation/*.xsl; do
@@ -40,25 +56,28 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace Documentation/texi.xsl \
       --replace http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd \
                 ${docbook_xml_dtd_45}/xml/dtd/docbook/docbookx.dtd
-
-    cat > stgit/_version.py <<EOF
-    __version__ = "${version}"
-    EOF
   '';
 
-  makeFlags = [
+  makeFlags = lib.strings.concatStringsSep " " [
     "prefix=${placeholder "out"}"
     "MAN_BASE_URL=${placeholder "out"}/share/man"
     "XMLTO_EXTRA=--skip-validation"
+    "PERL_PATH=${perl}/bin/perl"
   ];
 
-  buildFlags = [ "all" "doc" ];
+  buildPhase = ''
+    make all ${makeFlags}
+  '';
 
-  checkTarget = "test";
-  checkFlags = [ "PERL_PATH=${perl}/bin/perl" ];
+  checkPhase = ''
+    make test ${makeFlags}
+  '';
 
-  installTargets = [ "install" "install-doc" "install-html" ];
-  postInstall = ''
+  installPhase = ''
+    make install install-man install-html ${makeFlags}
+
+    wrapProgram $out/bin/stg --prefix PATH : ${lib.makeBinPath [ git ]}
+
     installShellCompletion --cmd stg \
       --fish completion/stg.fish \
       --bash completion/stgit.bash \


### PR DESCRIPTION

###### Description of changes

Version 2 of stgit was rewritten in Rust but in general offers the same feature set. We therefore do not require a Python build environment anymore but a Rust one. However, we overwrite the default build, check and install phases to use the Makefiles provided by stgit. In addition, the following changes are necessary:

- stgit now requires libcurl
- perl is required during build (to build docs correctly) and during check (to run the extensive test suite)

Changelog for v2.0.0: https://github.com/stacked-git/stgit/releases/tag/v2.0.0
Changelog for v2.3.0: https://github.com/stacked-git/stgit/releases/tag/v2.3.0
List of changelogs v2.0.0...v2.3.0: https://stacked-git.github.io/changelog/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable: (checkPhase runs the extensive test suite and I tested a few commands locally)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (nothing depends on stgit)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
