### PR TITLE
[22.05] element-{web,desktop}: 1.11.15 -> 1.11.16

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "lib/electron-main.js",
-  "version": "1.11.15",
+  "version": "1.11.16",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {
@@ -50,6 +50,7 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.213.0",
     "@babel/core": "^7.18.10",
     "@babel/preset-env": "^7.18.10",
     "@babel/preset-typescript": "^7.18.6",
@@ -70,7 +71,7 @@
     "babel-jest": "^28.1.3",
     "chokidar": "^3.5.2",
     "detect-libc": "^1.0.3",
-    "electron": "20.3.4",
+    "electron": "^21",
     "electron-builder": "^23.6.0",
     "electron-builder-squirrel-windows": "^23.6.0",
     "electron-devtools-installer": "^3.1.1",
@@ -93,7 +94,7 @@
     "rimraf": "^3.0.2",
     "tar": "^6.1.2",
     "ts-jest": "^28.0.8",
-    "ts-node": "^10.4.0",
+    "ts-node": "^10.9.1",
     "typescript": "4.5.5"
   },
   "hakDependencies": {

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -112,6 +112,8 @@ mkYarnPackage rec {
     mimeTypes = [ "x-scheme-handler/element" ];
   };
 
+  dontPatchShebangs = true;
+
   passthru = {
     updateScript = ./update.sh;
 

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.11.15",
-  "desktopSrcHash": "l+IjI3uvnOjaJA6IszDSuOO08SMqbUf8rI/u12g5Rxo=",
-  "desktopYarnHash": "024vd7xiwialfrag325558qjrqlfxzy9xq7jb15ysawand1k2xyv",
-  "webHash": "05q60p06y6z82g11nnc5w1rz069cyii64b77zrdag4v6gfap6b1d"
+  "version": "1.11.16",
+  "desktopSrcHash": "EeED62HRpaWN91yxcDvwwNUWmDRU38lyT5ba1S4go6Q=",
+  "desktopYarnHash": "1f0bghcbzab2dkvxmvhhc0dzyk3js09v2sh93gsjsq9mkhld1k0w",
+  "webHash": "0phkgk0f2b12q2b4z3j7glxjf2a3kvz7yw71yccgndgwa4f4wn8r"
 }


### PR DESCRIPTION

###### Description of changes
Backport of 8e832b78fdb99c22e254a001028f84a5cb1a81ee (#205752) to 22.05.

ChangeLog web: https://github.com/vector-im/element-web/releases/tag/v1.11.16
ChangeLog desktop: https://github.com/vector-im/element-desktop/releases/tag/v1.11.16

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
