### PR TITLE
[staging-22.05] nss_latest|cacert: 3.86

### DIFF
--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -30,7 +30,7 @@ let
   ]));
   extraCertificatesBundle = writeText "cacert-extra-certificates-bundle.crt" (lib.concatStringsSep "\n\n" extraCertificateStrings);
 
-  srcVersion = "3.83";
+  srcVersion = "3.86";
   version = if nssOverride != null then nssOverride.version else srcVersion;
   meta = with lib; {
     homepage = "https://curl.haxx.se/docs/caextract.html";
@@ -45,7 +45,7 @@ let
 
     src = if nssOverride != null then nssOverride.src else fetchurl {
       url = "mirror://mozilla/security/nss/releases/NSS_${lib.replaceStrings ["."] ["_"] version}_RTM/src/nss-${version}.tar.gz";
-      sha256 = "sha256-qyPqZ/lkCQuLc8gKZ0CCVxw25fTrqSBXrGSMnB3vASg=";
+      sha256 = "sha256-PzhfxoZHa7uoEQNfpoIbVCR11VdHsYwgwiHU1mVzuXU=";
     };
 
     dontBuild = true;

--- a/pkgs/development/libraries/nss/85_security_load_3.85+.patch
+++ b/pkgs/development/libraries/nss/85_security_load_3.85+.patch
@@ -12,13 +12,13 @@ index ad8f3b84e..74676d039 100644
      if (!lib) {
          PR_fprintf(PR_STDERR, "loading softokn3 failed");
 diff --git nss/lib/pk11wrap/pk11load.c nss/lib/pk11wrap/pk11load.c
-index 9e7a0a546..a0a23a1a4 100644
+index 119c8c512..720d39ccc 100644
 --- nss/lib/pk11wrap/pk11load.c
 +++ nss/lib/pk11wrap/pk11load.c
-@@ -466,6 +466,15 @@ secmod_LoadPKCS11Module(SECMODModule *mod, SECMODModule **oldModule)
-          * unload the library if anything goes wrong from here on out...
-          */
+@@ -486,6 +486,15 @@ secmod_LoadPKCS11Module(SECMODModule *mod, SECMODModule **oldModule)
+ #else
          library = PR_LoadLibrary(mod->dllName);
+ #endif // defined(_WIN32)
 +#ifndef NSS_STATIC_SOFTOKEN
 +        if ((library == NULL) &&
 +            !rindex(mod->dllName, PR_GetDirectorySeparator())) {
@@ -32,7 +32,7 @@ index 9e7a0a546..a0a23a1a4 100644
  
          if (library == NULL) {
 diff --git nss/lib/util/secload.c nss/lib/util/secload.c
-index 12efd2f75..8b74478f6 100644
+index 1cebae4e2..9194bb761 100644
 --- nss/lib/util/secload.c
 +++ nss/lib/util/secload.c
 @@ -70,9 +70,14 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
@@ -66,8 +66,8 @@ index 12efd2f75..8b74478f6 100644
 @@ -89,6 +99,10 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
                                                         | PR_LD_ALT_SEARCH_PATH
  #endif
-                                           );
-+            if (! dlh) {
+             );
++            if (!dlh) {
 +                strcpy(fullName + referencePathSize, name);
 +                dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL);
 +            }

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -40,10 +40,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Based on http://patch-tracker.debian.org/patch/series/dl/nss/2:3.15.4-1/85_security_load.patch
-    (if (lib.versionOlder version "3.77") then
-      ./85_security_load.patch
-    else
+    (if (lib.versionOlder version "3.84") then
       ./85_security_load_3.77+.patch
+    else
+      ./85_security_load_3.85+.patch
     )
     ./fix-cross-compilation.patch
   ];

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,6 +5,6 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.84";
-  hash = "sha256-mjh//jUP8U8AHZQ/lswMBkiRVR1x4al6Xdv/5/EgeiU=";
+  version = "3.85";
+  hash = "sha256-r9nWRRCxFU3rvWyrNXHp/2SjNziY4DSD5Mhc2toT0pc=";
 }

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,6 +5,6 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.85";
-  hash = "sha256-r9nWRRCxFU3rvWyrNXHp/2SjNziY4DSD5Mhc2toT0pc=";
+  version = "3.86";
+  hash = "sha256-PzhfxoZHa7uoEQNfpoIbVCR11VdHsYwgwiHU1mVzuXU=";
 }


### PR DESCRIPTION
###### Description of changes
backport of #205221

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).