### PR TITLE
libsForQt5.mauiPackages: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/applications/maui/srcs.nix
+++ b/pkgs/applications/maui/srcs.nix
@@ -12,123 +12,139 @@
     };
   };
   booth = {
-    version = "1.0.0";
+    version = "1.0.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/booth/1.0.0/booth-1.0.0.tar.xz";
-      sha256 = "0cdn3vkbf1mlq32akz86mdyjfrq661h4jrfmp1x62ih63930hix2";
-      name = "booth-1.0.0.tar.xz";
+      url = "${mirror}/stable/maui/booth/1.0.1/booth-1.0.1.tar.xz";
+      sha256 = "02p3xxfk1fsqd8z55gmkhj68j8sjbgjyrj2anpq8qsmblznsvmdn";
+      name = "booth-1.0.1.tar.xz";
     };
   };
   buho = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/buho/2.2.0/buho-2.2.0.tar.xz";
-      sha256 = "1jj9kygh5b88ksg22969zlsrbgps6z7z2n77g6ldqzvg8mmh2cwr";
-      name = "buho-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/buho/2.2.1/buho-2.2.1.tar.xz";
+      sha256 = "1iv30avnfdh78zq7kxigxlkzdp2jfzx0sl88vssjcisniabyd1ri";
+      name = "buho-2.2.1.tar.xz";
     };
   };
   clip = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/clip/2.2.0/clip-2.2.0.tar.xz";
-      sha256 = "0ggymdscd7c942vvii3mswkq84lkygdcbvpg3s2lhqaqxpivy96z";
-      name = "clip-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/clip/2.2.1/clip-2.2.1.tar.xz";
+      sha256 = "00w9kgqw4dxb9b9rq11jzdb9pj48qdkdj23wdjwdk52nyfkw7sbh";
+      name = "clip-2.2.1.tar.xz";
     };
   };
   communicator = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/communicator/2.2.0/communicator-2.2.0.tar.xz";
-      sha256 = "0njyjzf8w2aamrj1yajjw7551dc72db9m0iv14mnb0gcd9pphni7";
-      name = "communicator-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/communicator/2.2.1/communicator-2.2.1.tar.xz";
+      sha256 = "1h689dr9iy07r7ypyfgrb3n0ljigz847m6vq1jaia6phgix07hn6";
+      name = "communicator-2.2.1.tar.xz";
     };
   };
   index-fm = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/index/2.2.0/index-fm-2.2.0.tar.xz";
-      sha256 = "0v39sfdqb21669cx96nd78vprwaxsvg3cpp3lly43n09nv6gkw41";
-      name = "index-fm-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/index/2.2.1/index-fm-2.2.1.tar.xz";
+      sha256 = "1gin3may65f8nafbgyv90k31z69xwx1awnnxmciqn5zz7cdh9slm";
+      name = "index-fm-2.2.1.tar.xz";
     };
   };
   mauikit = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit/2.2.0/mauikit-2.2.0.tar.xz";
-      sha256 = "05bvgwl1yfbfrlxhl6ngvkdk34rg4y12fsrddm8f19b6dkvjzxq2";
-      name = "mauikit-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/mauikit/2.2.1/mauikit-2.2.1.tar.xz";
+      sha256 = "0rwjd2g82j1cvspr0l889nss6p26yf19h39q20h3d9ls7fbj897h";
+      name = "mauikit-2.2.1.tar.xz";
     };
   };
   mauikit-accounts = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-accounts/2.2.0/mauikit-accounts-2.2.0.tar.xz";
-      sha256 = "1wc67mhhmxq0dq1g10338zm52kx274yry2ja34kagva3qkbhbb2i";
-      name = "mauikit-accounts-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-accounts/2.2.1/mauikit-accounts-2.2.1.tar.xz";
+      sha256 = "13k9y7z9mw17rdn1z9ixgi1bf6q2hf0afp53nb8d9gz5mqkaf6qh";
+      name = "mauikit-accounts-2.2.1.tar.xz";
+    };
+  };
+  mauikit-calendar = {
+    version = "1.0.0";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/mauikit-calendar/1.0.0/mauikit-calendar-1.0.0.tar.xz";
+      sha256 = "1zqaf0nddb220w14ar9gg6p695p0my8whn8p8wgxm7mwjfb6hlil";
+      name = "mauikit-calendar-1.0.0.tar.xz";
+    };
+  };
+  mauikit-documents = {
+    version = "1.0.0";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/mauikit-documents/1.0.0/mauikit-documents-1.0.0.tar.xz";
+      sha256 = "1dniab7f113vbxng9b1nwmh6wviv1m1gb842k98vxgnhmsljq24a";
+      name = "mauikit-documents-1.0.0.tar.xz";
     };
   };
   mauikit-filebrowsing = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-filebrowsing/2.2.0/mauikit-filebrowsing-2.2.0.tar.xz";
