### PR TITLE
pms: init at unstable-2022-11-12

### DIFF
--- a/pkgs/applications/audio/pms/default.nix
+++ b/pkgs/applications/audio/pms/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub, buildGoModule }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "pms";
   version = "unstable-2022-11-12";
 

--- a/pkgs/applications/audio/pms/default.nix
+++ b/pkgs/applications/audio/pms/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "pms";
+  version = "unstable-2022-11-12";
+
+  src = fetchFromGitHub {
+    owner = "ambientsound";
+    repo = "pms";
+    rev = "40d6e37111293187ab4542c7a64bd73d1b13974f";
+    sha256 = "sha256-294MiS4c2PO2lFSSRrg8ns7sXzZsEUAqPG3q2z3TRUg=";
+  };
+
+  vendorHash = "sha256-XNFzG4hGDUN0wWbpBoQWUH1bWIgoYcyP4tNRGSV4ro4=";
+
+  meta = with lib; {
+    description = "An interactive Vim-like console client for MPD";
+    homepage = "https://ambientsound.github.io/pms/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ deejayem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30652,6 +30652,8 @@ with pkgs;
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };
 
+  pms = callPackage ../applications/audio/pms { };
+
   pragha = libsForQt5.callPackage ../applications/audio/pragha { };
 
   rofi-mpd = callPackage ../applications/audio/rofi-mpd { };


### PR DESCRIPTION
###### Description of changes

Add pms mpd client (https://ambientsound.github.io/pms/  /   https://github.com/ambientsound/pms) - "Practical Music Search is an interactive Vim-like console client for the Music Player Daemon."

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
