### PR TITLE
etesync-dav: fix build

### DIFF
--- a/pkgs/applications/misc/etesync-dav/default.nix
+++ b/pkgs/applications/misc/etesync-dav/default.nix
@@ -13,26 +13,8 @@ let
           inherit version;
           sha256 = "ff177185f891302dc253437fe63081e7a46a4e99aca61dfe086fb23e54fff2dc";
         };
-        disabledTests = [
-          "test_outside_request"
-        ];
-      });
-      werkzeug = super.werkzeug.overridePythonAttrs (old: rec {
-        version = "2.0.3";
-        src = old.src.override {
-          inherit version;
-          sha256 = "b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c";
-        };
-      });
-      wtforms = super.wtforms.overridePythonAttrs (old: rec {
-        version = "2.3.3";
-        src = old.src.override {
-          inherit version;
-          sha256 = "81195de0ac94fbc8368abbaf9197b88c4f3ffd6c2719b5bf5fc9da744f3d829c";
-        };
-        checkPhase = ''
-          ${self.python.interpreter} tests/runtests.py
-        '';
+        doCheck = false;
+        patches = [];
       });
     };
   };
@@ -54,6 +36,7 @@ in python.pkgs.buildPythonApplication rec {
     msgpack
     (python.pkgs.toPythonModule (radicale3.override { python3 = python; }))
     requests
+    setuptools
   ] ++ requests.optional-dependencies.socks;
 
   doCheck = false;

--- a/pkgs/development/python-modules/etebase/default.nix
+++ b/pkgs/development/python-modules/etebase/default.nix
@@ -10,22 +10,21 @@
 , Security
 , msgpack
 }:
-
 buildPythonPackage rec {
   pname = "etebase";
-  version = "0.31.5";
+  version = "0.31.6";
 
   src = fetchFromGitHub {
     owner = "etesync";
     repo = "etebase-py";
     rev = "v${version}";
-    hash = "sha256-87t3toMaApnOSPBKfTGGLo2VRLqU8irFac9lg3kA1eE=";
+    hash = "sha256-T61nPW3wjBRjmJ81w59T1b/Kxrwwqvyj3gILE9OF/5Q=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    name = "${pname}-${version}";
-    hash = "sha256-Qg0aJ6CZaPxGneIs4o402A+fhI/nlJ9X/XdMFqkD/YY=";
+    name = "${pname}-5";
+    hash = "sha256-361iMWxOLYXXAVrVOmXPDo+y8waLz8EMWMTK3r5ci20=";
   };
 
   format = "pyproject";


### PR DESCRIPTION
###### Description of changes

This pull request fixes etesync-dav and in the process updates one of it's dependencies, etebase ( 0.31.5 -> 0.31.6 ).  In etesync-dav the werkzeug override was removed since it was causing the build to fail and it was not necessary. Unfortunately falsk-wtf override is still needed. But the current patches do not apply to it, so they where removed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
