### PR TITLE
lib.replaceChars: warn about being a deprecated alias

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -328,7 +328,7 @@ rec {
        escape ["(" ")"] "(foo)"
        => "\\(foo\\)"
   */
-  escape = list: replaceChars list (map (c: "\\${c}") list);
+  escape = list: replaceStrings list (map (c: "\\${c}") list);
 
   /* Escape occurence of the element of `list` in `string` by
      converting to its ASCII value and prefixing it with \\x.
@@ -341,7 +341,7 @@ rec {
        => "foo\\x20bar"
 
   */
-  escapeC = list: replaceChars list (map (c: "\\x${ toLower (lib.toHexString (charToInt c))}") list);
+  escapeC = list: replaceStrings list (map (c: "\\x${ toLower (lib.toHexString (charToInt c))}") list);
 
   /* Quote string to be used safely within the Bourne shell.
 
@@ -471,19 +471,8 @@ rec {
     ["\"" "'" "<" ">" "&"]
     ["&quot;" "&apos;" "&lt;" "&gt;" "&amp;"];
 
-  # Obsolete - use replaceStrings instead.
-  replaceChars = builtins.replaceStrings or (
-    del: new: s:
-    let
-      substList = lib.zipLists del new;
-      subst = c:
-        let found = lib.findFirst (sub: sub.fst == c) null substList; in
-        if found == null then
-          c
-        else
-          found.snd;
-    in
-      stringAsChars subst s);
+  # warning added 12-12-2022
+  replaceChars = lib.warn "replaceChars is a deprecated alias of replaceStrings, replace usages of it with replaceStrings." builtins.replaceStrings;
 
   # Case conversion utilities.
   lowerChars = stringToCharacters "abcdefghijklmnopqrstuvwxyz";
@@ -497,7 +486,7 @@ rec {
        toLower "HOME"
        => "home"
   */
-  toLower = replaceChars upperChars lowerChars;
+  toLower = replaceStrings upperChars lowerChars;
 
   /* Converts an ASCII string to upper-case.
 
@@ -507,7 +496,7 @@ rec {
        toUpper "home"
        => "HOME"
   */
-  toUpper = replaceChars lowerChars upperChars;
+  toUpper = replaceStrings lowerChars upperChars;
 
   /* Appends string context from another string.  This is an implementation
      detail of Nix and should be used carefully.

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -8,9 +8,9 @@ let
   systemd = cfg.package;
 in rec {
 
-  shellEscape = s: (replaceChars [ "\\" ] [ "\\\\" ] s);
+  shellEscape = s: (replaceStrings [ "\\" ] [ "\\\\" ] s);
 
-  mkPathSafeName = lib.replaceChars ["@" ":" "\\" "[" "]"] ["-" "-" "-" "" ""];
+  mkPathSafeName = lib.replaceStrings ["@" ":" "\\" "[" "]"] ["-" "-" "-" "" ""];
 
   # a type for options that take a unit name
   unitNameType = types.strMatching "[a-zA-Z0-9@%:_.\\-]+[.](service|socket|device|mount|automount|swap|target|path|timer|scope|slice)";
@@ -258,7 +258,7 @@ in rec {
 
   makeJobScript = name: text:
     let
-      scriptName = replaceChars [ "\\" "@" ] [ "-" "_" ] (shellEscape name);
+      scriptName = replaceStrings [ "\\" "@" ] [ "-" "_" ] (shellEscape name);
       out = (pkgs.writeShellScriptBin scriptName ''
         set -e
         ${text}

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -48,7 +48,7 @@ rec {
     trim = s: removeSuffix "/" (removePrefix "/" s);
     normalizedPath = strings.normalizePath s;
   in
-    replaceChars ["/"] ["-"]
+    replaceStrings ["/"] ["-"]
     (replacePrefix "." (strings.escapeC ["."] ".")
     (strings.escapeC (stringToCharacters " !\"#$%&'()*+,;<=>=@[\\]^`{|}~-")
     (if normalizedPath == "/" then normalizedPath else trim normalizedPath)));
@@ -67,7 +67,7 @@ rec {
         else if builtins.isInt arg || builtins.isFloat arg then toString arg
         else throw "escapeSystemdExecArg only allows strings, paths and numbers";
     in
-      replaceChars [ "%" "$" ] [ "%%" "$$" ] (builtins.toJSON s);
+      replaceStrings [ "%" "$" ] [ "%%" "$$" ] (builtins.toJSON s);
 
   # Quotes a list of arguments into a single string for use in a Exec*
   # line.
@@ -112,7 +112,7 @@ rec {
         else if isAttrs item then
           map (name:
             let
-              escapedName = ''"${replaceChars [''"'' "\\"] [''\"'' "\\\\"] name}"'';
+              escapedName = ''"${replaceStrings [''"'' "\\"] [''\"'' "\\\\"] name}"'';
             in
               recurse (prefix + "." + escapedName) item.${name}) (attrNames item)
         else if isList item then

--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -160,7 +160,7 @@ let
     config = rec {
       device = mkIf options.label.isDefined
         "/dev/disk/by-label/${config.label}";
-      deviceName = lib.replaceChars ["\\"] [""] (escapeSystemdPath config.device);
+      deviceName = lib.replaceStrings ["\\"] [""] (escapeSystemdPath config.device);
       realDevice = if config.randomEncryption.enable then "/dev/mapper/${deviceName}" else config.device;
     };
 

--- a/nixos/modules/programs/xfs_quota.nix
+++ b/nixos/modules/programs/xfs_quota.nix
@@ -94,7 +94,7 @@ in
         '';
 
         wantedBy = [ "multi-user.target" ];
-        after = [ ((replaceChars [ "/" ] [ "-" ] opts.fileSystem) + ".mount") ];
+        after = [ ((replaceStrings [ "/" ] [ "-" ] opts.fileSystem) + ".mount") ];
 
         restartTriggers = [ config.environment.etc.projects.source ];
 

--- a/nixos/modules/services/mail/listmonk.nix
+++ b/nixos/modules/services/mail/listmonk.nix
@@ -8,7 +8,7 @@ let
   # Escaping is done according to https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS
   setDatabaseOption = key: value:
     "UPDATE settings SET value = '${
-      lib.replaceChars [ "'" ] [ "''" ] (builtins.toJSON value)
+      lib.replaceStrings [ "'" ] [ "''" ] (builtins.toJSON value)
     }' WHERE key = '${key}';";
   updateDatabaseConfigSQL = pkgs.writeText "update-database-config.sql"
     (concatStringsSep "\n" (mapAttrsToList setDatabaseOption

--- a/nixos/modules/services/networking/supplicant.nix
+++ b/nixos/modules/services/networking/supplicant.nix
@@ -13,7 +13,7 @@ let
   serviceName = iface: "supplicant-${if (iface=="WLAN") then "wlan@" else (
                                      if (iface=="LAN") then "lan@" else (
                                      if (iface=="DBUS") then "dbus"
-                                     else (replaceChars [" "] ["-"] iface)))}";
+                                     else (replaceStrings [" "] ["-"] iface)))}";
 
   # TODO: Use proper privilege separation for wpa_supplicant
   supplicantService = iface: suppl:
@@ -27,7 +27,7 @@ let
       driverArg = optionalString (suppl.driver != null) "-D${suppl.driver}";
       bridgeArg = optionalString (suppl.bridge!="") "-b${suppl.bridge}";
       confFileArg = optionalString (suppl.configFile.path!=null) "-c${suppl.configFile.path}";
-      extraConfFile = pkgs.writeText "supplicant-extra-conf-${replaceChars [" "] ["-"] iface}" ''
+      extraConfFile = pkgs.writeText "supplicant-extra-conf-${replaceStrings [" "] ["-"] iface}" ''
         ${optionalString suppl.userControlled.enable "ctrl_interface=DIR=${suppl.userControlled.socketDir} GROUP=${suppl.userControlled.group}"}
         ${optionalString suppl.configFile.writable "update_config=1"}
         ${suppl.extraConf}
@@ -223,7 +223,7 @@ in
         text = ''
           ${flip (concatMapStringsSep "\n") (filter (n: n!="WLAN" && n!="LAN" && n!="DBUS") (attrNames cfg)) (iface:
             flip (concatMapStringsSep "\n") (splitString " " iface) (i: ''
-              ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="${i}", TAG+="systemd", ENV{SYSTEMD_WANTS}+="supplicant-${replaceChars [" "] ["-"] iface}.service", TAG+="SUPPLICANT_ASSIGNED"''))}
+              ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="${i}", TAG+="systemd", ENV{SYSTEMD_WANTS}+="supplicant-${replaceStrings [" "] ["-"] iface}.service", TAG+="SUPPLICANT_ASSIGNED"''))}
 
           ${optionalString (hasAttr "WLAN" cfg) ''
             ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", TAG!="SUPPLICANT_ASSIGNED", TAG+="systemd", PROGRAM="/run/current-system/systemd/bin/systemd-escape -p %E{INTERFACE}", ENV{SYSTEMD_WANTS}+="supplicant-wlan@$result.service"

--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -315,7 +315,7 @@ let
 
   peerUnitServiceName = interfaceName: publicKey: dynamicRefreshEnabled:
     let
-      keyToUnitName = replaceChars
+      keyToUnitName = replaceStrings
         [ "/" "-"    " "     "+"     "="      ]
         [ "-" "\\x2d" "\\x20" "\\x2b" "\\x3d" ];
       unitName = keyToUnitName publicKey;

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -38,7 +38,7 @@ let
   grubConfig = args:
     let
       efiSysMountPoint = if args.efiSysMountPoint == null then args.path else args.efiSysMountPoint;
-      efiSysMountPoint' = replaceChars [ "/" ] [ "-" ] efiSysMountPoint;
+      efiSysMountPoint' = replaceStrings [ "/" ] [ "-" ] efiSysMountPoint;
     in
     pkgs.writeText "grub-config.xml" (builtins.toXML
     { splashImage = f cfg.splashImage;

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1377,12 +1377,12 @@ in
       # networkmanager falls back to "/proc/sys/net/ipv6/conf/default/use_tempaddr"
       "net.ipv6.conf.default.use_tempaddr" = tempaddrValues.${cfg.tempAddresses}.sysctl;
     } // listToAttrs (forEach interfaces
-        (i: nameValuePair "net.ipv4.conf.${replaceChars ["."] ["/"] i.name}.proxy_arp" i.proxyARP))
+        (i: nameValuePair "net.ipv4.conf.${replaceStrings ["."] ["/"] i.name}.proxy_arp" i.proxyARP))
       // listToAttrs (forEach interfaces
         (i: let
           opt = i.tempAddress;
           val = tempaddrValues.${opt}.sysctl;
-         in nameValuePair "net.ipv6.conf.${replaceChars ["."] ["/"] i.name}.use_tempaddr" val));
+         in nameValuePair "net.ipv6.conf.${replaceStrings ["."] ["/"] i.name}.use_tempaddr" val));
 
     security.wrappers = {
       ping = {
@@ -1495,7 +1495,7 @@ in
           in
           ''
             # override to ${msg} for ${i.name}
-            ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.${replaceChars ["."] ["/"] i.name}.use_tempaddr=${val}"
+            ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.${replaceStrings ["."] ["/"] i.name}.use_tempaddr=${val}"
           '') (filter (i: i.tempAddress != cfg.tempAddresses) interfaces);
       })
     ] ++ lib.optional (cfg.wlanInterfaces != {})

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -57,7 +57,7 @@ let
 
         hardware.enableAllFirmware = lib.mkForce false;
 
-        ${replaceChars ["\n"] ["\n  "] extraConfig}
+        ${replaceStrings ["\n"] ["\n  "] extraConfig}
       }
     '';
 

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -6,7 +6,7 @@
 let
   inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
   inherit (pkgs.lib) concatStringsSep maintainers mapAttrs mkMerge
-    removeSuffix replaceChars singleton splitString;
+    removeSuffix replaceStrings singleton splitString;
 
   /*
     * The attrset `exporterTests` contains one attribute
@@ -182,7 +182,7 @@ let
         enable = true;
         extraFlags = [ "--web.collectd-push-path /collectd" ];
       };
-      exporterTest = let postData = replaceChars [ "\n" ] [ "" ] ''
+      exporterTest = let postData = replaceStrings [ "\n" ] [ "" ] ''
         [{
           "values":[23],
           "dstypes":["gauge"],

--- a/pkgs/applications/audio/munt/libmt32emu.nix
+++ b/pkgs/applications/audio/munt/libmt32emu.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "munt";
     repo = "munt";
-    rev = "${pname}_${lib.replaceChars [ "." ] [ "_" ] version}";
+    rev = "${pname}_${lib.replaceStrings [ "." ] [ "_" ] version}";
     sha256 = "sha256-XGds9lDfSiY0D8RhYG4TGyjYEVvVYuAfNSv9+VxiJEs=";
   };
 

--- a/pkgs/applications/audio/munt/mt32emu-qt.nix
+++ b/pkgs/applications/audio/munt/mt32emu-qt.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  char2underscore = char: str: lib.replaceChars [ char ] [ "_" ] str;
+  char2underscore = char: str: lib.replaceStrings [ char ] [ "_" ] str;
 in
 mkDerivation rec {
   pname = "mt32emu-qt";

--- a/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
+++ b/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  char2underscore = char: str: lib.replaceChars [ char ] [ "_" ] str;
+  char2underscore = char: str: lib.replaceStrings [ char ] [ "_" ] str;
 in
 stdenv.mkDerivation rec {
   pname = "mt32emu-smf2wav";

--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -13,7 +13,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rncbc";
     repo = "qjackctl";
-    rev = "${pname}_${lib.replaceChars ["."] ["_"] version}";
+    rev = "${pname}_${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "sha256-PchW9cM5qEP51G9RXUZ3j/AvKqTkgNiw3esqSQqsy0M=";
   };
 

--- a/pkgs/applications/audio/roomeqwizard/default.nix
+++ b/pkgs/applications/audio/roomeqwizard/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   version = "5.20.5";
 
   src = fetchurl {
-    url = "https://www.roomeqwizard.com/installers/REW_linux_${lib.replaceChars [ "." ] [ "_" ] version}.sh";
+    url = "https://www.roomeqwizard.com/installers/REW_linux_${lib.replaceStrings [ "." ] [ "_" ] version}.sh";
     sha256 = "NYTRiOZmwkni4k+jI2SV84z5umO7+l+eKpwPCdlDD3U=";
   };
 

--- a/pkgs/applications/editors/jetbrains/linux.nix
+++ b/pkgs/applications/editors/jetbrains/linux.nix
@@ -21,7 +21,7 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
   desktopItem = makeDesktopItem {
     name = pname;
     exec = pname;
-    comment = lib.replaceChars ["\n"] [" "] meta.longDescription;
+    comment = lib.replaceStrings ["\n"] [" "] meta.longDescription;
     desktopName = product;
     genericName = meta.description;
     categories = [ "Development" ];

--- a/pkgs/applications/emulators/atari800/default.nix
+++ b/pkgs/applications/emulators/atari800/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "atari800";
     repo = "atari800";
-    rev = "ATARI800_${replaceChars ["."] ["_"] version}";
+    rev = "ATARI800_${replaceStrings ["."] ["_"] version}";
     sha256 = "sha256-+eJXhqPyU0GhmzF7DbteTXzEnn5klCor9Io/UgXQfQg=";
   };
 

--- a/pkgs/applications/emulators/desmume/default.nix
+++ b/pkgs/applications/emulators/desmume/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "TASVideos";
     repo = "desmume";
-    rev = "release_${lib.replaceChars ["."] ["_"] finalAttrs.version}";
+    rev = "release_${lib.replaceStrings ["."] ["_"] finalAttrs.version}";
     hash = "sha256-vmjKXa/iXLTwtqnG+ZUvOnOQPZROeMpfM5J3Jh/Ynfo=";
   };
 

--- a/pkgs/applications/emulators/retroarch/mkLibretroCore.nix
+++ b/pkgs/applications/emulators/retroarch/mkLibretroCore.nix
@@ -16,7 +16,7 @@
 }@args:
 
 let
-  d2u = if normalizeCore then (lib.replaceChars [ "-" ] [ "_" ]) else (x: x);
+  d2u = if normalizeCore then (lib.replaceStrings [ "-" ] [ "_" ]) else (x: x);
   coreDir = placeholder "out" + libretroCore;
   coreFilename = "${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";
   mainProgram = "retroarch-${core}";

--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -105,7 +105,7 @@ let
     };
   };
 
-  d2u = lib.replaceChars ["."] ["_"];
+  d2u = lib.replaceStrings ["."] ["_"];
 
 in {
 

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -81,7 +81,7 @@ let
 
   };
 
-  d2u = lib.replaceChars ["."] ["_"];
+  d2u = lib.replaceStrings ["."] ["_"];
 
 in {
 

--- a/pkgs/applications/science/math/weka/default.nix
+++ b/pkgs/applications/science/math/weka/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.9.6";
 
   src = fetchurl {
-    url = "mirror://sourceforge/weka/${lib.replaceChars ["."]["-"] "${pname}-${version}"}.zip";
+    url = "mirror://sourceforge/weka/${lib.replaceStrings ["."]["-"] "${pname}-${version}"}.zip";
     sha256 = "sha256-8fVN4MXYqXNEmyVtXh1IrauHTBZWgWG8AvsGI5Y9Aj0=";
   };
 

--- a/pkgs/applications/science/misc/openmodelica/omlibrary/fakegit.nix
+++ b/pkgs/applications/science/misc/openmodelica/omlibrary/fakegit.nix
@@ -13,7 +13,7 @@ let
 
   hashname = r:
     let
-      rpl = lib.replaceChars [ ":" "/" ] [ "_" "_" ];
+      rpl = lib.replaceStrings [ ":" "/" ] [ "_" "_" ];
     in
     (rpl r.url) + "-" + (rpl r.rev);
 

--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -39,14 +39,14 @@ assert (repos != []) || (url != "") || (urls != []);
 let
   name_ =
     lib.concatStrings [
-      (lib.replaceChars ["."] ["_"] groupId) "_"
-      (lib.replaceChars ["."] ["_"] artifactId) "-"
+      (lib.replaceStrings ["."] ["_"] groupId) "_"
+      (lib.replaceStrings ["."] ["_"] artifactId) "-"
       version
     ];
   mkJarUrl = repoUrl:
     lib.concatStringsSep "/" [
       (lib.removeSuffix "/" repoUrl)
-      (lib.replaceChars ["."] ["/"] groupId)
+      (lib.replaceStrings ["."] ["/"] groupId)
       artifactId
       version
       "${artifactId}-${version}${lib.optionalString (!isNull classifier) "-${classifier}"}.jar"

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -32,7 +32,7 @@ let version_ = lib.splitString "-" crateVersion;
     completeDepsDir = lib.concatStringsSep " " completeDeps;
     completeBuildDepsDir = lib.concatStringsSep " " completeBuildDeps;
     envFeatures = lib.concatStringsSep " " (
-      map (f: lib.replaceChars ["-"] ["_"] (lib.toUpper f)) crateFeatures
+      map (f: lib.replaceStrings ["-"] ["_"] (lib.toUpper f)) crateFeatures
     );
 in ''
   ${echo_colored colors}

--- a/pkgs/development/compilers/elm/makeDotElm.nix
+++ b/pkgs/development/compilers/elm/makeDotElm.nix
@@ -3,7 +3,7 @@
 ver: deps:
   let cmds = lib.mapAttrsToList (name: info: let
                pkg = stdenv.mkDerivation {
-                 name = lib.replaceChars ["/"] ["-"] name + "-${info.version}";
+                 name = lib.replaceStrings ["/"] ["-"] name + "-${info.version}";
 
                  src = fetchurl {
                    url = "https://github.com/${name}/archive/${info.version}.tar.gz";

--- a/pkgs/development/interpreters/gauche/default.nix
+++ b/pkgs/development/interpreters/gauche/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "shirok";
     repo = pname;
-    rev = "release${lib.replaceChars [ "." ] [ "_" ] version}";
+    rev = "release${lib.replaceStrings [ "." ] [ "_" ] version}";
     sha256 = "0ki1w7sa10ivmg51sqjskby0gsznb0d3738nz80x589033km5hmb";
   };
 

--- a/pkgs/development/libraries/icu/base.nix
+++ b/pkgs/development/libraries/icu/base.nix
@@ -9,7 +9,7 @@ let
 
   baseAttrs = {
     src = fetchurl {
-      url = "https://github.com/unicode-org/icu/releases/download/release-${lib.replaceChars [ "." ] [ "-" ] version}/icu4c-${lib.replaceChars [ "." ] [ "_" ] version}-src.tgz";
+      url = "https://github.com/unicode-org/icu/releases/download/release-${lib.replaceStrings [ "." ] [ "-" ] version}/icu4c-${lib.replaceStrings [ "." ] [ "_" ] version}-src.tgz";
       inherit sha256;
     };
 

--- a/pkgs/development/libraries/java/hsqldb/default.nix
+++ b/pkgs/development/libraries/java/hsqldb/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "hsqldb";
   version = "2.7.1";
-  underscoreMajMin = lib.strings.replaceChars ["."] ["_"] (lib.versions.majorMinor version);
+  underscoreMajMin = lib.replaceStrings ["."] ["_"] (lib.versions.majorMinor version);
 
   src = fetchurl {
     url = "mirror://sourceforge/project/hsqldb/hsqldb/hsqldb_${underscoreMajMin}/hsqldb-${version}.zip";

--- a/pkgs/development/libraries/muparser/default.nix
+++ b/pkgs/development/libraries/muparser/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "muparser";
   version = "2.2.3";
-  url-version = lib.replaceChars ["."] ["_"] version;
+  url-version = lib.replaceStrings ["."] ["_"] version;
 
   src = fetchurl {
     url = "mirror://sourceforge/muparser/muparser_v${url-version}.zip";

--- a/pkgs/development/libraries/opendkim/default.nix
+++ b/pkgs/development/libraries/opendkim/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "trusteddomainproject";
     repo = "OpenDKIM";
-    rev = "rel-opendkim-${lib.replaceChars ["."] ["-"] version}";
+    rev = "rel-opendkim-${lib.replaceStrings ["."] ["-"] version}";
     sha256 = "0nx3in8sa6xna4vfacj8g60hfzk61jpj2ldag80xzxip9c3rd2pw";
   };
 

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "PixarAnimationStudios";
     repo = "OpenSubdiv";
-    rev = "v${lib.replaceChars ["."] ["_"] version}";
+    rev = "v${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "sha256-ejxQ5mGIIrEa/rAfkTrRbIRerrAvEPoWn7e0lIqS1JQ=";
   };
 

--- a/pkgs/development/mobile/androidenv/build-app.nix
+++ b/pkgs/development/mobile/androidenv/build-app.nix
@@ -16,7 +16,7 @@ let
   extraArgs = removeAttrs args ([ "name" ] ++ builtins.attrNames androidSdkFormalArgs);
 in
 stdenv.mkDerivation ({
-  name = lib.replaceChars [" "] [""] name; # Android APKs may contain white spaces in their names, but Nix store paths cannot
+  name = lib.replaceStrings [" "] [""] name; # Android APKs may contain white spaces in their names, but Nix store paths cannot
   ANDROID_HOME = "${androidsdk}/libexec/android-sdk";
   buildInputs = [ jdk ant ];
   buildPhase = ''

--- a/pkgs/development/mobile/titaniumenv/build-app.nix
+++ b/pkgs/development/mobile/titaniumenv/build-app.nix
@@ -34,7 +34,7 @@ let
   extraArgs = removeAttrs args [ "name" "preRebuild" "androidsdkArgs" "xcodewrapperArgs" ];
 in
 stdenv.mkDerivation ({
-  name = lib.replaceChars [" "] [""] name;
+  name = lib.replaceStrings [" "] [""] name;
 
   buildInputs = [ nodejs titanium alloy python which file jdk ];
 

--- a/pkgs/development/mobile/xcodeenv/build-app.nix
+++ b/pkgs/development/mobile/xcodeenv/build-app.nix
@@ -53,7 +53,7 @@ let
   extraArgs = removeAttrs args ([ "name" "scheme" "xcodeFlags" "release" "certificateFile" "certificatePassword" "provisioningProfile" "signMethod" "generateIPA" "generateXCArchive" "enableWirelessDistribution" "installURL" "bundleId" "version" ] ++ builtins.attrNames xcodewrapperFormalArgs);
 in
 stdenv.mkDerivation ({
-  name = lib.replaceChars [" "] [""] name; # iOS app names can contain spaces, but in the Nix store this is not allowed
+  name = lib.replaceStrings [" "] [""] name; # iOS app names can contain spaces, but in the Nix store this is not allowed
   buildPhase = ''
     # Be sure that the Xcode wrapper has priority over everything else.
     # When using buildInputs this does not seem to be the case.

--- a/pkgs/development/mobile/xcodeenv/simulate-app.nix
+++ b/pkgs/development/mobile/xcodeenv/simulate-app.nix
@@ -9,7 +9,7 @@ let
   xcodewrapper = composeXcodeWrapper xcodewrapperArgs;
 in
 stdenv.mkDerivation {
-  name = lib.replaceChars [" "] [""] name;
+  name = lib.replaceStrings [" "] [""] name;
   buildCommand = ''
     mkdir -p $out/bin
     cat > $out/bin/run-test-simulator << "EOF"

--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -95,7 +95,7 @@ buildPythonPackage rec {
     changelog = let
       major = versions.major version;
       minor = versions.minor version;
-      dashVer = replaceChars ["."] ["-"] version;
+      dashVer = replaceStrings ["."] ["-"] version;
     in
       "https://scikit-learn.org/stable/whats_new/v${major}.${minor}.html#version-${dashVer}";
     homepage = "https://scikit-learn.org";

--- a/pkgs/development/tools/haskell/lambdabot/default.nix
+++ b/pkgs/development/tools/haskell/lambdabot/default.nix
@@ -20,8 +20,8 @@ let allPkgs = pkgs: mueval.defaultPkgs pkgs ++ [ pkgs.lambdabot-trusted ] ++ pac
                             ++ lib.optional withDjinn haskellPackages.djinn
                             ++ lib.optional (aspell != null) aspell
                            );
-    modulesStr = lib.replaceChars ["\n"] [" "] modules;
-    configStr = lib.replaceChars ["\n"] [" "] configuration;
+    modulesStr = lib.replaceStrings ["\n"] [" "] modules;
+    configStr = lib.replaceStrings ["\n"] [" "] configuration;
 
 in haskellLib.overrideCabal (self: {
   patches = (self.patches or []) ++ [ ./custom-config.patch ];

--- a/pkgs/development/tools/misc/segger-ozone/default.nix
+++ b/pkgs/development/tools/misc/segger-ozone/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   version = "3.22a";
 
   src = fetchurl {
-    url = "https://www.segger.com/downloads/jlink/Ozone_Linux_V${(lib.replaceChars ["."] [""] version)}_x86_64.tgz";
+    url = "https://www.segger.com/downloads/jlink/Ozone_Linux_V${(lib.replaceStrings ["."] [""] version)}_x86_64.tgz";
     sha256 = "0v1r8qvp1w2f3yip9fys004pa0smlmq69p7w77lfvghs1rmg1649";
   };
 

--- a/pkgs/development/web/kcgi/default.nix
+++ b/pkgs/development/web/kcgi/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "kcgi";
   version = "0.10.8";
-  underscoreVersion = lib.replaceChars ["."] ["_"] version;
+  underscoreVersion = lib.replaceStrings ["."] ["_"] version;
 
   src = fetchFromGitHub {
     owner = "kristapsdz";

--- a/pkgs/games/nexuiz/default.nix
+++ b/pkgs/games/nexuiz/default.nix
@@ -11,7 +11,7 @@
 let
   version = "2.5.2";
 
-  version_short = lib.replaceChars [ "." ] [ "" ] version;
+  version_short = lib.replaceStrings [ "." ] [ "" ] version;
 in stdenv.mkDerivation {
   pname = "nexuiz";
   inherit version;

--- a/pkgs/games/terraria-server/default.nix
+++ b/pkgs/games/terraria-server/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "terraria-server";
   version = "1.4.4.9";
-  urlVersion = lib.replaceChars [ "." ] [ "" ] version;
+  urlVersion = lib.replaceStrings [ "." ] [ "" ] version;
 
   src = fetchurl {
     url = "https://terraria.org/api/download/pc-dedicated-server/terraria-server-${urlVersion}.zip";

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -44,7 +44,7 @@ crystal.buildCrystalPackage rec {
       substituteInPlace src/invidious.cr \
           --replace ${lib.escapeShellArg branchTemplate} '"master"' \
           --replace ${lib.escapeShellArg commitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"' \
-          --replace ${lib.escapeShellArg versionTemplate} '"${lib.replaceChars ["-"] ["."] (lib.substring 9 10 version)}"' \
+          --replace ${lib.escapeShellArg versionTemplate} '"${lib.replaceStrings ["-"] ["."] (lib.substring 9 10 version)}"' \
           --replace ${lib.escapeShellArg assetCommitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"'
 
       # Patch the assets and locales paths to be absolute

--- a/pkgs/tools/typesetting/tex/pgf-tikz/pgf-1.x.nix
+++ b/pkgs/tools/typesetting/tex/pgf-tikz/pgf-1.x.nix
@@ -10,7 +10,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pgf-tikz";
     repo = "pgf";
-    rev = "refs/tags/version-${lib.replaceChars ["."] ["-"] finalAttrs.version}";
+    rev = "refs/tags/version-${lib.replaceStrings ["."] ["-"] finalAttrs.version}";
     hash = "sha256-WZ/191iEDd5VK1bnV9JZx2BZfACUeAUhAqrlyx+ZvA4=";
   };
 

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -4,7 +4,7 @@ let
   self = haxePackages;
   haxePackages = with self; {
 
-    withCommas = lib.replaceChars ["."] [","];
+    withCommas = lib.replaceStrings ["."] [","];
 
     # simulate "haxelib dev $libname ."
     simulateHaxelibDev = libname: ''


### PR DESCRIPTION
replaceStrings has been in nix since 2015(nix 1.10)

so it is safe to remove the fallback

https://github.com/nixos/nix/commit/d6d5885c1567454754a0d260521bafa0bd5e7fdb

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
