### PR TITLE
linux_logo: 6.0 -> 6.01

### DIFF
--- a/pkgs/tools/misc/linux-logo/default.nix
+++ b/pkgs/tools/misc/linux-logo/default.nix
@@ -3,30 +3,25 @@
 , fetchFromGitHub
 , gettext
 , which
-, nix-update-script
 }:
 
 stdenv.mkDerivation rec {
   pname = "linux_logo";
-  version = "6.0";
+  version = "6.01";
 
   src = fetchFromGitHub {
     owner = "deater";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-q8QznEgnALJS//l7XXHZlq07pI2jCCm2USEU96rO8N0=";
+    rev = "v${version}";
+    hash = "sha256-yBAxPwgKyFFIX0wuG7oG+FbEDpA5cPwyyJgWrFErJ7I=";
   };
 
   nativeBuildInputs = [ gettext which ];
 
-  passthru.updateScript = nix-update-script {
-    attrPath = pname;
-  };
-
   meta = with lib; {
     description = "Prints an ASCII logo and some system info";
     homepage = "http://www.deater.net/weave/vmwprod/linux_logo";
-    changelog = "https://github.com/deater/linux_logo/blob/${version}/CHANGES_IN_${version}";
+    changelog = "https://github.com/deater/linux_logo/blob/${src.rev}/CHANGES";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ azahi ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes

Closes #181445

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
