### PR TITLE
kodiPackages.youtube: 6.8.18+matrix.1 → 6.8.22+matrix.1

### DIFF
--- a/pkgs/applications/video/kodi/addons/youtube/default.nix
+++ b/pkgs/applications/video/kodi/addons/youtube/default.nix
@@ -1,13 +1,13 @@
-{ lib, buildKodiAddon, fetchpatch, fetchzip, addonUpdateScript, six, requests, inputstreamhelper }:
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, six, requests, inputstreamhelper }:
 
 buildKodiAddon rec {
   pname = "youtube";
   namespace = "plugin.video.youtube";
-  version = "6.8.18+matrix.1";
+  version = "6.8.22+matrix.1";
 
   src = fetchzip {
     url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
-    sha256 = "F950rnE/YxwWI0ieHC2TdGNSfrQDHlStnxLbA6UjEaM=";
+    sha256 = "V1ALhD0zLm6Rq2KFpZXULPiB7sAPaNDhCpxScr+apDE=";
   };
 
   propagatedBuildInputs = [
@@ -22,15 +22,6 @@ buildKodiAddon rec {
       attrPath = "kodi.packages.youtube";
     };
   };
-
-  patches = [
-    # This patch can be removed once https://github.com/anxdpanic/plugin.video.youtube/pull/260 has been merged.
-    (fetchpatch {
-      name = "fix-addon-path";
-      url = "https://patch-diff.githubusercontent.com/raw/anxdpanic/plugin.video.youtube/pull/260.patch";
-      sha256 = "11c9sfwl5kvfll2jws5b4i46s60v6gkfns4al13p4m5ch9rk06hs";
-    })
-  ];
 
   meta = with lib; {
     homepage = "https://github.com/anxdpanic/plugin.video.youtube";


### PR DESCRIPTION

###### Description of changes

Updating to the latest version of https://github.com/anxdpanic/plugin.video.youtube/, which lets us drop this patch I added. I can't find a good permalink for a changelog. Here's what I have found:

- 113 commits going from v6.8.18...v6.8.22: https://github.com/anxdpanic/plugin.video.youtube/compare/v6.8.18...v6.8.22
- Release notes for all the versions we're jumping:
  - https://github.com/anxdpanic/plugin.video.youtube/releases/tag/v6.8.18
  - https://github.com/anxdpanic/plugin.video.youtube/releases/tag/v6.8.20
  - https://github.com/anxdpanic/plugin.video.youtube/releases/tag/6.x.x-dev
  - https://github.com/anxdpanic/plugin.video.youtube/releases/tag/v6.8.21
  - https://github.com/anxdpanic/plugin.video.youtube/releases/tag/v6.8.22

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
