### PR TITLE
vaultwarden: Add update script to keep web vault in sync

### DIFF
--- a/nixos/modules/services/security/vaultwarden/default.nix
+++ b/nixos/modules/services/security/vaultwarden/default.nix
@@ -162,8 +162,8 @@ in {
 
     webVaultPackage = mkOption {
       type = package;
-      default = pkgs.vaultwarden-vault;
-      defaultText = literalExpression "pkgs.vaultwarden-vault";
+      default = pkgs.vaultwarden.webvault;
+      defaultText = literalExpression "pkgs.vaultwarden.webvault";
       description = lib.mdDoc "Web vault package to use.";
     };
   };

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -87,6 +87,9 @@ let
                 testRunner = pkgs.writers.writePython3Bin "test-runner"
                   {
                     libraries = [ pkgs.python3Packages.selenium ];
+                    flakeIgnore = [
+                      "E501"
+                    ];
                   } ''
 
                   from selenium.webdriver.common.by import By
@@ -106,25 +109,25 @@ let
 
                   wait.until(EC.title_contains("Create Account"))
 
-                  driver.find_element(By.CSS_SELECTOR, 'input#email').send_keys(
-                    '${userEmail}'
+                  driver.find_element(By.CSS_SELECTOR, 'input#register-form_input_email').send_keys(
+                      '${userEmail}'
                   )
-                  driver.find_element(By.CSS_SELECTOR, 'input#name').send_keys(
-                    'A Cat'
+                  driver.find_element(By.CSS_SELECTOR, 'input#register-form_input_name').send_keys(
+                      'A Cat'
                   )
-                  driver.find_element(By.CSS_SELECTOR, 'input#masterPassword').send_keys(
-                    '${userPassword}'
+                  driver.find_element(By.CSS_SELECTOR, 'input#register-form_input_master-password').send_keys(
+                      '${userPassword}'
                   )
-                  driver.find_element(By.CSS_SELECTOR, 'input#masterPasswordRetype').send_keys(
-                    '${userPassword}'
+                  driver.find_element(By.CSS_SELECTOR, 'input#register-form_input_confirm-master-password').send_keys(
+                      '${userPassword}'
                   )
 
-                  driver.find_element(By.XPATH, "//button[contains(., 'Submit')]").click()
+                  driver.find_element(By.XPATH, "//button[contains(., 'Create Account')]").click()
 
                   wait.until_not(EC.title_contains("Create Account"))
 
-                  driver.find_element(By.CSS_SELECTOR, 'input#masterPassword').send_keys(
-                    '${userPassword}'
+                  driver.find_element(By.CSS_SELECTOR, 'input#login_input_master-password').send_keys(
+                      '${userPassword}'
                   )
                   driver.find_element(By.XPATH, "//button[contains(., 'Log In')]").click()
 
@@ -133,10 +136,10 @@ let
                   driver.find_element(By.XPATH, "//button[contains(., 'Add Item')]").click()
 
                   driver.find_element(By.CSS_SELECTOR, 'input#name').send_keys(
-                    'secrets'
+                      'secrets'
                   )
                   driver.find_element(By.CSS_SELECTOR, 'input#loginPassword').send_keys(
-                    '${storedPassword}'
+                      '${storedPassword}'
                   )
 
                   driver.find_element(By.XPATH, "//button[contains(., 'Save')]").click()

--- a/pkgs/tools/security/vaultwarden/default.nix
+++ b/pkgs/tools/security/vaultwarden/default.nix
@@ -1,7 +1,11 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, fetchurl, nixosTests
+{ lib, stdenv, callPackage, rustPlatform, fetchFromGitHub, fetchurl, nixosTests
 , pkg-config, openssl
 , libiconv, Security, CoreServices
 , dbBackend ? "sqlite", libmysqlclient, postgresql }:
+
+let
+  webvault = callPackage ./webvault.nix {};
+in
 
 rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
@@ -34,7 +38,11 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = dbBackend;
 
-  passthru.tests = nixosTests.vaultwarden;
+  passthru = {
+    inherit webvault;
+    tests = nixosTests.vaultwarden;
+    updateScript = callPackage ./update.nix {};
+  };
 
   meta = with lib; {
     description = "Unofficial Bitwarden compatible server written in Rust";

--- a/pkgs/tools/security/vaultwarden/update.nix
+++ b/pkgs/tools/security/vaultwarden/update.nix
@@ -1,0 +1,22 @@
+{ writeShellScript
+, lib
+, nix-update
+, curl
+, git
+, gnugrep
+, gnused
+, jq
+}:
+
+writeShellScript "update-vaultwarden" ''
+  PATH=${lib.makeBinPath [ curl git gnugrep gnused jq nix-update ]}
+
+  set -euxo pipefail
+
+  VAULTWARDEN_VERSION=$(curl --silent https://api.github.com/repos/dani-garcia/vaultwarden/releases/latest | jq -r '.tag_name')
+  nix-update "vaultwarden" --version "$VAULTWARDEN_VERSION"
+
+  URL="https://raw.githubusercontent.com/dani-garcia/vaultwarden/''${VAULTWARDEN_VERSION}/docker/Dockerfile.j2"
+  WEBVAULT_VERSION=$(curl --silent "$URL" | grep "set vault_version" | sed -E "s/.*\"([^\"]+)\".*/\\1/")
+  nix-update "vaultwarden.webvault" --version "$WEBVAULT_VERSION"
+''

--- a/pkgs/tools/security/vaultwarden/webvault.nix
+++ b/pkgs/tools/security/vaultwarden/webvault.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, nixosTests }:
 
 stdenv.mkDerivation rec {
-  pname = "vaultwarden-vault";
+  pname = "vaultwarden-webvault";
   version = "2022.11.1";
 
   src = fetchurl {

--- a/pkgs/tools/security/vaultwarden/webvault.nix
+++ b/pkgs/tools/security/vaultwarden/webvault.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "vaultwarden-webvault";
-  version = "2022.11.1";
+  version = "2022.10.0";
 
   src = fetchurl {
     url = "https://github.com/dani-garcia/bw_web_builds/releases/download/v${version}/bw_web_v${version}.tar.gz";
-    sha256 = "sha256-nd32Q0uTsnrdVPDe1Yglvkg2QcwgLR+x0dFvKSD8o8I=";
+    hash = "sha256-Sf1YnOikjZmloTQvdrFH/UAevQqKQEkNNrCRUhvNZfA=";
   };
 
   buildCommand = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1558,6 +1558,7 @@ mapAliases ({
   varnish63 = throw "varnish63 was removed from nixpkgs, because it is unmaintained upstream. Please switch to a different release"; # Added 2021-07-26
   varnish65 = throw "varnish65 was removed from nixpkgs, because it is unmaintained upstream. Please switch to a different release"; # Added 2021-09-15
   varnish70 = throw "varnish70 was removed from nixpkgs, because it was superseded upstream. Please switch to a different release"; # Added 2022-03-17
+  vaultwarden-vault = vaultwarden.webvault; # Added 2022-12-13
   varnish71 = throw "varnish71 was removed from nixpkgs, because it was superseded upstream. Please switch to a different release"; # Added 2022-11-08
   vdirsyncerStable  = vdirsyncer; # Added 2020-11-08, see https://github.com/NixOS/nixpkgs/issues/103026#issuecomment-723428168
   venus = throw "venus has been removed from nixpkgs, as it's unmaintained"; # Added 2021-02-05

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37528,8 +37528,6 @@ with pkgs;
   vaultwarden-mysql = vaultwarden.override { dbBackend = "mysql"; };
   vaultwarden-postgresql = vaultwarden.override { dbBackend = "postgresql"; };
 
-  vaultwarden-vault = callPackage ../tools/security/vaultwarden/vault.nix { };
-
   vazir-fonts = callPackage ../data/fonts/vazir-fonts { };
 
   vhs = callPackage ../applications/misc/vhs { };


### PR DESCRIPTION
- Adds an update script to fetch the compatible web vault version
- Removes `vaultwarden-vault` from top-level to prevent independent
  updates through e.g. r-ryantm. Istead the vault is now accessible
  at `vaultwarden.vault`.
- Downgrade `vaultwarden.vault` to 2022.10.0, see https://github.com/dani-garcia/vaultwarden/releases/tag/1.26.0
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
