### PR TITLE
src-cli: init at 4.5.0

### DIFF
--- a/pkgs/development/tools/misc/src-cli/default.nix
+++ b/pkgs/development/tools/misc/src-cli/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "src-cli";
+  version = "4.5.0";
+
+  src = fetchFromGitHub {
+    owner = "sourcegraph";
+    repo = "src-cli";
+    rev = "${version}";
+    sha256 = "sha256-sCZDe5p71WQN/tIt/DcTXWOiYso4fvh+U3jXkguOGrQ=";
+  };
+
+  vendorSha256 = "sha256-7JgcT1cGDtYGoT6QLPZ4fk40AzT3uv15VXk+Fgcl2S8=";
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Command line interface to Sourcegraph";
+    homepage = "https://github.com/sourcegraph/src-cli";
+    changelog = "https://github.com/sourcegraph/src-cli/blob/${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ loicreynier ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18055,6 +18055,8 @@ with pkgs;
 
   sqlmap = with python3Packages; toPythonApplication sqlmap;
 
+  src-cli = callPackage ../development/tools/misc/src-cli { };
+
   sselp = callPackage ../tools/X11/sselp{ };
 
   statix = callPackage ../tools/nix/statix { };


### PR DESCRIPTION
###### Description of changes

Add [`src-cli`](https://github.com/sourcegraph/src-cli) the [Sourcegraph](https://sourcegraph.com) CLI utility.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).