### PR TITLE
nixos: add configuration for firewalld

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -829,6 +829,7 @@
   ./services/networking/firewall.nix
   ./services/networking/firewall-iptables.nix
   ./services/networking/firewall-nftables.nix
+  ./services/networking/firewalld.nix
   ./services/networking/flannel.nix
   ./services/networking/freenet.nix
   ./services/networking/freeradius.nix

--- a/nixos/modules/services/networking/firewalld.nix
+++ b/nixos/modules/services/networking/firewalld.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.firewalld;
+in
+{
+  options.services.firewalld = {
+    enable = lib.mkEnableOption (lib.mdDoc ''
+      Whether to enable DBus-enabled firewall daemon.
+
+      ::: {.warning}
+      Enabling this service WILL disable the existing NixOS
+      firewall! Default firewall rules provided by packages are not
+      considered at the moment.
+      :::
+    '');
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.firewalld;
+      defaultText = lib.literalExpression "pkgs.firewalld";
+      description = lib.mdDoc "The firewalld package to use.";
+    };
+
+    config = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = {};
+      example = {
+        DefaultZone = "drop";
+      };
+      description = lib.mdDoc ''
+        Each attribute in this set specifies an option in firewalld.conf.
+
+        If set to non-empty, the permanent configuration will be immutable and
+        cannot be modified via firewalld. The runtime configuration remains mutable.
+
+        Refer to [`firewalld.conf(5)`](https://firewalld.org/documentation/man-pages/firewalld.conf.html)
+        for available configuration options.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable) {
+    networking.firewall.enable = false;
+    security.polkit.enable = lib.mkDefault true;
+
+    environment.systemPackages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+
+    environment.etc."firewalld/firewalld.conf" = lib.mkIf (cfg.config != {}) {
+      text = lib.generators.toKeyValue {} cfg.config;
+    };
+
+    systemd.services.firewalld = {
+      aliases = [ "dbus-org.fedoraproject.FirewallD1.service" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -218,6 +218,7 @@ in {
   firejail = handleTest ./firejail.nix {};
   firewall = handleTest ./firewall.nix { nftables = false; };
   firewall-nftables = handleTest ./firewall.nix { nftables = true; };
+  firewalld = handleTest ./firewalld.nix {};
   fish = handleTest ./fish.nix {};
   flannel = handleTestOn ["x86_64-linux"] ./flannel.nix {};
   fluentd = handleTest ./fluentd.nix {};

--- a/nixos/tests/firewalld.nix
+++ b/nixos/tests/firewalld.nix
@@ -1,0 +1,55 @@
+import ./make-test-python.nix {
+  name = "firewalld";
+
+  nodes = {
+    walled = {
+      services.firewalld.enable = true;
+      services.httpd.enable = true;
+      services.httpd.adminAddr = "foo@example.org";
+    };
+
+    open = {
+      services.firewalld = {
+        enable = true;
+        config.DefaultZone = "trusted";
+      };
+      services.httpd.enable = true;
+      services.httpd.adminAddr = "foo@example.org";
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    walled.wait_for_unit("firewalld");
+    walled.wait_for_unit("httpd")
+
+    open.wait_for_unit("network.target")
+
+    with subtest("enable denial logging"):
+      walled.succeed("firewall-cmd --set-log-denied=all")
+      walled.succeed("firewall-cmd --runtime-to-permanent")
+
+    with subtest("walled local httpd works"):
+      walled.succeed("curl -v http://localhost/ >&2")
+
+    with subtest("incoming connections are blocked"):
+      open.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
+
+    with subtest("outgoing connections are allowed"):
+      walled.succeed("curl -v http://open/ >&2")
+
+    with subtest("runtime configuration can be changed"):
+      walled.succeed("firewall-cmd --add-service=http")
+      open.succeed("curl -v http://walled/ >&2")
+
+    with subtest("runtime configuration are not permanent"):
+      walled.succeed("firewall-cmd --complete-reload")
+      open.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
+
+    with subtest("permanent configuration are permanent"):
+      walled.succeed("firewall-cmd --add-service=http --permanent")
+      walled.succeed("firewall-cmd --complete-reload")
+      open.succeed("curl -v http://walled/ >&2")
+  '';
+}

--- a/pkgs/applications/networking/firewalld/default.nix
+++ b/pkgs/applications/networking/firewalld/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nixosTests
 , autoreconfHook
 , bash
 , docbook_xml_dtd_42
@@ -102,6 +103,8 @@ stdenv.mkDerivation rec {
     wrapPythonProgramsIn "$out/bin" "$out ${pythonPath}"
     wrapPythonProgramsIn "$out/share/firewalld/testsuite/python" "$out ${pythonPath}"
   '';
+
+  passthru.tests = nixosTests.firewalld;
 
   meta = with lib; {
     description = "Firewall daemon with D-Bus interface";

--- a/pkgs/applications/networking/firewalld/default.nix
+++ b/pkgs/applications/networking/firewalld/default.nix
@@ -46,7 +46,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/firewall/config/__init__.py.in \
-      --replace "/usr/share" "$out/share"
+      --replace "/usr/share" "$out/share" \
+      --replace "/usr/lib/" "$out/lib/"
 
     for file in config/firewall-{applet,config}.desktop.in; do
       substituteInPlace $file \

--- a/pkgs/applications/networking/firewalld/default.nix
+++ b/pkgs/applications/networking/firewalld/default.nix
@@ -12,9 +12,11 @@
 , libnotify
 , libxml2
 , libxslt
+, networkmanager
 , networkmanagerapplet
 , pkg-config
 , python3
+, wrapQtAppsHook
 , wrapGAppsNoGuiHook
 , withGui ? false
 }:
@@ -55,13 +57,14 @@ stdenv.mkDerivation rec {
     done
   '' + lib.optionalString withGui ''
     substituteInPlace src/firewall-applet.in \
-      --replace "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-conenction-editor"
+      --replace "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-connection-editor"
   '';
 
   nativeBuildInputs = [
     autoreconfHook
     docbook_xml_dtd_42
     docbook-xsl-nons
+    gobject-introspection
     glib
     intltool
     libxml2
@@ -69,14 +72,15 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     python3.pkgs.wrapPython
-  ] ++ lib.optionals withGui [
-    gobject-introspection
     wrapGAppsNoGuiHook
+  ] ++ lib.optionals withGui [
+    wrapQtAppsHook
   ];
 
   buildInputs = [
     bash
     glib
+    networkmanager
   ] ++ lib.optionals withGui [
     gtk3
     libnotify
@@ -84,9 +88,12 @@ stdenv.mkDerivation rec {
   ];
 
   dontWrapGApps = true;
+  dontWrapQtApps = true;
 
-  preFixup = lib.optionalString withGui ''
+  preFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '' + lib.optionalString withGui ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   postFixup = ''

--- a/pkgs/applications/networking/firewalld/default.nix
+++ b/pkgs/applications/networking/firewalld/default.nix
@@ -109,6 +109,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Firewall daemon with D-Bus interface";
     homepage = "https://github.com/firewalld/firewalld";
+    platforms = platforms.linux;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ SuperSandro2000 ];
   };

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -29,6 +29,13 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional withXtables iptables
     ++ lib.optional withPython python3;
 
+  patches = [ ./fix-py-libnftables.patch ];
+
+  postPatch = ''
+    substituteInPlace "py/nftables.py" \
+      --subst-var-by "out" "$out"
+  '';
+
   configureFlags = [
     "--with-json"
     "--with-cli=editline"

--- a/pkgs/os-specific/linux/nftables/fix-py-libnftables.patch
+++ b/pkgs/os-specific/linux/nftables/fix-py-libnftables.patch
@@ -1,0 +1,13 @@
+diff --git a/py/nftables.py b/py/nftables.py
+index 6daeafc2..07e2c048 100644
+--- a/py/nftables.py
++++ b/py/nftables.py
+@@ -64,7 +64,7 @@ class Nftables:
+ 
+     validator = None
+ 
+-    def __init__(self, sofile="libnftables.so.1"):
++    def __init__(self, sofile="@out@/lib/libnftables.so.1"):
+         """Instantiate a new Nftables class object.
+ 
+         Accepts a shared object file to open, by default standard search path

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28893,7 +28893,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  firewalld = callPackage ../applications/networking/firewalld { };
+  firewalld = libsForQt5.callPackage ../applications/networking/firewalld { };
 
   firewalld-gui = firewalld.override { withGui = true; };
 


### PR DESCRIPTION
###### Description of changes

Add new module to allow for configuration of firewalld.

This PR contains a couple auxiliary fixes:

- `nftables`: Fixed python module default SO import path.
- `firewalld`: Fixed `firewall-applet` and `networkmanager` integration.

I can split this into other PRs if that's desired.

TODO (in a future PR, maybe):

- Add an option to allow for overlaying extra default configurations. NetworkManager is known to ship with a zone configuration (disabled by default on NixOS, though).
- Patch `firewalld` to let it load base config from the default config directory (ie. `/lib/firewalld/firewalld.conf`). This should allow for `services.firewalld.config` to be used in tandem with ordinary user configs.

Fixes #165882
Fixes #249609

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
