### PR TITLE
resholve: fold in python package deps

### DIFF
--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -22,6 +22,7 @@ rec {
   resholve = callPackage ./resholve.nix {
     inherit (source) rSrc version;
     inherit (deps.oil) oildev;
+    inherit (deps) configargparse;
     inherit resholve-utils;
   };
   # funcs to validate and phrase invocations of resholve

--- a/pkgs/development/misc/resholve/deps.nix
+++ b/pkgs/development/misc/resholve/deps.nix
@@ -1,4 +1,6 @@
-{ callPackage
+{ lib
+, callPackage
+, fetchFromGitHub
 , python27
 , ...
 }:
@@ -15,5 +17,64 @@
 
 rec {
   # binlore = callPackage ./binlore.nix { };
-  oil = callPackage ./oildev.nix { inherit python27; };
+  oil = callPackage ./oildev.nix {
+    inherit python27;
+    inherit six;
+    inherit typing;
+  };
+  configargparse = python27.pkgs.buildPythonPackage rec {
+    pname = "configargparse";
+    version = "1.5.3";
+
+    src = fetchFromGitHub {
+      owner = "bw2";
+      repo = "ConfigArgParse";
+      rev = "v${version}";
+      sha256 = "1dsai4bilkp2biy9swfdx2z0k4akw4lpvx12flmk00r80hzgbglz";
+    };
+
+    doCheck = false;
+
+    pythonImportsCheck = [ "configargparse" ];
+
+    meta = with lib; {
+      description = "A drop-in replacement for argparse";
+      homepage = "https://github.com/bw2/ConfigArgParse";
+      license = licenses.mit;
+    };
+  };
+  six = python27.pkgs.buildPythonPackage rec {
+    pname = "six";
+    version = "1.16.0";
+
+    src = python27.pkgs.fetchPypi {
+      inherit pname version;
+      sha256 = "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926";
+    };
+
+    doCheck = false;
+
+    meta = {
+      description = "A Python 2 and 3 compatibility library";
+      homepage = "https://pypi.python.org/pypi/six/";
+      license = lib.licenses.mit;
+    };
+  };
+  typing = python27.pkgs.buildPythonPackage rec {
+    pname = "typing";
+    version = "3.10.0.0";
+
+    src = python27.pkgs.fetchPypi {
+      inherit pname version;
+      sha256 = "13b4ad211f54ddbf93e5901a9967b1e07720c1d1b78d596ac6a439641aa1b130";
+    };
+
+    doCheck = false;
+
+    meta = with lib; {
+      description = "Backport of typing module to Python versions older than 3.5";
+      homepage = "https://docs.python.org/3/library/typing.html";
+      license = licenses.psfl;
+    };
+  };
 }

--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -13,6 +13,8 @@
 , cmark
 , file
 , glibcLocales
+, six
+, typing
 }:
 
 rec {
@@ -95,7 +97,7 @@ rec {
 
     nativeBuildInputs = [ re2c file makeWrapper ];
 
-    propagatedBuildInputs = with python27.pkgs; [ six typing ];
+    propagatedBuildInputs = [ six typing ];
 
     doCheck = true;
 

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -6,6 +6,7 @@
 , rSrc
 , version
 , oildev
+, configargparse
 , binlore
 , resholve-utils
 }:
@@ -19,7 +20,7 @@ python27.pkgs.buildPythonApplication {
 
   propagatedBuildInputs = [
     oildev
-    python27.pkgs.configargparse
+    configargparse
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Pull some python package expressions in to resholve's deps to protect it and dependents from breakages as py27 support is removed (or rots) across the python package set.

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>13 packages built:</summary>
  <ul>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>resholve</li>
    <li>shunit2</li>
    <li>yadm</li>
  </ul>
</details>

Result of `nixpkgs-review pr 205387` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>15 packages built:</summary>
  <ul>
    <li>arch-install-scripts</li>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>dgoss</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>resholve</li>
    <li>shunit2</li>
    <li>yadm</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @bobrik 