### PR TITLE
river-tag-overlay: init  at 1.0.0

### DIFF
--- a/pkgs/applications/misc/river-tag-overlay/default.nix
+++ b/pkgs/applications/misc/river-tag-overlay/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromSourcehut, nixos, wayland, pixman, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "river-tag-overlay";
+  version = "1.0.0";
+
+  src = fetchFromSourcehut {
+    owner = "~leon_plickat";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-hLyXdLi/ldvwPJ1oQQsH5wgflQJuXu6vhYw/qdKAV9E=";
+  };
+
+  buildInputs = [ pixman wayland ];
+  nativeBuildInputs = [ pkg-config ];
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "PREFIX="
+  ];
+
+  meta = with lib; {
+    description = "A pop-up showing tag status";
+    homepage = "https://sr.ht/~leon_plickat/river-tag-overlay";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ edrex ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/river-tag-overlay/default.nix
+++ b/pkgs/applications/misc/river-tag-overlay/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ edrex ];
     platforms = platforms.linux;
+    broken = stdenv.isAarch64;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30966,6 +30966,8 @@ with pkgs;
 
   pragha = libsForQt5.callPackage ../applications/audio/pragha { };
 
+  river-tag-overlay = callPackage ../applications/misc/river-tag-overlay { };
+
   rofi-mpd = callPackage ../applications/audio/rofi-mpd { };
 
   rofi-bluetooth = callPackage ../applications/misc/rofi-bluetooth { };


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - no pkg tests
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
