### PR TITLE
russ: init at unstable-2022-11-19

### DIFF
--- a/pkgs/applications/networking/feedreaders/russ/default.nix
+++ b/pkgs/applications/networking/feedreaders/russ/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, xorg
+, AppKit
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "russ";
+  version = "unstable-2022-11-19";
+
+  src = fetchFromGitHub {
+    owner = "ckampfe";
+    repo = "russ";
+    rev = "4648f52847b4f90f1c1eb367efccc143c4dca589";
+    sha256 = "sha256-78LessfHj/RebxbGNARfzXBVmdGMKyPgtK3F7QCFfC8=";
+  };
+
+  cargoSha256 = "sha256-H/lOUGAfSwh4ce06BbJf8tQcTg747hb5/cUzerBaflg=";
+
+  buildInputs = [
+    xorg.libxcb
+  ] ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    Security
+  ];
+
+  # some tests appear to rely on the network
+  doCheck = false;
+
+  meta = with lib; {
+    description = "TUI RSS reader with vim-like controls and a local-first, offline-first focus";
+    homepage = "https://github.com/ckampfe/russ";
+    changelog = "https://github.com/ckampfe/russ/blob/master/CHANGELOG.md";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11334,6 +11334,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  russ = callPackage ../applications/networking/feedreaders/russ {
+    inherit (darwin.apple_sdk.frameworks) AppKit Security;
+  };
+
   rust-code-analysis = callPackage ../development/tools/rust-code-analysis { };
 
   rust-motd = callPackage ../tools/misc/rust-motd {


### PR DESCRIPTION
###### Description of changes

https://github.com/ckampfe/russ

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
