### PR TITLE
[22.05] traefik: add patch for CVE-2022-41717

### DIFF
--- a/pkgs/servers/traefik/2.6.3-CVE-2022-41717.patch
+++ b/pkgs/servers/traefik/2.6.3-CVE-2022-41717.patch
@@ -1,0 +1,370 @@
+Analogous to upstream abd569701f1d10872e970ac3bd753b3f2957491f
+
+Bigger because we have to bump to go 1.17 to satisfy new module versions
+
+diff --git a/go.mod b/go.mod
+index e3cf48ede..9d02a8826 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/traefik/traefik/v2
+ 
+-go 1.16
++go 1.17
+ 
+ // github.com/docker/docker v17.12.0-ce-rc1.0.20200204220554-5f6d6f3f2203+incompatible => v19.03.6
+ require (
+@@ -71,10 +71,10 @@ require (
+ 	github.com/vulcand/predicate v1.1.0
+ 	go.elastic.co/apm v1.13.1
+ 	go.elastic.co/apm/module/apmot v1.13.1
+-	golang.org/x/mod v0.4.2
+-	golang.org/x/net v0.0.0-20220927171203-f486391704dc
++	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
++	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10
+ 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
+-	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2
++	golang.org/x/tools v0.1.12
+ 	google.golang.org/grpc v1.38.0
+ 	gopkg.in/DataDog/dd-trace-go.v1 v1.19.0
+ 	gopkg.in/fsnotify.v1 v1.4.7
+@@ -88,6 +88,240 @@ require (
+ 	sigs.k8s.io/gateway-api v0.4.0
+ )
+ 
++require (
++	cloud.google.com/go v0.81.0 // indirect
++	github.com/AlecAivazis/survey/v2 v2.2.3 // indirect
++	github.com/Azure/azure-sdk-for-go v40.3.0+incompatible // indirect
++	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
++	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
++	github.com/Azure/go-autorest/autorest v0.11.19 // indirect
++	github.com/Azure/go-autorest/autorest/adal v0.9.13 // indirect
++	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8 // indirect
++	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2 // indirect
++	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
++	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
++	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
++	github.com/Azure/go-autorest/logger v0.2.1 // indirect
++	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
++	github.com/DataDog/datadog-go v3.2.0+incompatible // indirect
++	github.com/Masterminds/goutils v1.1.1 // indirect
++	github.com/Masterminds/semver/v3 v3.1.1 // indirect
++	github.com/Microsoft/go-winio v0.4.17 // indirect
++	github.com/Microsoft/hcsshim v0.8.23 // indirect
++	github.com/OpenDNS/vegadns2client v0.0.0-20180418235048-a3fa4a771d87 // indirect
++	github.com/VividCortex/gohistogram v1.0.0 // indirect
++	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
++	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.1.1 // indirect
++	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1183 // indirect
++	github.com/armon/go-metrics v0.3.10 // indirect
++	github.com/armon/go-radix v1.0.0 // indirect
++	github.com/beorn7/perks v1.0.1 // indirect
++	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
++	github.com/buger/goterm v1.0.0 // indirect
++	github.com/cespare/xxhash/v2 v2.1.1 // indirect
++	github.com/cheekybits/genny v1.0.0 // indirect
++	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible // indirect
++	github.com/circonus-labs/circonusllhist v0.1.3 // indirect
++	github.com/cloudflare/cloudflare-go v0.20.0 // indirect
++	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
++	github.com/compose-spec/godotenv v1.0.0 // indirect
++	github.com/containerd/cgroups v1.0.1 // indirect
++	github.com/containerd/console v1.0.2 // indirect
++	github.com/containerd/continuity v0.1.0 // indirect
++	github.com/containerd/typeurl v1.0.2 // indirect
++	github.com/coreos/go-semver v0.3.0 // indirect
++	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
++	github.com/cpu/goacmedns v0.1.1 // indirect
++	github.com/deepmap/oapi-codegen v1.6.1 // indirect
++	github.com/dimchansky/utfbom v1.1.1 // indirect
++	github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e // indirect
++	github.com/dnsimple/dnsimple-go v0.70.1 // indirect
++	github.com/docker/buildx v0.5.2-0.20210422185057-908a856079fc // indirect
++	github.com/docker/distribution v2.7.1+incompatible // indirect
++	github.com/docker/docker-credential-helpers v0.6.4-0.20210125172408-38bea2ce277a // indirect
++	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
++	github.com/docker/go-metrics v0.0.1 // indirect
++	github.com/docker/go-units v0.4.0 // indirect
++	github.com/eapache/queue v1.1.0 // indirect
++	github.com/elastic/go-licenser v0.3.1 // indirect
++	github.com/elastic/go-sysinfo v1.1.1 // indirect
++	github.com/elastic/go-windows v1.0.0 // indirect
++	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
++	github.com/exoscale/egoscale v0.67.0 // indirect
++	github.com/fatih/color v1.12.0 // indirect
++	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
++	github.com/fsnotify/fsnotify v1.4.9 // indirect
++	github.com/fvbommel/sortorder v1.0.1 // indirect
++	github.com/go-errors/errors v1.0.1 // indirect
++	github.com/go-logfmt/logfmt v0.5.0 // indirect
++	github.com/go-logr/logr v0.4.0 // indirect
++	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48 // indirect
++	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
++	github.com/go-zookeeper/zk v1.0.2 // indirect
++	github.com/gofrs/flock v0.8.0 // indirect
++	github.com/gofrs/uuid v3.3.0+incompatible // indirect
++	github.com/gogo/googleapis v1.4.0 // indirect
++	github.com/gogo/protobuf v1.3.2 // indirect
++	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
++	github.com/golang/mock v1.6.0 // indirect
++	github.com/golang/snappy v0.0.3 // indirect
++	github.com/google/btree v1.0.1 // indirect
++	github.com/google/go-cmp v0.5.6 // indirect
++	github.com/google/go-querystring v1.1.0 // indirect
++	github.com/google/gofuzz v1.2.0 // indirect
++	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
++	github.com/google/uuid v1.2.0 // indirect
++	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
++	github.com/googleapis/gnostic v0.5.5 // indirect
++	github.com/gophercloud/gophercloud v0.16.0 // indirect
++	github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae // indirect
++	github.com/gorilla/context v1.1.1 // indirect
++	github.com/gravitational/trace v0.0.0-20190726142706-a535a178675f // indirect
++	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect
++	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
++	github.com/hashicorp/consul/sdk v0.8.0 // indirect
++	github.com/hashicorp/errwrap v1.0.0 // indirect
++	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
++	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
++	github.com/hashicorp/go-msgpack v0.5.5 // indirect
++	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
++	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
++	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
++	github.com/hashicorp/go-uuid v1.0.2 // indirect
++	github.com/hashicorp/golang-lru v0.5.4 // indirect
++	github.com/hashicorp/hcl v1.0.0 // indirect
++	github.com/hashicorp/memberlist v0.3.0 // indirect
++	github.com/hashicorp/raft v1.3.2 // indirect
++	github.com/hashicorp/raft-autopilot v0.1.5 // indirect
++	github.com/hashicorp/serf v0.9.6 // indirect
++	github.com/hashicorp/yamux v0.0.0-20210826001029-26ff87cf9493 // indirect
++	github.com/huandu/xstrings v1.3.1 // indirect
++	github.com/iij/doapi v0.0.0-20190504054126-0bbf12d6d7df // indirect
++	github.com/imdario/mergo v0.3.12 // indirect
++	github.com/inconshreveable/mousetrap v1.0.0 // indirect
++	github.com/infobloxopen/infoblox-go-client v1.1.1 // indirect
++	github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea // indirect
++	github.com/jarcoal/httpmock v1.0.6 // indirect
++	github.com/jcchavezs/porto v0.1.0 // indirect
++	github.com/jmespath/go-jmespath v0.4.0 // indirect
++	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
++	github.com/jonboulle/clockwork v0.1.0 // indirect
++	github.com/json-iterator/go v1.1.11 // indirect
++	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 // indirect
++	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
++	github.com/kolo/xmlrpc v0.0.0-20200310150728-e0350524596b // indirect
++	github.com/labbsr0x/bindman-dns-webhook v1.0.2 // indirect
++	github.com/labbsr0x/goh v1.0.1 // indirect
++	github.com/linode/linodego v0.31.1 // indirect
++	github.com/liquidweb/go-lwApi v0.0.5 // indirect
++	github.com/liquidweb/liquidweb-cli v0.6.9 // indirect
++	github.com/liquidweb/liquidweb-go v1.6.3 // indirect
++	github.com/looplab/fsm v0.1.0 // indirect
++	github.com/mailgun/minheap v0.0.0-20170619185613-3dbe6c6bf55f // indirect
++	github.com/mailgun/multibuf v0.0.0-20150714184110-565402cd71fb // indirect
++	github.com/mailgun/timetools v0.0.0-20141028012446-7e6055773c51 // indirect
++	github.com/marten-seemann/qpack v0.2.1 // indirect
++	github.com/marten-seemann/qtls-go1-16 v0.1.4 // indirect
++	github.com/marten-seemann/qtls-go1-17 v0.1.0 // indirect
++	github.com/mattn/go-colorable v0.1.8 // indirect
++	github.com/mattn/go-isatty v0.0.12 // indirect
++	github.com/mattn/go-shellwords v1.0.12 // indirect
++	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
++	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
++	github.com/miekg/pkcs11 v1.0.3 // indirect
++	github.com/mitchellh/go-homedir v1.1.0 // indirect
++	github.com/mitchellh/go-testing-interface v1.14.0 // indirect
++	github.com/mitchellh/reflectwalk v1.0.1 // indirect
++	github.com/moby/buildkit v0.8.2-0.20210401015549-df49b648c8bf // indirect
++	github.com/moby/locker v1.0.1 // indirect
++	github.com/moby/sys/mount v0.2.0 // indirect
++	github.com/moby/sys/mountinfo v0.4.1 // indirect
++	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
++	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
++	github.com/modern-go/reflect2 v1.0.1 // indirect
++	github.com/morikuni/aec v1.0.0 // indirect
++	github.com/namedotcom/go v0.0.0-20180403034216-08470befbe04 // indirect
++	github.com/nrdcg/auroradns v1.0.1 // indirect
++	github.com/nrdcg/desec v0.6.0 // indirect
++	github.com/nrdcg/dnspod-go v0.4.0 // indirect
++	github.com/nrdcg/freemyip v0.2.0 // indirect
++	github.com/nrdcg/goinwx v0.8.1 // indirect
++	github.com/nrdcg/namesilo v0.2.1 // indirect
++	github.com/nrdcg/porkbun v0.1.1 // indirect
++	github.com/nxadm/tail v1.4.8 // indirect
++	github.com/onsi/ginkgo v1.16.4 // indirect
++	github.com/opencontainers/go-digest v1.0.0 // indirect
++	github.com/opencontainers/image-spec v1.0.2 // indirect
++	github.com/opencontainers/runc v1.0.2 // indirect
++	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
++	github.com/oracle/oci-go-sdk v24.3.0+incompatible // indirect
++	github.com/ovh/go-ovh v1.1.0 // indirect
++	github.com/pkg/errors v0.9.1 // indirect
++	github.com/pquerna/otp v1.3.0 // indirect
++	github.com/prometheus/common v0.26.0 // indirect
++	github.com/prometheus/procfs v0.6.0 // indirect
++	github.com/sacloud/libsacloud v1.36.2 // indirect
++	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b // indirect
++	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
++	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210127161313-bd30bebeac4f // indirect
++	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
++	github.com/segmentio/fasthash v1.0.3 // indirect
++	github.com/shopspring/decimal v1.2.0 // indirect
++	github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9 // indirect
++	github.com/softlayer/softlayer-go v1.0.3 // indirect
++	github.com/softlayer/xmlrpc v0.0.0-20200409220501-5f089df7cb7e // indirect
++	github.com/spf13/cast v1.3.1 // indirect
++	github.com/spf13/cobra v1.2.1 // indirect
++	github.com/spf13/pflag v1.0.5 // indirect
++	github.com/stretchr/objx v0.3.0 // indirect
++	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.287 // indirect
++	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.287 // indirect
++	github.com/theupdateframework/notary v0.6.1 // indirect
++	github.com/tonistiigi/fsutil v0.0.0-20201103201449-0834f99b7b85 // indirect
++	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
++	github.com/transip/gotransip/v6 v6.6.1 // indirect
++	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 // indirect
++	github.com/vinyldns/go-vinyldns v0.9.16 // indirect
++	github.com/vultr/govultr/v2 v2.7.1 // indirect
++	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
++	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
++	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
++	go.elastic.co/apm/module/apmhttp v1.13.1 // indirect
++	go.elastic.co/fastjson v1.1.0 // indirect
++	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
++	go.etcd.io/etcd/client/pkg/v3 v3.5.0 // indirect
++	go.etcd.io/etcd/client/v3 v3.5.0 // indirect
++	go.opencensus.io v0.23.0 // indirect
++	go.uber.org/atomic v1.7.0 // indirect
++	go.uber.org/multierr v1.6.0 // indirect
++	go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277 // indirect
++	go.uber.org/zap v1.18.1 // indirect
++	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
++	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
++	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
++	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
++	golang.org/x/sys v0.3.0 // indirect
++	golang.org/x/term v0.3.0 // indirect
++	golang.org/x/text v0.5.0 // indirect
++	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
++	google.golang.org/api v0.44.0 // indirect
++	google.golang.org/appengine v1.6.7 // indirect
++	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
++	google.golang.org/protobuf v1.27.1 // indirect
++	gopkg.in/inf.v0 v0.9.1 // indirect
++	gopkg.in/ini.v1 v1.62.0 // indirect
++	gopkg.in/ns1/ns1-go.v2 v2.6.2 // indirect
++	gopkg.in/redis.v5 v5.2.9 // indirect
++	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
++	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
++	gopkg.in/yaml.v2 v2.4.0 // indirect
++	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
++	k8s.io/klog/v2 v2.10.0 // indirect
++	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
++	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
++	sigs.k8s.io/yaml v1.2.0 // indirect
++)
++
+ // Containous forks
+ replace (
+ 	github.com/abbot/go-http-auth => github.com/containous/go-http-auth v0.4.1-0.20200324110947-a37a7636d23e
+diff --git a/go.sum b/go.sum
+index 770735100..0eda18680 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1727,6 +1727,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
+ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
++github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+ github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
+ github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
+ github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
+@@ -1835,8 +1836,9 @@ golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWP
+ golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+-golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
+ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
++golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
++golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
+@@ -1874,8 +1876,9 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
++golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
++golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+ golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -1940,8 +1943,9 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
+ golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+ golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+ golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+-golang.org/x/net v0.0.0-20220927171203-f486391704dc h1:FxpXZdoBqT8RjqTy6i1E8nXHhW21wK7ptQ/EPIGxzPQ=
+-golang.org/x/net v0.0.0-20220927171203-f486391704dc/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
++golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
++golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 h1:Frnccbp+ok2GkUS2tC84yAq/U9Vg+0sIO7aRL3T4Xnc=
++golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
+ golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+@@ -1969,8 +1973,9 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
++golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180622082034-63fc586f45fe/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+@@ -2088,13 +2093,16 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
++golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
++golang.org/x/term v0.3.0 h1:qoo4akIqOcDME5bhc/NgxUdovd6BSS2uMsVjB56q1xI=
++golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
+ golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+@@ -2104,8 +2112,9 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
++golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=
++golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+@@ -2187,8 +2196,9 @@ golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+ golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+-golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 h1:BonxutuHCTL0rBDnZlKjpGIQFTjyUVTexFOdWkB6Fg0=
+ golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
++golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
++golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkgs/servers/traefik/default.nix
+++ b/pkgs/servers/traefik/default.nix
@@ -12,9 +12,10 @@ buildGoModule rec {
 
   patches = [
     ./2.6.3-CVE-2022-39271.patch
+    ./2.6.3-CVE-2022-41717.patch
   ];
 
-  vendorSha256 = "sha256-6JFCd1DtJfCG3b4LpuvOyK77YhZz9qyv6OotpXOPB1Q=";
+  vendorSha256 = "sha256-dKN6hYotSzuD0LUnXYEVk6n7tGlCrbLPEee/QopMt8M=";
 
   subPackages = [ "cmd/traefik" ];
 


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-41717

This addresses the generic golang vulnerability CVE-2022-41717 for http2 as used in `traefik`. As patched in upstream's https://github.com/traefik/traefik/commit/abd569701f1d10872e970ac3bd753b3f2957491f, included in 2.9.6.

2.9.6 also addresses two more CVEs:

https://nvd.nist.gov/vuln/detail/CVE-2022-46153
https://nvd.nist.gov/vuln/detail/CVE-2022-23469

But these are both quite obscure (no matter what CVSS says) and the fixes aren't particularly easy to port. Given we only have to support this branch for another ~20 days (?), it's probably not worth the time to work on them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
