### PR TITLE
nixos/hardware/device-tree: fix application of overlays

### DIFF
--- a/pkgs/os-specific/linux/device-tree/default.nix
+++ b/pkgs/os-specific/linux/device-tree/default.nix
@@ -22,21 +22,19 @@ with lib; {
 
         # skip incompatible and non-matching overlays
         if [[ ! "$dtbCompat" =~ "$overlayCompat" ]]; then
-          echo -n "Skipping overlay ${o.name}: incompatible with $(basename "$dtb")"
-          continue
-        fi
-        ${optionalString (o.filter != null) ''
-        if [[ "''${dtb//${o.filter}/}" ==  "$dtb" ]]; then
-          echo -n "Skipping overlay ${o.name}: filter does not match $(basename "$dtb")"
-          continue
-        fi
+          echo "Skipping overlay ${o.name}: incompatible with $(basename "$dtb")"
+        elif ${if (o.filter == null) then "false" else ''
+          [[ "''${dtb//${o.filter}/}" ==  "$dtb" ]]
         ''}
-
-        echo -n "Applying overlay ${o.name} to $(basename "$dtb")... "
-        mv "$dtb"{,.in}
-        fdtoverlay -o "$dtb" -i "$dtb.in" "${o.dtboFile}"
-        echo "ok"
-        rm "$dtb.in"
+        then
+          echo "Skipping overlay ${o.name}: filter does not match $(basename "$dtb")"
+        else
+          echo -n "Applying overlay ${o.name} to $(basename "$dtb")... "
+          mv "$dtb"{,.in}
+          fdtoverlay -o "$dtb" -i "$dtb.in" "${o.dtboFile}"
+          echo "ok"
+          rm "$dtb.in"
+        fi
         '')}
 
       done


### PR DESCRIPTION
###### Description of changes

Previously whenever an overlay was found to be incompatible with a base device tree blob, the entire base dtb would be skipped in favor of processing the next one. This had the unfortunate effect where overlays would not fully be applied if any incompatibility was found. For example, this is an issue with build device trees specific for one flavor of raspberry pi if the overlay was not compatible _everywhere_.

The solution is to forego the `continue` keyword if an overlay is in compatible and instead use a compound conditional statement to skip incompatible overlays but continue trying to apply it to any remaining dtbs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
