### PR TITLE
ocamlPackages.ansiterminal: 0.8.2 → 0.8.5

### DIFF
--- a/pkgs/development/ocaml-modules/ansiterminal/default.nix
+++ b/pkgs/development/ocaml-modules/ansiterminal/default.nix
@@ -1,16 +1,12 @@
-{ lib, buildDunePackage, fetchFromGitHub }:
+{ lib, buildDunePackage, fetchurl }:
 
 buildDunePackage rec {
   pname = "ANSITerminal";
-  version = "0.8.2";
+  version = "0.8.5";
 
-  useDune2 = true;
-
-  src = fetchFromGitHub {
-    owner = "Chris00";
-    repo = pname;
-    rev = version;
-    sha256 = "0dyjischrgwlxqz1p5zbqq76jvk6pl1qj75i7ydhijssr9pj278d";
+  src = fetchurl {
+    url = "https://github.com/Chris00/ANSITerminal/releases/download/${version}/ANSITerminal-${version}.tbz";
+    hash = "sha256-q3OyGLajAmfSu8QzEtzzE5gbiwvsVV2SsGuHZkst0w4=";
   };
 
   doCheck = true;
@@ -22,7 +18,7 @@ buildDunePackage rec {
       movements on ANSI terminals. It also works on the windows shell (but
       this part is currently work in progress).
     '';
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/Chris00/ANSITerminal";
     license = licenses.lgpl3;
     maintainers = [ maintainers.jirkamarsik ];
   };


### PR DESCRIPTION
###### Description of changes

Cleaning: https://github.com/Chris00/ANSITerminal/blob/0.8.5/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
