### PR TITLE
python39Packages.httpx: 0.23.0 -> 0.23.1

### DIFF
--- a/pkgs/development/python-modules/h11/default.nix
+++ b/pkgs/development/python-modules/h11/default.nix
@@ -4,6 +4,7 @@
 , pytestCheckHook
 , pythonOlder
 , httpcore
+, httpx
 , wsproto
 }:
 
@@ -23,7 +24,7 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   passthru.tests = {
-    inherit httpcore wsproto;
+    inherit httpcore httpx wsproto;
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -8,8 +8,11 @@
 , click
 , fetchFromGitHub
 , h2
+, hatch-fancy-pypi-readme
+, hatchling
 , httpcore
 , isPyPy
+, multipart
 , pygments
 , python
 , pythonOlder
@@ -26,8 +29,8 @@
 
 buildPythonPackage rec {
   pname = "httpx";
-  version = "0.23.0";
-  format = "setuptools";
+  version = "0.23.1";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -35,8 +38,13 @@ buildPythonPackage rec {
     owner = "encode";
     repo = pname;
     rev = version;
-    hash = "sha256-s11Yeizm3y3w5D6ACQ2wp/KJ0+1ALY/R71IlTP2pMC4=";
+    hash = "sha256-1gRBHbGFUkaFvVgHHoXfpo9j0L074SyevFwMY202+uk=";
   };
+
+  nativeBuildInputs = [
+    hatch-fancy-pypi-readme
+    hatchling
+  ];
 
   propagatedBuildInputs = [
     certifi
@@ -69,6 +77,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     chardet
+    multipart
     pytestCheckHook
     pytest-asyncio
     pytest-trio
@@ -79,7 +88,7 @@ buildPythonPackage rec {
     ++ passthru.optional-dependencies.socks;
 
   postPatch = ''
-    substituteInPlace setup.py \
+    substituteInPlace pyproject.toml \
       --replace "rfc3986[idna2008]>=1.3,<2" "rfc3986>=1.3"
   '';
 
@@ -112,6 +121,7 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
+    changelog = "https://github.com/encode/httpx/blob/${src.rev}/CHANGELOG.md";
     description = "The next generation HTTP client";
     homepage = "https://github.com/encode/httpx";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/multipart/default.nix
+++ b/pkgs/development/python-modules/multipart/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "multipart";
+  version = "0.2.4";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06ba205360bc7096fefe618e4f1e9b2cdb890b4f2157053a81f386912a2522cb";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "dont-test-semicolon-separators-in-urlencoded-data.patch";
+      url = "https://github.com/defnull/multipart/commit/4d4ac6b79c453918ebf40c690e8d57d982ee840b.patch";
+      hash = "sha256-rMeMhQEhonWAHzy5M8Im5mL6km5a9O0CGVOV+T3UNqo=";
+    })
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "multipart" ];
+
+  meta = {
+    description = "Parser for multipart/form-data";
+    homepage = "https://github.com/defnull/multipart";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6873,6 +6873,8 @@ self: super: with self; {
 
   msgraph-core = callPackage ../development/python-modules/msgraph-core { };
 
+  multipart = callPackage ../development/python-modules/multipart { };
+
   netmap = callPackage ../development/python-modules/netmap { };
 
   onetimepad = callPackage ../development/python-modules/onetimepad { };


### PR DESCRIPTION
fixes the build on [staging-next](https://github.com/NixOS/nixpkgs/pull/205270)

###### Description of changes
https://github.com/encode/httpx/releases/tag/0.23.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
