### PR TITLE
python310Packages.h2: disable timing sensitive test

### DIFF
--- a/pkgs/development/python-modules/h2/default.nix
+++ b/pkgs/development/python-modules/h2/default.nix
@@ -30,6 +30,11 @@ buildPythonPackage rec {
     hypothesis
   ];
 
+  disabledTests = [
+    # timing sensitive
+    "test_changing_max_frame_size"
+  ];
+
   pythonImportsCheck = [
     "h2.connection"
     "h2.config"


### PR DESCRIPTION
###### Description of changes

```
E           hypothesis.errors.Flaky: Hypothesis test_changing_max_frame_size(self=<test.test_basic_logic.TestBasicClient at 0x7ffff628d180>, frame_factory=<test.helpers.FrameFactory at 0x7ffff588f430>, frame_size=13274860) produces unreliable results: Falsified on the first call but did not on a subsequent one
E           Falsifying example: test_changing_max_frame_size(
E               frame_size=13274860,
E               self=<test.test_basic_logic.TestBasicClient at 0x7ffff628d180>,
E               frame_factory=<test.helpers.FrameFactory at 0x7ffff588f430>,
E           )
E           Unreliable test timings! On an initial run, this test took 327.87ms, which exceeded the deadline of 200.00ms, but on a subsequent run it took 101.16 ms, which did not. If you expect this sort of variability in your test timings, consider turning deadlines off for this test by setting deadline=None.

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
