### PR TITLE
lunarml: init at unstable-2023-06-25

### DIFF
--- a/pkgs/development/compilers/lunarml/default.nix
+++ b/pkgs/development/compilers/lunarml/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+, mlton
+, lua5_3
+}:
+
+let
+  pname = "lunarml";
+in
+stdenvNoCC.mkDerivation {
+  inherit pname;
+
+  version = "unstable-2023-06-25";
+
+  src = fetchFromGitHub {
+    owner = "minoki";
+    repo = "LunarML";
+    rev = "f58f90cf7a2f26340403245907ed183f6a12ab52";
+    sha256 = "djHJfUAPplsejFW9L3fbwTeeWgvR+gKkI8TmwIh8n7E=";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  nativeBuildInputs = [
+    mlton
+  ];
+
+  nativeCheckInputs = [
+    lua5_3
+  ];
+
+  postBuild = ''
+    make -C thirdparty install
+  '';
+
+  doCheck = true;
+
+  installPhase = ''
+    mkdir -p $doc/${pname} $out/{bin,lib}
+    cp -r bin $out
+    cp -r lib $out
+    cp -r doc/* README.* LICENSE* $doc/${pname}
+    cp -r example $doc/${pname}
+  '';
+
+  meta = {
+    description = "Standard ML compiler that produces Lua/JavaScript";
+    homepage = "https://github.com/minoki/LunarML";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ toastal ];
+    platforms = mlton.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16313,6 +16313,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };
 
+  lunarml = callPackage ../development/compilers/lunarml { };
+
   manticore = callPackage ../development/compilers/manticore { };
 
   marst = callPackage ../development/compilers/marst { };


### PR DESCRIPTION
###### Description of changes

https://github.com/minoki/LunarML

`doCheck` passes their built-in tests. I had a chat with the upstream project and got it slightly restructured in a way that cut the Nix code by 2/3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
