### PR TITLE
root: 6.26.08 -> 6.26.10; add xrootd support and workaround

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -83,6 +83,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper cmake pkg-config git ];
+  propagatedBuildInputs = [
+    nlohmann_json
+  ];
   buildInputs = [
     davix
     ftgl
@@ -106,7 +109,6 @@ stdenv.mkDerivation rec {
     libjpeg
     libtiff
     libpng
-    nlohmann_json
     patchRcPathCsh
     patchRcPathFish
     patchRcPathPosix

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -216,12 +216,13 @@ stdenv.mkDerivation rec {
         --set ${lib.optionalString stdenv.isDarwin "DY"}LD_LIBRARY_PATH "$out/lib"
     done
 
-    # Make ldd and sed available to the ROOT executable
-    wrapProgram "$out/bin/root" --prefix PATH : "${lib.makeBinPath [
-      gnused # sed
-      stdenv.cc # c++ ld etc.
-      stdenv.cc.libc # ldd
-    ]}"
+    # Make ldd and sed available to the ROOT executable by prefixing PATH.
+    wrapProgram "$out/bin/root" \
+      --prefix PATH : "${lib.makeBinPath [
+        gnused # sed
+        stdenv.cc # c++ ld etc.
+        stdenv.cc.libc # ldd
+      ]}"
 
     # Patch thisroot.{sh,csh,fish}
 

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , callPackage
-, fetchFromGitHub
+, fetchurl
 , fetchpatch
 , makeWrapper
 , cmake
@@ -71,17 +71,15 @@ in
 
 stdenv.mkDerivation rec {
   pname = "root";
-  version = "6.26.08";
+  version = "6.26.10";
 
   passthru = {
     tests = import ./tests { inherit callPackage; };
   };
 
-  src = fetchFromGitHub {
-    owner = "root-project";
-    repo = "root";
-    rev = "v${builtins.replaceStrings [ "." ] [ "-" ] version}";
-    sha256 = "sha256-cNd1GvEbO/a+WdDe8EHYGmdlw3TrOT2fWaSk+s7fw7U=";
+  src = fetchurl {
+    url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
+    hash = "sha256-jla+w5cQQBeqVPnrVU3noaE0R0/gs7sPQ6cPxPq9Yl8=";
   };
 
   nativeBuildInputs = [ makeWrapper cmake pkg-config git ];

--- a/pkgs/development/libraries/physics/hepmc3/default.nix
+++ b/pkgs/development/libraries/physics/hepmc3/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchurl, cmake, coreutils, python, root }:
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, coreutils
+, python
+, root
+}:
 
 let
   pythonVersion = with lib.versions; "${major python.version}${minor python.version}";
@@ -16,9 +23,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-zQ91yA91VJxZzCqCns52Acd96Xyypat1eQysjh1YUDI=";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ root_py ]
-    ++ lib.optional withPython python;
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    root_py
+  ]
+  ++ lib.optional withPython python;
 
   cmakeFlags = [
     "-DHEPMC3_ENABLE_PYTHON=${if withPython then "ON" else "OFF"}"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
*   Update to 6.26.10 and go back to `fetchurl`.
*   Enable xrootd support and apply the `[DY]LD_LIBRARY_PATH` workaround before we have #200830 gets ready.
    That is also how the upstream-provided `./setxrd.sh` works. Considering the importance of this feature, it would be worthwhile to apply the workaround first.
*   Use `stdenv.hostPlatform.is*` instead of `stdenv.is*`. This brings us closer toward cross-compilation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
