### PR TITLE
openboard: 1.6.1 -> unstable-2022-11-28

### DIFF
--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -1,10 +1,10 @@
-{ mkDerivation, lib, fetchFromGitHub, fetchpatch, copyDesktopItems, makeDesktopItem, qmake
-, qtbase, qtxmlpatterns, qttools, qtwebkit, libGL, fontconfig, openssl, poppler
+{ stdenv, lib, fetchFromGitHub, fetchpatch, copyDesktopItems, makeDesktopItem, qmake
+, qtbase, qtxmlpatterns, qttools, qtwebengine, libGL, fontconfig, openssl, poppler, wrapQtAppsHook
 , ffmpeg, libva, alsa-lib, SDL, x264, libvpx, libvorbis, libtheora, libogg
 , libopus, lame, fdk_aac, libass, quazip, libXext, libXfixes }:
 
 let
-  importer = mkDerivation rec {
+  importer = stdenv.mkDerivation rec {
     pname = "openboard-importer";
     version = "unstable-2016-10-08";
 
@@ -16,44 +16,38 @@ let
     };
 
     nativeBuildInputs = [ qmake ];
+    buildInputs = [ qtbase ];
+    dontWrapQtApps = true;
 
     installPhase = ''
       install -Dm755 OpenBoardImporter $out/bin/OpenBoardImporter
     '';
   };
-in mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "openboard";
-  version = "1.6.1";
+  version = "unstable-2022-11-28";
 
   src = fetchFromGitHub {
     owner = "OpenBoard-org";
     repo = "OpenBoard";
-    rev = "v${version}";
-    sha256 = "sha256-OlGXGIMghil/GG6eso20+CWo/hCjarXGs6edXX9pc/M=";
+    rev = "9de37af2df1a7c0d88f71c94ab2db1815d082862";
+    sha256 = "sha256-TiKrSyxtF1g1bepCoFxoxGOdREXhsMrS3g8uZKSiugg=";
   };
-
-  patches = [
-    # Fix build with poppler >= 22.01
-    (fetchpatch {
-      url = "https://github.com/OpenBoard-org/OpenBoard/commit/3a9b043e0fafec08e4123f362dcb7750f7476b59.patch";
-      sha256 = "sha256-yD163FK79HBU1W7m6sLxhfsRo4r/38zYTFWgeyqwU1o=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace OpenBoard.pro \
-      --replace '/usr/include/quazip' '${quazip}/include/QuaZip-Qt5-${quazip.version}/quazip' \
+      --replace '/usr/include/quazip5' '${quazip}/include/QuaZip-Qt5-${quazip.version}/quazip' \
       --replace '-lquazip5' '-lquazip1-qt5' \
       --replace '/usr/include/poppler' '${poppler.dev}/include/poppler'
   '';
 
-  nativeBuildInputs = [ qmake copyDesktopItems ];
+  nativeBuildInputs = [ qmake copyDesktopItems wrapQtAppsHook ];
 
   buildInputs = [
     qtbase
     qtxmlpatterns
     qttools
-    qtwebkit
+    qtwebengine
     libGL
     fontconfig
     openssl


### PR DESCRIPTION
###### Description of changes

`qtwebkit` marked as insecure in #201028. Bumped to latest commit as webengine support isn't tagged and `1.6.1` is so old.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
