### PR TITLE
sapling: a few tweaks

### DIFF
--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -17,6 +17,8 @@
 , CoreFoundation
 , CoreServices
 , Security
+
+, enableMinimal ? false
 }:
 
 let
@@ -129,10 +131,17 @@ let
     # 1) This applies on all systems (so no conditional a la postFixup)
     # 2) This doesn't require any kind of fixup itself, so we leave it out
     #    of postFixup for that reason, too
+    # 3) If asked, we optionally patch in a hardcoded path to the 'nodejs' package,
+    #    so that 'sl web' always works
+    # 4) 'sl web' will still work if 'nodejs' is in $PATH, just not OOTB
     preFixup = ''
       sitepackages=$out/lib/${python38Packages.python.libPrefix}/site-packages
       chmod +w $sitepackages
       cp -r ${isl} $sitepackages/edenscm-isl
+    '' + lib.optionalString (!enableMinimal) ''
+      chmod +w $sitepackages/edenscm-isl/run-isl
+      substituteInPlace $sitepackages/edenscm-isl/run-isl \
+        --replace 'NODE=node' 'NODE=${nodejs}/bin/node'
     '';
 
     postFixup = lib.optionalString stdenv.isLinux ''

--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -138,9 +138,9 @@ let
     ]);
 
     buildInputs = [
-      curl
       openssl
     ] ++ lib.optionals stdenv.isDarwin [
+      curl
       libiconv
       CoreFoundation
       CoreServices

--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -123,6 +123,18 @@ let
       sed -i "s|https://files.pythonhosted.org/packages/[[:alnum:]]*/[[:alnum:]]*/[[:alnum:]]*/|file://$NIX_BUILD_TOP/$sourceRoot/hack_pydeps/|g" $sourceRoot/setup.py
     '';
 
+    # Now, copy the "sl web" (aka edenscm-isl) results into the output of this
+    # package, so that the command can actually work. NOTES:
+    #
+    # 1) This applies on all systems (so no conditional a la postFixup)
+    # 2) This doesn't require any kind of fixup itself, so we leave it out
+    #    of postFixup for that reason, too
+    preFixup = ''
+      sitepackages=$out/lib/${python38Packages.python.libPrefix}/site-packages
+      chmod +w $sitepackages
+      cp -r ${isl} $sitepackages/edenscm-isl
+    '';
+
     postFixup = lib.optionalString stdenv.isLinux ''
       wrapProgram $out/bin/sl \
         --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
@@ -165,12 +177,7 @@ stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out
-
     cp -r ${sapling}/* $out
-
-    sitepackages=$out/lib/${python38Packages.python.libPrefix}/site-packages
-    chmod +w $sitepackages
-    cp -r ${isl} $sitepackages/edenscm-isl
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

A couple of minor changes; notably it seems `sl web` broke somehow in the mean time, so I slightly tweaked the copying of `edenscm-isl` in `postFixup`.

This also adds a fixed path to `nodejs` in the resulting `sl web` binary, so that it can always work for a user OOTB. It is optional, and on by default, and we can reverse this as well if we think it should be off by default or renamed (e.g. git has `git` as well as `gitAndTools`). The hope is to keep `nodejs` out of the closure so that we can write a `fetchSapling` path down the line more easily, for instance.

I also added some comments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)