### PR TITLE
python310Packages.bonsai: init at 5.1.1

### DIFF
--- a/pkgs/development/python-modules/bonsai/default.nix
+++ b/pkgs/development/python-modules/bonsai/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, setuptools
+, cyrus_sasl
+, openldap
+, typing-extensions
+, gevent
+, tornado
+, trio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "bonsai";
+  version = "1.5.1";
+
+  disabled = pythonOlder "3.7";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "noirello";
+    repo = "bonsai";
+    rev = "v${version}";
+    hash = "sha256-UR/Ds5famD8kuDa6IIIyEv45eJuAcoygXef8XE+5Cxk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  buildInputs = [
+    cyrus_sasl
+    openldap
+  ];
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
+    typing-extensions
+  ];
+
+  passthru.optional-dependencies = {
+    gevent = [ gevent ];
+    tornado = [ tornado ];
+    trio = [ trio ];
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # requires running LDAP server
+    "tests/test_asyncio.py"
+    "tests/test_ldapclient.py"
+    "tests/test_ldapconnection.py"
+    "tests/test_ldapentry.py"
+    "tests/test_ldapreference.py"
+    "tests/test_pool.py"
+  ];
+
+  disabledTests = [
+    # requires running LDAP server
+    "test_set_async_connect"
+  ];
+
+  pythonImportsCheck = [ "bonsai" ];
+
+  meta = {
+    changelog = "https://github.com/noirello/bonsai/blob/${src.rev}/CHANGELOG.rst";
+    description = "Python 3 module for accessing LDAP directory servers";
+    homepage = "https://github.com/noirello/bonsai";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1341,6 +1341,8 @@ self: super: with self; {
 
   bond-async = callPackage ../development/python-modules/bond-async { };
 
+  bonsai = callPackage ../development/python-modules/bonsai { };
+
   booleanoperations = callPackage ../development/python-modules/booleanoperations { };
 
   boolean-py = callPackage ../development/python-modules/boolean-py { };


### PR DESCRIPTION
###### Description of changes
Add a Python 3 module for accessing LDAP directory servers
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
