### PR TITLE
sgx-sdk: fix linking issues with tests

### DIFF
--- a/pkgs/os-specific/linux/sgx/sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/default.nix
@@ -16,7 +16,7 @@
 , nasm
 , ocaml
 , ocamlPackages
-, openssl
+, openssl_1_1
 , perl
 , python3
 , texinfo
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libtool
-    openssl
+    openssl_1_1
   ];
 
   BINUTILS_DIR = "${binutils}/bin";


### PR DESCRIPTION
###### Description of changes

Currently, the sgx-sdk.runTestsHW attribute fails to build due to linking errors. It looks like OpenSSL versions are mixed up:

```
/nix/store/92h8cksyz9gycda22dgbvvj2ksm01ca4-binutils-2.39/bin/ld: /nix/store/5clafn4bl1xn5n933fnik65fn3h3n7lc-sgx-sdk-2.16.100.4/lib64/libsgx_pcl.a(pcl_gcm128.o): in function `pcl_CRYPTO_gcm128_aad':
(.nipx+0x121): undefined reference to `U64'
/nix/store/92h8cksyz9gycda22dgbvvj2ksm01ca4-binutils-2.39/bin/ld: /nix/store/5clafn4bl1xn5n933fnik65fn3h3n7lc-sgx-sdk-2.16.100.4/lib64/libsgx_pcl.a(pcl_gcm128.o): in function `pcl_CRYPTO_gcm128_decrypt':
(.nipx+0x1a6): undefined reference to `U64'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:342: enclave.so] Error 1
make[1]: Leaving directory '/build/sgx-sdk-2.16.100.4/share/SampleCode/SampleEnclavePCL'
make: *** [Makefile:217: all] Error 2
error: builder for '/nix/store/fs0aldm5xv68vsscjqngpvygcsqnb4aq-SampleEnclavePCL-HW.drv' failed with exit code 2;
```

And indeed sgx-sdk pulls in OpenSSL 3 while ipp-crypto pulls in OpenSSL 1.1.

Fix by pinning the OpenSSL version for the SGX SDK to OpenSSL 1.1 as well. This fixes a regression from around d761390cd04a1a9510b9a4f42803878e0ca268ba where OpenSSL 3 was introduced and a couple of packages where pinned to 1.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
