### PR TITLE
vmware-workstation: 16.2.3 -> 16.2.4

### DIFF
--- a/pkgs/applications/virtualization/vmware-workstation/default.nix
+++ b/pkgs/applications/virtualization/vmware-workstation/default.nix
@@ -49,8 +49,8 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vmware-workstation";
-  version = "16.2.3";
-  build = "19376536";
+  version = "16.2.4";
+  build = "20089737";
 
   buildInputs = [
     libxslt
@@ -76,8 +76,8 @@ stdenv.mkDerivation rec {
     ++ lib.optionals enableInstaller [ sqlite bzip2 ];
 
   src = fetchurl {
-    url = "https://download3.vmware.com/software/WKST-1623-LX-New/VMware-Workstation-Full-${version}-${build}.x86_64.bundle";
-    sha256 = "sha256-+JE1KnRfawcaBannIyEr1TNZTF7YXRYYaFMVq0/erbM=";
+    url = "https://download3.vmware.com/software/WKST-1624-LX/VMware-Workstation-Full-${version}-${build}.x86_64.bundle";
+    sha256 = "sha256-LkZwjbRmMO3JbNsRUU1eM49TAMRvUakBMumkzRHD88A=";
   };
 
   unpackPhase = ''

--- a/pkgs/os-specific/linux/vmware/default.nix
+++ b/pkgs/os-specific/linux/vmware/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mkubecek";
     repo = "vmware-host-modules";
-    rev = "w${vmware-workstation.version}-k5.18";
-    sha256 = "sha256-sAeCjaSrBXGP5szfCY5CpMrGwzCw4aM67EN+YfA3AWA=";
+    rev = "d9244035eb0638ea4602f3e50beb5d9a7f441d03"; # tip of branch workstation-16.2.4
+    sha256 = "sha256-SJhHfHxxhOlX2s2Nia5n+HB+/Th4fMDgxQjN/JHWKVc=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mkubecek/vmware-host-modules";
     license = licenses.gpl2Only;
     platforms = [ "x86_64-linux" ];
-    broken = (kernel.kernelOlder "5.5" && kernel.isHardened) || kernel.kernelAtLeast "5.19";
+    broken = (kernel.kernelOlder "5.5" && kernel.isHardened);
     maintainers = with maintainers; [ deinferno ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Updates VMWare Workstation to 16.2.4 for NixOS 22.11

Note [mkubecek/vmware-host-modules](https://github.com/mkubecek/vmware-host-modules) no longer provides tags for patched trees, so that's why I'm pointing `rev` to a commit instead (the current branch tip for `workstation-16.2.4`).

The module update also introduces support for Linux v6.0.

Upstream release notes: https://docs.vmware.com/en/VMware-Workstation-Pro/16.2.4/rn/vmware-workstation-1624-pro-release-notes/index.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
