### PR TITLE
vscode, vscodium: 1.73.1 -> 1.74.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
@@ -69,6 +69,8 @@ vscode-utils.buildVscodeExtension {
   name = "${pname}-${version}";
   src = "${vsix}/${pname}.zip";
   vscodeExtUniqueId = "${publisher}.${pname}";
+  vscodeExtPublisher = publisher;
+  vscodeExtName = pname;
 
   nativeBuildInputs = lib.optionals setDefaultServerPath [ jq moreutils ];
 

--- a/pkgs/applications/editors/vscode/extensions/vscode-lldb/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-lldb/default.nix
@@ -8,6 +8,8 @@ let
   version = "1.8.1";
 
   vscodeExtUniqueId = "${publisher}.${pname}";
+  vscodeExtPublisher = publisher;
+  vscodeExtName = pname;
 
   src = fetchFromGitHub {
     owner = "vadimcn";
@@ -52,7 +54,7 @@ let
 
 in stdenv.mkDerivation {
   pname = "vscode-extension-${publisher}-${pname}";
-  inherit src version vscodeExtUniqueId;
+  inherit src version vscodeExtUniqueId vscodeExtPublisher vscodeExtName;
 
   installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
 

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -5,6 +5,8 @@ let
     src,
     # Same as "Unique Identifier" on the extension's web page.
     # For the moment, only serve as unique extension dir.
+    vscodeExtPublisher,
+    vscodeExtName,
     vscodeExtUniqueId,
     configurePhase ? ''
       runHook preConfigure
@@ -23,7 +25,10 @@ let
 
     name = "vscode-extension-${name}";
 
-    inherit vscodeExtUniqueId;
+    passthru = {
+      inherit vscodeExtPublisher vscodeExtName vscodeExtUniqueId;
+    };
+
     inherit configurePhase buildPhase dontPatchELF dontStrip;
 
     installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
@@ -54,9 +59,12 @@ let
   }: assert "" == name; assert null == src;
   buildVscodeExtension ((removeAttrs a [ "mktplcRef" "vsix" ]) // {
     name = "${mktplcRef.publisher}-${mktplcRef.name}-${mktplcRef.version}";
+    version = mktplcRef.version;
     src = if (vsix != null)
       then vsix
       else fetchVsixFromVscodeMarketplace mktplcRef;
+    vscodeExtPublisher = mktplcRef.publisher;
+    vscodeExtName = mktplcRef.name;
     vscodeExtUniqueId = "${mktplcRef.publisher}.${mktplcRef.name}";
   });
 

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -18,17 +18,17 @@ let
   archive_fmt = if stdenv.isDarwin then "zip" else "tar.gz";
 
   sha256 = {
-    x86_64-linux = "1m5mz6wdrivqrw699iivvh62bdn4yzm6hmph455sdyvk5icq59dq";
-    x86_64-darwin = "1zn0h9p05kb3fcn816fpxh8asaglycjmpiwkrmxd0s8jwjq7m4gn";
-    aarch64-linux = "1gs810iz08jxqfhcgi6ab41m46ib5h3m7i3pnyvlimxx99r5lirf";
-    aarch64-darwin = "1dvasr1h28snxi33m6yx95pp3jd4irwy6yav4ilwrcl22cf6ybvi";
-    armv7l-linux = "1j5vrpdaqihcr02pdsd5nz07zsk0027xmkfp30npnjy1gjrjvnim";
+    x86_64-linux = "0f5l720gc47dygbk7mahx7pb088a8bfrnf69j3igvczbnfapx5sy";
+    x86_64-darwin = "0qmji8bfnqvrxv4yk3rscvns1hk5wfwwdng8jblh5bilf657g1fc";
+    aarch64-linux = "0qcmcsb97q303izhw8k4242nsb72my1vnf24hsfml4vr76f5qqbd";
+    aarch64-darwin = "1cc8p5s8vr5bml715yx2lzkqa9q85rziswrhl1d11zagymvswjzn";
+    armv7l-linux = "086c3wazjk30f8r8dgi0bjsvzcc6sa9d80cy4500pim7rb7s6ppn";
   }.${system} or throwSystem;
 in
   callPackage ./generic.nix rec {
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
-    version = "1.73.1";
+    version = "1.74.1";
     pname = "vscode";
 
     executableName = "code" + lib.optionalString isInsiders "-insiders";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -15,11 +15,11 @@ let
   archive_fmt = if stdenv.isDarwin then "zip" else "tar.gz";
 
   sha256 = {
-    x86_64-linux = "09ymqhg10flv3w38cb3fhrf5fvxz6aa12y75i009j01rjckvsymr";
-    x86_64-darwin = "0kd9a8vk4ddp78m0y1fbzbpgpr5rwhxnfbg52wvky0grl58dh6v6";
-    aarch64-linux = "17hwxwvvl3vy2s6wl1n2qkkdhlrf40z8wy0r5jhqrni79f6drkjz";
-    aarch64-darwin = "1skgnn6rq0rkhj98q8y19cyyllk8xa1752lwn4qcgi568anap1lw";
-    armv7l-linux = "0drz8kigjl82m3hfkpbqnmymy6fpgwmgbpkdwl2jkbl81iijvxvp";
+    x86_64-linux = "07njvkgashg9mbkdf7cw40xdxh08qs8gbgh24gdznvs397bvk2jk";
+    x86_64-darwin = "155f7rbyb413igvxddrrad0y1s7i9rfldm6d9fvbyz6p8nzyqfvh";
+    aarch64-linux = "08wz44js381hjlnpssd09i2xz9min603n7a5v3x2sah4z9vi220d";
+    aarch64-darwin = "0ikw0kcbvjwn6b0ac5zfp0shavay31yfhn000xrw9il3py741x7k";
+    armv7l-linux = "1pvybhaf96ayjl832vz9c0y2m07mb5a16c2hr13l0vw52sbl30md";
   }.${system} or throwSystem;
 
   sourceRoot = if stdenv.isDarwin then "" else ".";
@@ -29,7 +29,7 @@ in
 
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
-    version = "1.73.1.22314";
+    version = "1.74.1.22349";
     pname = "vscodium";
 
     executableName = "codium";


### PR DESCRIPTION
I have `Allow edits and access to secrets by maintainers` enabled and you can push stuff here if you want.

Ofborg failures are (hopefully) not related to this bump:
- https://hydra.nixos.org/job/nixpkgs/trunk/vscode-extensions.vadimcn.vscode-lldb.x86_64-darwin
- https://github.com/NixOS/nixpkgs/pull/159220#issuecomment-1036231572

###### Description of changes

The update is not that trivial probably because of https://github.com/microsoft/vscode/commit/23b25e9d4d3aad79f59a087f25bffb859afea88e.

I guess I will open a PR first and hopefully get some feedback :upside_down_face: 

- Closes #205080
- Closes #205042
- Closes #205074
- Closes #205672
- Closes #205661
- Closes #206324

###### To test

If you use vscode-fhs, please help test vscode-fhs.

For vscode-with-extensions, to test some extensions, e.g. `vscode-extensions.vadimcn.vscode-lldb`, use 

```
nix-build -I nixpkgs=. -E 'with import <nixpkgs> { config = { allowUnfree = true; }; }; vscode-with-extensions.override { vscodeExtensions = with vscode-extensions; [ vadimcn.vscode-lldb ]; }'
```

**Don't just** `nix-build -A vscode-extensions.vadimcn.vscode-lldb`, e.g. the former will fail to eval on f007395f951878c8c0b507f6e8f621d417b90744 but the latter does build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
