### PR TITLE
python3Packages.certifi: Ignore /no-cert-file.crt in NIX_SSL_CERT_FILE

### DIFF
--- a/pkgs/development/python-modules/certifi/env.patch
+++ b/pkgs/development/python-modules/certifi/env.patch
@@ -1,8 +1,8 @@
 diff --git a/certifi/core.py b/certifi/core.py
-index de02898..3ec9147 100644
+index de02898..c033d20 100644
 --- a/certifi/core.py
 +++ b/certifi/core.py
-@@ -4,6 +4,7 @@ certifi.py
+@@ -4,15 +4,25 @@ certifi.py
  
  This module returns the installation location of cacert.pem or its contents.
  """
@@ -10,16 +10,26 @@ index de02898..3ec9147 100644
  import sys
  
  
-@@ -12,7 +13,7 @@ if sys.version_info >= (3, 11):
++def get_cacert_path_from_environ():
++    path = os.environ.get("NIX_SSL_CERT_FILE", None)
++
++    if path == "/no-cert-file.crt":
++        return None
++
++    return path
++
++
+ if sys.version_info >= (3, 11):
+ 
      from importlib.resources import as_file, files
  
      _CACERT_CTX = None
 -    _CACERT_PATH = None
-+    _CACERT_PATH = os.environ.get("NIX_SSL_CERT_FILE", None)
++    _CACERT_PATH = get_cacert_path_from_environ()
  
      def where() -> str:
          # This is slightly terrible, but we want to delay extracting the file
-@@ -39,14 +40,16 @@ if sys.version_info >= (3, 11):
+@@ -39,14 +49,16 @@ if sys.version_info >= (3, 11):
          return _CACERT_PATH
  
      def contents() -> str:
@@ -34,11 +44,11 @@ index de02898..3ec9147 100644
  
      _CACERT_CTX = None
 -    _CACERT_PATH = None
-+    _CACERT_PATH = os.environ.get("NIX_SSL_CERT_FILE", None)
++    _CACERT_PATH = get_cacert_path_from_environ()
  
      def where() -> str:
          # This is slightly terrible, but we want to delay extracting the
-@@ -74,7 +77,9 @@ elif sys.version_info >= (3, 7):
+@@ -74,7 +86,9 @@ elif sys.version_info >= (3, 7):
          return _CACERT_PATH
  
      def contents() -> str:
@@ -49,16 +59,16 @@ index de02898..3ec9147 100644
  
  else:
      import os
-@@ -84,6 +89,8 @@ else:
+@@ -84,6 +98,8 @@ else:
      Package = Union[types.ModuleType, str]
      Resource = Union[str, "os.PathLike"]
  
-+    _CACERT_PATH = os.environ.get("NIX_SSL_CERT_FILE", None)
++    _CACERT_PATH = get_cacert_path_from_environ()
 +
      # This fallback will work for Python versions prior to 3.7 that lack the
      # importlib.resources module but relies on the existing `where` function
      # so won't address issues with environments like PyOxidizer that don't set
-@@ -102,7 +109,14 @@ else:
+@@ -102,7 +118,14 @@ else:
      def where() -> str:
          f = os.path.dirname(__file__)
  


### PR DESCRIPTION
###### Description of changes

Follow up for https://github.com/NixOS/nixpkgs/pull/205127

This is somehow the easy way out of this pickle. The alternative would be to add cacert everywhere else, but I don't think that we should go that route, since we appy a custom patch to certifi and the behavior of certifi shouldn't change.

cc #205270 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
