### PR TITLE
python3Packages.pynrrd: unbreak

### DIFF
--- a/pkgs/development/python-modules/nptyping/default.nix
+++ b/pkgs/development/python-modules/nptyping/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, beartype
+, invoke
+, mypy
+, numpy
+, pandas
+, feedparser
+, typeguard
+}:
+
+buildPythonPackage rec {
+  pname = "nptyping";
+  version = "2.4.1";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ramonhagenaars";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-jV2MVMP/tlYN3djoViemGaJyzREoOJJamwG97WFhIvc=";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  checkInputs = [
+    beartype feedparser invoke mypy pandas pytestCheckHook typeguard
+  ];
+
+  # tries to download data
+  disabledTests = [ "test_pandas_stubs_fork_is_synchronized" ];
+  disabledTestPaths = [
+    # missing pyright import:
+    "tests/test_pyright.py"
+    # can't find mypy stubs for pandas:
+    "tests/test_mypy.py"
+    "tests/pandas_/test_mypy_dataframe.py"
+    # tries to build wheel of package, broken/unnecessary under Nix:
+    "tests/test_wheel.py"
+  ];
+
+  pythonImportsCheck = [
+    "nptyping"
+  ];
+
+  meta = with lib; {
+    description = "Type hints for numpy";
+    homepage = "https://github.com/ramonhagenaars/nptyping";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/nptyping/default.nix
+++ b/pkgs/development/python-modules/nptyping/default.nix
@@ -15,6 +15,7 @@
 buildPythonPackage rec {
   pname = "nptyping";
   version = "2.4.1";
+  format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
@@ -25,14 +26,25 @@ buildPythonPackage rec {
     hash = "sha256-jV2MVMP/tlYN3djoViemGaJyzREoOJJamwG97WFhIvc=";
   };
 
-  propagatedBuildInputs = [ numpy ];
-
-  checkInputs = [
-    beartype feedparser invoke mypy pandas pytestCheckHook typeguard
+  propagatedBuildInputs = [
+    numpy
   ];
 
-  # tries to download data
-  disabledTests = [ "test_pandas_stubs_fork_is_synchronized" ];
+  checkInputs = [
+    beartype
+    feedparser
+    invoke
+    mypy
+    pandas
+    pytestCheckHook
+    typeguard
+  ];
+
+  disabledTests = [
+    # tries to download data
+    "test_pandas_stubs_fork_is_synchronized"
+  ];
+
   disabledTestPaths = [
     # missing pyright import:
     "tests/test_pyright.py"
@@ -50,6 +62,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Type hints for numpy";
     homepage = "https://github.com/ramonhagenaars/nptyping";
+    changelog = "https://github.com/ramonhagenaars/nptyping/blob/v${version}/HISTORY.md";
     license = licenses.mit;
     maintainers = with maintainers; [ bcdarwin ];
   };

--- a/pkgs/development/python-modules/pynrrd/default.nix
+++ b/pkgs/development/python-modules/pynrrd/default.nix
@@ -1,8 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, numpy
 , pythonOlder
+, numpy
+, nptyping
+, typing-extensions
 }:
 
 buildPythonPackage rec {
@@ -21,6 +23,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     numpy
+    nptyping
+    typing-extensions
   ];
 
   pythonImportsCheck = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6407,6 +6407,8 @@ self: super: with self; {
 
   nplusone = callPackage ../development/python-modules/nplusone { };
 
+  nptyping  = callPackage ../development/python-modules/nptyping { };
+
   npyscreen = callPackage ../development/python-modules/npyscreen { };
 
   nsapi = callPackage ../development/python-modules/nsapi { };


### PR DESCRIPTION
python3Packages.nptyping: init at 2.4.1

###### Description of changes

~Routine update~Unbreak due to staging-next breakage; add a dependency.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
