### PR TITLE
python310Packages.exceptiongroup: run tests

### DIFF
--- a/pkgs/development/python-modules/exceptiongroup/default.nix
+++ b/pkgs/development/python-modules/exceptiongroup/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, flit-core
+, fetchFromGitHub
+, flit-scm
 , pytestCheckHook
 , pythonOlder
 }:
@@ -9,22 +9,26 @@
 buildPythonPackage rec {
   pname = "exceptiongroup";
   version = "1.0.4";
-  format = "flit";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-vRSWe3nNm9tU2XMjIW+P31M+J435N6oqkAiefW4G5ew=";
+  src = fetchFromGitHub {
+    owner = "agronholm";
+    repo = "exceptiongroup";
+    rev = version;
+    hash = "sha256-csyDWVvcsAMzgomb0xq0NbVP7qYQpDv9obBGANlwiVI=";
   };
 
   nativeBuildInputs = [
-    flit-core
+    flit-scm
   ];
 
-  # Tests are only in the source available but tagged releases
-  # are incomplete as files are generated during the release process
-  doCheck = false;
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [
     "exceptiongroup"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
