### PR TITLE
[release-22.05] firefox*: 107.0.1 -> 108.0; firefox-esr-unwrapped: 102.5.0esr -> 102.6.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "107.0.1";
+  version = "108.0";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ach/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ach/firefox-108.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "679049d8cf97256cd92a52296c435e414443ea0715edcf4bfcf14d43464ba572";
+      sha256 = "b6951773f41261fa8e932267630eda0cab5b3ddf12125a6846d250206151cb1d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/af/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/af/firefox-108.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "04addc678368a5c63014037c16e6af976016bca3fcfd5444d6cabdfd4216a954";
+      sha256 = "9cec99e30f644fec0c4734de7698989bf2fab936ad4f1eec57ba05147212c505";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/an/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/an/firefox-108.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "fe222e59a9fd64fc35311b4f65b93798e9015cd3cef86ae401ba049d145722ed";
+      sha256 = "b1487e98f27d407f67763eb059a8b3a137495325c05daf69b04190919d72a5ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ar/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ar/firefox-108.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "bab5153a4d5e99f6851adcbe2ed3c4991a35ed0af71e2c2971fb11f513099ebf";
+      sha256 = "40b9bd078a4549179e5f2ae730b9c1d5db486897391769353b2b093ae8d9f933";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ast/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ast/firefox-108.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "ffbd3daa36feb9b822219e4b1ba1cb8bb1d879cc190f93c3e2722a4dd2fa8501";
+      sha256 = "b3d2f094f52d0768a0d32a364f4976b0da38f1426a7a2bbe17a5bd7d2451dc8d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/az/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/az/firefox-108.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "5d127a505c13b65d37d3a6f13fa678be255dd3b529f8b1d8c601de4db4a033d5";
+      sha256 = "697a26012211189778ec174b86f46005e5fe3579b28302c93a0152c2f3e04840";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/be/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/be/firefox-108.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "e42c84c5c04a29ad7a8603044ee1d5c7ca9a4d362b48e8526e1e37436adf13c7";
+      sha256 = "259adb8609ce04a85cf7e0ad06a885f484702e43c0c2c6e110b10cd87d3d7433";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/bg/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/bg/firefox-108.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "0257a1f6d4a98c0968af2634cb78fb3df9a16a4b116a0896ef63bfcd2db0833f";
+      sha256 = "685d537594410610f54b1518619ff187c97b53f9ab03d7a3e875da5c4c29c080";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/bn/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/bn/firefox-108.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "b5cfd2e009df5746bd39cc043da1a4daeb43bac612ec76876c2f04824786d0bd";
+      sha256 = "cb669c9f0852cd5a06ca5f852d3bf5df7dc424a8263cb89e4d3593bbcc2210d5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/br/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/br/firefox-108.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "2abdc59c0ae1567845202412b173748158f11afc21eee49d7bdbadf2dc5c41a2";
+      sha256 = "b1515ae6c9e8acd57745a86392046105a5d0be2735cf15ce28551bcc4fad9dab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/bs/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/bs/firefox-108.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "2e618ec5a3ffe2d6680648eade01142d1e231aae7824fc3e81a316cd0f6ffd56";
+      sha256 = "b692a84fd8b839607e209f663ceaee0ec9468b8dfc5d32a0556aa6825de782b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ca-valencia/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ca-valencia/firefox-108.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "954913fa0b3b68b5d29da2d26687d13f0cc08f95b14b85d94af59ae785874e5a";
+      sha256 = "603711bf9c60df5088363f20b282534bb4272a362b24e25a53cc9d9e26b457dd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ca/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ca/firefox-108.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6f243974105752147f98813fa392a53e2e22f09ca92633f233fbbae6c424ea61";
+      sha256 = "033966501867d0aa5f6f17a22da9248a80e16fc6487e297b353affb33a2d4155";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/cak/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/cak/firefox-108.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "897d28dcb54fe9eb9dd2fad53fb86e745d9581bd3b5d8a4b84d96c9af5025cfb";
+      sha256 = "98224bc7dc74ff0b313b053674c0fd13fb0c28b55d029ac0980d28d7034f05ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/cs/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/cs/firefox-108.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "fe9b41feae2a492156347637a901d0a4df29812ce4e4cfd8260a07a9eabce03c";
+      sha256 = "f3c181bb092002883bd8cff7ffbe34bae20c6c6afd9ffba392da58153f755693";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/cy/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/cy/firefox-108.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "4175f0ab0de25d7af5424a2d0fa0adc3bd0d077e4149e947508de0bfa67fb168";
+      sha256 = "9b8549dbc69e2fc397c62974599d2a394136abb6db51bba8a9c20b8fb6d2bb7e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/da/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/da/firefox-108.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "daa41afbf1a488a42162df4fb5010ec4bae0d3bf35dae62a137551f50b92e051";
+      sha256 = "078d4b2a26d0ce1ee389f10ae922170c834d1264d16b7e5eff563b3444e0c95d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/de/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/de/firefox-108.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "4136c703a113f0f5087c1e6d7f7d1b2ea65fa5360035ad4355d293157e0a8413";
+      sha256 = "f58c0552738e771df296ee6b8955de1734662178b3faaf116c3cebd4c946da4f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/dsb/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/dsb/firefox-108.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "b06c087516c09db77c0cf8ba11abb3a0bd0ed86939dc39d4a8a4512fc3e7eb47";
+      sha256 = "79c7c8a7fec1fdf44d93f7f7642b79dd3fcb93855034327fec9b8f306ea1800f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/el/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/el/firefox-108.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "85352071cec3c2ed578132803a939b6385c230c192e5ec69ebca498d8ae71315";
+      sha256 = "b68fdad776f10975a687d1e9ebbd22c4ddd5824563693b977a30446dd64befad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/en-CA/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/en-CA/firefox-108.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "69b4bf7143e5518b2c4592a0a74420896d6ba0acfdffef3d9c4dc6ff2df86cc7";
+      sha256 = "cc1f146e165f102567d4220348d060e64b4de783754d94827da263d35c38e58d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/en-GB/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/en-GB/firefox-108.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "e7bf37874eea05beff108ef9fcece799befda8373f7cfa105698ff5406b1d5e0";
+      sha256 = "8be4158a41d69f0cf9d5d2ee6c3ad8e80eb6d131bf6e91862562858888a9b784";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/en-US/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/en-US/firefox-108.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "dd08d4dfb69e379ce680a303c6c89c67056ce1d8ec0276345a8e8a0f04cd7dca";
+      sha256 = "4b87f3a9eb03efeb9b228f07eb8c2131fbe43979f7d72eb499c669249df7b420";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/eo/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/eo/firefox-108.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "022e776b11d369c1d97f32d09a492e030ec2e40994063eff412d43004c05bb1f";
+      sha256 = "c8e120fee5f3e98c71fc349e9464b1df1b8b39dd6a539c97524f72a91afc556d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/es-AR/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/es-AR/firefox-108.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "a3937f1a972e2e67237c879a3ebd27b116f45508e8d7fd0d66e0cbf83eb06573";
+      sha256 = "fcd654ac683c35945ece4756b9b6cccf9658b5963a74d97e27ec6a4edfffceff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/es-CL/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/es-CL/firefox-108.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "74263f87137d16b132f432b5af86061a55813c37c3fbdfb573b775fe09e16947";
+      sha256 = "c920e4ccc17b1fc53456d5b9c89a73f3ed21c12a24a1f2b871848da5434f838c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/es-ES/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/es-ES/firefox-108.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "e94d261eec4c9b969e6ca87aac3f42fa68b7061485de416938f6cdb7793a18f2";
+      sha256 = "1e5d5916b353b032fcc7ed534a9170885d70fe67f64fb3a7b10c4c07097bcd1e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/es-MX/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/es-MX/firefox-108.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "58b5e70829eee800a36b04477d5a5f57ff7fa31b5efb4413042a5e1009dad6b2";
+      sha256 = "133d5fc5b908a2978c30765bcc7d975a627eabea122a2412e338075965214b62";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/et/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/et/firefox-108.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e4f86517ce715fe88ae66e38575768662dba80bf9e352fb9cc57caef4c44c775";
+      sha256 = "14542c095607274d935bb1c908a74465cc68fb48545a077f87044618e8bea6ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/eu/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/eu/firefox-108.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "94a75621210ace53265c076c2847070b28d131b08519e6e68320adacf2d3e84e";
+      sha256 = "c037122941aa911040e6a17b36055440b5fd7ca52450809a868616458e6836d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/fa/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/fa/firefox-108.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "56d47f0162adcf5d08b5f5ee73d71c5d0bc4bb69a84b5222fd8217db35bf2110";
+      sha256 = "24e8383ae440b3e43282a21b4ff75ff2e785c14519e1a26c4592cbf2b8372a44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ff/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ff/firefox-108.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "5dca9a9b42dd5d0a200ca7e94a7045b826ecddd7c9fc338b4027b421b4d31993";
+      sha256 = "5d4223ecc1c9e40bf55dd80ee935b64eb80d90559250383a97debf232334fe71";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/fi/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/fi/firefox-108.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "1646c4de234154e4c3e3c3ca8702dd82521c9bd59104741f0bbb612994d54c3d";
+      sha256 = "df89a4d5b7546f0eb4b0e0e339df1dff3496087eb1d7ef0e5d6363f6ccda0715";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/fr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/fr/firefox-108.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "347f607a05bbfa7944f5b1ef769916059a3370d6a8b10839e58c85c2f2e965a0";
+      sha256 = "b5d1afa0168865ad1eeb06ac3f3d2ffe3aa1839e33b81852cfb5b02ff65cf168";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/fy-NL/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/fy-NL/firefox-108.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "a066356b7551cab7e138e555c4f41fa9c28272b78cd6449ec66b1493172741a0";
+      sha256 = "a79e13b2cf30ecdf161dff50c814bdd1c3ea8a788a287a812dbff18d7e47b603";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ga-IE/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ga-IE/firefox-108.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "e54b7b37b6612f9b7fdba45285d4c56cb69807ec269625628c4e0780f6309156";
+      sha256 = "34f714309286796c54c3bd05467c9d2dfbfbc7dcd8f16cd149a06e596da5ece2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/gd/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/gd/firefox-108.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "d4526b78c9531d6b7f77eb72f50b743e5a54723d70261ec08eb6b24c1989766d";
+      sha256 = "2cdd989a65daf8292e2e304b51f758420eac88ce3c59885efd67d7ffee1b33e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/gl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/gl/firefox-108.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "2b72e89ae20301a437591476e3c485bc03130b43a72fb394489e874e31852513";
+      sha256 = "a85cd54f0ffcbfde9bdcb7ed8939d9f7981b2c2b2aaa578082c0e99f5de82f13";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/gn/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/gn/firefox-108.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "737eae505377ab61a5c282b0eb8953716a314f3c9de477d32d64d7fb9a78f183";
+      sha256 = "78fb37ebef93586a679d8b85cd63f608ecfce86e0c48d68c12be160a6e2a1645";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/gu-IN/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/gu-IN/firefox-108.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "ce7c9e7729b56e042d1456dfcc319c96b1f750c9665830b6e1fde70de0b1ec60";
+      sha256 = "2a6308bd2aeb83a814d040a65944c7d13224453df2e2461f9f49093f4b695ee0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/he/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/he/firefox-108.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "99407349c83cba54c28f0183039c206cc39749679286f9cdf8ef24d060aeef3f";
+      sha256 = "113c4c8622b52f1343ba464bff4ecb6584b57319c7a5b87e3633a498aac556e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/hi-IN/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/hi-IN/firefox-108.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "3acb62c55ec5dde45de80fce6a4b2062f9216cefc53ef2f05edd628d960e180e";
+      sha256 = "d5070f22e1cf2a6c96043b0ad4ff6c03b86b737f5fbe5fcc7a480e7d5f43704a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/hr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/hr/firefox-108.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "bc37456f119e8b551e00ea8ed5a2ddaf9d46ab1902af9c88fc9ebe58af1a1839";
+      sha256 = "a43b685c109493be76f0cb563ee37bfa56cdcefd47552605131e277164490df6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/hsb/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/hsb/firefox-108.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "15f8ceed2e43cf430c116003bd90f738e86cb09e03c5031d9012f2ccddbfb2ae";
+      sha256 = "723c72102b1957d50dce39f7cd3d14013f83f26bc2f45c0cdd48a5425702ce4d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/hu/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/hu/firefox-108.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "553bb483a839d718a978c3de376b839f4545e4419c85e0ce9655e05a3e24d056";
+      sha256 = "73d01f6c449dde42f030599dc88a4fdeaee39e5c103e2a6d104834de313f8dfd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/hy-AM/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/hy-AM/firefox-108.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "93e245e49974914c61ae12fd5efa1811a998ebb095da30931757291f9e3b47b9";
+      sha256 = "a9c3a114df97ddfb8ab421becd32099007f23de31fd45fbd2f58465bc7c728ff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ia/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ia/firefox-108.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "140855a39273b8fff673b6ff0904fd09ccd878fb85ea923241fd77d7e738f5aa";
+      sha256 = "7414edb036bb8eae20baca49c15a072b846cb066a060c8f13167a6caac3e7813";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/id/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/id/firefox-108.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "c0a85f9d403adb33939d0a7e813a9a43021cf5631ca0ed60f65f9be0f10479a6";
+      sha256 = "75fa751294e37bb1c9015d885f087578cc4c6192d303af02afa94176dc93148c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/is/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/is/firefox-108.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "7e73445563483fd100ab8ed16e2757e80f3e504e598d3110b92c1eeb3f5c1a79";
+      sha256 = "9969925fd46a1d6d7808968e1bdf3b3bb791821f5f6eeda5df1fd3b6ea019105";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/it/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/it/firefox-108.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "b715fb3c86ec071361b47bb4e85bec4372a7af998515429dac5a3f40d1e8feb9";
+      sha256 = "0429dc99554c2047e7b5d0a37eb7965a483cc24189134de8ad700a7a65a5ccde";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ja/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ja/firefox-108.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "7a8e53117ff5b8650b54bc4776fc07b2fbffe8a4ca3b457af020bf294459cc88";
+      sha256 = "835d9ff99678360bf2427e814d52d8d2c33a05b66642cdd4e4a5892b1e06e920";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ka/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ka/firefox-108.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "6ec4c352f11249f0c088088f6b2c34c02e4e2476c1202e9b0be7d32971f68bdf";
+      sha256 = "b79de320bbdff5cdb0a4de0f9d67c595de9640b819aabb47a95ec1dc23820e63";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/kab/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/kab/firefox-108.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "e8a15014c2b350b05e4e0a27d02e33fe9dbecccde6d33b218872fd1a0b5b345f";
+      sha256 = "c2a940e4972d591e3fae01938af3674c9c75074db6b20a5a71cc6f3b0f365308";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/kk/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/kk/firefox-108.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "c832f0ecb4552e60e8689100d9b05f198325bcf6e8c97b2909bfe5e5e8622604";
+      sha256 = "ec96c45bdfba4b58bfd71edc0c80564114e468e84473af7201592a670b9c0d6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/km/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/km/firefox-108.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "1ade8728a00304d5815e5adc346cbaaf5d7e46449361d07e29a6ad94051438ff";
+      sha256 = "4ccb48df90814255b7afa7171d2f37dca55020a4f6cccca44b24d486546d32d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/kn/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/kn/firefox-108.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "3adaaca262bcc56f6005b2f6eb1e0fd48e08b3898f438eda52986bdd41eb5275";
+      sha256 = "bfc79bad909e4c987191d66a945e5577219fb7209b3162624a4197e4ee7929e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ko/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ko/firefox-108.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "2fd33ab883f8f213c9a6cbc1ba78b4d531140fa0fecc6d9f78729a780a29f777";
+      sha256 = "1cb13dc47d035488b045849316cf09d1dde156c3069fa97d36dc86b79ef9f087";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/lij/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/lij/firefox-108.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "c8f4b970079bc8b36b8237bd54fce184867dd30334a579643fa6e7753fbfda63";
+      sha256 = "c525208fa0f43d0b976757920ea8fb23bb70b0167a4adcdb4fc6529dee24c2f2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/lt/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/lt/firefox-108.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5fe663f86b54f5967bcae34aa406951fbbe5b8c542a9632b381c2ca675c648e6";
+      sha256 = "50f8cc9ed3a9c36defaf2c3c68cd04f3c463892bed9565b3860d036023d1c994";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/lv/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/lv/firefox-108.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "d12493b3996270a75f881a97b0cee106ffe3b28c64655a04758f0b898bb14796";
+      sha256 = "4487e7ce489314aa7338c0036531ba3997dea9f103f2b76a29d41db6ab8540e4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/mk/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/mk/firefox-108.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "3e8a93ec3d7776d778722cecab257a3c10bbb90844740cd26a06c2c8a8ab8d29";
+      sha256 = "e19b7e3367a030dde240058385ee5eb8252f0f8a7bbff05cfbc1780bb573aa14";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/mr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/mr/firefox-108.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "01364a69e1a1369779e49c20135347b34ff57b652cbbd1b12898f77ead9fe005";
+      sha256 = "850aadee9b69ce1813f2ade8ab32b4aa990a6ced260d0cb623dc20468ef8b46c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ms/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ms/firefox-108.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0240a4907cd9e931c7b3fc7df64507317d4739867d19eddf6a89c3010fcd7a67";
+      sha256 = "0155f1befa516ffaba4d3eb8372219b672c989287abc2519e69f144f04562664";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/my/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/my/firefox-108.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "8fb50408d531bd1fcc11888f2b3b96638f880bc014f41b1098548e7f344ee82a";
+      sha256 = "d5ec2e05cfc3ea636e5ee2fb01db11c054f2c6c10a6fb5f839003978ddff4b03";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/nb-NO/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/nb-NO/firefox-108.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "e457b5ff990cfb6760d5292311b2f3267d2d46e86c8029afce7b8417b3f03fab";
+      sha256 = "0676c75e0be185ae5a89dd87e6b0ac960ab300df9b9999d4ee097a22c059648f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ne-NP/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ne-NP/firefox-108.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "01dbb19cc98844ba6a08adb881de8782607c2f441801582be1b182a12b4b6e66";
+      sha256 = "de5205a9c2e0c48d2e2ea2ec803fa22c9a91ba0ef50c275d00921fafc5b95a1b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/nl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/nl/firefox-108.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "7606cc6004726bfd004a067c59e22719afde54c2c229fc2c29cdfef064a01035";
+      sha256 = "f7af36abeafde05bce3810b2cab03136ebd2b40a9cb158564704ce8218963790";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/nn-NO/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/nn-NO/firefox-108.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "17e2abf060ac6483f6a441e94e1ac6cff9d08440ee815a5f8fa9dac4d7864a5d";
+      sha256 = "2969c8594d78c41b9fac76f4ada74c5ef834639a3b8e3da83c15d3952af01c59";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/oc/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/oc/firefox-108.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "245d12e40994486041c22d9bf2a855011bcd83137bfd7ffdad724e44e5006403";
+      sha256 = "8a55a8ccacc4342e99d54cd58ca04a8f779897c8bd5b82e2a42536d7b6562cb1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/pa-IN/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/pa-IN/firefox-108.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "41250b0d8cb5e558344a82d740469a2df047411650d29d82704e7aa5471f164a";
+      sha256 = "86adf572bbf98b13fce452d4d7ccbebded451346a3baa3490adfb281dc7a1897";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/pl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/pl/firefox-108.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "e6315515538b335d1566d09187ddd2576cbdbe5368f41bea7f25bc033f166287";
+      sha256 = "9af76801beddbf7f95c82a2554585765480b9d7ba2089b4a368d9869d7919617";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/pt-BR/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/pt-BR/firefox-108.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "b1857d4019af37b41c465298c1dd26da3b0a2b26a5e28cc40f9e09ec61d01332";
+      sha256 = "ab5d7ad4f5293aea5128a51b37a0ffec8025cf2c28ac1e6ebb7fac2cddbbf185";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/pt-PT/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/pt-PT/firefox-108.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "45152bd04dc1fd55d0673f3d873909481383c31c2f77c90720dd5030937d25fb";
+      sha256 = "4368aafa8e6b8b7d8c38f0d8e240ebaf8f8d9f2cb5db716e8a7994d90f41dd85";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/rm/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/rm/firefox-108.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "49c135e5f234e85422a549ff349e8a62ab710ee275704c30a0f6b7ed3cdcc328";
+      sha256 = "894fef86560d58746bf6b4cb22cfb6ee530e8070fdc205ac0fd9f628a152e04d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ro/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ro/firefox-108.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "a7bf5c93b0524756b5e56ccd1485de42bee2a8e320488b819e38378cd1822544";
+      sha256 = "7ebd21474bdd636505d526f627796bfe9f18393c4822bf0445721f8e2aaa3d77";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ru/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ru/firefox-108.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "ee0aa353c311cfb5bf9a267fc58fa93cab0560608f68761a06569c08e55793d7";
+      sha256 = "76eea954965e628ea246cb9956a184e168fc3b24413b89b1c5659bce9ec259ab";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/sco/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/sco/firefox-108.0.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "535d7fd08a2df01e89d048ac48e6c37173be604f0ed5a0a413c0f5f1c8cb4ed5";
+      sha256 = "86e2f63d0edd8c12753ec74239be8d019830ad8cd38fe5a0927d9c405669b626";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/si/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/si/firefox-108.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "94ed849a09d72970d2612169b18e408ff196b8e68b7219acc84914d40b8d68e0";
+      sha256 = "6ee0342525f151c3e641978dea40dba1960e55102d9d54285643e0ede09d42b6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/sk/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/sk/firefox-108.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4b2069dc20127490a2581ce7cc1baad5dee291c1de31573c371bd257a282b12f";
+      sha256 = "aec36efc38150057174e6a0365d09898a5c25623b69e39ca479a500952493341";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/sl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/sl/firefox-108.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "019ab5a41bf32aedb3d564e041b03f66cf05492a66626d4b535f9e9f833fe422";
+      sha256 = "fa9501dd26b4e0d4572c145ab5d54bf469f41f985d1cb7c8448412f275ac6d07";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/son/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/son/firefox-108.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "1b8d8fbf7cf533fa6b1604fd8cf8c42426fff5878f5569e025081ae330c19f8d";
+      sha256 = "7fa75a93a584a88f20fe8e90c7e231e39172c0f21fdf183a64e36bdc3a98a2f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/sq/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/sq/firefox-108.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7d81a2caafcefb19b3e1f4f3c086344b9c689e37f58048f6f853ba95296b8e47";
+      sha256 = "9d7208ace7ae100cb1635f2206d5873d4685c0674716255f5c17a303ac9f5187";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/sr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/sr/firefox-108.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "a608df5ff130f46d728fae614a1c46508f46dda6663b5fdd92ecd182a0542489";
+      sha256 = "fb210329fb5d8f49251969c88aa563b2fa8abef0a246a450b819cdff4ec2dec5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/sv-SE/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/sv-SE/firefox-108.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "38231c4d903bc7a408b2198e0ebdfd12b9296cee50eea0ca666a1043d9f87fd8";
+      sha256 = "88f9138ef978a197d1549117824e7d6f790db2fa243308b39bbea38747294da0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/szl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/szl/firefox-108.0.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "27a1971065f55272a013e70565846d245ae183d58c16162ae01cd2e5383e9f83";
+      sha256 = "35dd4dcac109ee7ce282eeb34b98ca9f52c48a61295e8d98ade571d634968e97";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ta/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ta/firefox-108.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "0e2624c80ad6fbdd70bcd2714744e06e0a772dd068309b255cfb62fdfdd684f4";
+      sha256 = "b3aca8c7fdf49e0178e548f9cdd16fbb6a7ef86437469ca66022a786612a9b9e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/te/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/te/firefox-108.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "cdabaa4ff7a990df92824d59b3973b2748f8cfee8f186186cc5b2247180655d4";
+      sha256 = "c4e8c6be7ce4b5827c157b5a9313d4be4feed0bb32b4c0fa303d8233e38cd554";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/th/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/th/firefox-108.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "eddf5f314dd9c485eda09565b92239f5b1e7ea5f09f6a4c01515cd11a168b968";
+      sha256 = "24723a85f28c5cd5f1efc9bd6637f4256f4e34e4badefa464ef546984d48a936";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/tl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/tl/firefox-108.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "f67fd064e27f9f9c5c9167a0a430d0f06d45b26b6f5fec49e542b613117281cb";
+      sha256 = "33dcf80b737cd3580a5004427e95658418846c59fd1d8743f17cde45518ab474";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/tr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/tr/firefox-108.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "ca484719e16ab2bc608b6d8208ba9c25a0ffa98bd838b625877d7845fd596b2e";
+      sha256 = "ee84eabd88a6de1a3e97fbca0cb04fe77366a727af6ac754ee6a5f668e31495f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/trs/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/trs/firefox-108.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "a799b5a3179c944bc18b09ab871f7077d6e3265900b4bb8449978e69410c4473";
+      sha256 = "a91e3152a596ded79dd50cf2c304f63fe10c46813ce312afd866393956fc3f4b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/uk/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/uk/firefox-108.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "3eb9a9f499607e925c427492a1b9b1214ee7c16155e31940a79dc3edc813a26e";
+      sha256 = "3aacf5eccf9a839a802b870f120ade2babc76ad3935c208317604fbb7f517ccd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/ur/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/ur/firefox-108.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "7971c6e83e755916a151e7903af6b288733a63b24c398ba4cce7342c4081b38a";
+      sha256 = "534e70e0cad2c88fd938f72f27ce08f9bfde6c4b5ee171863c5a1422038bc02e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/uz/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/uz/firefox-108.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "0d886aa525269812703ffa190b099e000a57b4a9c57a25e13a4ce32568317c4b";
+      sha256 = "a68efdfde59ea7406eca684b7cf5c60037568a75c53d783647231cab45e6818e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/vi/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/vi/firefox-108.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "0a91a3c835e1d9d5711254eda497d46fa39706d0dd10884512589b44aa1e61b9";
+      sha256 = "aca3d2b8def22ab9c8098ff62f0bf7b56bfaaf04995ebb0c97a5179b909c55b9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/xh/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/xh/firefox-108.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "9123afc977a433d710ec1af0f36addd8659a326cab03b00405e74f20e9f9f117";
+      sha256 = "a6881b471e96a6b98f3fbae1f73221603e8f019d49d2342b4c1014035ee1fd6b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/zh-CN/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/zh-CN/firefox-108.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "59d89538258bdb155222d4780a80a1c49f1b5c651534de7721d491b38c8e311c";
+      sha256 = "1603e76a24926bfe95c6728d0cf0ef250585dc119aa469c8a4441f702e364926";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-x86_64/zh-TW/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-x86_64/zh-TW/firefox-108.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "26cd6d287862fa319529d77f337a8b676cc353d3bde0ee7b958d95729ce4ca7f";
+      sha256 = "c1d1950ff259f6eda3d34ab313af38af0fb91a6e7bf884a2a775425033d07640";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ach/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ach/firefox-108.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "17916342b19ad39673f4a34d07be61def15e3799639ef54fb59d82226e7deaa8";
+      sha256 = "56abe1e7bdbf83c421c06fbe2e287d588917178d3a0c0f0094f1f21f8bcfee07";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/af/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/af/firefox-108.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "226cb26dcd4499f51656fde0f8d2a803114d0535e43fcfb4cf7dd01eb1501f69";
+      sha256 = "781a8f92b12dfb17a8bd1ce7febafbe22c7b28fb340eeee28e94f946d6e9b320";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/an/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/an/firefox-108.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "de833c13e1bcc4a4656b188b97a53a4a64f080cf71a929043b577c85ff54a267";
+      sha256 = "73d5bc9349edf3173b4f41c9df3c732fe44263198e1a742460894c0db94fdfd8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ar/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ar/firefox-108.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "5fdd5b8bdcfea67f7175a4655e4afe1d68ce4a93a9b33d93946d51274804b2e5";
+      sha256 = "50c943ae795656e4550fab6b1f0e6ee6be0b1c1f301666b99c42b1c5e40b258e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ast/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ast/firefox-108.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "19b7db5b389b5e30496c4a24bd0a85ee43352a6a9b6941514bdcc0974c7cadb4";
+      sha256 = "7c6afa5f7b7d36439573c5e3f1055c0b096e6d9cd222533f9f9b7d9090be88f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/az/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/az/firefox-108.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "ec152cb4fc1de7b41dd7fd6fa340d942b0027f8ebc686a3afea9fc3dc7083e91";
+      sha256 = "317fce57a29265d9488bf9f9a63839e7e25ed2d389a1918d42577f6cd04233d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/be/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/be/firefox-108.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "fae4640a3fe360990cc5f71856fa3e674ab36b7b26b1aa9d4fd6c67c6e71db5a";
+      sha256 = "40efc486d4a3cc6133df414a6b7773438056831660558a42f1a2efa09a738016";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/bg/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/bg/firefox-108.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "aa642ee200a4b6cd46a50c2f8cfaecb827c7bf7d213997b409d2fba64d28af5d";
+      sha256 = "4506c0496d572932085bfe87e5c103795c931051b3e3bb5436db79d2a318f81d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/bn/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/bn/firefox-108.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "35bc8b83f5bd4ab35368700c095cc2943c8de72c091dc5fbe2b12e189a8b87ab";
+      sha256 = "2fbfbec560b24bdedf7b52040aa5caa0955b00ff7d8551d467df458eb8f73e17";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/br/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/br/firefox-108.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "c725df029f856eda9d8fb43ea0f9b87287adf125d32548c9e7f1c87e8a697e32";
+      sha256 = "24355c0756b5d1540d8f160c739ade86e9e8e27d83f0bef4f36a99cb949ae41e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/bs/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/bs/firefox-108.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "663746e7be72ce12ec9396670a49da3ab04abc75bd7f9f79d66ef4e424401c0d";
+      sha256 = "abedf170c0126f3990b1fb4d57a95dcba450987c8a80c1ffd121eff5f4f67111";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ca-valencia/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ca-valencia/firefox-108.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "554ce3be6cbb09ad9a5d674686bf2c0a40688e6850869482f018c0d41de0f3c4";
+      sha256 = "6d65f1dfb996edbee731ecf283fe97e7b74ce8a66916520678ca3c69484c8861";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ca/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ca/firefox-108.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "2ad814d95f190f98ded9359cb6168d5cc15771eb8541acd858fee5b094c5c425";
+      sha256 = "6f548a7b523785a73af8280a7baa7b9ca8a2c39b21c95dd5a49f794df00aee56";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/cak/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/cak/firefox-108.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "291900dfcaa9c99a24d782f34c8cb62121e48f297a9d42aec2db66d1a7c84100";
+      sha256 = "bce493d13f481f0504a4051a45ef74f7fad67031dd25fe9edabbb9674d8c5f46";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/cs/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/cs/firefox-108.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "fb986a313af88f69da9a1f257dba530d5b31e8e8d35dc702f7da5352a4ffcc77";
+      sha256 = "e282714c83bba9da9ee1c0c69dbd3f8fc30525d5cfc6e6cc81d25e349da8be3e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/cy/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/cy/firefox-108.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "188e4e1ca521621329e14607df75f1df0ca3c355717e690113c8be5e11034b3a";
+      sha256 = "ac2491f7be6dbd675bb752eb2e8af48b9783a3a16786169c5ecebe1b7e77794d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/da/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/da/firefox-108.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "c432993913915a89d4f68d78bf41120b3e5d9976894d0076e2f8bffad9fa7722";
+      sha256 = "2c7af614756a6de3aa2401dc54a2a61b809a0104496d3bcbd2c0de9462e34639";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/de/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/de/firefox-108.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "4d750c064b5313b00d71c2fa66547d6be8c5c14966395b7d3fdbca63fd12769e";
+      sha256 = "ace978aac190d5bb19afd962cb0b4221a9c1b5ffdc02b74ac13f389e60d6f366";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/dsb/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/dsb/firefox-108.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "b953dca01df3c55b049784a933e6df067021063e57b10dade22ffcbcfdf0131b";
+      sha256 = "8dfb7fb9dd65bcce11d53899636fe481e56c57ab9f96c0eb9d0be77df61e200a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/el/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/el/firefox-108.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "8ae94ca0a9c6e73d6e51c410d171bb37e81998e626f59db1edbf921959c97cd1";
+      sha256 = "00fb884e77393bfdde94312cfb7d759b8dc38f7514ce055a8c45d2697ff28f5a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/en-CA/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/en-CA/firefox-108.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "49c985c770df41cbc9e538a3c536bb1ba6d6858ba82a6c76b47caf48c8a626ed";
+      sha256 = "88b9a335a0f1d1aad13868c80444b2569f1d453005051ed23c5fb1dc60a58623";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/en-GB/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/en-GB/firefox-108.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "967bc2dc6292dda1d2a6a99083a31d4ff078b65a0bd6540dd3bac189a314863b";
+      sha256 = "ec41453c120b5c1e64023d6f45b84792c858aeeca8c5a0ad402f67fd3b98c0a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/en-US/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/en-US/firefox-108.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "5e08758e3aabf09ffd6e142295c9ed00f048b49d5d74daee29e30f5ddbbb9fd0";
+      sha256 = "3be27a6ca32732ed28c1f0b23d17811e23f2bc258804d785235d6f587d39ee86";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/eo/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/eo/firefox-108.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "5a668e9f4aff0d34f58d6d0042f8bcc08bc0c493bb6c335b354d7ca5b5deca2d";
+      sha256 = "aabd8fcdcf126a1282ba6f24adc9cb10c67b298b0fdd945d056349825dea57a9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/es-AR/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/es-AR/firefox-108.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "eff5a4acce1eebfc21f547e383302c7f666c180883880d20f76b0f5561d68221";
+      sha256 = "2eb508ceea57399803c9225dd50a35080c82608f992fc029e0d44f8e39d1e392";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/es-CL/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/es-CL/firefox-108.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "6b515a3c1a64b3dd4c1eaadf97086ef125bc846987750e038f964c625106f53e";
+      sha256 = "f4861de41a02f356d49d1155ad6b8134707f9ff3ac2778909cbc8c63870d46ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/es-ES/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/es-ES/firefox-108.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "c3a162e0ff91620e5235c3ec315389fea5b3650c96cf8fc4c3df313ce49710f5";
+      sha256 = "f71c4e233bb774cea8119f2a704cd32818b0b6b97638a222e61c0c9212c50450";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/es-MX/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/es-MX/firefox-108.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "4543dc01ef8fb7448963a4363685358470de9026d6d0f786f00d0dc1f64395cb";
+      sha256 = "a52ed25865f45caac5f05e621f84545da7a14f488a62d7ea2ea6e7f53e6ccdbf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/et/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/et/firefox-108.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "11ac8d0fe6f8c8d44be3b4f305bfbecbae2c6a34496627036bf65635cd43d093";
+      sha256 = "95f24a5af92ba1128e40482b37954ebecdbec5252f595cb217bbea5056f8c7ac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/eu/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/eu/firefox-108.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "f5d83ec06b5ba3070e6399d5831ca8f4ec6ead4d8ba87de7f9e7d903da984803";
+      sha256 = "dca9cc7271bec0952a8da1a2a1f9d95d2be50d24dc4a65aa1a78663d16d61f76";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/fa/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/fa/firefox-108.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "66e40da6369bc03b54bc71b6ac9cee85bf6dadbc1296f54190f6073fe65a72f7";
+      sha256 = "ff145e0a7fcaac3e5770501c9103c3fd53109a971efb30d4f1a5e9234ce6159b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ff/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ff/firefox-108.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "5de72fd8ee6fea17899d4409ca5dcc928193121e66ea34e62d4b71646b38f1ca";
+      sha256 = "2386ade5034cd327a988eee8352f1d06c0e39f6b8064779709b0be480416d379";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/fi/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/fi/firefox-108.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "16cfc9f01a314842b7bb6bfe99c2f8f644c7b864d5d05e81d94797be3518a49f";
+      sha256 = "e1b908a250a35f81e64b3421c2ac45dca43020b684319e0bc57d25aed3335663";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/fr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/fr/firefox-108.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "cd9f6d103850f91111fdee1070f5ef73fc04b86d50b5d0ce660bf999009b11b7";
+      sha256 = "184c7d46542ee3ced202e6f38c2790e6cf3cd2940eced78eca17c065370aac36";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/fy-NL/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/fy-NL/firefox-108.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "5320380cf6e47e0e51f0572d9cf10ca61623365393557534f6b04c1e63b611b2";
+      sha256 = "d4fe0c82879f57e46c26df52642e2cc23c76062df16f8143e58b19c5a39bca55";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ga-IE/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ga-IE/firefox-108.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "7f3828bf3a0981d308ab0af9f652ed4dbcc757f7777385fb38292618f20b97e4";
+      sha256 = "77bc3e8ed744dfc1e86e6815ea7978291b26f895d94d8aeacc9cc4d5d0452c00";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/gd/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/gd/firefox-108.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "9b2b54863ed580d246838c2b95af719883af9ceb3323aa6eab43c9481e7f95aa";
+      sha256 = "365f5a0541206c0f9fe4de887e526337ae66131623ae0ac66c7ac1247841b579";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/gl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/gl/firefox-108.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "586293da9f6da75c1b3eceb724f28cbd3b00146849ac86c170808881c376e48b";
+      sha256 = "9e7678af7fbdcd765a69bd1813cd880e9f2e234225043b538b8d0beea4ae8910";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/gn/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/gn/firefox-108.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "6d480fc3647c544294fad67e6ce67d0146f236b38e78ce1a0d2ddca360fb133b";
+      sha256 = "7471650db1459ae204152262d9610b79fd498b2f0e06ea8ea5b2caa03aefa212";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/gu-IN/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/gu-IN/firefox-108.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "a81b65482841b059e164355450092a20c20cd1e8461abdf6a8c5eae790e659d4";
+      sha256 = "5c11d77dd2545fe9c4d107832999c4259d4232af1e523ce6efba58820cd4be0a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/he/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/he/firefox-108.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "24bda19053a4ab3dde56c562b35bfc9c7e5cd315b615b67eda8f5531e32d6d49";
+      sha256 = "98ad8be52761b404c0b669d362c49c8790cd8aafe67abbc4eaa0c326fb55de4b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/hi-IN/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/hi-IN/firefox-108.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "e140eb8e2eb77e27fcabbfed85d53636803b6091a806031ee962bce56a478409";
+      sha256 = "a4da7c91d56e11f9b7dbbd779a566514fb2985378e0822a858fb68ba6d12d939";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/hr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/hr/firefox-108.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "30a32e8cf2f9515d3856fa666f2f3292e2c1fd9508b0fa2697bf8057e7b9be26";
+      sha256 = "9e1de928ab92880828c1b4e8f568780392363b8baa7e0f93db9acdf857def05f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/hsb/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/hsb/firefox-108.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "0c6209f1e56c026effcf2939b1dffcb3989ff50ffca678d53640fa09e89085f3";
+      sha256 = "238ff3f87b3425ea54fc73bf5f0c0aeadbff7428747b5a9218a5945b11d068a3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/hu/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/hu/firefox-108.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "4524c4d5dd376fc1111556e7361c6c1aa22073edf5d25f0054a153cf728c2ffb";
+      sha256 = "eb8823158e91b969aea46811e973585611ce5d4221f1b92c6196b46ba5fd615f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/hy-AM/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/hy-AM/firefox-108.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "8915e6fcbe7e8347aaedf68c34759280f666db986e9b5d9675aed8bb5ecbfa07";
+      sha256 = "de42d34669f8dfe3f53659aab9acc094794da78301dbceb04abb7e12ebbe15f3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ia/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ia/firefox-108.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "35b60a830578ab16b5525151505fd793e1d9f67d2baeb27ab28f8cbe01e55ad5";
+      sha256 = "322457f09cba1dd38685643e3f5c8ff890054097112745d9319782467d31b384";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/id/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/id/firefox-108.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "4dc777ddf92d169f3f0cf546ce7fc2894aaa004a3faba22ce56125e84dade215";
+      sha256 = "b72e6c6b4eece8156e188efd36575f9b433d8ca2c356254c54bf6245e50d4b27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/is/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/is/firefox-108.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "28dd54716bd8b9f3e3f91ba3bfa6d36a087e9b39d9aa8f81334d9c6895c2c41d";
+      sha256 = "637bfee9bbe84257b194fa6d57aa2b3726805b5dc5ec324cf4361948cccfc341";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/it/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/it/firefox-108.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "2f26236e622b2bfb4913861641846e474c9d7931f069901355b0360b4aeedf3e";
+      sha256 = "ff8b0a88af76898e323c07dda2756f38a0416cbbae2dbcba53b20d5eb050b47a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ja/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ja/firefox-108.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "95e7e60f5e1a2f2b432460ac44775316318a63b17a00f4f4b4f6281dd86c301f";
+      sha256 = "b41d6a06811d521b585e027fed4bd1572895c880ae48707ffd6bba54c9c80f94";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ka/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ka/firefox-108.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "f008c35f2146dc9f662457f03d347b1308a4a745c7048659d73640e687647a51";
+      sha256 = "54c66f3fa76920b0244756425fd712c77686a3ee8e44a32434f788a38c770997";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/kab/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/kab/firefox-108.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "d49b7fcdafa3b67ab2b2daa07558f026ff87701b9c99666904de4612a24372bc";
+      sha256 = "6619413c322a5923cbfab95ba5190a9d441f4adc83fe57fd496fd185a29e5753";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/kk/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/kk/firefox-108.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "7e614c1f3dfd1d0e71b3c8542aeced1c8615e413af7a3005ac72c98a40a2db3e";
+      sha256 = "e6c12831368405bbd5a1a20d8ae2780813ebfadd254559480a2826ff28f697df";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/km/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/km/firefox-108.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "335d3c85e557cbb57e8bacb4956f36f71ee9cc37be9bd4bd57e9517ed26b4c4b";
+      sha256 = "d771af960fa8ac584a6e6935ea5315416525134ba525249394674e8476ada69d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/kn/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/kn/firefox-108.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "01b3463e6ac28725811c61cc85f3d88ede4e146f6c7773d761b48a4988691511";
+      sha256 = "bcefcd94660e0be805c2d14ddec105d5c60b4bf9b0200a53f7042bab48ec95b5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ko/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ko/firefox-108.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a763244ae30a28a46b7ab448504e8cf5668d9b6d2c170dd93fcf1a4a800e5d6d";
+      sha256 = "6a2ded017635605f1d8f2faae95ceec297abc22dc57ab6db8fd42668ee4bea08";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/lij/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/lij/firefox-108.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "eb7728f8355a8787c17fc928803a23e43070c1a4a41e4858a1517b081bc1098a";
+      sha256 = "18b197e5d832b312be5529cd14e939f74cc233c1aeae186f961881a25615d326";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/lt/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/lt/firefox-108.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "386746b9fc800d3fb43d43676b1b34fa59d4e8aa971e70a39f5f21cc1e728a18";
+      sha256 = "184f64a74edddf7c1f192dea1191457b2d9436faf1ff0168038f3faf3d2e5221";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/lv/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/lv/firefox-108.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "c1059ba74bef1156290331081f24e1781c7cad51c3347c6b334c643b0a64ed36";
+      sha256 = "06d698ec349364ee548999a3739d9ebd4166d27a16e730e437322e3b438ae1e2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/mk/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/mk/firefox-108.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "b109b661e34c6f2d64b61fba854af116bdeb71b15eb2863c0d1cadac4337c83c";
+      sha256 = "67429316eeac3b605f568da0971321dd9fe51b0b942b527a56e52c7f13720c7e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/mr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/mr/firefox-108.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "e6f51c3d75f395438fa16a694a1280a30ba505e70dfe514bea8b0554f77e3369";
+      sha256 = "0938cf62338a65f6be395706fbcf2ce0cefe732269b40b728b1001de23383d7d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ms/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ms/firefox-108.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "6d63dfeb4b2086c300d6308cbaf191060b756985bf61a10a3d4ed9206ca4d424";
+      sha256 = "96eae9eb57b69cb29abce306228361db299c0d0995e179d26a11685196713df7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/my/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/my/firefox-108.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "b4cf51f0be13cc81d0b3234e221f8d7863aadc06d2bf661283ed828e7d517cf0";
+      sha256 = "fade9b50b7707729eabef0e4ef4461af37aee4234069a6efb5f3d1afdcea3625";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/nb-NO/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/nb-NO/firefox-108.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "e50e376e80cbbc81d1f8d3a157bd3dd62b138cdbf8c28e76a1a05787b2b8fbab";
+      sha256 = "22781a6753d44889acbaf0d1e88d0c86972e5b47d36fa1aa6950e67df9dd6f24";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ne-NP/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ne-NP/firefox-108.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "d2ebcf67804929f4be1eed4b9e8eaf91d21413bc2fa68cb89c446b5466c01109";
+      sha256 = "24795b6da6633b1f6de4f1b9102dbde4b1177ad9894aa482d68c78915107de71";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/nl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/nl/firefox-108.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "d7b03f8903477a769e55bff76c913a17c6947435d609fe1899682daf73a772dc";
+      sha256 = "91595a90c6e771fe5d30aac08b39f5d15e458afb4867b33bdc202796f2636276";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/nn-NO/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/nn-NO/firefox-108.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "bbb2935b8bfe2dce798cdd6c63ff495561aa1a39814090cbb91dca77a98fc53f";
+      sha256 = "010d6b1388b385b7a41643739feef519de5e486b4cff0a109c83d973ce08b9e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/oc/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/oc/firefox-108.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "7a087519d0b36cf1e341837944ed2ebb86c293f4e208e7150ef458d89acf87b4";
+      sha256 = "76a8ccb6d65ede9a4d0d64b9eb1d907853bba544ea417c0abd0143d34194aac3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/pa-IN/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/pa-IN/firefox-108.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "af120c7110f8923f21ae9b29e30700cb21bfe396af15c283d4222afc92e794e9";
+      sha256 = "8a307d344d472cf8414bd86880fe1dbd9743d39836fe86e14fdc51abbe15d2a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/pl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/pl/firefox-108.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "e772270c68859cb1be157f861d45b96d261b40d54ba01f8641f0cd36e8b93eb2";
+      sha256 = "bee5bbeee0165b18d352b5cfb6ee3e6ab998ddf11052f77fb4f7cbd14881a970";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/pt-BR/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/pt-BR/firefox-108.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "eeced9960d8d45f6603adc0b8163fcb9f85b5b10c636fe2b6c9343a989820dac";
+      sha256 = "04782c1ed890c530498771abdcf10c47e3a954147430f417c2cb9d348ea2666e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/pt-PT/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/pt-PT/firefox-108.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "457dc498fa2ae9a489c260436258f380c6553be5597c66668f5b983e7a15ab81";
+      sha256 = "78ef4f882f913aa8d0afcc009a5eda11206ba4192bfccf335b48ee3cf5d7a5e6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/rm/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/rm/firefox-108.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "a3adeb8c4d8041ed213960fecb786258b38f9403473f85fe26de4becedd8b615";
+      sha256 = "8dc4562c4dd39d984a9e889848a281b04e7d00861cb8a42a7ff0bd007cfa54e1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ro/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ro/firefox-108.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "aabdc4124e2ee756f36a2dda6004cbaf8fbc33f6de41374f59b9d86401ebff2a";
+      sha256 = "3a643cba7e2842cc9cd41607d69918c651dfd6925c6fd676bd4a356d828fbcf5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ru/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ru/firefox-108.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "92d2a7b0a67bbe71d19cb9e2bf7d702f1c5ad9c50693d1a47030da6fa0581b28";
+      sha256 = "06ae820981ab243156bd2f23ca7b211abe37ff8e2ce599fbff1375beb9f7a310";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/sco/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/sco/firefox-108.0.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "688890b0cea77ef5c89f84bb8e8949a41a925e1ccfdeb7f4fcb9224f1b264457";
+      sha256 = "7300fffe8616203fe7281bd5b59ce7f7e38422f71b433b780dd7a76e982806c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/si/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/si/firefox-108.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "190283d7ef6c61ce73c59a6c04b6f046c7001b1f5909e252ccc104147a5b109b";
+      sha256 = "1af9921b29d867e651ae93f1a1b179f5b8cab85a40730a1eb3cbb3fd1fca8bf8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/sk/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/sk/firefox-108.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "52b401719a52ce606aa84fabdf858f2aa5302155f8266f7a35fb493697ccd7d6";
+      sha256 = "b25e71a2d93fdf6492ee6aabd3334fe76bb7485f317fc897349df4054a36d29b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/sl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/sl/firefox-108.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "a271eec2e80adcbf81fe2f97a4bb6dc3177a901486329898c652152820093acf";
+      sha256 = "d933490dcf276ee4e2a61c7537d6e03cd42ca0e61e8818a4478f4a83d46c6522";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/son/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/son/firefox-108.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "6573f0fb20dd563c1d534f293d510a3954929c3f2b4313838e239108a75f214a";
+      sha256 = "a263986678e2c6e309330e6320e2a3b0193a5a27a2eea24cdf4902ef553c5031";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/sq/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/sq/firefox-108.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "3c8c319eff5722f370b084be6b6ffda15d18ee21321d90833f7216d76aaacafa";
+      sha256 = "e88768b98f0090b31264f775cc32ce32e8ef929f33b1e250cb2dd5f5fe0ecd5b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/sr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/sr/firefox-108.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "6dc3a73c53684c59d69e20d28b263e43cf00c05855c0c12c67ccb91d575ce324";
+      sha256 = "05d08fae3d9a284fb432791555c8434fadfaffffd90ea3b1fe69ccc09794b49d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/sv-SE/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/sv-SE/firefox-108.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "46693aaae23b4395517bd3b2e76818ed3042c9a667110eafe0e817340cfecc1f";
+      sha256 = "4912b143f4a527243d13d128f9d3bff516795b58d05c451139ceea0ec3609d1f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/szl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/szl/firefox-108.0.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "afbd85b5a417c3ccd8bb1ecabcac238265fe152c12f89410315abe7849843302";
+      sha256 = "d47b9ecc61977553c7be966159cb82ca501c7affa5682fb3770b3f8d1645464a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ta/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ta/firefox-108.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "cb06f14c4e95fd4715d23c35312ae6d0b11ada176f8dc4dcfcc0c500343f8f1c";
+      sha256 = "81fcfec603292745e851a8896cd3c3caef0415c03087c1bfb14d8c102e29edae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/te/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/te/firefox-108.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "267ed08bc07e24c5ce31018ed1315777d9c7f8b764616a4cdb9e57be8b86464e";
+      sha256 = "77210e502969bff34024bb6686782319f4a6e500084c78b1275adad701e5028f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/th/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/th/firefox-108.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "383c3b0a28815b4e47db8b88a5bcda8f30af0cc71872262a459f55b1d69a822f";
+      sha256 = "6b55b5e89a0c336c42b5840558bf7253b193bc7568d34c58405430359e7d7dd0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/tl/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/tl/firefox-108.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "1fe44aae6c7faf704ccd164c7365eb1ec15f1ae7a33738bda835020787659a87";
+      sha256 = "4f51e452e71a255b03babcb3dd144a63a40bd4194095b3d3a69a0d86a4e085ba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/tr/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/tr/firefox-108.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "1e0db7166c51e00cb0f3a861b30ead22f943091b0b99bb102cb681d19f7c3b13";
+      sha256 = "21f300244f4680823232a17260f97e42c317b68b04e12f70899c570c107ffb6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/trs/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/trs/firefox-108.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "656b9f67aa76d6a7c910ed6ca5728ec0863ae793849f064cef140f0f8d801d80";
+      sha256 = "70eec318b1b3cbdc4e9f52cd61c95de34f238a2178c84d25d4485ace907e211c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/uk/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/uk/firefox-108.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "72ead37f19177664e038c6b7dccc10a4c12559bf6d7cf06e7fe69a97c62949aa";
+      sha256 = "28d0f9addea5dc2f7d9251f63938a17f3c197389b68e09f1f907b3dcdc86093e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/ur/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/ur/firefox-108.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "971c4b0fc84af8ea3a083f7547c960c76ea8a2f3f6f030ef3eca5ac2d9fb241a";
+      sha256 = "0ff037ccc3ab4cf0237ea4f1a05afdfc2e9b2cbdd8d5fdc4febd7485e2fbcf29";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/uz/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/uz/firefox-108.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "8df8449366f676e0162dbd6a03548625c1d4ba57bf552636b84bccd0f63bf1ce";
+      sha256 = "c25a9b38d03b4151249c7147bd607227066a87af012af7ef3c379d09fe700ec6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/vi/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/vi/firefox-108.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "092a3098c6a0baf1cce80b414eb7a37133d1eb374170475c4da421ec4d1fcf0b";
+      sha256 = "fca5145827605d2594732e768bc49b70bd20ffa4706ce4bf48373c0a12c11a58";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/xh/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/xh/firefox-108.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "4a33a349b668ff856ec8c37d0a2db3d444f21d97568b0ce1e506562a960f51e3";
+      sha256 = "316e76123e952c1dc03b30468035deb285faa492e2f244704aa967f5ce3d2e90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/zh-CN/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/zh-CN/firefox-108.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "e8a972eb36404d073e33f401f9600b2db18c288976fafb78e3910de9af7f45cb";
+      sha256 = "bd9e0d035629181a74a93f5d487a64ca74ca2112dbac980ad7469ed339a43b36";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/107.0.1/linux-i686/zh-TW/firefox-107.0.1.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/108.0/linux-i686/zh-TW/firefox-108.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "cf695fe37a1bc36da284882d48b824292c15fb1bd2de2386dd7a3bfa4134fe57";
+      sha256 = "40b6a9d8c16517669067a453b7676cffa43f60e47d4cd116f77994883363c7aa";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -220,7 +220,7 @@ buildStdenv.mkDerivation ({
     "profilingPhase"
   ];
 
-  patches = lib.optionals (lib.versionOlder version "103") [
+  patches = lib.optionals (lib.versionOlder version "102.6.0") [
     (fetchpatch {
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1773259
       name = "rust-cbindgen-0.24.2-compat.patch";

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -235,7 +235,7 @@ buildStdenv.mkDerivation ({
 
   postPatch = ''
     rm -rf obj-x86_64-pc-linux-gnu
-    patchShebangs mach
+    patchShebangs mach build
   ''
   + extraPostPatch;
 

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 rec {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "107.0.1";
+    version = "108.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "e57e4bfcecbcc6dbe73f23577a14a2998c8c3f3d602f85ea06f99e0974e78481b9f7bdb019cb4e9733e59f56be1407edd64a2adb7b284bb4a87b46b1e2295dea";
+      sha512 = "fa800f62cca395a51b9a04373a27be48fc3860208e34ecf74d908127638d1eb8c41cf9898be6896777d408127d5c4b7104d9ee89c97da923b2dc6ea32186187e";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -29,10 +29,10 @@ rec {
 
   firefox-esr-102 = buildMozillaMach rec {
     pname = "firefox-esr";
-    version = "102.5.0esr";
+    version = "102.6.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "f4e105209c61e9537ddc90afdb05ede0a31caceb9b164d96276c811abbd646d14bc246c00caa386c0b0561055096d30b298329c69270dd085b943bdbc3a91a13";
+      sha512 = "c0f0160bea612d0ae74c29dd44beb7fd9a1c292694b8cd5c4faf2e54feb5c27684eee821b67dd40df714d69866a4e3a8b19e22182d9bc3023050d2d96b02d308";
     };
 
     meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/108.0/releasenotes/
https://www.mozilla.org/en-US/firefox/102.6.0/releasenotes/

Backport of #205798 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
