### PR TITLE
crystfel: fix symlib hard-coding

### DIFF
--- a/pkgs/applications/science/physics/crystfel/default.nix
+++ b/pkgs/applications/science/physics/crystfel/default.nix
@@ -54,7 +54,7 @@ let
     # We hard-code this by providing a little patch and then passing the absolute path to syminfo.lib as a
     # preprocessor flag.
     preBuild = ''
-      makeFlagsArray+=(CFLAGS='-DNIX_PROVIDED_SYMOP_FILE=\"$out/share/syminfo.lib\"')
+      makeFlagsArray+=(CFLAGS='-DNIX_PROVIDED_SYMOP_FILE=\"${placeholder "out"}/share/syminfo.lib\"')
       export NIX_LDFLAGS="-L${gfortran.cc}/lib64 -L${gfortran.cc}/lib $NIX_LDFLAGS";
     '';
     makeFlags = [ "CFLAGS='-DNIX_PROVIDED_SYMOP_FILE=\"${placeholder "out"}/share/syminfo.lib\"" ];

--- a/pkgs/applications/science/physics/crystfel/libccp4-use-hardcoded-syminfo-lib.patch
+++ b/pkgs/applications/science/physics/crystfel/libccp4-use-hardcoded-syminfo-lib.patch
@@ -1,11 +1,12 @@
 diff --git a/ccp4/csymlib.c b/ccp4/csymlib.c
-index 76bc70b..7a0c5dc 100644
+index 76bc70b..3616121 100644
 --- a/ccp4/csymlib.c
 +++ b/ccp4/csymlib.c
-@@ -137,24 +137,7 @@ CCP4SPG *ccp4spg_load_spacegroup(const int numspg, const int ccp4numspg,
+@@ -136,25 +136,7 @@ CCP4SPG *ccp4spg_load_spacegroup(const int numspg, const int ccp4numspg,
+     }
    }
  
-   /* Open the symop file: */
+-  /* Open the symop file: */
 -  if (!(symopfile = getenv("SYMINFO"))) {
 -    if (debug)
 -      printf("Environment variable SYMINFO not set ... guessing location of symmetry file. \n");
@@ -28,3 +29,12 @@ index 76bc70b..7a0c5dc 100644
  
    filein = fopen(symopfile,"r");
    if (!filein) {
+@@ -162,8 +144,6 @@ CCP4SPG *ccp4spg_load_spacegroup(const int numspg, const int ccp4numspg,
+     return NULL;
+   }
+ 
+-  if (!(getenv("SYMINFO"))) free(symopfile);
+-
+   parser = ccp4_parse_start(20);
+   if (parser == NULL) 
+     ccp4_signal(CSYM_ERRNO(CSYMERR_ParserFail),"ccp4spg_load_spacegroup",NULL);


### PR DESCRIPTION
###### Description of changes

The dependent `libccp4` library usually checks an environment variable to locate a specific file, `syminfo.lib`. To fix this in nixpkgs, I patched the library to use a constant, hard-coded string. This string is injected from outside via a CPP argument (`NIX_PROVIDED_SYMOP_FILE`) so we are nicely reproducible.

This had two problems:

1. The library was trying to `free(..)` the constant string, which failed. I removed the `free` in the `.patch` file.
2. The hard-coded path was actually wrong. I used `$out/share/syminfo.lib`, where `${placeholder "out"}/share/syminfo.lib` was needed. I fixed this, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
