### PR TITLE
Revert "[Backport release-22.11] miniupnpc: use cmake for build"

### DIFF
--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -72,6 +72,10 @@ stdenv.mkDerivation rec {
     "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
   ];
 
+  # fix "Killed: 9  test/test_bitcoin"
+  # https://github.com/NixOS/nixpkgs/issues/179474
+  hardeningDisable = lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [ "fortify" "stackprotector" ];
+
   checkInputs = [ python3 ];
 
   doCheck = true;

--- a/pkgs/tools/networking/miniupnpc/default.nix
+++ b/pkgs/tools/networking/miniupnpc/default.nix
@@ -1,7 +1,8 @@
 { lib
 , stdenv
 , fetchurl
-, cmake
+, which
+, cctools
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jrc84lkc7xb53rb8dbswxrxj21ndj1iiclmk3r9wkp6xm55w6j8";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ which cctools ];
 
   patches = lib.optional stdenv.isFreeBSD ./freebsd.patch;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9312,7 +9312,9 @@ with pkgs;
 
   minissdpd = callPackage ../tools/networking/minissdpd { };
 
-  miniupnpc = callPackage ../tools/networking/miniupnpc { };
+  miniupnpc = callPackage ../tools/networking/miniupnpc {
+    inherit (darwin) cctools;
+  };
 
   miniupnpd = callPackage ../tools/networking/miniupnpd { };
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#202832

This pr introduced a regression in the stable channel as described in #204291.