### PR TITLE
skim: fix fish shell keybindings

### DIFF
--- a/nixos/modules/programs/skim.nix
+++ b/nixos/modules/programs/skim.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.skim = {
-      fuzzyCompletion = mkEnableOption (mdDoc "fuzzy Completion with skim");
+      fuzzyCompletion = mkEnableOption (mdDoc "fuzzy completion with skim");
       keybindings = mkEnableOption (mdDoc "skim keybindings");
       package = mkPackageOption pkgs "skim" {};
     };
@@ -25,6 +25,10 @@ in
       source ${cfg.package}/share/skim/completion.zsh
     '' + optionalString cfg.keybindings ''
       source ${cfg.package}/share/skim/key-bindings.zsh
+    '';
+
+    programs.fish.interactiveShellInit = optionalString cfg.keybindings ''
+      source ${cfg.package}/share/skim/key-bindings.fish && skim_key_bindings
     '';
   };
 }

--- a/pkgs/tools/misc/skim/default.nix
+++ b/pkgs/tools/misc/skim/default.nix
@@ -30,9 +30,7 @@ rustPlatform.buildRustPackage rec {
     install -D -m 444 plugin/skim.vim -t $vim/plugin
 
     install -D -m 444 shell/* -t $out/share/skim
-    install -D shell/key-bindings.fish $out/share/fish/vendor_functions.d/sk_key_bindings.fish
-    mkdir -p $out/share/fish/vendor_conf.d
-    echo sk_key_bindings > $out/share/fish/vendor_conf.d/load-sk-key-bindings.fish
+
     installManPage man/man1/*
 
     cat <<SCRIPT > $out/bin/sk-share


### PR DESCRIPTION
###### Description of changes

TL;DR: This fixes a typo that prevented the fish keybindings from being loaded. Also, the keybindings are now only loaded if `programs.skim.keybindings` is `true`, which matches the behavior for bash and zsh.

Since #204352, skim's fish keybindings are installed like this:
https://github.com/NixOS/nixpkgs/blob/2a7fae33a433147cc9c78dbd33702fa9ad7c4ad0/pkgs/tools/misc/skim/default.nix#L33-L35

There seems to a typo here: `sk_key_bindings` should be `skim_key_bindings`. This causes an error every time fish starts:
```text
fish: Unknown command: sk_key_bindings
/etc/profiles/per-user/alex/share/fish/vendor_conf.d/load-sk-key-bindings.fish (line 1): 
sk_key_bindings
^
from sourcing file /etc/profiles/per-user/alex/share/fish/vendor_conf.d/load-sk-key-bindings.fish
	called on line 246 of file /nix/store/qnn7gp4q6la4ikgi3bw9g59ix10va7xp-fish-3.5.1/share/fish/config.fish
from sourcing file /nix/store/qnn7gp4q6la4ikgi3bw9g59ix10va7xp-fish-3.5.1/share/fish/config.fish
	called during startup
```

This fixes the typo, and also now only loads the keybindings when `programs.skim.keybindings` is `true`. The current behavior (installing to `vendor_conf.d`) is that they are always loaded, which does not seem like the expected behavior.
The `programs.skim.fuzzyCompletion` option still doesn't do anything for fish, but I'm not sure how to fix that right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
