### PR TITLE
stdenv: handle `env` gracefully

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -383,10 +383,13 @@ printWords() {
 ######################################################################
 # Initialisation.
 
-# export all vars that should be in the ENV
-for envVar in "${!env[@]}"; do
-    declare -x "${envVar}=${env[${envVar}]}"
-done
+# If using structured attributes, export variables from `env` to the environment.
+# When not using structured attributes, those variables are already exported.
+if [[ -n $__structuredAttrs ]]; then
+    for envVar in "${!env[@]}"; do
+        declare -x "${envVar}=${env[${envVar}]}"
+    done
+fi
 
 
 # Set a fallback default value for SOURCE_DATE_EPOCH, used by some build tools

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -47,6 +47,7 @@ let
           declare -p string
           echo "env.string = $string"
           [[ $string == "testing-string" ]] || (echo "'\$string' was not 'testing-string'" && false)
+          [[ "$(declare -p string)" == 'declare -x string="testing-string"' ]] || (echo "'\$string' was not exported" && false)
           touch $out
         '';
       } // extraAttrs);

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -95,6 +95,25 @@ in
 {
   test-env-attrset = testEnvAttrset { name = "test-env-attrset"; stdenv' = bootStdenv; };
 
+  # Test compatibility with derivations using `env` as a regular variable.
+  test-env-derivation = bootStdenv.mkDerivation rec {
+    name = "test-env-derivation";
+    env = bootStdenv.mkDerivation {
+      name = "foo";
+      buildCommand = ''
+        mkdir "$out"
+        touch "$out/bar"
+      '';
+    };
+
+    passAsFile = [ "buildCommand" ];
+    buildCommand = ''
+      declare -p env
+      [[ $env == "${env}" ]]
+      touch "$out"
+    '';
+  };
+
   test-prepend-append-to-var = testPrependAndAppendToVar {
     name = "test-prepend-append-to-var";
     stdenv' = bootStdenv;


### PR DESCRIPTION
Derivations not using `__structuredAttrs` should not attempt to set environment variables from `env`.

Derivations using `__structuredAttrs` should fail if `env` is not exportable.

See https://github.com/NixOS/nixpkgs/pull/175649#issuecomment-1347847767