### PR TITLE
python3.pkgs.deploykit: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/deploykit/default.nix
+++ b/pkgs/development/python-modules/deploykit/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Execute commands remote via ssh and locally in parallel with python";
     homepage = "https://github.com/numtide/deploykit";
+    changelog = "https://github.com/numtide/deploykit/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ mic92 zowoq ];
     platforms = platforms.unix;

--- a/pkgs/development/python-modules/deploykit/default.nix
+++ b/pkgs/development/python-modules/deploykit/default.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "deploykit";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "numtide";
     repo = pname;
     rev = version;
-    hash = "sha256-eKyqsGgnJmF2wUYa7HjC1Jwsh03qVTJEP1MtL7JL4Ts=";
+    hash = "sha256-I1vAefWQBBRNykDw38LTNwdiPFxpPkLzCcevYAXO+Zo=";
   };
 
   buildInputs = [

--- a/pkgs/development/python-modules/deploykit/default.nix
+++ b/pkgs/development/python-modules/deploykit/default.nix
@@ -5,12 +5,16 @@
 , bash
 , openssh
 , pytestCheckHook
+, pythonOlder
 , stdenv
 }:
 
 buildPythonPackage rec {
   pname = "deploykit";
   version = "1.0.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "numtide";
@@ -33,6 +37,10 @@ buildPythonPackage rec {
 
   # don't swallow stdout/stderr
   pytestFlagsArray = [ "-s" ];
+
+  pythonImportsCheck = [
+    "deploykit"
+  ];
 
   meta = with lib; {
     description = "Execute commands remote via ssh and locally in parallel with python";


### PR DESCRIPTION
Diff: https://github.com/numtide/deploykit/compare/1.0.1...1.0.2

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
