### PR TITLE
python310Packages.aiolivisi: init at 0.0.14

### DIFF
--- a/pkgs/development/python-modules/aiolivisi/default.nix
+++ b/pkgs/development/python-modules/aiolivisi/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchPypi
+, pydantic
+, pytestCheckHook
+, pythonOlder
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "aiolivisi";
+  version = "0.0.14";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-n7EQCOItr6MZRnTCfkJrq39bDbw09XyIRzSuZR2TsNg=";
+  };
+
+  postPatch = ''
+    # https://github.com/StefanIacobLivisi/aiolivisi/pull/3
+    substituteInPlace setup.py \
+      --replace 'REQUIREMENTS = list(val.strip() for val in open("requirements.txt"))' "" \
+      --replace "REQUIREMENTS," "[],"
+  '';
+
+  propagatedBuildInputs = [
+    aiohttp
+    pydantic
+    websockets
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "aiolivisi"
+  ];
+
+  meta = with lib; {
+    description = "Module to communicate with LIVISI Smart Home Controller";
+    homepage = "https://github.com/StefanIacobLivisi/aiolivisi";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1898,7 +1898,8 @@
       pylitterbot
     ];
     "livisi" = ps: with ps; [
-    ]; # missing inputs: aiolivisi
+      aiolivisi
+    ];
     "llamalab_automate" = ps: with ps; [
     ];
     "local_calendar" = ps: with ps; [
@@ -4396,6 +4397,7 @@
     "lifx"
     "light"
     "litterrobot"
+    "livisi"
     "local_calendar"
     "local_file"
     "local_ip"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -244,6 +244,8 @@ self: super: with self; {
 
   aiolip = callPackage ../development/python-modules/aiolip { };
 
+  aiolivisi = callPackage ../development/python-modules/aiolivisi { };
+
   aiolyric = callPackage ../development/python-modules/aiolyric { };
 
   aiomisc = callPackage ../development/python-modules/aiomisc { };


### PR DESCRIPTION
###### Description of changes
Module to communicate with LIVISI Smart Home Controller

https://github.com/StefanIacobLivisi/aiolivisi
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
