### PR TITLE
vector: 0.25.2 -> 0.26.0

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -32,7 +32,8 @@
 
 let
   pname = "vector";
-  version = "0.25.2";
+  pinData = lib.importJSON ./pin.json;
+  version = pinData.version;
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -41,10 +42,10 @@ rustPlatform.buildRustPackage {
     owner = "vectordotdev";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-gkhVabfAV250zofss7b/3ulb09Wk5EMGz9GSaS5eCzA=";
+    sha256 = pinData.sha256;
   };
 
-  cargoHash = "sha256-zxwwXFCdcbB+Kx2SNyAIDsII6SN5+QHJQlzOUx+us2o=";
+  cargoSha256 = pinData.cargoSha256;
   nativeBuildInputs = [ pkg-config cmake perl ];
   buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]
     ++ lib.optionals stdenv.isDarwin [ Security libiconv coreutils CoreServices ];

--- a/pkgs/tools/misc/vector/pin.json
+++ b/pkgs/tools/misc/vector/pin.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.26.0",
+  "sha256": "sha256-0h9hcNgaVBDBeSKo39TvrMlloTS5ZoXrbVhm7Y43U+o=",
+  "cargoSha256": "sha256-UHc8ZyLJ1pxaBuP6bOXdbAI1oVZD4CVHAIa8URnNdaI="
+}

--- a/pkgs/tools/misc/vector/update.sh
+++ b/pkgs/tools/misc/vector/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i oil -p jq sd nix-prefetch-github ripgrep
+
+# TODO set to `verbose` or `extdebug` once implemented in oil
+shopt --set xtrace
+# we need failures inside of command subs to get the correct cargoSha256
+shopt --unset inherit_errexit
+
+const directory = $(dirname $0 | xargs realpath)
+const owner = "vectordotdev"
+const repo = "vector"
+const latest_rev = $(curl -q https://api.github.com/repos/${owner}/${repo}/releases/latest | \
+  jq -r '.tag_name')
+const latest_version = $(echo $latest_rev | sd 'v' '')
+const current_version = $(jq -r '.version' $directory/pin.json)
+if ("$latest_version" === "$current_version") {
+  echo "$repo is already up-to-date"
+  return 0
+} else {
+  const tarball_meta = $(nix-prefetch-github $owner $repo --rev "$latest_rev")
+  const tarball_hash = "sha256-$(echo $tarball_meta | jq -r '.sha256')"
+
+  jq ".version = \"$latest_version\" | \
+      .\"sha256\" = \"$tarball_hash\" | \
+      .\"cargoSha256\" = \"\"" $directory/pin.json | sponge $directory/pin.json
+
+  const new_cargo_sha256 = $(nix-build -A vector 2>&1 | \
+    tail -n 2 | \
+    head -n 1 | \
+    sd '\s+got:\s+' '')
+
+  jq ".cargoSha256 = \"$new_cargo_sha256\"" $directory/pin.json | sponge $directory/pin.json
+}


### PR DESCRIPTION
###### Description of changes

adding an update script as well because somehow the update bot is not picking these updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
