### PR TITLE
catppuccin-gtk: 0.2.7 -> 0.4.1

### DIFF
--- a/pkgs/data/themes/catppuccin-gtk/default.nix
+++ b/pkgs/data/themes/catppuccin-gtk/default.nix
@@ -2,67 +2,71 @@
 , stdenvNoCC
 , fetchFromGitHub
 , gtk3
+, colloid-gtk-theme
 , gnome-themes-extra
 , gtk-engine-murrine
+, python3
 , sassc
-, tweaks ? [ ]
+, accents ? [ "blue" ]
 , size ? "standard"
+, tweaks ? [ ]
+, variant ? "frappe"
 }:
 let
+  validAccents = [ "blue" "flamingo" "green" "lavender" "maroon" "mauve" "peach" "pink" "red" "rosewater" "sapphire" "sky" "teal" "yellow" ];
   validSizes = [ "standard" "compact" ];
-  validTweaks = [ "nord" "dracula" "black" "rimless" "normal" ];
+  validTweaks = [ "black" "rimless" "normal" ];
+  validVariants = [ "latte" "frappe" "macchiato" "mocha" ];
 
-  unknownTweaks = lib.subtractLists validTweaks tweaks;
-  illegalMix = (lib.elem "nord" tweaks) && (lib.elem "dracula" tweaks);
-
-  assertIllegal = lib.assertMsg (!illegalMix) ''
-    Tweaks "nord" and "dracula" cannot be mixed. Tweaks: ${toString tweaks}
-  '';
-
-  assertSize = lib.assertMsg (lib.elem size validSizes) ''
-    You entered a wrong size: ${size}
-    Valid sizes are: ${toString validSizes}
-  '';
-
-  assertUnknown = lib.assertMsg (unknownTweaks == [ ]) ''
-    You entered wrong tweaks: ${toString unknownTweaks}
-    Valid tweaks are: ${toString validTweaks}
-  '';
+  pname = "catppuccin-gtk";
 in
 
-assert assertIllegal;
-assert assertSize;
-assert assertUnknown;
+lib.checkListOfEnum "${pname}: theme accent" validAccents accents
+lib.checkListOfEnum "${pname}: color variant" validVariants [variant]
+lib.checkListOfEnum "${pname}: size variant" validSizes [size]
+lib.checkListOfEnum "${pname}: tweaks" validTweaks tweaks
 
 stdenvNoCC.mkDerivation rec {
-  pname = "catppuccin-gtk";
-  version = "0.2.7";
+  inherit pname;
+  version = "0.4.1";
 
   src = fetchFromGitHub {
-    repo = "gtk";
     owner = "catppuccin";
-    rev = "v-${version}";
-    sha256 = "sha256-oTAfURHMWqlKHk4CNz5cn6vO/7GmQJM2rXXGDz2e+0w=";
+    repo = "gtk";
+    rev = "v${version}";
+    sha256 = "sha256-dzRXt9/OdPyiy3mu9pmPYeu69OXCnR+zEqbD1C5BKqM=";
   };
 
   nativeBuildInputs = [ gtk3 sassc ];
 
-  buildInputs = [ gnome-themes-extra ];
+  buildInputs = [
+    gnome-themes-extra
+    (python3.withPackages (ps: [ ps.catppuccin ]))
+  ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
+  postUnpack = ''
+    rm -rf source/colloid
+    cp -r ${colloid-gtk-theme.src} source/colloid
+    chmod -R +w source/colloid
+  '';
+
   postPatch = ''
-    patchShebangs --build clean-old-theme.sh install.sh
+    patchShebangs --build colloid/clean-old-theme.sh colloid/install.sh
   '';
 
   installPhase = ''
     runHook preInstall
 
+    mkdir -p $out/share/themes
     export HOME=$(mktemp -d)
 
-    bash install.sh -d $out/share/themes -t all \
-      ${lib.optionalString (size != "") "-s ${size}"} \
-      ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks}
+    python3 install.py ${variant} \
+      ${lib.optionalString (accents != []) "--accent " + builtins.toString accents} \
+      ${lib.optionalString (size != []) "--size " + size} \
+      ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks} \
+      --dest $out/share/themes
 
     runHook postInstall
   '';

--- a/pkgs/development/python-modules/catppuccin/default.nix
+++ b/pkgs/development/python-modules/catppuccin/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, pygments
+}:
+
+buildPythonPackage rec {
+  pname = "catppuccin";
+  version = "1.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-mHNuV3yIuFL2cixDOr+//+/b9iD2fN82cfLzZkegxKc=";
+  };
+
+  propagatedBuildInputs = [ pygments ];
+
+  pythonImportsCheck = [ "catppuccin" ];
+
+  meta = with lib; {
+    description = "Soothing pastel theme for Python";
+    homepage = "https://github.com/catppuccin/python";
+    maintainers = with maintainers; [ fufexan ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1550,6 +1550,8 @@ self: super: with self; {
 
   catboost = callPackage ../development/python-modules/catboost { };
 
+  catppuccin = callPackage ../development/python-modules/catppuccin { };
+
   cattrs = callPackage ../development/python-modules/cattrs { };
 
   cbeams = callPackage ../misc/cbeams { };


### PR DESCRIPTION
###### Description of changes

Update `catppuccin-gtk` and add new python module for it.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
