### PR TITLE
plasma-vault: add gocryptfs support

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-vault/0004-gocryptfs-path.patch
+++ b/pkgs/desktops/plasma-5/plasma-vault/0004-gocryptfs-path.patch
@@ -1,0 +1,13 @@
+diff --git a/kded/engine/backends/gocryptfs/gocryptfsbackend.cpp b/kded/engine/backends/gocryptfs/gocryptfsbackend.cpp
+index 2d6df94..3e8ec9a 100644
+--- a/kded/engine/backends/gocryptfs/gocryptfsbackend.cpp
++++ b/kded/engine/backends/gocryptfs/gocryptfsbackend.cpp
+@@ -202,7 +202,7 @@ QProcess *GocryptfsBackend::gocryptfs(const QStringList &arguments) const
+     auto config = KSharedConfig::openConfig(PLASMAVAULT_CONFIG_FILE);
+     KConfigGroup backendConfig(config, "GocryptfsBackend");
+ 
+-    return process("gocryptfs", arguments + backendConfig.readEntry("extraMountOptions", QStringList{}), {});
++    return process(NIXPKGS_GOCRYPTFS, arguments + backendConfig.readEntry("extraMountOptions", QStringList{}), {});
+ }
+ 
+ QString GocryptfsBackend::getConfigFilePath(const Device &device) const

--- a/pkgs/desktops/plasma-5/plasma-vault/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-vault/default.nix
@@ -20,6 +20,7 @@ mkDerivation {
     ./0001-encfs-path.patch
     ./0002-cryfs-path.patch
     ./0003-fusermount-path.patch
+    ./0004-gocryptfs-path.patch
   ];
 
   buildInputs = [
@@ -33,11 +34,8 @@ mkDerivation {
   CXXFLAGS = [
     ''-DNIXPKGS_ENCFS=\"${lib.getBin encfs}/bin/encfs\"''
     ''-DNIXPKGS_ENCFSCTL=\"${lib.getBin encfs}/bin/encfsctl\"''
-
     ''-DNIXPKGS_CRYFS=\"${lib.getBin cryfs}/bin/cryfs\"''
-
     ''-DNIXPKGS_FUSERMOUNT=\"${lib.getBin fuse}/bin/fusermount\"''
-
     ''-DNIXPKGS_GOCRYPTFS=\"${lib.getBin gocryptfs}/bin/gocryptfs\"''
   ];
 

--- a/pkgs/desktops/plasma-5/plasma-vault/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-vault/default.nix
@@ -9,6 +9,7 @@
 , encfs
 , cryfs
 , fuse
+, gocryptfs
 }:
 
 mkDerivation {
@@ -36,6 +37,8 @@ mkDerivation {
     ''-DNIXPKGS_CRYFS=\"${lib.getBin cryfs}/bin/cryfs\"''
 
     ''-DNIXPKGS_FUSERMOUNT=\"${lib.getBin fuse}/bin/fusermount\"''
+
+    ''-DNIXPKGS_GOCRYPTFS=\"${lib.getBin gocryptfs}/bin/gocryptfs\"''
   ];
 
 }


### PR DESCRIPTION
###### Description of changes

Adds support for the gocryptfs engine to plasma-vault's encryption choices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
