### PR TITLE
ocamlPackages.xenstore: 2.1.1 → 2.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/xenstore-tool/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore-tool/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "xenstore-tool";
 
-  inherit (xenstore_transport) src version useDune2 minimumOCamlVersion;
+  inherit (xenstore_transport) src version;
 
   buildInputs = [ xenstore_transport xenstore lwt ];
 

--- a/pkgs/development/ocaml-modules/xenstore/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore/default.nix
@@ -1,25 +1,23 @@
 { lib, buildDunePackage, fetchurl
-, cstruct, ppx_cstruct, lwt, ounit, stdlib-shims
+, cstruct, ppx_cstruct, lwt, ounit2
 }:
 
 buildDunePackage rec {
   pname = "xenstore";
-  version = "2.1.1";
+  version = "2.2.0";
 
-  minimumOCamlVersion = "4.04";
-
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-xenstore/releases/download/${version}/xenstore-${version}.tbz";
-    sha256 = "283814ea21adc345c4d59cfcb17b2f7c1185004ecaecc3871557c961874c84f5";
+    url = "https://github.com/mirage/ocaml-xenstore/releases/download/v${version}/xenstore-${version}.tbz";
+    hash = "sha256-1Mnqtt5zHeRdYJHvhdQNjN8d4yxUEKD2cpwtoc7DGC0=";
   };
 
   nativeBuildInputs = [ ppx_cstruct ];
-  propagatedBuildInputs = [ stdlib-shims cstruct lwt ];
+  propagatedBuildInputs = [ cstruct lwt ];
 
   doCheck = true;
-  checkInputs = [ ounit ];
+  checkInputs = [ ounit2 ];
 
   meta = with lib; {
     description = "Xenstore protocol in pure OCaml";

--- a/pkgs/development/ocaml-modules/xenstore_transport/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore_transport/default.nix
@@ -4,8 +4,7 @@ buildDunePackage rec {
   pname = "xenstore_transport";
   version = "1.3.0";
 
-  minimumOCamlVersion = "4.04";
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "xapi-project";


### PR DESCRIPTION
###### Description of changes

Fixes & improvements: https://github.com/mirage/ocaml-xenstore/blob/v2.2.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

