### PR TITLE
cvc4: Use cmakeFlags

### DIFF
--- a/pkgs/applications/science/logic/cvc4/default.nix
+++ b/pkgs/applications/science/logic/cvc4/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, cln, gmp, git, swig, pkg-config
-, readline, libantlr3c, boost, jdk, python3, antlr3_4
+, readline, libantlr3c, boost, jdk, python3, antlr3_4, symfpu
 }:
 
 stdenv.mkDerivation rec {
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ gmp git python3.pkgs.toml readline swig libantlr3c antlr3_4 boost jdk python3 ]
     ++ lib.optionals (!stdenv.isDarwin) [ cln ];
+  propagatedBuildInputs = [ symfpu ];
 
   prePatch = ''
     patch -p1 -i ${./minisat-fenv.patch} -d src/prop/minisat
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_SWIG_BINDINGS_PYTHON=ON"
     "-DENABLE_GPL=ON"
     "-DUSE_READLINE=ON"
+    "-DUSE_SYMFPU=ON"
   ] ++  lib.optionals (!stdenv.isDarwin) [
     "-DUSE_CLN=ON"
   ];

--- a/pkgs/applications/science/logic/cvc4/default.nix
+++ b/pkgs/applications/science/logic/cvc4/default.nix
@@ -16,12 +16,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ gmp git python3.pkgs.toml readline swig libantlr3c antlr3_4 boost jdk python3 ]
     ++ lib.optionals (!stdenv.isDarwin) [ cln ];
-  configureFlags = [
-    "--enable-language-bindings=c,c++,java"
-    "--enable-gpl"
-    "--with-readline"
-    "--with-boost=${boost.dev}"
-  ] ++ lib.optionals (!stdenv.isDarwin) [ "--with-cln" ];
 
   prePatch = ''
     patch -p1 -i ${./minisat-fenv.patch} -d src/prop/minisat
@@ -33,6 +27,12 @@ stdenv.mkDerivation rec {
   '';
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Production"
+    "-DBUILD_SWIG_BINDINGS_JAVA=ON"
+    "-DBUILD_SWIG_BINDINGS_PYTHON=ON"
+    "-DENABLE_GPL=ON"
+    "-DUSE_READLINE=ON"
+  ] ++  lib.optionals (!stdenv.isDarwin) [
+    "-DUSE_CLN=ON"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

cvc4 uses CMake to build but has still `configureFlags`. Migrate them to `cmakeFlags`.
Add symfpu as dependency.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

