### PR TITLE
cudaPackages: add cudaFlags

### DIFF
--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -33,10 +33,21 @@ mypkg = let
 in callPackage { inherit cudaPackages; };
 ```
 
-cudaPackages also provides a default set of cudaCapabilites for cards based on the
-CUDA version.  You may provide capabilities to add support or reduce
-binary size through `config` using `cudaCapabilities = [ "6.0" "7.0" ];` and
+The CUDA NVCC compiler requires flags to determine which hardware you
+want to target for in terms of SASS (real hardware) or PTX (JIT kernels).
+
+Nixpkgs tries to target support real architecture defaults based on the
+CUDA toolkit version with PTX support for future hardware.  Experienced
+users may optmize this configuration for a variety of reasons such as
+reducing binary size and compile time, supporting legacy hardware, or
+optimizing for specific hardware.
+
+You may provide capabilities to add support or reduce binary size through
+`config` using `cudaCapabilities = [ "6.0" "7.0" ];` and
 `cudaForwardCompat = true;` if you want PTX support for future hardware.
 
-You may further reduce final size by dropping static library output using
-`cudaRemoveStatic` in `config`.
+Please consult [GPUs supported](https://en.wikipedia.org/wiki/CUDA#GPUs_supported)
+for your specific card(s).
+
+Library maintainers should consult [NVCC Docs](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/)
+and release notes for their software package.

--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -32,3 +32,11 @@ mypkg = let
   }});
 in callPackage { inherit cudaPackages; };
 ```
+
+cudaPackages also provides a default set of cudaCapabilites for cards based on the
+CUDA version.  You may provide capabilities to add support or reduce
+binary size through `config` using `cudaCapabilities = [ "6.0" "7.0" ];` and
+`cudaForwardCompat = true;` if you want PTX support for future hardware.
+
+You may further reduce final size by dropping static library output using
+`cudaRemoveStatic` in `config`.

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -2,11 +2,10 @@
 , opencv3, gtest, blas, gomp, llvmPackages, perl
 , cudaSupport ? config.cudaSupport or false, cudaPackages ? {}, nvidia_x11
 , cudnnSupport ? cudaSupport
-, cudaCapabilities ? [ "3.7" "5.0" "6.0" "7.0" "7.5" "8.0" "8.6" ]
 }:
 
 let
-  inherit (cudaPackages) cudatoolkit cudnn;
+  inherit (cudaPackages) cudatoolkit cudaFlags cudnn;
 in
 
 assert cudnnSupport -> cudaSupport;
@@ -51,7 +50,7 @@ stdenv.mkDerivation rec {
       "-DUSE_OLDCMAKECUDA=ON"  # see https://github.com/apache/incubator-mxnet/issues/10743
       "-DCUDA_ARCH_NAME=All"
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
-      "-DMXNET_CUDA_ARCH=${lib.concatStringsSep ";" cudaCapabilities}"
+      "-DMXNET_CUDA_ARCH=${cudaFlags.cudaCapabilitiesSemiColonString}"
     ] else [ "-DUSE_CUDA=OFF" ])
     ++ lib.optional (!cudnnSupport) "-DUSE_CUDNN=OFF";
 

