### PR TITLE
openconnect: add xdg-utils build dependency

### DIFF
--- a/pkgs/tools/networking/openconnect/common.nix
+++ b/pkgs/tools/networking/openconnect/common.nix
@@ -15,6 +15,8 @@
 , zlib
 , vpnc-scripts
 , PCSC
+, useDefaultExternalBrowser ? true
+, xdg-utils
 , autoreconfHook
 }:
 
@@ -32,7 +34,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gmp libxml2 stoken zlib (if useOpenSSL then openssl else gnutls) ]
     ++ lib.optional stdenv.isDarwin PCSC
-    ++ lib.optional stdenv.isLinux p11-kit;
+    ++ lib.optional stdenv.isLinux p11-kit
+    ++ lib.optional (stdenv.isLinux && useDefaultExternalBrowser) xdg-utils;
   nativeBuildInputs = [ pkg-config autoreconfHook ];
 
   meta = with lib; {

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -26,6 +26,3 @@ in rec {
     useOpenSSL = true;
   };
 }
-
-
-


### PR DESCRIPTION
###### Description of changes

libopenconnect >=9.00 added support for a DEFAULT_EXTERNAL_BROWSER build value that enables support for using xdg-open to spawn an external browser from consumers of the library such as GNOME/NetworkManager-openconnect. This functionality is needed to support external browser SAML authentication flows for various VPN protocols supported by libopenconnect.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] ~Tested basic functionality of all binary files (usually in `./result/bin/`)~ This change is mainly for the library component. The binary works fine but that doesn't really help much. Verified `xdg-open` is picked up during the build.
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
