### PR TITLE
tsm-client: 8.1.15.1 -> 8.1.17.0

### DIFF
--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -53,17 +53,14 @@
 # going to the `downloadPage` (see `meta` below).
 # Find the "Backup-archive client" table on that page.
 # Look for "Download Documents" of the latest release.
-# Here, two links must be checked if existing:
-# * "IBM Spectrum Protect Client ... Downloads and READMEs":
-#   In the table at the page's bottom,
-#   check the date of the "Linux x86_64 client"
-# * "IBM Spectrum Protect BA client ... interim fix downloads"
-# Look for the "Linux x86_64 client ..." rows
-# in the table at the bottom of each page.
-# Follow the "HTTPS" link of the row with the latest date stamp.
-# In the directory listing to show up, pick the big `.tar` file.
+# Follow the "Download Information" link.
+# Look for the "Linux x86_64 client ..." rows in the table at
+# the bottom of the page and follow their "HTTPS" links (one
+# link per row -- each link might point to the latest release).
+# In the directory listings to show up,
+# check the big `.tar` file.
 #
-# (as of 2022-09-29)
+# (as of 2022-12-10)
 
 
 let
@@ -108,10 +105,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.15.2";
+    version = "8.1.17.0";
     src = fetchurl {
       url = mkSrcUrl version;
-      hash = "sha512-ljygVoW7zR+LVHf4LSoBn3qEHISobsxheLxs9NyKWQiwPWpfhSgJO+bX4QRzAmrpSTNrETxHkuXqzGSHaaBlzg==";
+      hash = "sha512-MP8BjnESFoEzl6jdhtuwX9PolDF7o4QL7i1NeDV0ltIJMUOqSeAULpTJ1bbErJokJSbrj41kDwMVI+ZuAUb1eA==";
     };
     inherit meta passthru;
 


### PR DESCRIPTION
###### Description of changes

IBM's "Authorized Program Analysis Report"s (something like release notes): https://www.ibm.com/support/pages/node/6845804
README: https://www.ibm.com/support/pages/node/617857#8117Readme
Security Bulletin: https://www.ibm.com/support/pages/node/6842073 (CVE-2022-34165, CVE-2022-42003, CVE-2022-42004, CVE-2021-33813, CVE-2018-25032)

~~Note that the old download link structure no longer works.  Also the security bulletins seem to be no longer public.  Luckily, there is a new download link -- time will tell if further updates are also published there.  Until then, I just put the verbatim download URL in the `url` field.  Details are in the commit message.~~  The new version is in the usual place again.

Both test derivations still build fine.  I also tested the client with the tsm-backup nixos module and a real TSM server and file upload worked fine.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>tsm-client</li>
    <li>tsm-client-withGui</li>
  </ul>
</details>
