### PR TITLE
treewide: remove e-user from maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3847,12 +3847,6 @@
     githubId = 15128988;
     name = "Maksim Dzabraev";
   };
-  e-user = {
-    email = "nixos@sodosopa.io";
-    github = "outergod";
-    githubId = 93086;
-    name = "Alexander Kahl";
-  };
   eadwu = {
     email = "edmund.wu@protonmail.com";
     github = "eadwu";

--- a/pkgs/applications/audio/sisco.lv2/default.nix
+++ b/pkgs/applications/audio/sisco.lv2/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     description = "Simple audio oscilloscope with variable time scale, triggering, cursors and numeric readout in LV2 plugin format";
     homepage = "http://x42.github.io/sisco.lv2/";
     license = licenses.gpl2;
-    maintainers = [ maintainers.e-user ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/semodule-utils/default.nix
+++ b/pkgs/os-specific/linux/semodule-utils/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "SELinux policy core utilities (packaging additions)";
     license = licenses.gpl2;
     inherit (libsepol.meta) homepage platforms;
-    maintainers = [ maintainers.e-user ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -101,6 +101,6 @@ stdenv.mkDerivation rec {
     changelog = "https://sssd.io/release-notes/sssd-${version}.html";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ e-user illustris ];
+    maintainers = with maintainers; [ illustris ];
   };
 }

--- a/pkgs/tools/misc/ding-libs/default.nix
+++ b/pkgs/tools/misc/ding-libs/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "'D is not GLib' utility libraries";
     homepage = "https://pagure.io/SSSD/ding-libs";
     platforms = with lib.platforms; linux;
-    maintainers = with lib.maintainers; [ e-user ];
+    maintainers = with lib.maintainers; [ ];
     license = [ lib.licenses.gpl3 lib.licenses.lgpl3 ];
   };
 }

--- a/pkgs/tools/text/sgml/jade/default.nix
+++ b/pkgs/tools/text/sgml/jade/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     license = "custom";
     homepage = "http://www.jclark.com/jade/";
     platforms = with lib.platforms; linux;
-    maintainers = with lib.maintainers; [ e-user ];
+    maintainers = with lib.maintainers; [ ];
   };
 }


### PR DESCRIPTION
According to https://github.com/NixOS/nixpkgs/pull/22789#issuecomment-757687683, the maintainer doesn't use NixOS anymore.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
