### PR TITLE
xgboost: adding self to maintainers list

### DIFF
--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/dmlc/xgboost";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar nviets ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Adding self to maintainers list to clean up open PRs in the xgboost package. See:

- https://github.com/NixOS/nixpkgs/pull/184147
- https://github.com/NixOS/nixpkgs/pull/152354
- https://github.com/NixOS/nixpkgs/pull/187525
- https://github.com/NixOS/nixpkgs/pull/184874

@abbradar @bcdarwin @trivialfis