-      sha256 = "1377mgkx1q66jzdlra87airqkmkl9cfj6n5xw1my1nihxcjq9bz1";
-      name = "mauikit-filebrowsing-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-filebrowsing/2.2.1/mauikit-filebrowsing-2.2.1.tar.xz";
+      sha256 = "1szghmp1p9pvsfqx8sk345j7riqxv2kib41l277rm14pwbs6zx1c";
+      name = "mauikit-filebrowsing-2.2.1.tar.xz";
     };
   };
   mauikit-imagetools = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-imagetools/2.2.0/mauikit-imagetools-2.2.0.tar.xz";
-      sha256 = "07clir651sfi4c9awv0jnq4pck2cfzfv0fdkwcapl6hh0zq9qvpr";
-      name = "mauikit-imagetools-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-imagetools/2.2.1/mauikit-imagetools-2.2.1.tar.xz";
+      sha256 = "1wfhzkw4bs3518gylfxyp1arg2w204f73wg1l2s4pygbdh5ylav2";
+      name = "mauikit-imagetools-2.2.1.tar.xz";
     };
   };
   mauikit-texteditor = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-texteditor/2.2.0/mauikit-texteditor-2.2.0.tar.xz";
-      sha256 = "0x1cblydgqkhcy86x6yd8dipwhy9l5d7xlmk5igh5dllnzvcaicq";
-      name = "mauikit-texteditor-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-texteditor/2.2.1/mauikit-texteditor-2.2.1.tar.xz";
+      sha256 = "0dzzlmdpl0y843lywfjc4za152r87kncafkmmbp8bdwc9j5fdzzv";
+      name = "mauikit-texteditor-2.2.1.tar.xz";
     };
   };
   mauiman = {
-    version = "1.0.0";
+    version = "1.0.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauiman/1.0.0/mauiman-1.0.0.tar.xz";
-      sha256 = "1risxzgjg684c8zwmwl03ihfrxx44lbb4j43v8z3wnjkq7p44w82";
-      name = "mauiman-1.0.0.tar.xz";
+      url = "${mirror}/stable/maui/mauiman/1.0.1/mauiman-1.0.1.tar.xz";
+      sha256 = "0awqb8kygacirlhha58bzgrd47zsxmfm3h5k68g8liymqn00fh30";
+      name = "mauiman-1.0.1.tar.xz";
     };
   };
   nota = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/nota/2.2.0/nota-2.2.0.tar.xz";
-      sha256 = "1nr8craafima1khkcxv47v1868yfwykjzaczlmmqmjha7bm1dlbd";
-      name = "nota-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/nota/2.2.1/nota-2.2.1.tar.xz";
+      sha256 = "1fl4w0l3l6rdgxw5w479nzbcff7rmdcxil7y6jdr8z2q50lkazj8";
+      name = "nota-2.2.1.tar.xz";
     };
   };
   pix = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/pix/2.2.0/pix-2.2.0.tar.xz";
-      sha256 = "0nghp69ax73yf0wybd724a3lgbj7jiiznnmwp67n2ls74q8yrwwy";
-      name = "pix-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/pix/2.2.1/pix-2.2.1.tar.xz";
+      sha256 = "0j2kpcxgdz21phdl0mx84ynalzf6bf3qalq524j7p297pdkrq3d6";
+      name = "pix-2.2.1.tar.xz";
     };
   };
   shelf = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/shelf/2.2.0/shelf-2.2.0.tar.xz";
-      sha256 = "028ll3pi4h3jxgilsf4s5ic2rq0z9q8kh9pram9dsjvgz24p7g0c";
-      name = "shelf-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/shelf/2.2.1/shelf-2.2.1.tar.xz";
+      sha256 = "1h24mrzq5p63b11caml51az99gjipdlyrbx3na2jsxy4rvzryddm";
+      name = "shelf-2.2.1.tar.xz";
     };
   };
   station = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/station/2.2.0/station-2.2.0.tar.xz";
-      sha256 = "0za3jh5clkx8xf436vzs83nrsw5fyna4wcy73ihlf3xbra0358v1";
-      name = "station-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/station/2.2.1/station-2.2.1.tar.xz";
+      sha256 = "1ch5c4728hahh90nlpqwnlaljpingvwrjwxajan1j2kgwb5lynwz";
+      name = "station-2.2.1.tar.xz";
     };
   };
   strike = {
@@ -140,11 +156,11 @@
     };
   };
   vvave = {
-    version = "2.2.0";
+    version = "2.2.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/vvave/2.2.0/vvave-2.2.0.tar.xz";
-      sha256 = "0qnwklc875j6g2rg610dmvcizg3m4q80fhjk4c3i1xzn8dybbg5s";
-      name = "vvave-2.2.0.tar.xz";
+      url = "${mirror}/stable/maui/vvave/2.2.1/vvave-2.2.1.tar.xz";
+      sha256 = "0mg4p44da16xkcra1akvh6f2fixd682clmd6wqgc34j7n1a9y773";
+      name = "vvave-2.2.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Description of changes
https://mauikit.org/blog/maui-2-2-1-release/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @milahu 