### PR TITLE
element-{web,desktop}: 1.11.15 -> 1.11.16

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -57,6 +57,11 @@ stdenv.mkDerivation rec {
     runHook postConfigure
   '';
 
+  # Only affects unused scripts in $out/share/element/electron/scripts. Also
+  # breaks because there are some `node`-scripts with a `npx`-shebang and
+  # this shouldn't be in the closure just for unused scripts.
+  dontPatchShebangs = true;
+
   buildPhase = ''
     runHook preBuild
 

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.11.15",
-  "desktopSrcHash": "l+IjI3uvnOjaJA6IszDSuOO08SMqbUf8rI/u12g5Rxo=",
-  "desktopYarnHash": "024vd7xiwialfrag325558qjrqlfxzy9xq7jb15ysawand1k2xyv",
-  "webSrcHash": "YLQ4z333RMx9qyVRTBbDCWLTy5QqLlHmYpmOa8vlCbg=",
-  "webYarnHash": "1ll2sj9q3h2b76383bqv8a8ckqlk8b131zwx223fnz8mfqsc9br0"
+  "version": "1.11.16",
+  "desktopSrcHash": "EeED62HRpaWN91yxcDvwwNUWmDRU38lyT5ba1S4go6Q=",
+  "desktopYarnHash": "1f0bghcbzab2dkvxmvhhc0dzyk3js09v2sh93gsjsq9mkhld1k0w",
+  "webSrcHash": "T6UcGNm4i+Nc4Yk/mVFc4L9jxWQtOpjps1ZtEhilHW0=",
+  "webYarnHash": "1jyzym34lzadniqrysbm1m5agw03hzw6ymmdxpbay38afrhrciyk"
 }


### PR DESCRIPTION

###### Description of changes
ChangeLog web: https://github.com/vector-im/element-web/releases/tag/v1.11.16
ChangeLog desktop: https://github.com/vector-im/element-desktop/releases/tag/v1.11.16

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
