### PR TITLE
spdx-to-osv: init at 0.1.0

### DIFF
--- a/pkgs/tools/security/spdx-to-osv/default.nix
+++ b/pkgs/tools/security/spdx-to-osv/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, jre, maven }:
+
+let
+  pname = "spdx-to-osv";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "spdx";
+    repo = "spdx-to-osv";
+    rev = "v${version}";
+    sha256 = "tC79cIHsSyYQ5qtqmxS7352F8cpHXhdKDSb4mEIYa30=";
+  };
+
+  repository = stdenv.mkDerivation {
+    name = "${pname}-${version}-repository";
+    inherit src;
+
+    buildInputs = [ maven ];
+
+    buildPhase = ''
+      mvn package -Dmaven.repo.local=$out
+    '';
+
+    installPhase = ''
+      find $out -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
+    '';
+
+    dontFixup = true;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-sgzt280FmPEgD3dpOM/jmjp4uh0rCOs00qstS1TExSo=";
+  };
+in stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ maven ];
+
+  # Tests are requiring Internet access.
+  buildPhase = ''
+    mvn --offline -Dmaven.repo.local=${repository} package -Dmaven.test.skip
+  '';
+
+  installPhase = ''
+    install -D \
+      target/${pname}-${version}-jar-with-dependencies.jar \
+      $out/share/${pname}-${version}.jar
+
+    mkdir $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-jar $out/share/${pname}-${version}.jar"
+  '';
+
+  meta = with lib; {
+    description = "Produce an Open Source Vulnerability JSON file based on information in an SPDX document";
+    homepage = "https://github.com/spdx/spdx-to-osv";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1449,6 +1449,8 @@ with pkgs;
 
   smbscan = callPackage ../tools/security/smbscan { };
 
+  spdx-to-osv  = callPackage ../tools/security/spdx-to-osv { };
+
   spectre-cli = callPackage ../tools/security/spectre-cli { };
 
   steamtinkerlaunch = callPackage ../tools/games/steamtinkerlaunch {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [spdx-to-osv](https://github.com/spdx/spdx-to-osv), a tool to "[p]roduce an Open Source Vulnerability JSON file based on information in an SPDX document" at version 0.1.0. For an usage example, take a look at this blog post <https://security.googleblog.com/2022/06/sbom-in-action-finding-vulnerabilities.html>.

As the application is built with Maven, the derivation follows the [manual section for Maven](https://nixos.org/manual/nixpkgs/stable/#maven), especially section ''17.21.1.2. Double Invocation" and "17.21.2. Building a JAR".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