--- a/pkgs/development/compilers/cudatoolkit/extension.nix
+++ b/pkgs/development/compilers/cudatoolkit/extension.nix
@@ -10,6 +10,8 @@ final: prev: let
   ### Add classic cudatoolkit package
   cudatoolkit = buildCudaToolkitPackage ((attrs: attrs // { gcc = prev.pkgs.${attrs.gcc}; }) cudatoolkitVersions.${final.cudaVersion});
 
+  cudaFlags = final.callPackage ./flags.nix {};
+
 in {
-  inherit cudatoolkit;
+  inherit cudatoolkit cudaFlags;
 }

--- a/pkgs/development/compilers/cudatoolkit/flags.nix
+++ b/pkgs/development/compilers/cudatoolkit/flags.nix
@@ -4,6 +4,15 @@
 }:
 let
 
+  # Flags are determined based on your CUDA toolkit by default.  You may benefit
+  # from improved performance, reduced file size, or greater hardware suppport by
+  # passing a configuration based on your specific GPU environment.
+  #
+  # config.cudaCapabilities: list of hardware generations to support (e.g., "8.0")
+  # config.cudaForwardCompat: bool for compatibility with future GPU generations
+  #
+  # Please see the accompanying documentation or https://github.com/NixOS/nixpkgs/pull/205351
+
   defaultCudaCapabilities = rec {
     cuda9 = [
       "3.0"

--- a/pkgs/development/compilers/cudatoolkit/flags.nix
+++ b/pkgs/development/compilers/cudatoolkit/flags.nix
@@ -33,7 +33,7 @@ let
 
   };
 
-  cudaNames = {
+  cudaMicroarchitectureNames = {
     "3" = "Kepler";
     "5" = "Maxwell";
     "6" = "Pascal";
@@ -54,7 +54,7 @@ let
   cudaPTXArchs = archMapper "compute" cudaRealCapabilities;
   cudaArchs = cudaRealArchs ++ [ (lib.last cudaPTXArchs) ];
 
-  cudaArchNames = lib.unique (map (v: cudaNames.${lib.versions.major v}) cudaRealCapabilities);
+  cudaArchNames = lib.unique (map (v: cudaMicroarchitectureNames.${lib.versions.major v}) cudaRealCapabilities);
   cudaCapabilities = cudaRealCapabilities ++ lib.optional (config.cudaForwardCompat or true) capabilitiesForward;
   cudaGencode = gencodeMapper "sm" cudaRealCapabilities ++ lib.optionals (config.cudaForwardCompat or true) (gencodeMapper "compute" [ (lib.last cudaPTXArchs) ]);
 

--- a/pkgs/development/compilers/cudatoolkit/flags.nix
+++ b/pkgs/development/compilers/cudatoolkit/flags.nix
@@ -1,0 +1,69 @@
+{ config
+, lib
+, cudatoolkit
+}:
+let
+
+  defaultCudaCapabilities = rec {
+    cuda9 = [
+      "3.0"
+      "3.5"
+      "5.0"
+      "5.2"
+      "6.0"
+      "6.1"
+      "7.0"
+    ];
+
+    cuda10 = cuda9 ++ [
+      "7.5"
+    ];
+
+    cuda11 = [
+      "3.5"
+      "5.0"
+      "5.2"
+      "6.0"
+      "6.1"
+      "7.0"
+      "7.5"
+      "8.0"
+      "8.6"
+    ];
+
+  };
+
+  cudaNames = {
+    "3" = "Kepler";
+    "5" = "Maxwell";
+    "6" = "Pascal";
+    "7" = "Volta";
+    "8" = "Ampere";
+    "9" = "Hopper";
+  };
+
+  defaultCudaArchList = defaultCudaCapabilities."cuda${lib.versions.major cudatoolkit.version}";
+  cudaRealCapabilities = config.cudaCapabilities or defaultCudaArchList;
+  capabilitiesForward = "${lib.last cudaRealCapabilities}+PTX";
+
+  dropDot = ver: builtins.replaceStrings ["."] [""] ver;
+
+  archMapper = feat: map (ver: "${feat}_${dropDot ver}");
+  gencodeMapper = feat: map (ver: "-gencode=arch=compute_${dropDot ver},code=${feat}_${dropDot ver}");
+  cudaRealArchs = archMapper "sm" cudaRealCapabilities;
+  cudaPTXArchs = archMapper "compute" cudaRealCapabilities;
+  cudaArchs = cudaRealArchs ++ [ (lib.last cudaPTXArchs) ];
+
+  cudaArchNames = lib.unique (map (v: cudaNames.${lib.versions.major v}) cudaRealCapabilities);
+  cudaCapabilities = cudaRealCapabilities ++ lib.optional (config.cudaForwardCompat or true) capabilitiesForward;
+  cudaGencode = gencodeMapper "sm" cudaRealCapabilities ++ lib.optionals (config.cudaForwardCompat or true) (gencodeMapper "compute" [ (lib.last cudaPTXArchs) ]);
+
+  cudaCapabilitiesCommaString = lib.strings.concatStringsSep "," cudaCapabilities;
+  cudaCapabilitiesSemiColonString = lib.strings.concatStringsSep ";" cudaCapabilities;
+  cudaRealCapabilitiesCommaString = lib.strings.concatStringsSep "," cudaRealCapabilities;
+
+in
+{
+   inherit cudaArchs cudaArchNames cudaCapabilities cudaCapabilitiesCommaString cudaCapabilitiesSemiColonString
+     cudaRealCapabilities cudaRealCapabilitiesCommaString cudaGencode cudaRealArchs cudaPTXArchs;
+}

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -2,6 +2,7 @@
 , lib
 , zlib
 , useCudatoolkitRunfile ? false
+, config
 , cudaVersion
 , cudaMajorVersion
 , cudatoolkit # if cuda>=11: only used for .cc
@@ -9,14 +10,14 @@
 , autoPatchelfHook
 , autoAddOpenGLRunpathHook
 , fetchurl
-, # The distributed version of CUDNN includes both dynamically liked .so files,
+, # The distributed version of CUDNN includes both dynamically linked .so files,
   # as well as statically linked .a files.  However, CUDNN is quite large
   # (multiple gigabytes), so you can save some space in your nix store by
   # removing the statically linked libraries if you are not using them.
   #
   # Setting this to true removes the statically linked .a files.
   # Setting this to false keeps these statically linked .a files.
-  removeStatic ? false
+  removeStatic ? config.cudaRemoveStatic or false
 }:
 
 { fullVersion

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -2,7 +2,6 @@
 , lib
 , zlib
 , useCudatoolkitRunfile ? false
-, config
 , cudaVersion
 , cudaMajorVersion
 , cudatoolkit # if cuda>=11: only used for .cc
@@ -10,14 +9,14 @@
 , autoPatchelfHook
 , autoAddOpenGLRunpathHook
 , fetchurl
-, # The distributed version of CUDNN includes both dynamically linked .so files,
+, # The distributed version of CUDNN includes both dynamically liked .so files,
   # as well as statically linked .a files.  However, CUDNN is quite large
   # (multiple gigabytes), so you can save some space in your nix store by
   # removing the statically linked libraries if you are not using them.
   #
   # Setting this to true removes the statically linked .a files.
   # Setting this to false keeps these statically linked .a files.
-  removeStatic ? config.cudaRemoveStatic or false
+  removeStatic ? false
 }:
 
 { fullVersion

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -41,7 +41,6 @@
 , zlib
 
   # CUDA flags:
-, cudaCapabilities ? [ "sm_35" "sm_50" "sm_60" "sm_70" "sm_75" "compute_80" ]
 , cudaSupport ? false
 , cudaPackages ? {}
 
@@ -50,7 +49,7 @@
 }:
 
 let
-  inherit (cudaPackages) cudatoolkit cudnn nccl;
+  inherit (cudaPackages) cudatoolkit cudaFlags cudnn nccl;
 
   pname = "jaxlib";
   version = "0.3.22";
@@ -165,7 +164,7 @@ let
       build --action_env TF_CUDA_PATHS="${cudatoolkit_joined},${cudnn},${nccl}"
       build --action_env TF_CUDA_VERSION="${lib.versions.majorMinor cudatoolkit.version}"
       build --action_env TF_CUDNN_VERSION="${lib.versions.major cudnn.version}"
-      build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="${lib.concatStringsSep "," cudaCapabilities}"
+      build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="${cudaFlags.cudaRealCapabilitiesCommaString}"
     '' + ''
       CFG
     '';

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -22,8 +22,6 @@
 , tensorboardSupport ? true
 # XLA without CUDA is broken
 , xlaSupport ? cudaSupport
-# Default from ./configure script
-, cudaCapabilities ? [ "sm_35" "sm_50" "sm_60" "sm_70" "sm_75" "compute_80" ]
 , sse42Support ? stdenv.hostPlatform.sse4_2Support
 , avx2Support  ? stdenv.hostPlatform.avx2Support
 , fmaSupport   ? stdenv.hostPlatform.fmaSupport
@@ -32,7 +30,7 @@
 }:
 
 let
-  inherit (cudaPackages) cudatoolkit cudnn nccl;
+  inherit (cudaPackages) cudatoolkit cudaFlags cudnn nccl;
 in
 
 assert cudaSupport -> cudatoolkit != null
@@ -305,7 +303,7 @@ let
     TF_CUDA_PATHS = lib.optionalString cudaSupport "${cudatoolkit_joined},${cudnn},${nccl}";
     GCC_HOST_COMPILER_PREFIX = lib.optionalString cudaSupport "${cudatoolkit_cc_joined}/bin";
     GCC_HOST_COMPILER_PATH = lib.optionalString cudaSupport "${cudatoolkit_cc_joined}/bin/gcc";
-    TF_CUDA_COMPUTE_CAPABILITIES = lib.concatStringsSep "," cudaCapabilities;
+    TF_CUDA_COMPUTE_CAPABILITIES= builtins.concatStringsSep "," cudaFlags.cudaRealArchs;
 
     postPatch = ''
       # bazel 3.3 should work just as well as bazel 3.1

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -303,7 +303,7 @@ let
     TF_CUDA_PATHS = lib.optionalString cudaSupport "${cudatoolkit_joined},${cudnn},${nccl}";
     GCC_HOST_COMPILER_PREFIX = lib.optionalString cudaSupport "${cudatoolkit_cc_joined}/bin";
     GCC_HOST_COMPILER_PATH = lib.optionalString cudaSupport "${cudatoolkit_cc_joined}/bin/gcc";
-    TF_CUDA_COMPUTE_CAPABILITIES= builtins.concatStringsSep "," cudaFlags.cudaRealArchs;
+    TF_CUDA_COMPUTE_CAPABILITIES = builtins.concatStringsSep "," cudaFlags.cudaRealArchs;
 
     postPatch = ''
       # bazel 3.3 should work just as well as bazel 3.1

--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -15,7 +15,7 @@
 }:
 
 let
-  inherit (torch.cudaPackages) cudatoolkit cudnn;
+  inherit (torch.cudaPackages) cudatoolkit cudaFlags cudnn;
 
   cudatoolkit_joined = symlinkJoin {
     name = "${cudatoolkit.name}-unsplit";
@@ -45,7 +45,7 @@ in buildPythonPackage rec {
   propagatedBuildInputs = [ numpy pillow torch scipy ];
 
   preBuild = lib.optionalString cudaSupport ''
-    export TORCH_CUDA_ARCH_LIST="${cudaArchStr}"
+    export TORCH_CUDA_ARCH_LIST="${cudaFlags.cudaCapabilitiesSemiColonString}"
     export FORCE_CUDA=1
   '';
 


### PR DESCRIPTION
###### Description of changes

cudaPackages in Nix provides a central place for the CUDA environment in Nix and there has been a migration of relevant packages into that space.  Unfortunately, Nix continues to apply code generation decisions at a local package level and presently those are applied inconsistently.

This change:

- Introduces a single "cudaCapabilities" that applies across a build through `cudaPackages.cudaFlags`
- Makes common conventions (Arch, Names, and Flags) available via `cudaPackages` to package developers
- Provides a simple user override via Nix's `config` to alter compile flags, translating as needed for the packages
- Fixes upstream typos

Examples of flags available following the change:
```
nix-repl> pkgs.cudaPackages.cudaFlags.cudaCapabilities
[ "3.5" "5.0" "5.2" "6.0" "6.1" "7.0" "7.5" "8.0" "8.6" "8.6+PTX" ]

nix-repl> pkgs.cudaPackages.cudaFlags.cudaCapabilitiesCommaString
"3.5,5.0,5.2,6.0,6.1,7.0,7.5,8.0,8.6,8.6+PTX"

nix-repl> pkgs.cudaPackages.cudaFlags.cudaArchNames
[ "Kepler" "Maxwell" "Pascal" "Volta" "Ampere" ]
```

Note: In this PR I've tried to choose flags that represent what Nix does presently and are supported by the toolkit versions. I am not partial to any particular choice here (other than it be consistent across packages) and expect experienced users will override them anyway for their own tradeoffs (support of new hardware or reduced final binary size).  Improvements welcome!

@samuela @NixOS/cuda-maintainers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
$ nix-build pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks --arg supportedSystems '[ "aarch64-darwin" "aarch64-linux" "x86_64-linux" "x86_64-darwin"  ]
/nix/store/jy2q5cb9rwmx87jdd611381wmb0cqbj5-nixpkgs-release-checks
$ nix-build --expr 'with (import ./. {}).pkgs; python3.withPackages(ps: with ps; [ jaxlib pytorch tensorflow torchvision ])'
/nix/store/cifn082kdcd5fwxrh55rcnazybmalcvs-python3-3.10.8-env
$ nix-build --expr 'with (import ./. { config = { allowUnfree = true; cudaSupport = true; }; }).pkgs; magma' $EXTRA
/nix/store/h1jssha9fzkcww1xhqpsbynvam4srx5c-magma-2.6.2
$ nix-build --expr 'with (import ./. { config = { allowUnfree = true; cudaSupport = true; }; }).pkgs; python3.withPackages(ps: with ps; [ jaxlib pytorch tensorflow torchvision ])'
/nix/store/p8lk2z3y60zz34ckzza8ag2v390za8qj-python3-3.10.8-env
# mxnet is presently marked as broken but was updated to be consistent
```
