### PR TITLE
generic-updater: enable passing path to .nix file

### DIFF
--- a/pkgs/common-updater/git-updater.nix
+++ b/pkgs/common-updater/git-updater.nix
@@ -13,9 +13,11 @@
 # an explicit url is needed when src.meta.homepage or src.url don't
 # point to a git repo (eg. when using fetchurl, fetchzip, ...)
 , url ? null
+# Path to the .nix file to update - this file must contain the version and hash
+, file ? null
 }:
 
 genericUpdater {
-  inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
+  inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable file;
   versionLister = "${common-updater-scripts}/bin/list-git-tags ${lib.optionalString (url != null) "--url=${url}"}";
 }

--- a/pkgs/development/libraries/mbedtls/generic.nix
+++ b/pkgs/development/libraries/mbedtls/generic.nix
@@ -8,6 +8,7 @@
 , ninja
 , perl # Project uses Perl for scripting and testing
 , python3
+, gitUpdater
 
 , enableThreading ? true # Threading can be disabled to increase security https://tls.mbed.org/kb/development/thread-safety-and-multi-threading
 }:
@@ -37,6 +38,12 @@ stdenv.mkDerivation rec {
     "-Wno-error=format"
     "-Wno-error=format-truncation"
   ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "${pname}-";
+    ignoredVersions = "^[^${lib.versions.major version}]";
+    file = "pkgs/development/libraries/mbedtls/${lib.versions.major version}.nix";
+  };
 
   meta = with lib; {
     homepage = "https://www.trustedfirmware.org/projects/mbed-tls/";


### PR DESCRIPTION
###### Description of changes

This allows packages that are split into multiple files (for example, generic.nix and 3.nix) to use the generic update script (and therefore be updated by r-ryantm).

Tested with `nix-shell maintainers/scripts/update.nix --argstr package` on a handful of packages.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
