### PR TITLE
python3Packages.jpylyzer: skip `test_testfiles` by default

### DIFF
--- a/pkgs/development/python-modules/jpylyzer/default.nix
+++ b/pkgs/development/python-modules/jpylyzer/default.nix
@@ -5,6 +5,10 @@
 , six
 , lxml
 , pytestCheckHook
+, doFullCheck ? false  # weird filenames cause issues on some filesystems
+
+# for passthru.tests
+, jpylyzer
 }:
 
 let
@@ -33,18 +37,22 @@ in buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook lxml ];
 
-  # don't depend on testFiles on darwin as it may not be extractable due to
-  # weird filenames
-  preCheck = lib.optionalString (!stdenv.isDarwin) ''
+  # don't depend on testFiles unless doFullCheck as it may not be extractable
+  # on some filesystems due to weird filenames
+  preCheck = lib.optionalString doFullCheck ''
     sed -i '/^testFilesDir = /ctestFilesDir = "${testFiles}"' tests/unit/test_testfiles.py
   '';
-  disabledTestPaths = lib.optionals stdenv.isDarwin [
+  disabledTestPaths = lib.optionals (!doFullCheck) [
     "tests/unit/test_testfiles.py"
   ];
 
   pythonImportsCheck = [ "jpylyzer" ];
 
   disallowedReferences = [ testFiles ];
+
+  passthru.tests = {
+    withFullCheck = jpylyzer.override { doFullCheck = true; };
+  };
 
   meta = with lib; {
     description = "JP2 (JPEG 2000 Part 1) image validator and properties extractor";


### PR DESCRIPTION
###### Description of changes
See #205780

Skip these extended tests by default, because the test files include files with weird filenames which some filesystems find objectionable.

Imperfect passthru self-reference because `finalAttrs` isn't available with `buildPythonPackage`.

cc @mpasternacki

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
