### PR TITLE
haskell.packages.ghc94.gi-gtk: unbreak dependencies and package

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -214,4 +214,20 @@ in {
   # failing during the Setup.hs phase: https://github.com/gtk2hs/gtk2hs/issues/323.
   gtk2hs-buildtools = appendPatch ./patches/gtk2hs-buildtools-fix-ghc-9.4.x.patch super.gtk2hs-buildtools;
 
+  haskell-gi-base = __CabalEagerPkgConfigWorkaround super.haskell-gi-base;
+  haskell-gi = __CabalEagerPkgConfigWorkaround super.haskell-gi;
+  gi-adwaita = __CabalEagerPkgConfigWorkaround super.gi-adwaita;
+  gi-atk = __CabalEagerPkgConfigWorkaround super.gi-atk;
+  gi-cairo = __CabalEagerPkgConfigWorkaround super.gi-cairo;
+  gi-gdk = __CabalEagerPkgConfigWorkaround super.gi-gdk;
+  gi-gdkpixbuf = __CabalEagerPkgConfigWorkaround super.gi-gdkpixbuf;
+  gi-gdk_4_0_5 = __CabalEagerPkgConfigWorkaround super.gi-gdk_4_0_5;
+  gi-gio = __CabalEagerPkgConfigWorkaround super.gi-gio;
+  gi-glib = __CabalEagerPkgConfigWorkaround super.gi-glib;
+  gi-gmodule = __CabalEagerPkgConfigWorkaround (overrideCabal (drv: {libraryPkgconfigDepends = [pkgs.glib];}) super.gi-gmodule);
+  gi-gobject = __CabalEagerPkgConfigWorkaround super.gi-gobject;
+  gi-gtk = __CabalEagerPkgConfigWorkaround super.gi-gtk;
+  gi-gtk_4_0_6 = __CabalEagerPkgConfigWorkaround super.gi-gtk_4_0_6;
+  gi-harfbuzz = __CabalEagerPkgConfigWorkaround super.gi-harfbuzz;
+  gi-pango = __CabalEagerPkgConfigWorkaround super.gi-pango;
 }

--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -485,7 +485,7 @@ rec {
           builtins.genericClosure {
             startSet = builtins.map (drv:
               { key = drv.outPath; val = drv; }
-            ) drvs;
+            ) (builtins.filter (i: !builtins.isNull i) drvs);
             operator = { val, ... }:
               if !lib.isDerivation val
               then [ ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
on current nixos-unstable and on haskell-updates the gi-gtk package and some of its dependencies are broken
###### Things done
for some reason the haskell-gi packages have more dependencies on ghc-9.4 luckily they all are packaged already and it is a single line per package to make them build.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
