### PR TITLE
awscli: 1.25.76 -> 1.27.38

### DIFF
--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -1,50 +1,57 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , botocore
 , jmespath
 , s3transfer
-, futures ? null
-, docutils
-, nose
-, mock
-, isPy3k
+, setuptools
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "boto3";
-  version = "1.24.75"; # N.B: if you change this, change botocore and awscli to a matching version
+  version = "1.26.38"; # N.B: if you change this, change botocore and awscli to a matching version
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-e/oiQt+bH6c+F/TX959rIlYPVdXaLifleOWF725LFKc=";
+  src = fetchFromGitHub {
+    owner = "boto";
+    repo = pname;
+    rev = version;
+    hash = "sha256-/QkR6gL0XkXofnFDcKa7J0ZbZbgT0IKnqtq2wcilbEs=";
   };
 
-  propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];
-  checkInputs = [ docutils nose mock ];
+  propagatedBuildInputs = [
+    botocore
+    jmespath
+    s3transfer
+    setuptools
+  ];
 
-  checkPhase = ''
-    runHook preCheck
-    # This method is not in mock. It might have appeared in some versions.
-    sed -i 's/action.assert_called_once()/self.assertEqual(action.call_count, 1)/' \
-      tests/unit/resources/test_factory.py
-    nosetests -d tests/unit --verbose
-    runHook postCheck
-  '';
+  doCheck = true;
 
-  # Network access
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  pythonImportsCheck = [ "boto3" ];
+  pythonImportsCheck = [
+    "boto3"
+  ];
 
-  meta = {
+  disabledTestPaths = [
+    # Integration tests require networking
+    "tests/integration"
+  ];
+
+  meta = with lib; {
     homepage = "https://github.com/boto/boto3";
-    license = lib.licenses.asl20;
+    changelog = "https://github.com/boto/boto3/blob/${version}/CHANGELOG.rst";
+    license = licenses.asl20;
     description = "AWS SDK for Python";
     longDescription = ''
       Boto3 is the Amazon Web Services (AWS) Software Development Kit (SDK) for
       Python, which allows Python developers to write software that makes use of
       services like Amazon S3 and Amazon EC2.
     '';
+    maintainers = with maintainers; [ anthonyroussel ];
   };
 }

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -4,43 +4,51 @@
 , python-dateutil
 , jmespath
 , docutils
-, simplejson
-, mock
-, nose
 , urllib3
+, pytestCheckHook
+, jsonschema
 }:
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.27.75"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.29.38"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-+LHaK0HojFjbUdsMbv9spWQliUjOSlrH6WrDWkabDU8=";
+    hash = "sha256-K5jH2oZozcAitNila1BoZFTQoQwRUYcC/eQYgdIGGLY=";
   };
 
   propagatedBuildInputs = [
     python-dateutil
     jmespath
     docutils
-    simplejson
     urllib3
   ];
 
-  checkInputs = [ mock nose ];
+  checkInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
 
-  checkPhase = ''
-    nosetests -v
-  '';
+  doCheck = true;
 
-  # Network access
-  doCheck = false;
+  disabledTestPaths = [
+    # Integration tests require networking
+    "tests/integration"
 
-  pythonImportsCheck = [ "botocore" ];
+    # Disable slow tests (only run unit tests)
+    "tests/functional"
+  ];
+
+  pythonImportsCheck = [
+    "botocore"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/boto/botocore";
+    changelog = "https://github.com/boto/botocore/blob/${version}/CHANGELOG.rst";
     license = licenses.asl20;
     description = "A low-level interface to a growing number of Amazon Web Services";
+    maintainers = with maintainers; [ anthonyroussel ];
   };
 }

--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -20,7 +20,6 @@
 , openapi-spec-validator
 , python-dateutil
 , python-jose
-, pytz
 , pyyaml
 , requests
 , responses
@@ -37,20 +36,15 @@
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "4.0.3";
+  version = "4.0.12";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-iutWdX5oavPkpj+Qr7yXPLIxrarYfFzonmiTbBCbC+k=";
+    hash = "sha256-MPjzFljxjNsV62JsjLOgdSDw2MIZMib7yzMmrhL7okY=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "werkzeug>=0.5,<2.2.0" "werkzeug>=0.5"
-  '';
 
   propagatedBuildInputs = [
     aws-xray-sdk
@@ -68,7 +62,6 @@ buildPythonPackage rec {
     openapi-spec-validator
     python-dateutil
     python-jose
-    pytz
     pyyaml
     requests
     responses
@@ -139,6 +132,8 @@ buildPythonPackage rec {
     "tests/test_awslambda/test_lambda_eventsourcemapping.py"
     "tests/test_awslambda/test_lambda_invoke.py"
     "tests/test_batch/test_batch_jobs.py"
+    "tests/test_kinesis/test_kinesis.py"
+    "tests/test_kinesis/test_kinesis_stream_consumers.py"
   ];
 
   disabledTests = [

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -28,11 +28,11 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli";
-  version = "1.25.76"; # N.B: if you change this, change botocore and boto3 to a matching version too
+  version = "1.27.38"; # N.B: if you change this, change botocore and boto3 to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-PSr0zZEGXFxcFSN7QQ5Ux0Z4aCwwm9na+2hIv/gR6+s=";
+    hash = "sha256-SjeFBWwfd+9sXcZL9NdqFyuBIQtql3KB3lnygeVVHU0=";
   };
 
   # https://github.com/aws/aws-cli/issues/4837
@@ -82,6 +82,7 @@ with py.pkgs; buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://aws.amazon.com/cli/";
+    changelog = "https://github.com/aws/aws-cli/blob/${version}/CHANGELOG.rst";
     description = "Unified tool to manage your AWS services";
     license = licenses.asl20;
     mainProgram = "aws";

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -49,7 +49,7 @@ with localPython.pkgs; buildPythonApplication rec {
     substituteInPlace setup.py \
       --replace "six>=1.11.0,<1.15.0" "six==1.16.0" \
       --replace "requests>=2.20.1,<=2.26" "requests==2.28.1" \
-      --replace "botocore>1.23.41,<1.24.0" "botocore>1.23.41,<1.27.76" \
+      --replace "botocore>1.23.41,<1.24.0" "botocore>1.23.41,<2" \
       --replace "pathspec==0.9.0" "pathspec>=0.10.0,<0.11.0" \
       --replace "colorama>=0.2.5,<0.4.4" "colorama>=0.2.5,<=0.4.6" \
       --replace "termcolor == 1.1.0" "termcolor>=2.0.0,<2.1.0"


### PR DESCRIPTION
###### Description of changes

* python310Packages.boto3: 1.24.75 -> 1.26.38
  * Enable tests
  * Added myself to maintainers

* python310Packages.botocore: 1.27.75 -> 1.29.38
  * Added myself to maintainers
  * Fix awsebcli build

* awscli: 1.25.76 -> 1.27.38

* python310Packages.moto: 4.0.3 -> 4.0.12
  * Tests was failing because of https://github.com/spulec/moto/pull/5632

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
