### PR TITLE
rustdesk: fix for rust 1.65

### DIFF
--- a/pkgs/applications/networking/remote/rustdesk/default.nix
+++ b/pkgs/applications/networking/remote/rustdesk/default.nix
@@ -38,6 +38,11 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-IlrfqwNyaSHE9Ct0mn7MUxEg7p1Ku34eOMYelEAYFW8=";
   };
 
+  patches = [
+    # based on https://github.com/rustdesk/rustdesk/pull/1900
+    ./fix-for-rust-1.65.diff
+  ];
+
   cargoSha256 = "sha256-1OMWEk+DerltF7kwdo4d04rbgIFLHBRq3vZaL7jtrdE=";
 
   LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";

--- a/pkgs/applications/networking/remote/rustdesk/fix-for-rust-1.65.diff
+++ b/pkgs/applications/networking/remote/rustdesk/fix-for-rust-1.65.diff
@@ -1,0 +1,31 @@
+diff --git a/libs/hbb_common/src/config.rs b/libs/hbb_common/src/config.rs
+index 74982de5..308bcf80 100644
+--- a/libs/hbb_common/src/config.rs
++++ b/libs/hbb_common/src/config.rs
+@@ -656,7 +656,7 @@ const PEERS: &str = "peers";
+ 
+ impl PeerConfig {
+     pub fn load(id: &str) -> PeerConfig {
+-        let _ = CONFIG.read().unwrap(); // for lock
++        let _lock = CONFIG.read().unwrap();
+         match confy::load_path(&Self::path(id)) {
+             Ok(config) => config,
+             Err(err) => {
+@@ -667,7 +667,7 @@ impl PeerConfig {
+     }
+ 
+     pub fn store(&self, id: &str) {
+-        let _ = CONFIG.read().unwrap(); // for lock
++        let _lock = CONFIG.read().unwrap();
+         if let Err(err) = confy::store_path(Self::path(id), self) {
+             log::error!("Failed to store config: {}", err);
+         }
+@@ -808,7 +808,7 @@ pub struct LanPeers {
+ 
+ impl LanPeers {
+     pub fn load() -> LanPeers {
+-        let _ = CONFIG.read().unwrap(); // for lock
++        let _lock = CONFIG.read().unwrap();
+         match confy::load_path(&Config::file_("_lan_peers")) {
+             Ok(peers) => peers,
+             Err(err) => {


### PR DESCRIPTION
###### Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/205366. This broke when I updated Rust to 1.65 in https://github.com/NixOS/nixpkgs/pull/199664. It was fixed upstream in https://github.com/rustdesk/rustdesk/pull/1900 but unreleased. This project is quite active, so the patch does not apply cleanly. I ported it over so that it does on top of the currently released version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
