### PR TITLE
python310Packages.devtools: 0.8.0 -> 0.10.0, python310Packages.executing: 0.8.2 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/devtools/default.nix
+++ b/pkgs/development/python-modules/devtools/default.nix
@@ -60,6 +60,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python's missing debug print command and other development tools";
     homepage = "https://python-devtools.helpmanual.io/";
+    changelog = "https://github.com/samuelcolvin/python-devtools/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ jdahm ];
   };

--- a/pkgs/development/python-modules/executing/default.nix
+++ b/pkgs/development/python-modules/executing/default.nix
@@ -2,11 +2,12 @@
 , asttokens
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools-scm
-, pytestCheckHook
 , littleutils
+, pytestCheckHook
 , pythonAtLeast
+, pythonOlder
 , rich
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
@@ -14,25 +15,25 @@ buildPythonPackage rec {
   version = "1.2.0";
   format = "pyproject";
 
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "alexmojaki";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-3M3uSJ5xQ5Ciy8Lz21u9zjju/7SBSFHobCqSiJ6AP8M=";
+    hash = "sha256-3M3uSJ5xQ5Ciy8Lz21u9zjju/7SBSFHobCqSiJ6AP8M=";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     setuptools-scm
   ];
 
-  preBuild = ''
-    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
-  '';
-
   checkInputs = [
-    pytestCheckHook
     asttokens
     littleutils
+    pytestCheckHook
   ] ++ lib.optionals (pythonAtLeast "3.11") [
     rich
   ];

--- a/pkgs/development/python-modules/littleutils/default.nix
+++ b/pkgs/development/python-modules/littleutils/default.nix
@@ -1,24 +1,32 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchPypi
-, lib
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "littleutils";
   version = "0.2.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0vwijrylppmk0nbddqvn527r9cg3zw8d6zk6r58hslry42jf7jp6";
+    hash = "sha256-5srjpCA+Uw1RyWZ+0xD/47GUjyh249aWBbPeS32WkW8=";
   };
 
-  # This tiny package has no unit tests at all
+  # Module has no tests
   doCheck = false;
-  pythonImportsCheck = [ "littleutils" ];
+
+  pythonImportsCheck = [
+    "littleutils"
+  ];
 
   meta = with lib; {
     description = "Small collection of Python utility functions";
     homepage = "https://github.com/alexmojaki/littleutils";
+    changelog = "https://github.com/alexmojaki/littleutils/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ jluttine ];
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
