### PR TITLE
git-workspace: 1.0.3 -> 1.1.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-workspace/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-workspace/default.nix
@@ -1,26 +1,34 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , rustPlatform
-, libiconv, Security
-, pkg-config, openssl
+, libiconv
+, Security
+, pkg-config
+, openssl
+, testers
+, git-workspace
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "git-workspace";
-  version = "1.0.3";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "orf";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-sPvb8EKrr9ZUMV1yMTXkFYgjW+LRJwJAXoc7lrWykaI=";
+    sha256 = "sha256-rCy6+cjjFgcMqYn48Gfw+tTIMmsTD9lz8h14EfXWatI=";
   };
 
-  cargoSha256 = "sha256-WAoYFCJCWKFvWN8XyRBZdzjCrcR6jMp8ZztSLHDP+r0=";
+  cargoSha256 = "sha256-aO9DYD20KQL2cLWy3uIQLJ1oR4PHNbgZLYi/Y8O6UHk=";
 
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  passthru.tests.version = testers.testVersion { package = git-workspace; };
 
   meta = with lib; {
     description = "Sync personal and work git repositories from multiple providers";


### PR DESCRIPTION
###### Description of changes
https://github.com/orf/git-workspace/releases/tag/v1.1.0
https://github.com/orf/git-workspace/compare/v1.0.3...v1.1.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
