### PR TITLE
jd-gui: patch to work with Gradle 6

### DIFF
--- a/pkgs/tools/security/jd-gui/default.nix
+++ b/pkgs/tools/security/jd-gui/default.nix
@@ -1,4 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, jre, jdk, gradle_5, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, jre
+, jdk
+, gradle_6
+, makeDesktopItem
+, copyDesktopItems
+, perl
+, writeText
+, runtimeShell
+}:
 
 let
   pname = "jd-gui";
@@ -8,14 +20,23 @@ let
     owner = "java-decompiler";
     repo = pname;
     rev = "v${version}";
-    sha256 = "010bd3q2m4jy4qz5ahdx86b5f558s068gbjlbpdhq3bhh4yrjy20";
+    hash = "sha256-QHiZPYFwDQzbXVSuhwzQqBRXlkG9QVU+Jl6SKvBoCwQ=";
   };
+
+  patches = [
+    # https://github.com/java-decompiler/jd-gui/pull/362
+    (fetchpatch {
+      name = "nebula-plugin-gradle-6-compatibility.patch";
+      url = "https://github.com/java-decompiler/jd-gui/commit/91f805f9dc8ce0097460e63c8095ccea870687e6.patch";
+      hash = "sha256-9eaM9Mx2FaKIhGSOHjATKN/CrtvJeXyrH8Mdx8LNtpE=";
+    })
+  ];
 
   deps = stdenv.mkDerivation {
     name = "${pname}-deps";
-    inherit src;
+    inherit src patches;
 
-    nativeBuildInputs = [ jdk perl gradle_5 ];
+    nativeBuildInputs = [ jdk perl gradle_6 ];
 
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d);
@@ -32,7 +53,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "1qil12s0daxpxj5xj5dj6s2k89is0kiir2vcafkm3lasc41acmk3";
+    outputHash = "sha256-gqUyZE+MoZRYCcJx95Qc4dZIC3DZvxee6UQhpfveDI4=";
   };
 
   # Point to our local deps repo
@@ -68,10 +89,10 @@ let
   };
 
 in stdenv.mkDerivation rec {
-  inherit pname version src;
+  inherit pname version src patches;
   name = "${pname}-${version}";
 
-  nativeBuildInputs = [ jdk gradle_5 copyDesktopItems ];
+  nativeBuildInputs = [ jdk gradle_6 copyDesktopItems ];
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)


### PR DESCRIPTION
###### Description of changes

It was easy to get this working with Gradle 6. We just need to update Netflix's Nebula plugins to a version that contains https://github.com/nebula-plugins/gradle-ospackage-plugin/pull/341 (at least 7.1.0). I found https://github.com/java-decompiler/jd-gui/pull/362 doing this.

Updating to work with Gradle 7 will take more work, because it finally removed the `runtime` configuration, so that can happen as a follow up.

This is work connected with https://github.com/NixOS/nixpkgs/issues/205455.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
