### PR TITLE
python3Packages.screed: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8554,6 +8554,12 @@
     githubId = 22085373;
     name = "Luis Hebendanz";
   };
+  luizirber = {
+    email = "nixpkgs@luizirber.org";
+    github = "luizirber";
+    githubId = 6642;
+    name = "Luiz Irber";
+  };
   luizribeiro = {
     email = "nixpkgs@l9o.dev";
     matrix = "@luizribeiro:matrix.org";

--- a/pkgs/development/python-modules/screed/default.nix
+++ b/pkgs/development/python-modules/screed/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, bz2file
+, setuptools
+, setuptools-scm
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "screed";
+  version = "1.1.1";
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-EB4ZNImNLUoU+dnJd3S4wTyQpmuNK3NLtakPsO1iCbU=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  pythonImportsCheck = [ "screed" ];
+  checkInputs = [ pytestCheckHook ];
+
+  # These tests use the screed CLI and make assumptions on how screed is
+  # installed that break with nix. Can be enabled when upstream is fixed.
+  disabledTests = [
+    "Test_convert_shell"
+    "Test_fa_shell_command"
+    "Test_fq_shell_command"
+  ];
+
+  propagatedBuildInputs = [ bz2file setuptools ];
+
+  meta = with lib; {
+    description = "A simple read-only sequence database, designed for short reads";
+    homepage = "https://pypi.org/project/screed/";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/screed/default.nix
+++ b/pkgs/development/python-modules/screed/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A simple read-only sequence database, designed for short reads";
     homepage = "https://pypi.org/project/screed/";
+    maintainers = with maintainers; [ luizirber ];
     license = licenses.bsd3;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10375,6 +10375,8 @@ self: super: with self; {
 
   scrapy-splash = callPackage ../development/python-modules/scrapy-splash { };
 
+  screed = callPackage ../development/python-modules/screed { };
+
   screeninfo = callPackage ../development/python-modules/screeninfo { };
 
   screenlogicpy = callPackage ../development/python-modules/screenlogicpy { };


### PR DESCRIPTION
###### Description of changes

[screed](https://screed.readthedocs.io/en/latest/) is a library for working with genomic data formats (FASTA/Q).

In preparation for adding [sourmash](https://sourmash.bio/), which depends on it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Question: This package includes a CLI that I didn't package (and probably should go under `pkgs/applications/science/biology/screed`. What is the policy on including Python packages that are both libraries and applications?