### PR TITLE
searxng: unstable-2022-09-01 -> unstable-2023-01-15

### DIFF
--- a/pkgs/servers/web-apps/searxng/default.nix
+++ b/pkgs/servers/web-apps/searxng/default.nix
@@ -1,21 +1,23 @@
 { lib
 , python3
 , fetchFromGitHub
+, unstableGitUpdater
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "searxng";
-  version = "unstable-2022-09-01";
+  version = "unstable-2023-01-15";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "174e5242569812618af4ebd9a646ba2a6ded5459";
-    sha256 = "sha256-Q1+4HkgOoTRtW5XYWpC5dpukkrjG5fP0585soo/srmQ=";
+    rev = "13b0c251c45c3d14700723b25b601be56178e8df";
+    sha256 = "sha256-f6RKVarW3iSkDP++MdkRt1QAdnHX/fxcD2GMvQt3hnA=";
   };
 
   postPatch = ''
     sed -i 's/==.*$//' requirements.txt
+    sed -i 's/fasttext-predict/fasttext/' requirements.txt
   '';
 
   preBuild = ''
@@ -40,8 +42,12 @@ python3.pkgs.buildPythonApplication rec {
     httpx
     httpx-socks
     markdown-it-py
+    fasttext
+    pybind11
   ] ++ httpx.optional-dependencies.http2
   ++ httpx-socks.optional-dependencies.asyncio;
+
+  passthru.updateScript = unstableGitUpdater { url = src.meta.homepage; };
 
   # tests try to connect to network
   doCheck = false;
@@ -53,7 +59,7 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/searxng/searxng";
+    homepage = "https://docs.searxng.org/";
     description = "A fork of Searx, a privacy-respecting, hackable metasearch engine";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ kranzes ];


### PR DESCRIPTION
###### Description of changes

Also added an updater script.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).