### PR TITLE
python310Packages.angr: 9.2.28 -> 9.2.29

### DIFF
--- a/pkgs/development/python-modules/ailment/default.nix
+++ b/pkgs/development/python-modules/ailment/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "ailment";
-  version = "9.2.28";
+  version = "9.2.29";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-6+3lZygQEezEbGIMbB6NINjVDkgt5sYO2FV5wpienuY=";
+    hash = "sha256-Yso47p4d8buJTdXOrm7luvtxpFu+oTFhqTBueQaXqII=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/angr/default.nix
+++ b/pkgs/development/python-modules/angr/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "angr";
-  version = "9.2.28";
+  version = "9.2.29";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-16/hocVfd2RI8qQ9Qt7EM/gGfyGpWabyZhtfwOscqQY=";
+    hash = "sha256-cAruoJhQpxK/+sRcyoLoBlG35b11UV2Tjwt2+QUx46E=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/archinfo/default.nix
+++ b/pkgs/development/python-modules/archinfo/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "archinfo";
-  version = "9.2.28";
+  version = "9.2.29";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-LUrLO9BFbpB2p6PtTZPdpLsGHPh088aPHIyoxgv4dGg=";
+    hash = "sha256-kS7NTlZnWwcvuRV/Eq3K0MJ/bGYcR5BWIbdPONuTqII=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/claripy/default.nix
+++ b/pkgs/development/python-modules/claripy/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "claripy";
-  version = "9.2.28";
+  version = "9.2.29";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-CGYX8IzVBqhF0IenTFKtx79J81X6UGkvm/XvFovnHYE=";
+    hash = "sha256-X2c1TVbf/KTUOfjQ8Izt+vyxhQrAki3hCBBwKxgkxbw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/cle/default.nix
+++ b/pkgs/development/python-modules/cle/default.nix
@@ -16,7 +16,7 @@
 
 let
   # The binaries are following the argr projects release cycle
-  version = "9.2.28";
+  version = "9.2.29";
 
   # Binary files from https://github.com/angr/binaries (only used for testing and only here)
   binaries = fetchFromGitHub {
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-t3TO1rHf5iA+9WW3Adi37fL7XjRUZFPowUWchX9eEVI=";
+    hash = "sha256-fK0j6+UqQVadQPU34oLp50gB+/0YnNnNg/rGuIt5I54=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "pyvex";
-  version = "9.2.28";
+  version = "9.2.29";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-fDsJqilxIt/LApXVrTm3JyOrZ6BR0+IbnFux/huF2ZU=";
+    hash = "sha256-buqtEiifBKbR7FP08ne5v0nWqkO+d2cVHxNCCZJDrdU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
