### PR TITLE
systemd: 252.1 -> 252.3

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -123,7 +123,7 @@ assert withHomed -> withCryptsetup;
 let
   wantCurl = withRemote || withImportd;
   wantGcrypt = withResolved || withImportd;
-  version = "252.1";
+  version = "252.3";
 
   # Bump this variable on every (major) version change. See below (in the meson options list) for why.
   # command:
@@ -140,7 +140,7 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    hash = "sha256-G43qbNF7znTITSM78sOL0qi8nqaA7qIhmiqP/rZKjXY=";
+    hash = "sha256-F2wtg12amigd5KNCWmG3b9Yu6PUOby9mQgZ2VFtxl5A==";
   };
 
   # On major changes, or when otherwise required, you *must* reformat the patches,


### PR DESCRIPTION
Fixes sd-boot on (some?) Intel Macbooks, as reported in https://github.com/NixOS/nixpkgs/pull/201558#issuecomment-1348823127.

Full log:

```
13de548fca network: manage addresses in the way the kernel does
fcc174cbdd import: wire up SYSTEMD_IMPORT_BTRFS_{SUBVOL,QUOTA} to importd
6cb0724a06 machine-pool: simplify return values from setup_machine_directory()
1c9e7fc8f2 boot: Only do full driver initialization in VMs
79b97ec652 boot: improve support for qemu (helpers only)
87add68b39 boot: Make sure all partitions drivers are connected
989f0c52e1 boot: Use EFI_BOOT_MANAGER_POLICY_PROTOCOL to connect console devices
b89be71bf4 network: unset Link.ndisc_configured only when a new address or route is requested
fc4f804b07 network: fix indentation
fc60072926 dissect: rework DISSECT_IMAGE_ADD_PARTITION_DEVICES + DISSECT_IMAGE_OPEN_PARTITION_DEVICES
1267b35273 fuzz: shorten filename of testcase
7fc478f751 resolve: optimize conversion of TXT fields to json
772e89452e hexdecoct: fix NULL pointer dereferences in hexmem()
002fc46688 hexdecoct: add missing NULL check
be1088b7a0 test: add tests for base64_append()
acb0414a1f hexdecoct: several cleanups for base64_append()
9410eb20eb cryptsetup: retry TPM2 unseal operation if it fails with TPM2_RC_PCR_CHANGED
1c8abb343a man: mention that DefaultRouteOnDevice= create the IPv4 default route
6c869ad3bd selinux: accept the fact that getxyzcon() can return success and NULL
0fdeb7c640 oomd: print dry run output at INFO level
4119d25e62 journald: prevent segfault on empty attr/current
6fdf196f99 core: use correct scope of looking up units
6d7b0dacc6 test-network: add test for bond mac address config
6405eba4b6 network: Fix set bond device MAC address failed
dbc59253ec test-fs-util: Add relative path chase_symlinks() tests
6e99f9c8fb chase-symlink: when converting directory O_PATH fd to real fd, don't bother with /proc/
bc6fc812fd test: add basic tests for octescape()
2ea5de7881 escape: fix wrong octescape of bad character
8999727a82 network: drop REMOVING flag when a netlink message is sent to kernel
a064abff76 dissect: show color in log output
278a97708b log: Switch logging to runtime when FS becomes read-only
44984e15bb resolve: format zero-length RDATA according to rfc3597
d59009dc1d manager: do not append '\n' when writing sysctl settings
2a66b4c894 test: check if we can use SHA1 MD for signing before using it
d0b80bf81e dissect-image: log expected UUID for /var
b0b97848e8 bootspec: fix null-dereference-read
0ba8e9ecff virt: Support detection of LMHS SRE guests
787b2c32f3 terminal-util: Set OPOST when setting ONLCR
c7bf13b2d9 units: change Requires=systemd-networkd.service → BindsTo= one more time
e3d9376692 core/device: verify device syspath on switching root
9523f85b2e core/device: also serialize/deserialize device syspath
10b3ce781b core/device: update comment
2505010178 sd-netlink: fix segfault
4b885f3591 test: Add tests for systemd-cgtop args parsing
b97c1c427c cgtop: Do not rewrite -P or -k options
6cbf72a8d9 logind: Properly unescape names of lingering users
01a39e96b5 units: Use BindsTo=systemd-networkd in systemd-networkd-wait-online.service
b0c39ffc54 resolved: remove inappropriate assert()
e0521346ec stub: Detect empty LoadOptions when run from EFI shell
7ca40a8b08  stub: Fix cmdline handling
b39f2ab98f boot: Use xstr8_to_16 for path conversion
6387a74d2c boot: Use xstr8_to_16
ff7469af96 boot: Add xstrn8_to_16
475c130003 core: update audit messages
c74bc2cd49 dissect: fix fsck
ce55eb4ebd process-util: add new FORK_CLOEXEC_OFF flag for disabling O_CLOEXEC on remaining fds
36c3c4172d fd-util: add new fd_cloexec_many() helper
57b4329b38 fd-util: make fd_in_set() (and thus close_all_fds()) handle invalidated fds in the array
12c41564cd tmpfiles: log at info level when some allowed failures occur
77f524dda0 find-esp: include device sysname in the log message
8d23210a2e find-esp: downgrade and ignore error on retrieving PART_ENTRY_SCHEME when searching
eea92b179d sd-bus: Use goto finish instead of return in bus_add_match_full
0916514b8c strv: Make sure strv_make_nulstr() always returns a valid nulstr
2ddd7b5def bootctl: rework how we handle referenced but absent EFI boot entries
2daecc7179 bootctl: downgrade log message when firmware reports non-existent or invalid boot entry
9a7186e92a bootctl: make boot entry id logged in hex
62f58d94f8 dissect-image: do not try to close invalid fd
c1dd021d16 boot: Silence driver reconnect errors
a09a41c2f7 meson: install test-kernel-install only when -Dkernel-install=true
9b6f12262f udev: make sure auto-root logic also works in UKIs booted from XBOOTLDR
d5e3625a61 repart: respect --discard=no also for block devices
79f161ac65 portable: add a few more useful debug log messages
bcd42b3c88 oomd: fix unreachable test case in test-oomd-util
2bdf5b0382 oomd: always allow root-owned cgroups to set ManagedOOMPreference
da01d83ab4 network: wifi: try to reconfigure when connected
595dd9b2b9 resolved: Fix OpenSSL error messages
2ecb8fc841 basic/strv: check printf arguments to strv_extendf()
81e2c87a47 manager: fix format strings for trigger metadata
d337ac02d6 resolved: when configuring 127.0.0.1 as per-interface DNS server, contact it via "lo" always
813d52dbf8 resolved: use right conditionalization when setting unicast ifindex on UDP sockets
2b52748d45 nspawn: allow sched_rr_get_interval_time64 through seccomp filter
5c34bc9bc3 boot/measure: fix oom check
f68be4fd79 fuzz: fuzz-compress: fix copy-and-paste error: buf -> buf2 (#25431)
132f0ec7de Handle MACHINE_ID=uninitialized
25fcbdae7e shared/tpm2-util: Fix "Error: Esys invalid ESAPI handle (40000001)" warning
6189505d79 boot: Correctly handle @saved default patterns
148b2d8ad3 Revert "journal: Make sd_journal_previous/next() return 0 at HEAD/TAIL"
d34ea410f4 Fix reading /etc/machine-id in kernel-install (#25388)
7b99f68f1c systemctl: do not show unit properties with --all
f791ecd0c5 ac-power: check battery existence and status
c2620a6bdb pid1: skip cleanup if root is not tmpfs/ramfs
83a772aae2 Revert "initrd: extend SYSTEMD_IN_INITRD to accept non-ramfs rootfs"
4d11c9b3cd networkd-ipv4acd.c: Use net/if.h for getting IFF_LOOPBACK definition
aff1caf3fd boot: Replace firmware security hooks directly
f9d9a68ecc boot: Rework security arch override
c6d7b4014c boot: Manually convert filepaths if needed
c8c5b79fb6 boot: Do not require a loaded image path
5894d4bd79 boot: Fix memory leak
5c0b918c02 boot: Fix error message
542dbc623e tpm2: add some extra validation of device string before using it
b3228085ba tpm2-util: force default TCTI to be "device" with parameter "/dev/tpmrm0"
31c2abd305 Create CNAME
2ec3187d6c test: compile test-utmp.c only if UTMP is enabled
````
`

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
