### PR TITLE
MIDIVisualizer: Add Darwin support

### DIFF
--- a/pkgs/applications/audio/midi-visualizer/default.nix
+++ b/pkgs/applications/audio/midi-visualizer/default.nix
@@ -1,5 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libX11, glfw, makeWrapper,
-  libXrandr, libXinerama, libXcursor, gtk3, ffmpeg-full, ...}:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libX11
+, glfw
+, makeWrapper
+, libXrandr
+, libXinerama
+, libXcursor
+, gtk3
+, ffmpeg-full
+, AppKit
+, Carbon
+, Cocoa
+, CoreAudio
+, CoreMIDI
+, CoreServices
+, Kernel
+}:
 
 stdenv.mkDerivation rec {
   pname = "MIDIVisualizer";
@@ -15,16 +34,29 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config makeWrapper];
 
   buildInputs = [
-    libX11
     glfw
+    ffmpeg-full
+  ] ++ lib.optionals stdenv.isLinux [
+    libX11
     libXrandr
     libXinerama
     libXcursor
     gtk3
-    ffmpeg-full
+  ] ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    Carbon
+    Cocoa
+    CoreAudio
+    CoreMIDI
+    CoreServices
+    Kernel
   ];
 
-  installPhase = ''
+  installPhase = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications $out/bin
+    cp -r MIDIVisualizer.app $out/Applications/
+    ln -s ../Applications/MIDIVisualizer.app/Contents/MacOS/MIDIVisualizer $out/bin/
+  '' else ''
     mkdir -p $out/bin
     cp MIDIVisualizer $out/bin
 
@@ -36,7 +68,7 @@ stdenv.mkDerivation rec {
     description = "A small MIDI visualizer tool, using OpenGL";
     homepage = "https://github.com/kosua20/MIDIVisualizer";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.ericdallo ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21582,7 +21582,9 @@ with pkgs;
 
   micropython = callPackage ../development/interpreters/micropython { };
 
-  MIDIVisualizer = callPackage ../applications/audio/midi-visualizer { };
+  MIDIVisualizer = callPackage ../applications/audio/midi-visualizer {
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Carbon CoreAudio CoreMIDI CoreServices Kernel;
+  };
 
   mimalloc = callPackage ../development/libraries/mimalloc { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
