### PR TITLE
ma1sd: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/servers/ma1sd/default.nix
+++ b/pkgs/servers/ma1sd/default.nix
@@ -1,25 +1,41 @@
-{ lib, stdenv, fetchFromGitHub, jre, git, gradle_6, perl, makeWrapper }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, jre
+, git
+, gradle
+, perl
+, makeWrapper
+}:
 
 let
   pname = "ma1sd";
-  version = "2.4.0";
-  rev = version;
+  version = "2.5.0";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "ma1uta";
     repo = "ma1sd";
-    hash = "sha256-8UnhrGa8KKmMAAkzUXztMkxgYOX8MU1ioXuEStGi4Vc=";
+    rev = version;
+    hash = "sha256-K3kaujAhWsRQuTMW3SZOnE7Rmu8+tDXaxpLrb45OI4A=";
   };
 
+  patches = [
+    # https://github.com/ma1uta/ma1sd/pull/122
+    (fetchpatch {
+      name = "java-16-compatibility.patch";
+      url = "https://github.com/ma1uta/ma1sd/commit/be2e2e97ce21741ca6a2e29a06f5748f45dd414e.patch";
+      hash = "sha256-dvCeK/0InNJtUG9CWrsg7BE0FGWtXuHo3TU0iFFUmIk=";
+    })
+  ];
 
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";
-    inherit src version;
-    nativeBuildInputs = [ gradle_6 perl git ];
+    inherit src version patches;
+    nativeBuildInputs = [ gradle perl git ];
 
     buildPhase = ''
-      export MA1SD_BUILD_VERSION=${rev}
+      export MA1SD_BUILD_VERSION=${version}
       export GRADLE_USER_HOME=$(mktemp -d);
       gradle --no-daemon build -x test
     '';
@@ -35,21 +51,26 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0x2wmmhjgnb6p72d3kvnv2vg52l0c4151rs4jrazs9rvxjfc88dr";
+    outputHash = "sha256-Px8FLnREBC6pADcEPn/GfhrtGnmZqjXIX7l1xPjiCvQ=";
   };
 
 in
 stdenv.mkDerivation {
-  inherit pname src version;
-  nativeBuildInputs = [ gradle_6 perl makeWrapper ];
+  inherit pname src version patches;
+  nativeBuildInputs = [ gradle perl makeWrapper ];
   buildInputs = [ jre ];
+
+  postPatch = ''
+    substituteInPlace build.gradle \
+      --replace 'gradlePluginPortal()' "" \
+      --replace 'mavenCentral()' "mavenLocal(); maven { url '${deps}' }"
+  '';
 
   buildPhase = ''
     runHook preBuild
-    export MA1SD_BUILD_VERSION=${rev}
+    export MA1SD_BUILD_VERSION=${version}
     export GRADLE_USER_HOME=$(mktemp -d)
 
-    sed -ie "s#jcenter()#mavenLocal(); maven { url '${deps}' }#g" build.gradle
     gradle --offline --no-daemon build -x test
     runHook postBuild
   '';
@@ -64,6 +85,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "a federated matrix identity server; fork of mxisd";
     homepage = "https://github.com/ma1uta/ma1sd";
+    changelog = "https://github.com/ma1uta/ma1sd/releases/tag/${version}";
     sourceProvenance = with sourceTypes; [
       fromSource
       binaryBytecode  # deps


### PR DESCRIPTION
###### Description of changes

https://github.com/ma1uta/ma1sd/releases/tag/2.5.0

Looks like Gradle 7 support requested in https://github.com/ma1uta/ma1sd/issues/91 was added in https://github.com/ma1uta/ma1sd/commit/e456724caf1b46984a6085b8b5e8feb461e16ea6, and compilation against Java 16+ is fixed by https://github.com/ma1uta/ma1sd/pull/122.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
