### PR TITLE
netbeans: 15 -> 16

### DIFF
--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "15";
+  version = "16";
   desktopItem = makeDesktopItem {
     name = "netbeans";
     exec = "netbeans";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "mirror://apache/netbeans/netbeans/${version}/netbeans-${version}-bin.zip";
-    hash = "sha512-WxqAQiPKdMfQCw9Hxaa7K2VIGTJj+Hu9WO2ehG4yQUkHBd+l0f0siLKk/i2xqLE1ZA522rxKud6iwXDuAsjjDg==";
+    hash = "sha512-k+Zj6TKW0tOSYvM6V1okF4Qz62gZMETC6XG98W23Vtz3+vdiaddd8BC2DBg7p9Z1CofRq8sbwtpeTJM3FaXv0g==";
   };
 
   buildCommand = ''


### PR DESCRIPTION
###### Description of changes

Updated to latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```console
nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 256, done.
remote: Counting objects: 100% (221/221), done.
remote: Compressing objects: 100% (104/104), done.
remote: Total 256 (delta 153), reused 159 (delta 112), pack-reused 35
Receiving objects: 100% (256/256), 443.44 KiB | 173.00 KiB/s, done.
Resolving deltas: 100% (154/154), completed with 52 local objects.
From https://github.com/NixOS/nixpkgs
   cbd66894e60..bee0009e1e7  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-adf4a46812b6eb3353c942fef18c9dc19414a3db/nixpkgs bee0009e1e704fdeaf56ee9f1999e2e56b29c831
Preparing worktree (detached HEAD bee0009e1e7)
Updating files: 100% (32848/32848), done.
HEAD is now at bee0009e1e7 Merge pull request #205480 from trofi/ocaml-4_00_1-without-xlibsWrapper
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-adf4a46812b6eb3353c942fef18c9dc19414a3db/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff adf4a46812b6eb3353c942fef18c9dc19414a3db
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-adf4a46812b6eb3353c942fef18c9dc19414a3db/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package updated:
netbeans (15 → 16)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/asbachb/.cache/nixpkgs-review/rev-adf4a46812b6eb3353c942fef18c9dc19414a3db/build.nix
1 package built:
netbeans

$ /nix/store/ky430fi047b2m8h28bn1hbjyhl9y5i6h-nix-2.12.0/bin/nix-shell /home/asbachb/.cache/nixpkgs-review/rev-adf4a46812b6eb3353c942fef18c9dc19414a3db/shell.nix
```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
