### PR TITLE
elmPackages.elm-format: disable checks

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -37,6 +37,7 @@ let
       */
       elm-format = justStaticExecutables (overrideCabal (drv: {
         jailbreak = true;
+        doCheck = assert (drv.version == "0.8.5"); false; # golden tests fail with optparse-applicative 0.17
 
         description = "Formats Elm source code according to a standard set of rules based on the official Elm Style Guide";
         homepage = "https://github.com/avh4/elm-format";


### PR DESCRIPTION
Fixes the build with optparse-applicative 0.17