### PR TITLE
pipewire: 0.3.61 -> 0.3.62

### DIFF
--- a/pkgs/development/libraries/pipewire/0095-spa-data-dir.patch
+++ b/pkgs/development/libraries/pipewire/0095-spa-data-dir.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 56599ebd1..3bed2d3e3 100644
+index ea7a5e667..f1ed96e0d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -54,7 +54,7 @@ else
+@@ -55,7 +55,7 @@ else
  endif
  
  spa_plugindir = pipewire_libdir / spa_name
@@ -10,3 +10,4 @@ index 56599ebd1..3bed2d3e3 100644
 +spa_datadir = pipewire_libdir / spa_name
  
  alsadatadir = pipewire_datadir / 'alsa-card-profile' / 'mixer'
+ 

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -68,7 +68,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.61";
+    version = "0.3.62";
 
     outputs = [
       "out"
@@ -86,7 +86,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "H1212aCsMENSmxhJiKF/RnpWK1bEz4HX2a1PJW6CC2U=";
+      sha256 = "sha256-LrDhcLWm+2hsZt69kyuKOP7Jy3xH2I0MR/5gzOE8sSI=";
     };
 
     patches = [


### PR DESCRIPTION
###### Description of changes

This is a version bump of pipewire.

I had to update only one of the Nix-specific patches. I was able to remove all of the upstream patches because there are included in this release; Well, that's what Nix suggested.

I built it successfully, but I haven't tested it since it would cause large packages, such as QtWebEngine, to build. My laptop is not up to the task.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
