### PR TITLE
libax25: init at 0.0.12-rc5

### DIFF
--- a/pkgs/development/libraries/libax25/default.nix
+++ b/pkgs/development/libraries/libax25/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, fetchurl
+, glibc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libax25";
+  version = "0.0.12-rc5";
+
+  buildInputs = [ glibc ] ++ lib.optional stdenv.hostPlatform.isStatic [ glibc.static ];
+
+  # Due to recent unsolvable administrative domain problems with linux-ax25.org,
+  # the new domain is linux-ax25.in-berlin.de
+  src = fetchurl {
+    url = "https://linux-ax25.in-berlin.de/pub/ax25-lib/libax25-${version}.tar.gz";
+    hash = "sha256-vxV5GVDOHr38N/512ArZpnZ+a7FTbXBNpoSJkc9DI98=";
+  };
+
+  configureFlags = [ "--sysconfdir=/etc" ];
+
+  LDFLAGS = lib.optionals stdenv.hostPlatform.isStatic [ "-static-libgcc" "-static" ];
+
+  meta = with lib; {
+    description = "AX.25 library for hamradio applications";
+    homepage = "https://linux-ax25.in-berlin.de/wiki/Main_Page";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ sarcasticadmin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25435,6 +25435,8 @@ with pkgs;
 
   libatasmart = callPackage ../os-specific/linux/libatasmart { };
 
+  libax25 = callPackage ../development/libraries/libax25 { };
+
   libcgroup = callPackage ../os-specific/linux/libcgroup { };
 
   libkrun = callPackage ../development/libraries/libkrun {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`libax25` is an AX.25 library for hamradio applications that provides a set of functions making it easier to write hamradio programs. Adding `libax25` so that more ham related pkgs that depend on this library can be added to nixpkgs: `ax25call`, `pat`, etc. A couple of things to note:
 - The home for this repo was recently moved from http://linux-ax25.org to https://linux-ax25.in-berlin.de/
 - The kernel module `AX25` needs to be installed into the kernel to use this library (example: https://github.com/sarcasticadmin/ham-overlay/blob/master/iso.nix#L16)
 - There was a new grant given to revamp the ax.25 stack in the linux kernel (12/2021): https://www.ampr.org/apply/grants/2021-grants/grant-fixing-the-linux-kernel-ax-25/  

Originally tested an overlay of mine: https://github.com/sarcasticadmin/ham-overlay/blob/master/pkgs/libax25/default.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

CC: @pkharvey