### PR TITLE
nixos/minimal: remove environment.noXlibs true default

### DIFF
--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -3,29 +3,25 @@
 
 { config, lib, ... }:
 
-with lib;
-
 {
-  environment.noXlibs = mkDefault true;
+  documentation.enable = lib.mkDefault false;
 
-  documentation.enable = mkDefault false;
+  documentation.doc.enable = lib.mkDefault false;
 
-  documentation.doc.enable = mkDefault false;
+  documentation.info.enable = lib.mkDefault false;
 
-  documentation.info.enable = mkDefault false;
+  documentation.man.enable = lib.mkDefault false;
 
-  documentation.man.enable = mkDefault false;
+  documentation.nixos.enable = lib.mkDefault false;
 
-  documentation.nixos.enable = mkDefault false;
+  programs.command-not-found.enable = lib.mkDefault false;
 
-  programs.command-not-found.enable = mkDefault false;
+  services.logrotate.enable = lib.mkDefault false;
 
-  services.logrotate.enable = mkDefault false;
+  services.udisks2.enable = lib.mkDefault false;
 
-  services.udisks2.enable = mkDefault false;
-
-  xdg.autostart.enable = mkDefault false;
-  xdg.icons.enable = mkDefault false;
-  xdg.mime.enable = mkDefault false;
-  xdg.sounds.enable = mkDefault false;
+  xdg.autostart.enable = lib.mkDefault false;
+  xdg.icons.enable = lib.mkDefault false;
+  xdg.mime.enable = lib.mkDefault false;
+  xdg.sounds.enable = lib.mkDefault false;
 }

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -14,6 +14,8 @@
 
   documentation.nixos.enable = lib.mkDefault false;
 
+  fonts.fontconfig.enable = lib.mkDefault false;
+
   programs.command-not-found.enable = lib.mkDefault false;
 
   services.logrotate.enable = lib.mkDefault false;


### PR DESCRIPTION
###### Description of changes

noXlibs should not be enabled by default. It is an advanced setting that required multiple overrides to build on all my machines, which is not acceptable for normal users. For example nspawn containers use the minimal profile and depending on the program you use can lead to cache misses and sometimes packages fail to build. Debugging those build failures is impossible and very frustrating if you are not aware that this setting is activated, which in my experience, the most people are not.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
