### PR TITLE
gnome.zenity: relax meta.platforms

### DIFF
--- a/pkgs/applications/graphics/tev/default.nix
+++ b/pkgs/applications/graphics/tev/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.unix;
     badPlatforms = [ "aarch64-linux" ]; # fails on Hydra since forever
+    broken = stdenv.isDarwin; # needs apple frameworks + SDK fix? see #205247
     maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/desktops/gnome/core/zenity/default.nix
+++ b/pkgs/desktops/gnome/core/zenity/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tool to display dialogs from the commandline and shell scripts";
     homepage = "https://wiki.gnome.org/Projects/Zenity";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = teams.gnome.members;
   };
 }

--- a/pkgs/development/lua-modules/nfd/default.nix
+++ b/pkgs/development/lua-modules/nfd/default.nix
@@ -1,5 +1,5 @@
-{ fetchFromGitHub, buildLuarocksPackage, lua, pkg-config, lib
-, substituteAll, zenity }:
+{ stdenv, fetchFromGitHub, buildLuarocksPackage, lua, pkg-config, lib
+, substituteAll, zenity, AppKit }:
 
 buildLuarocksPackage {
   pname = "nfd";
@@ -24,6 +24,8 @@ buildLuarocksPackage {
 
   extraVariables.LUA_LIBDIR = "${lua}/lib";
   nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ AppKit ];
 
   fixupPhase = ''
     find $out -name nfd_zenity.so -execdir mv {} nfd.so \;

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -95,6 +95,7 @@ in
 
   nfd = callPackage ../development/lua-modules/nfd {
     inherit (pkgs.gnome) zenity;
+    inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
   };
 
   vicious = (callPackage ({ fetchFromGitHub }: stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Description of changes

- Relax the platforms for `gnome.zenity` from `linux` to `unix`. I'm not certain if relaxing it _this_ far is correct, but I have `allowUnsupportedSystem = true` set on macOS and didn't even realize this was marked Linux-only until now. Screenshot:

    <img width="746" alt="Screen Shot 2022-12-08 at 8 50 50 PM" src="https://user-images.githubusercontent.com/2548365/206614328-258ba5c8-cc1c-43d9-9711-60e2bdc21034.png">

- Marked `tev` unbuildable on darwin. It has build problems that were shielded by zenity not being buildable. See https://github.com/NixOS/nixpkgs/pull/205247#issuecomment-1344522245 for a little more context.
- Updated `luaPackages.nfd` to build on darwin. It also had build problems exposed by zenity being buildable, but the fix was straightforward.

Reviews for the full PR:

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages marked as broken and skipped:</summary>
  <ul>
    <li>lua52Packages.nfd</li>
    <li>lua53Packages.nfd</li>
    <li>tev</li>
  </ul>
</details>
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>gnome.zenity</li>
    <li>gnomeExtensions.ddterm</li>
    <li>kodi-cli</li>
    <li>lua51Packages.nfd</li>
    <li>luajitPackages.nfd</li>
    <li>vimPlugins.vCoolor-vim</li>
  </ul>
</details>

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
