### PR TITLE
libnma: bug fix removing path from eap scheme

### DIFF
--- a/pkgs/tools/networking/networkmanager/libnma/default.nix
+++ b/pkgs/tools/networking/networkmanager/libnma/default.nix
@@ -39,6 +39,9 @@ stdenv.mkDerivation rec {
   patches = [
     # Needed for wingpanel-indicator-network and switchboard-plug-network
     ./hardcode-gsettings.patch
+    # Removing path from eap schema to fix bug when creating new VPN connection
+    # https://gitlab.gnome.org/GNOME/libnma/-/issues/18
+    ./remove-path-from-eap.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/tools/networking/networkmanager/libnma/remove-path-from-eap.patch
+++ b/pkgs/tools/networking/networkmanager/libnma/remove-path-from-eap.patch
@@ -1,0 +1,32 @@
+From 0ab5c1e39e94e158650da847f8512ab5e2b03593 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Wed, 9 Nov 2022 08:00:19 +0000
+Subject: [PATCH] gschema: Remove path from eap schema
+
+This one needs to be relocatable, otherwise creating a new VPN
+connection will fail with:
+
+    settings object created with schema 'org.gnome.nm-applet.eap'
+    and path '/org/gnome/nm-applet/eap/<uuid>/',
+    but path '/org/gnome/nm-applet/eap/' is specified by schema
+
+Fixes: https://bugs.archlinux.org/task/76490
+---
+ org.gnome.nm-applet.eap.gschema.xml.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/org.gnome.nm-applet.eap.gschema.xml.in b/org.gnome.nm-applet.eap.gschema.xml.in
+index 0fc3ca9f..f4a56ea6 100644
+--- a/org.gnome.nm-applet.eap.gschema.xml.in
++++ b/org.gnome.nm-applet.eap.gschema.xml.in
+@@ -1,6 +1,6 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <schemalist>
+-  <schema id="org.gnome.nm-applet.eap" path="/org/gnome/nm-applet/eap/" gettext-domain="nm-applet">
++  <schema id="org.gnome.nm-applet.eap" gettext-domain="nm-applet">
+     <key name="ignore-ca-cert" type="b">
+       <default>false</default>
+       <summary>Ignore CA certificate</summary>
+-- 
+GitLab
+


### PR DESCRIPTION
Fixes known bug in libnma https://gitlab.gnome.org/GNOME/libnma/-/issues/18 By applying patch based on https://gitlab.gnome.org/GNOME/libnma/-/merge_requests/44

###### Description of changes

Fixes error when trying to create new VPN connection.
Which used to fail with error msg:
```
settings object created with schema 'org.gnome.nm-applet.eap'
and path '/org/gnome/nm-applet/eap/<uuid>/',
but path '/org/gnome/nm-applet/eap/' is specified by schema
```

Fixes: https://bugs.archlinux.org/task/76490
Fixes: https://gitlab.gnome.org/GNOME/libnma/-/issues/18


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
