### PR TITLE
doc/lib-functions: remove warnings, add `versions`, `cli`

### DIFF
--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -7,12 +7,14 @@ let
     asserts = "Assert functions";
     attrsets = "Attribute-set functions";
     strings = "String manipulation functions";
+    versions = "Version string functions";
     trivial = "Miscellaneous functions";
     lists = "List manipulation functions";
     debug = "Debugging functions";
     options = "NixOS / nixpkgs option handling";
     filesystem = "Filesystem functions";
     sources = "Source filtering functions";
+    cli = "Command-line serialization functions";
   };
 
   locationsXml = import ./lib-function-locations.nix { inherit pkgs nixpkgs libsets; };

--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -4,17 +4,17 @@ let
   inherit (lib) hasPrefix removePrefix;
 
   libsets = [
-    { name = "asserts"; description = "Assert functions"; }
-    { name = "attrsets"; description = "Attribute-set functions"; }
-    { name = "strings"; description = "String manipulation functions"; }
-    { name = "versions"; description = "Version string functions"; }
-    { name = "trivial"; description = "Miscellaneous functions"; }
-    { name = "lists"; description = "List manipulation functions"; }
-    { name = "debug"; description = "Debugging functions"; }
+    { name = "asserts"; description = "assertion functions"; }
+    { name = "attrsets"; description = "attribute set functions"; }
+    { name = "strings"; description = "string manipulation functions"; }
+    { name = "versions"; description = "version string functions"; }
+    { name = "trivial"; description = "miscellaneous functions"; }
+    { name = "lists"; description = "list manipulation functions"; }
+    { name = "debug"; description = "debugging functions"; }
     { name = "options"; description = "NixOS / nixpkgs option handling"; }
-    { name = "filesystem"; description = "Filesystem functions"; }
-    { name = "sources"; description = "Source filtering functions"; }
-    { name = "cli"; description = "Command-line serialization functions"; }
+    { name = "filesystem"; description = "filesystem functions"; }
+    { name = "sources"; description = "source filtering functions"; }
+    { name = "cli"; description = "command-line serialization functions"; }
   ];
 
   locationsXml = import ./lib-function-locations.nix { inherit pkgs nixpkgs libsets; };

--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -3,8 +3,20 @@ let
   inherit (pkgs) lib;
   inherit (lib) hasPrefix removePrefix;
 
-  locationsXml = import ./lib-function-locations.nix { inherit pkgs nixpkgs; };
-  functionDocs = import ./lib-function-docs.nix { inherit locationsXml pkgs; };
+  libsets = {
+    asserts = "Assert functions";
+    attrsets = "Attribute-set functions";
+    strings = "String manipulation functions";
+    trivial = "Miscellaneous functions";
+    lists = "List manipulation functions";
+    debug = "Debugging functions";
+    options = "NixOS / nixpkgs option handling";
+    filesystem = "Filesystem functions";
+    sources = "Source filtering functions";
+  };
+
+  locationsXml = import ./lib-function-locations.nix { inherit pkgs nixpkgs libsets; };
+  functionDocs = import ./lib-function-docs.nix { inherit locationsXml pkgs libsets; };
   version = pkgs.lib.version;
 
   epub-xsl = pkgs.writeText "epub.xsl" ''

--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -3,19 +3,19 @@ let
   inherit (pkgs) lib;
   inherit (lib) hasPrefix removePrefix;
 
