### PR TITLE
nixos/resilio: fix resilio configuration if sharedFolders list is empty

### DIFF
--- a/nixos/modules/services/networking/resilio.nix
+++ b/nixos/modules/services/networking/resilio.nix
@@ -54,7 +54,7 @@ let
 
   createConfig = pkgs.writeShellScriptBin "create-resilio-config" ''
     ${pkgs.jq}/bin/jq \
-      '.shared_folders |= map(.secret = $ARGS.named[.dir])' \
+      '.shared_folders |= if . == null then empty else map(.secret = $ARGS.named[.dir]) end' \
       ${
         lib.concatMapStringsSep " \\\n  "
         (entry: ''--arg '${entry.dir}' "$(cat '${entry.secretFile}')"'')


### PR DESCRIPTION

###### Description of changes

The script to generate the resilio configuration was failing with this error:

```
× resilio.service - Resilio Sync Service
     Loaded: loaded (/etc/systemd/system/resilio.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Sun 2022-12-11 13:44:27 CET; 56min ago
    Process: 7035 ExecStartPre=/nix/store/ph63ikmd1sid9pz2ss778yiip2l6zg3l-create-resilio-config/bin/create-resilio-config (code=exited, status=5)
         IP: 0B in, 0B out
        CPU: 51ms

Dec 11 13:44:27 xenon systemd[1]: Starting Resilio Sync Service...
Dec 11 13:44:27 xenon create-resilio-config[7043]: jq: error (at <stdin>:0): Cannot iterate over null (null)
Dec 11 13:44:27 xenon systemd[1]: resilio.service: Control process exited, code=exited, status=5/NOTINSTALLED
Dec 11 13:44:27 xenon systemd[1]: resilio.service: Failed with result 'exit-code'.
Dec 11 13:44:27 xenon systemd[1]: Failed to start Resilio Sync Service.
```

This commit fixes this jq error.

I am not sure why this only started failing recently, as it seems this jq script is older. But this fixes it nonetheless.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
