### PR TITLE
python2Packages: revert removal of `scandir` and `typing`

### DIFF
--- a/pkgs/development/python-modules/fs/default.nix
+++ b/pkgs/development/python-modules/fs/default.nix
@@ -5,6 +5,7 @@
 , setuptools
 , six
 , appdirs
+, scandir ? null
 , backports_os ? null
 , typing ? null
 , pytz
@@ -35,6 +36,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ six appdirs pytz setuptools ]
     ++ lib.optionals (!isPy3k) [ backports_os ]
     ++ lib.optionals (!pythonAtLeast "3.6") [ typing ]
+    ++ lib.optionals (!pythonAtLeast "3.5") [ scandir ]
     ++ lib.optionals (!pythonAtLeast "3.5") [ enum34 ];
 
   LC_ALL="en_US.utf-8";

--- a/pkgs/development/python-modules/pathlib2/default.nix
+++ b/pkgs/development/python-modules/pathlib2/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , six
 , pythonOlder
+, scandir ? null
 , glibcLocales
 , mock
 , typing
@@ -18,7 +19,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six ]
-    ++ lib.optionals (pythonOlder "3.5") [ typing ];
+    ++ lib.optionals (pythonOlder "3.5") [ scandir typing ];
   checkInputs = [ glibcLocales ]
     ++ lib.optional (pythonOlder "3.3") mock;
 

--- a/pkgs/development/python2-modules/scandir/add-aarch64-darwin-dirent.patch
+++ b/pkgs/development/python2-modules/scandir/add-aarch64-darwin-dirent.patch
@@ -1,0 +1,28 @@
+diff --git a/scandir.py b/scandir.py
+index 3f602fb..40af3e5 100644
+--- a/scandir.py
++++ b/scandir.py
+@@ -23,6 +23,7 @@ from os import listdir, lstat, stat, strerror
+ from os.path import join, islink
+ from stat import S_IFDIR, S_IFLNK, S_IFREG
+ import collections
++import platform
+ import sys
+ 
+ try:
+@@ -432,6 +433,15 @@ elif sys.platform.startswith(('linux', 'darwin', 'sunos5')) or 'bsd' in sys.plat
+                     ('__d_padding', ctypes.c_uint8 * 4),
+                     ('d_name', ctypes.c_char * 256),
+                 )
++            elif 'darwin' in sys.platform and 'arm64' in platform.machine():
++                _fields_ = (
++                    ('d_ino', ctypes.c_uint64),
++                    ('d_off', ctypes.c_uint64),
++                    ('d_reclen', ctypes.c_uint16),
++                    ('d_namlen', ctypes.c_uint16),
++                    ('d_type', ctypes.c_uint8),
++                    ('d_name', ctypes.c_char * 1024),
++                )
+             else:
+                 _fields_ = (
+                     ('d_ino', ctypes.c_uint32),  # must be uint32, not ulong

--- a/pkgs/development/python2-modules/scandir/default.nix
+++ b/pkgs/development/python2-modules/scandir/default.nix
@@ -1,0 +1,24 @@
+{ lib, python, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "scandir";
+  version = "1.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bkqwmf056pkchf05ywbnf659wqlp6lljcdb0y88wr9f0vv32ijd";
+  };
+
+  patches = [
+    ./add-aarch64-darwin-dirent.patch
+  ];
+
+  checkPhase = "${python.interpreter} test/run_tests.py";
+
+  meta = with lib; {
+    description = "A better directory iterator and faster os.walk()";
+    homepage = "https://github.com/benhoyt/scandir";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/python2-modules/typing/default.nix
+++ b/pkgs/development/python2-modules/typing/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy3k, isPyPy, unittestCheckHook
+, pythonAtLeast }:
+
+let
+  testDir = if isPy3k then "src" else "python2";
+
+in buildPythonPackage rec {
+  pname = "typing";
+  version = "3.10.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13b4ad211f54ddbf93e5901a9967b1e07720c1d1b78d596ac6a439641aa1b130";
+  };
+
+  disabled = pythonAtLeast "3.5";
+
+  # Error for Python3.6: ImportError: cannot import name 'ann_module'
+  # See https://github.com/python/typing/pull/280
+  # Also, don't bother on PyPy: AssertionError: TypeError not raised
+  doCheck = pythonOlder "3.6" && !isPyPy;
+
+  checkInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" testDir ];
+
+  meta = with lib; {
+    description = "Backport of typing module to Python versions older than 3.5";
+    homepage = "https://docs.python.org/3/library/typing.html";
+    license = licenses.psfl;
+  };
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -67,6 +67,8 @@ with self; with super; {
 
   rpm = disabled super.rpm;
 
+  scandir = callPackage ../development/python2-modules/scandir { };
+
   sequoia = disabled super.sequoia;
 
   setuptools = callPackage ../development/python2-modules/setuptools { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -75,6 +75,8 @@ with self; with super; {
 
   setuptools-scm = callPackage ../development/python2-modules/setuptools-scm { };
 
+  typing = callPackage ../development/python2-modules/typing { };
+
   zeek = disabled super.zeek;
 
   zipp = callPackage ../development/python2-modules/zipp { };


### PR DESCRIPTION
This reverts commit 7d4a0668d26c39bfcd1b40b21b7d169cedbfe9aa, ff692673773f18ca8940486f3a020212df2b7e76, and partially df79f4922ff0a6a8ae1b68d1a1b2d038bf44a961 (From https://github.com/NixOS/nixpkgs/pull/205329/ )

Closes https://github.com/NixOS/nixpkgs/issues/205742

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
