### PR TITLE
python310Packages.pyproject-metadata: 0.5.0 -> 0.6.1 

### DIFF
--- a/pkgs/development/python-modules/pyproject-metadata/default.nix
+++ b/pkgs/development/python-modules/pyproject-metadata/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "PEP 621 metadata parsing";
     homepage = "https://github.com/FFY00/python-pyproject-metadata";
+    changelog = "https://github.com/FFY00/python-pyproject-metadata/blob/${version}/CHANGELOG.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ fridh ];
   };

--- a/pkgs/development/python-modules/pyproject-metadata/default.nix
+++ b/pkgs/development/python-modules/pyproject-metadata/default.nix
@@ -1,21 +1,24 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, setuptools
-, wheel
 , packaging
 , pytestCheckHook
+, pythonOlder
+, setuptools
 , tomli
+, wheel
 }:
 
 buildPythonPackage rec {
   pname = "pyproject-metadata";
-  version = "0.5.0";
+  version = "0.6.1";
   format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi rec {
     inherit pname version;
-    hash = "sha256-6YN9I3V8XJ//+19/N8+be8LZc30OlZt/XV8YmVFulww=";
+    hash = "sha256-tfsJVDpkqRFl3+hXlnWfnkFe3Clr602zPR7PeGaoYr0=";
   };
 
   nativeBuildInputs = [
@@ -29,11 +32,16 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
+  ] ++ lib.optionals (pythonOlder "3.11") [
     tomli
   ];
 
   # Many broken tests, and missing test files
   doCheck = false;
+
+  pythonImportsCheck = [
+    "pyproject_metadata"
+  ];
 
   meta = with lib; {
     description = "PEP 621 metadata parsing";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
