### PR TITLE
trust-dns: init at 0.22.0

### DIFF
--- a/pkgs/servers/dns/trust-dns/default.nix
+++ b/pkgs/servers/dns/trust-dns/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, openssl
+, pkg-config
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "trust-dns";
+  version = "0.22.0";
+
+  src = fetchFromGitHub {
+    owner = "bluejekyll";
+    repo = "trust-dns";
+    rev = "v${version}";
+    sha256 = "sha256-b9tK1JbTwB3ZuRPh0wb3cOFj9dMW7URXIaFzUq0Yipw=";
+  };
+  cargoHash = "sha256-mpobdeTRWJzIEmhwtcM6UE66qRD5ot/0yLeQM6Tec+0=";
+
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ pkg-config ];
+
+  # tests expect internet connectivity to query real nameservers like 8.8.8.8
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Rust based DNS client, server, and resolver";
+    homepage = "https://trust-dns.org/";
+    maintainers = with maintainers; [ colinsane ];
+    platforms = platforms.linux;
+    license = with licenses; [ asl20 mit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26079,6 +26079,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  trust-dns = callPackage ../servers/dns/trust-dns { };
+
   tunctl = callPackage ../os-specific/linux/tunctl { };
 
   twa = callPackage ../tools/networking/twa { };


### PR DESCRIPTION
[trust-dns](https://github.com/bluejekyll/trust-dns/) is a Rust-based DNS client/server/resolver. the server uses .zone files that are largely compatible with bind. i've had a server deployed to `ns{1,2}.uninsane.org` for about a week using this derivation: seems to be stable enough for casual use.

this package also ships a DNS client and a resolver. BIND also ships a dig-like client but lives in pkgs/servers/dns. so i'm replicating that convention.

example use:
```sh
$ nix build '.#trust-dns'
# fetch example zone and config
$ wget https://raw.githubusercontent.com/bluejekyll/trust-dns/main/tests/test-data/named_test_configs/example.com.zone
$ wget https://raw.githubusercontent.com/bluejekyll/trust-dns/main/tests/test-data/named_test_configs/include.example.com.zone
$ wget https://raw.githubusercontent.com/bluejekyll/trust-dns/main/tests/test-data/named_test_configs/ipv4_only.toml
$ ./result/bin/named --config ipv4_only.toml --zonedir . --port 1053
# in a different shell, query the nameserver
$ dig @127.0.0.1 -p 1053 alias.example.com
# ...
;; ANSWER SECTION:
alias.example.com.	86400	IN	CNAME	www.example.com.

;; ADDITIONAL SECTION:
www.example.com.	86400	IN	A	127.0.0.1
;; Query time: 0 msec
;; SERVER: 127.0.0.1#1053(127.0.0.1) (UDP)
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
