### PR TITLE
darwin: fix generate-sdk-packages.sh

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/generate-sdk-packages.sh
+++ b/pkgs/os-specific/darwin/apple-source-releases/generate-sdk-packages.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl jq
 
-# usage:
-#   generate-sdk-packages.sh macos 11.0.1
+usage() {
+    cat <<EOF
+usage: $0 macos 11.0.1
+EOF
+}
+
+if [ "$#" != 2 ]; then
+    usage
+    exit 1
+fi
 
 cd $(dirname "$0")
 

--- a/pkgs/os-specific/darwin/apple-source-releases/generate-sdk-packages.sh
+++ b/pkgs/os-specific/darwin/apple-source-releases/generate-sdk-packages.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl
+#!nix-shell -i bash -p curl jq
 
 # usage:
 #   generate-sdk-packages.sh macos 11.0.1
@@ -16,14 +16,14 @@ outfile="$sdkName.nix"
 {"
 
 parse_line() {
-    readarray -t -d$'\t' package <<<$2
+    readarray -t -d$'-' package < <(printf "%s" $2)
     local pname=${package[0]} version=${package[1]}
 
     if [ -d $pname ]; then
-        sha256=$(nix-prefetch-url "https://opensource.apple.com/tarballs/$pname/$pname-$version.tar.gz")
+        sha256=$(nix-prefetch-url "https://github.com/apple-oss-distributions/$pname/archive/refs/tags/$pname-$version.tar.gz")
         >>$outfile echo "$pname = applePackage' \"$pname\" \"$version\" \"$sdkName\" \"$sha256\" {};"
     fi
 }
-readarray -s1 -c1 -C parse_line < <(curl -sS "https://opensource.apple.com/text/${sdkName//./}.txt")
+readarray -s1 -c1 -C parse_line < <(curl -sSL "https://github.com/apple-oss-distributions/distribution-${1//-/_}/raw/${sdkName//./}/release.json" | jq -r ".projects[].tag")
 
 >>$outfile echo '}'


### PR DESCRIPTION
###### Description of changes

The script is broken, since `https://opensource.apple.com/text/macos-1101.txt` is no longer available.

Also, #201348: the packages seem to have different sha256 now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
