### PR TITLE
wpaperd: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3704,6 +3704,12 @@
       fingerprint = "4749 0887 CF3B 85A1 6355  C671 78C7 DD40 DF23 FB16";
     }];
   };
+  DPDmancul = {
+    name = "Davide Peressoni";
+    email = "davide.peressoni@tuta.io";
+    matrix = "@dpd-:matrix.org";
+    githubId = 3186857;
+  };
   dpercy = {
     email = "dpercy@dpercy.dev";
     github = "dpercy";

--- a/pkgs/tools/wayland/wpaperd/default.nix
+++ b/pkgs/tools/wayland/wpaperd/default.nix
@@ -1,0 +1,36 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, libxkbcommon }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wpaperd";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "danyspin97";
+    repo = pname;
+    rev = version;
+    sha256 = "n1zlC2afog0UazsJEBAzXpnhVDeP3xqpNGXlJ65umHQ=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    libxkbcommon
+  ];
+
+  cargoSha256 = "8ZMdbJvedDqoDr2rhKM1TMB5N4aRde04x/9H212fe68=";
+
+  meta = with lib; {
+    description = "Minimal wallpaper daemon for Wayland";
+    longDescription = ''
+      It allows the user to choose a different image for each output (aka for each monitor)
+      just as swaybg. Moreover, a directory can be chosen and wpaperd will randomly choose
+      an image from it. Optionally, the user can set a duration, after which the image
+      displayed will be changed with another random one.
+    '';
+    homepage = "https://github.com/danyspin97/wpaperd";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ DPDmancul ];
+  };
+}

--- a/pkgs/tools/wayland/wpaperd/default.nix
+++ b/pkgs/tools/wayland/wpaperd/default.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://github.com/danyspin97/wpaperd";
     license = licenses.gpl3Plus;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ DPDmancul ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4001,6 +4001,8 @@ with pkgs;
 
   wob = callPackage ../tools/wayland/wob { };
 
+  wpaperd = callPackage ../tools/wayland/wpaperd { };
+
   wshowkeys = callPackage ../tools/wayland/wshowkeys { };
 
   wtype = callPackage ../tools/wayland/wtype { };


### PR DESCRIPTION
###### Description of changes

wpaperd is a minimal wallpaper daemon for Wayland. It allows the user to choose a different image for each output (aka for each monitor) just as swaybg. Moreover, a directory can be chosen and wpaperd will randomly choose an image from it. Optionally, the user can set a duration, after which the image displayed will be changed with another random one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
