### PR TITLE
python3Packages.autopep8: patch for pycodestyle-2.10.0

### DIFF
--- a/pkgs/development/python-modules/autopep8/default.nix
+++ b/pkgs/development/python-modules/autopep8/default.nix
@@ -1,5 +1,6 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
+, fetchpatch
 , buildPythonPackage
 , pycodestyle
 , glibcLocales
@@ -11,21 +12,26 @@ buildPythonPackage rec {
   pname = "autopep8";
   version = "2.0.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-ixZZx/AD5pMZn1LK/9wGWFuwcWkAu8anRC/ZMdZYwHc=";
+  src = fetchFromGitHub {
+    owner = "hhatto";
+    repo = "autopep8";
+    rev = "v${version}";
+    sha256 = "sha256-77ZVprACHUP8BmylTtvHvJMjb70E1YFKKdQDigAZG6s=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-pycodestyle-2.10.0.patch";
+      url = "https://github.com/hhatto/autopep8/pull/659.patch";
+      hash = "sha256-ulvQqJ3lUm8/9QZwH+whzrxbz8c11/ntc8zH2zfmXiE=";
+    })
+  ];
 
   propagatedBuildInputs = [ pycodestyle tomli ];
 
   checkInputs = [
     glibcLocales
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # missing tox.ini file from pypi package
-    "test_e101_skip_innocuous"
   ];
 
   LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
###### Description of changes

This adjusts autopep8 to fetch from GitHub so it can be patched (patch does not apply cleanly to PyPI source tarball), and a test that had to be disabled because it was fetched from PyPI is re-enabled since it could work now (and as far as I understand, pulling from git is generally preferred for Python packages in nixpkgs for test reasons)

This lets the package now build successfully with the recent pycodestyle 2.10.0 bump in #203378

Closes #205733

Ref hhatto/autopep8#659 and hhatto/autopep8#661

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review pr 205803` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>20 packages built:</summary>
  <ul>
    <li>cmake-format</li>
    <li>cmake-language-server</li>
    <li>python310Packages.autopep8</li>
    <li>python310Packages.django_silk</li>
    <li>python310Packages.pyls-flake8</li>
    <li>python310Packages.pyls-isort</li>
    <li>python310Packages.pyls-spyder</li>
    <li>python310Packages.pylsp-mypy</li>
    <li>python310Packages.python-lsp-black</li>
    <li>python310Packages.python-lsp-server</li>
    <li>spyder (python310Packages.spyder)</li>
    <li>python39Packages.autopep8</li>
    <li>python39Packages.django_silk</li>
    <li>python39Packages.pyls-flake8</li>
    <li>python39Packages.pyls-isort</li>
    <li>python39Packages.pyls-spyder</li>
    <li>python39Packages.pylsp-mypy</li>
    <li>python39Packages.python-lsp-black</li>
    <li>python39Packages.python-lsp-server</li>
    <li>python39Packages.spyder</li>
  </ul>
</details>