### PR TITLE
catfs: unstable-2020-03-21 -> 0.9.0

### DIFF
--- a/pkgs/os-specific/linux/catfs/default.nix
+++ b/pkgs/os-specific/linux/catfs/default.nix
@@ -6,24 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "catfs";
-  version = "unstable-2020-03-21";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "kahing";
     repo = pname;
-    rev = "daa2b85798fa8ca38306242d51cbc39ed122e271";
-    sha256 = "0zca0c4n2p9s5kn8c9f9lyxdf3df88a63nmhprpgflj86bh8wgf5";
+    rev = "v${version}";
+    hash = "sha256-OvmtU2jpewP5EqPwEFAf67t8UCI1WuzUO2QQj4cH1Ak=";
   };
 
-  cargoSha256 = "1agcwq409s40kyij487wjrp8mj7942r9l2nqwks4xqlfb0bvaimf";
-
-  cargoPatches = [
-    # update cargo lock
-    (fetchpatch {
-      url = "https://github.com/kahing/catfs/commit/f838c1cf862cec3f1d862492e5be82b6dbe16ac5.patch";
-      sha256 = "1r1p0vbr3j9xyj9r1ahipg4acii3m4ni4m9mp3avbi1rfgzhblhw";
-    })
-  ];
+  cargoHash = "sha256-xF1J2Pr4qtNFcd2kec4tnbdYxoLK+jRnzp8p+cmNOcI=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/os-specific/linux/catfs/default.nix
+++ b/pkgs/os-specific/linux/catfs/default.nix
@@ -15,6 +15,11 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-OvmtU2jpewP5EqPwEFAf67t8UCI1WuzUO2QQj4cH1Ak=";
   };
 
+  patches = [
+    # monitor https://github.com/kahing/catfs/issues/71
+    ./fix-for-rust-1.65.diff
+  ];
+
   cargoHash = "sha256-xF1J2Pr4qtNFcd2kec4tnbdYxoLK+jRnzp8p+cmNOcI=";
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/os-specific/linux/catfs/fix-for-rust-1.65.diff
+++ b/pkgs/os-specific/linux/catfs/fix-for-rust-1.65.diff
@@ -1,0 +1,13 @@
+diff --git a/src/catfs/file.rs b/src/catfs/file.rs
+index 6e781eb..92fdd80 100644
+--- a/src/catfs/file.rs
++++ b/src/catfs/file.rs
+@@ -569,7 +569,7 @@ impl Handle {
+         path: &dyn AsRef<Path>,
+         create: bool,
+     ) -> error::Result<()> {
+-        let _ = self.page_in_res.0.lock().unwrap();
++        drop(self.page_in_res.0.lock().unwrap());
+ 
+         let mut buf = [0u8; 0];
+         let mut flags = rlibc::O_RDWR;


### PR DESCRIPTION
###### Description of changes

https://github.com/kahing/catfs/releases/tag/v0.9.0

This broke when Rust upgraded in https://github.com/NixOS/nixpkgs/pull/199664. Rust has added a new default lint in https://github.com/rust-lang/rust/pull/97739 that requires code changes upstream.

I've added a patch that keeps the current behavior and fixes the lint warning. Not upstreaming because it's not obvious to me that it's the proper upstream fix, but the current behavior doesn't look harmful. We can monitor https://github.com/kahing/catfs/issues/71 for a full resolution.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