-  libsets = {
-    asserts = "Assert functions";
-    attrsets = "Attribute-set functions";
-    strings = "String manipulation functions";
-    versions = "Version string functions";
-    trivial = "Miscellaneous functions";
-    lists = "List manipulation functions";
-    debug = "Debugging functions";
-    options = "NixOS / nixpkgs option handling";
-    filesystem = "Filesystem functions";
-    sources = "Source filtering functions";
-    cli = "Command-line serialization functions";
-  };
+  libsets = [
+    { name = "asserts"; description = "Assert functions"; }
+    { name = "attrsets"; description = "Attribute-set functions"; }
+    { name = "strings"; description = "String manipulation functions"; }
+    { name = "versions"; description = "Version string functions"; }
+    { name = "trivial"; description = "Miscellaneous functions"; }
+    { name = "lists"; description = "List manipulation functions"; }
+    { name = "debug"; description = "Debugging functions"; }
+    { name = "options"; description = "NixOS / nixpkgs option handling"; }
+    { name = "filesystem"; description = "Filesystem functions"; }
+    { name = "sources"; description = "Source filtering functions"; }
+    { name = "cli"; description = "Command-line serialization functions"; }
+  ];
 
   locationsXml = import ./lib-function-locations.nix { inherit pkgs nixpkgs libsets; };
   functionDocs = import ./lib-function-docs.nix { inherit locationsXml pkgs libsets; };

--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -20,9 +20,9 @@ with pkgs; stdenv.mkDerivation {
     <root xmlns:xi="http://www.w3.org/2001/XInclude">
     EOF
 
-    ${lib.concatStrings (lib.mapAttrsToList (name: description: ''
+    ${lib.concatMapStrings ({ name, description }: ''
       docgen ${name} ${lib.escapeShellArg description}
-    '') libsets)}
+    '') libsets}
 
     echo "</root>" >> "$out/index.xml"
 

--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -9,7 +9,8 @@ with pkgs; stdenv.mkDerivation {
   buildInputs = [ nixdoc ];
   installPhase = ''
     function docgen {
-      nixdoc -c "$1" -d "$2" -f "$1.nix" > "$out/$1.xml"
+      # TODO: wrap lib.$1 in <literal>, make nixdoc not escape it
+      nixdoc -c "$1" -d "lib.$1: $2" -f "$1.nix" > "$out/$1.xml"
       echo "<xi:include href='$1.xml' />" >> "$out/index.xml"
     }
 

--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -1,30 +1,31 @@
-# Generates the documentation for library functions via nixdoc. To add
-# another library function file to this list, the include list in the
-# file `doc/functions/library.xml` must also be updated.
+# Generates the documentation for library functions via nixdoc.
 
-{ pkgs ? import ./.. {}, locationsXml }:
+{ pkgs, locationsXml, libsets }:
 
 with pkgs; stdenv.mkDerivation {
   name = "nixpkgs-lib-docs";
-  src = ./../../lib;
+  src = ../../lib;
 
   buildInputs = [ nixdoc ];
   installPhase = ''
     function docgen {
-      nixdoc -c "$1" -d "$2" -f "../lib/$1.nix"  > "$out/$1.xml"
+      nixdoc -c "$1" -d "$2" -f "$1.nix" > "$out/$1.xml"
+      echo "<xi:include href='$1.xml' />" >> "$out/index.xml"
     }
 
-    mkdir -p $out
-    ln -s ${locationsXml} $out/locations.xml
+    mkdir -p "$out"
 
-    docgen asserts 'Assert functions'
-    docgen attrsets 'Attribute-set functions'
-    docgen strings 'String manipulation functions'
-    docgen trivial 'Miscellaneous functions'
-    docgen lists 'List manipulation functions'
-    docgen debug 'Debugging functions'
-    docgen options 'NixOS / nixpkgs option handling'
-    docgen filesystem 'Filesystem functions'
-    docgen sources 'Source filtering functions'
+    cat > "$out/index.xml" << 'EOF'
+    <?xml version="1.0" encoding="utf-8"?>
+    <root xmlns:xi="http://www.w3.org/2001/XInclude">
+    EOF
+
+    ${lib.concatStrings (lib.mapAttrsToList (name: description: ''
+      docgen ${name} ${lib.escapeShellArg description}
+    '') libsets)}
+
+    echo "</root>" >> "$out/index.xml"
+
+    ln -s ${locationsXml} $out/locations.xml
   '';
 }

--- a/doc/doc-support/lib-function-locations.nix
+++ b/doc/doc-support/lib-function-locations.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import ./.. { }), nixpkgs ? { }}:
+{ pkgs, nixpkgs ? { }, libsets }:
 let
   revision = pkgs.lib.trivial.revisionWithDefault (nixpkgs.revision or "master");
 
