### PR TITLE
mygui: add darwin support

### DIFF
--- a/pkgs/development/libraries/mygui/default.nix
+++ b/pkgs/development/libraries/mygui/default.nix
@@ -1,9 +1,24 @@
-{  lib, stdenv, fetchFromGitHub, libX11, cmake, ois, freetype, libuuid,
-   boost, pkg-config, withOgre ? false, ogre ? null, libGL, libGLU ? null } :
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, boost
+, freetype
+, libuuid
+, ois
+, withOgre ? false
+, ogre
+, libGL
+, libGLU
+, libX11
+, Cocoa
+}:
 
 let
   renderSystem = if withOgre then "3" else "4";
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "mygui";
   version = "3.4.0";
 
@@ -14,17 +29,42 @@ in stdenv.mkDerivation rec {
     sha256 = "0a4zi8w18pjj813n7kmxldl1d9r1jp0iyhkw7pbqgl8f7qaq994w";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ libX11 ois freetype libuuid boost ]
-    ++ (if withOgre then [ ogre ] else [ libGL libGLU ]);
+  patches = [
+    ./disable-framework.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    freetype
+    libuuid
+    ois
+  ] ++ lib.optionals withOgre [
+    ogre
+  ] ++ lib.optionals (!withOgre && stdenv.isLinux) [
+    libGL
+    libGLU
+  ] ++ lib.optionals stdenv.isLinux [
+    libX11
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
+  ];
 
   # Tools are disabled due to compilation failures.
-  cmakeFlags = [ "-DMYGUI_BUILD_TOOLS=OFF" "-DMYGUI_BUILD_DEMOS=OFF" "-DMYGUI_RENDERSYSTEM=${renderSystem}" ];
+  cmakeFlags = [
+    "-DMYGUI_BUILD_TOOLS=OFF"
+    "-DMYGUI_BUILD_DEMOS=OFF"
+    "-DMYGUI_RENDERSYSTEM=${renderSystem}"
+  ];
 
   meta = with lib; {
     homepage = "http://mygui.info/";
     description = "Library for creating GUIs for games and 3D applications";
     license = licenses.lgpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/mygui/disable-framework.patch
+++ b/pkgs/development/libraries/mygui/disable-framework.patch
@@ -1,0 +1,19 @@
+diff --git a/CMake/Utils/MyGUIConfigTargets.cmake b/CMake/Utils/MyGUIConfigTargets.cmake
+index bba3f91..8f4f351 100644
+--- a/CMake/Utils/MyGUIConfigTargets.cmake
++++ b/CMake/Utils/MyGUIConfigTargets.cmake
+@@ -477,14 +477,6 @@ function(mygui_config_lib PROJECTNAME)
+ 		if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+ 			# add GCC visibility flags to shared library build
+ 			set_target_properties(${PROJECTNAME} PROPERTIES COMPILE_FLAGS "${MYGUI_GCC_VISIBILITY_FLAGS}")
+-			if (APPLE)
+-				# deal with Mac OS X's framework system
+-				set_target_properties(${PROJECTNAME} PROPERTIES FRAMEWORK TRUE)
+-				set_target_properties(${PROJECTNAME} PROPERTIES PUBLIC_HEADER "${${PROJECTNAME}_HEADERS}")
+-				set_target_properties(${PROJECTNAME} PROPERTIES OUTPUT_NAME ${PROJECTNAME})
+-				set_target_properties(${PROJECTNAME} PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
+-				set_target_properties(${PROJECTNAME} PROPERTIES INSTALL_NAME_DIR "@executable_path/../Frameworks")
+-			endif (APPLE)
+ 		endif ()
+ 	endif (MYGUI_STATIC)
+ 	mygui_install_target(${PROJECTNAME} "")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21645,6 +21645,7 @@ with pkgs;
   mygpoclient = with python3.pkgs; toPythonApplication mygpoclient;
 
   mygui = callPackage ../development/libraries/mygui {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
     ogre = ogre1_9;
   };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
