### PR TITLE
resholve: use stripped-down python27

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -31,6 +31,10 @@
 , rebuildBytecode ? true
 , reproducibleBuild ? false
 , enableOptimizations ? false
+, strip2to3 ? false
+, stripConfig ? false
+, stripIdlelib ? false
+, stripTests ? false
 , pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
 }:
 
@@ -318,6 +322,16 @@ in with passthru; stdenv.mkDerivation ({
     postFixup = ''
       # Include a sitecustomize.py file. Note it causes an error when it's in postInstall with 2.7.
       cp ${../../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
+    '' + optionalString strip2to3 ''
+      rm -R $out/bin/2to3 $out/lib/python*/lib2to3
+    '' + optionalString stripConfig ''
+      rm -R $out/bin/python*-config $out/lib/python*/config-*
+    '' + optionalString stripIdlelib ''
+      # Strip IDLE
+      rm -R $out/bin/idle* $out/lib/python*/idlelib
+    '' + optionalString stripTests ''
+      # Strip tests
+      rm -R $out/lib/python*/test $out/lib/python*/**/test{,s}
     '';
 
     enableParallelBuilding = true;

--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -1,19 +1,37 @@
 { lib
-, stdenv
+, pkgs
 , pkgsBuildHost
 , ...
 }:
 
 let
-  pkgs = import ../../../.. {
-    inherit (stdenv.hostPlatform) system;
-    # Allow python27 with known security issues only for resholve,
-    # see issue #201859 for the reasoning
-    # In resholve case this should not be a security issue,
-    # since it will only be used during build, not runtime
-    config.permittedInsecurePackages = [ pkgsBuildHost.python27.name ];
+  python27' = (pkgsBuildHost.python27.overrideAttrs (old:
+    {
+      # Overriding `meta.knownVulnerabilities` here, see #201859 for why it exists
+      # In resholve case this should not be a security issue,
+      # since it will only be used during build, not runtime
+      meta = (old.meta or { }) // { knownVulnerabilities = [ ]; };
+    }
+  )).override {
+    self = python27';
+    pkgsBuildHost = pkgsBuildHost // { python27 = python27'; };
+    # strip down that python version as much as possible
+    openssl = null;
+    bzip2 = null;
+    readline = null;
+    ncurses = null;
+    gdbm = null;
+    sqlite = null;
+    libffi = null;
+    rebuildBytecode = false;
+    stripBytecode = true;
+    strip2to3 = true;
+    stripConfig = true;
+    stripIdlelib = true;
+    stripTests = true;
+    enableOptimizations = false;
   };
-  callPackage = lib.callPackageWith pkgs;
+  callPackage = lib.callPackageWith (pkgs // { python27 = python27'; });
   source = callPackage ./source.nix { };
   deps = callPackage ./deps.nix { };
 in


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR strips down the modified `python27` derivation used by `resholve`. The idea is to reduce the possible security issues, and also to make it easier to bootstrap (e.g.: no need for having `sqlite` build in the `resholve`'s Python).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
