### PR TITLE
kubernetes-controller-tools: set version

### DIFF
--- a/pkgs/development/tools/kubernetes-controller-tools/default.nix
+++ b/pkgs/development/tools/kubernetes-controller-tools/default.nix
@@ -11,7 +11,15 @@ buildGoModule rec {
     sha256 = "sha256-244o+QZ0BGVe8t8AWf1wU6VHgYyzkATpr5ZTbZezk10=";
   };
 
+  patches = [ ./version.patch ];
+
   vendorSha256 = "sha256-sVdSKu6TDGIDV2o+kuCvGCItbFe9MwlM2Qjiz8n2rZU=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X sigs.k8s.io/controller-tools/pkg/version.version=v${version}"
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/tools/kubernetes-controller-tools/version.patch
+++ b/pkgs/development/tools/kubernetes-controller-tools/version.patch
@@ -1,0 +1,23 @@
+diff --git a/pkg/version/version.go b/pkg/version/version.go
+index 09c8efcf..b9ec798a 100644
+--- a/pkg/version/version.go
++++ b/pkg/version/version.go
+@@ -20,14 +20,12 @@ import (
+ 	"runtime/debug"
+ )
+ 
++var version string
++
+ // Version returns the version of the main module
+ func Version() string {
+-	info, ok := debug.ReadBuildInfo()
+-	if !ok || info == nil || info.Main.Version == "" {
+-		// binary has not been built with module support or doesn't contain a version.
+-		return "(unknown)"
+-	}
+-	return info.Main.Version
++	_ = debug.ReadBuildInfo
++	return version
+ }
+ 
+ // Print prints the main module version on stdout.


### PR DESCRIPTION

###### Description of changes

controller-gen likes to embed its internal version in generated files. As such, while the generated code is compile time equivalent to official releases, there is some thrashing if some users use nix and others us upstream artefacts. This change patches the version package and runtime value via ldflags.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