@@ -16,9 +16,7 @@ let
         subsetname = subsetname;
         functions = libDefPos toplib.${subsetname};
       })
-      (builtins.filter
-        (name: builtins.isAttrs toplib.${name})
-        (builtins.attrNames toplib));
+      (builtins.attrNames libsets);
 
   nixpkgsLib = pkgs.lib;
 

--- a/doc/doc-support/lib-function-locations.nix
+++ b/doc/doc-support/lib-function-locations.nix
@@ -16,7 +16,7 @@ let
         subsetname = subsetname;
         functions = libDefPos toplib.${subsetname};
       })
-      (builtins.attrNames libsets);
+      (builtins.map (x: x.name) libsets);
 
   nixpkgsLib = pkgs.lib;
 

--- a/doc/doc-support/parameters.xml
+++ b/doc/doc-support/parameters.xml
@@ -11,6 +11,7 @@
  <xsl:param name="html.script" select="'./highlightjs/highlight.pack.js ./highlightjs/loader.js'" />
  <xsl:param name="xref.with.number.and.title" select="0" />
  <xsl:param name="use.id.as.filename" select="1" />
+ <xsl:param name="generate.section.toc.level" select="1" />
  <xsl:param name="toc.section.depth" select="0" />
  <xsl:param name="admon.style" select="''" />
  <xsl:param name="callout.graphics.extension" select="'.svg'" />

--- a/doc/functions/library.xml
+++ b/doc/functions/library.xml
@@ -8,25 +8,7 @@
   Nixpkgs provides a standard library at <varname>pkgs.lib</varname>, or through <code>import &lt;nixpkgs/lib&gt;</code>.
  </para>
 
-<!-- These docs are generated via nixdoc. To add another generated
-      library function file to this list, the file
-      `lib-function-docs.nix` must also be updated. -->
-
- <xi:include href="./library/generated/asserts.xml" />
-
- <xi:include href="./library/generated/attrsets.xml" />
-
- <xi:include href="./library/generated/strings.xml" />
-
- <xi:include href="./library/generated/trivial.xml" />
-
- <xi:include href="./library/generated/lists.xml" />
-
- <xi:include href="./library/generated/debug.xml" />
-
- <xi:include href="./library/generated/options.xml" />
-
- <xi:include href="./library/generated/filesystem.xml" />
-
- <xi:include href="./library/generated/sources.xml" />
+ <!-- The index must have a root element to declare namespaces, but we
+      don't want to include it, so we select all of its children. -->
+ <xi:include href="./library/generated/index.xml" xpointer="xpointer(/root/*)" />
 </section>


### PR DESCRIPTION
Building the nixpkgs manual currently triggers a bunch of deprecation warnings, because every attribute in `lib` is evaluated to see if it's an attrset to generate locations for.

Instead, share the lib subsets to include in the documentation between `lib-function-docs` and `lib-function-locations` so they can coordinate.

I also wanted to add `modules` (the [upcoming](https://github.com/NixOS/nixpkgs/pull/204840) `lib.modules.typeCheck{,ing}` might especially be worth documenting) but there are several obstacles:
- that file contains many functions that are too internal to be exposed in the docs. Maybe they should actually be made local, or split into a different file if we don't want to break the API?
- `nixdoc` generates documentation for non-toplevel local functions like [`collectStructuredModules`](https://github.com/NixOS/nixpkgs/blob/99fed31f9da9265b6b608955610e4b72247e0dad/lib/modules.nix#L362-L387) (which then fail the build because they try to include location information that wasn't generated).

Fixes https://github.com/NixOS/nixpkgs/issues/116472