### PR TITLE
cirrus-cli: 0.92.0 -> 0.92.1

### DIFF
--- a/pkgs/development/tools/continuous-integration/cirrus-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/cirrus-cli/default.nix
@@ -1,17 +1,18 @@
 { lib
 , fetchFromGitHub
 , buildGoModule
+, installShellFiles
 }:
 
 buildGoModule rec {
   pname = "cirrus-cli";
-  version = "0.92.0";
+  version = "0.92.1";
 
   src = fetchFromGitHub {
     owner = "cirruslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-q6hpsyZZep8IERYh7/oVcCQdgc/s6HufiuE4oNPBaZc=";
+    sha256 = "sha256-ehJyC5NXB53i7ZpWTKySnMwWiqgbgBbnxIVWhyrXC0A=";
   };
 
   vendorSha256 = "sha256-Llq6siZn34sHsZFneT+MLXf2W9cXqi4DZwrH1R5laOY=";
@@ -20,6 +21,14 @@ buildGoModule rec {
     "-X github.com/cirruslabs/cirrus-cli/internal/version.Version=v${version}"
     "-X github.com/cirruslabs/cirrus-cli/internal/version.Commit=v${version}"
   ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    installShellCompletion --cmd cirrus \
+      --bash <($out/bin/cirrus completion bash) \
+      --zsh <($out/bin/cirrus completion zsh) \
+      --fish <($out/bin/cirrus completion fish)
+  '';
 
   # tests fail on read-only filesystem
   doCheck = false;


### PR DESCRIPTION
Diff: https://github.com/cirruslabs/cirrus-cli/compare/v0.92.0...v0.92.1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
