### PR TITLE
monotoneViz: use xorg.* packages directly instead of xlibsWrapper ind…

### DIFF
--- a/pkgs/applications/version-management/monotone-viz/default.nix
+++ b/pkgs/applications/version-management/monotone-viz/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl, ocamlPackages, gnome2, pkg-config, makeWrapper, glib
-, libtool, libpng, bison, expat, fontconfig, gd, pango, libjpeg, libwebp, xlibsWrapper, libXaw
+, libtool, libpng, bison, expat, fontconfig, gd, pango, libjpeg, libwebp, libX11, libXaw
 }:
 # We need an old version of Graphviz for format compatibility reasons.
 # This version is vulnerable, but monotone-viz will never feed it bad input.
 let graphviz_2_0 = import ./graphviz-2.0.nix {
-      inherit lib stdenv fetchurl pkg-config xlibsWrapper libpng libjpeg expat libXaw
+      inherit lib stdenv fetchurl pkg-config libX11 libpng libjpeg expat libXaw
         bison libtool fontconfig pango gd libwebp;
     }; in
 let inherit (gnome2) libgnomecanvas; in

--- a/pkgs/applications/version-management/monotone-viz/graphviz-2.0.nix
+++ b/pkgs/applications/version-management/monotone-viz/graphviz-2.0.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , pkg-config
-, xlibsWrapper
+, libX11
 , libpng
 , libjpeg
 , expat
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    xlibsWrapper
+    libX11
     libpng
     libjpeg
     expat
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       "--with-ltdl-include=${libtool}/include"
       "--with-ltdl-lib=${libtool.lib}/lib"
     ]
-    ++ lib.optional (xlibsWrapper == null) "--without-x";
+    ++ lib.optional (libX11 == null) "--without-x";
 
   meta = {
     description = "A program for visualising graphs";


### PR DESCRIPTION
…irection

Validated as no change in `out` output with `diffoscope`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
