### PR TITLE
firefox-mobile: init

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/mobile-config.nix
+++ b/pkgs/applications/networking/browsers/firefox/mobile-config.nix
@@ -1,0 +1,113 @@
+{ stdenv, lib, runCommand, fetchFromGitLab, wrapFirefox, firefox-unwrapped }:
+
+let
+  pkg = fetchFromGitLab {
+    owner = "postmarketOS";
+    repo = "mobile-config-firefox";
+    rev = "ff2f07873f4ebc6e220da0e9b9f04c69f451edda";
+    sha256 = "sha256-8wRz8corz00+0qROMiOmZAddM4tjfmE91bx0+P8JNx4=";
+  };
+  userChrome = runCommand "userChrome.css" {} ''
+    cat ${pkg}/src/userChrome/*.css > $out
+  '';
+  userContent = runCommand "userContent.css" {} ''
+    cat ${pkg}/src/userContent/*.css > $out
+  '';
+in wrapFirefox firefox-unwrapped {
+  # extraPolicies = (lib.importJSON "${pkg}/src/policies.json").policies;
+  extraPoliciesFiles = [ "${pkg}/src/policies.json" ];
+  extraPrefs = ''
+    // Copyright 2022 Arnaud Ferraris, Oliver Smith
+    // SPDX-License-Identifier: MPL-2.0
+
+    // This is a Firefox autoconfig file:
+    // https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig
+
+    // Import custom userChrome.css on startup or new profile creation
+    const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+    Cu.import("resource://gre/modules/Services.jsm");
+    Cu.import("resource://gre/modules/FileUtils.jsm");
+
+    var updated = false;
+
+    // Create <profile>/chrome/ directory if not already present
+    var chromeDir = Services.dirsvc.get("ProfD", Ci.nsIFile);
+    chromeDir.append("chrome");
+    if (!chromeDir.exists()) {
+        chromeDir.create(Ci.nsIFile.DIRECTORY_TYPE, FileUtils.PERMS_DIRECTORY);
+    }
+
+    // Create nsIFile objects for userChrome.css in <profile>/chrome/ and in /etc/
+    var chromeFile = chromeDir.clone();
+    chromeFile.append("userChrome.css");
+    var defaultChrome = new FileUtils.File("${userChrome}");
+
+    // No auto-upgrade. Should this be replaced with symlinking?
+    // // Remove the existing userChrome.css if older than the installed one
+    // if (chromeFile.exists() && defaultChrome.exists() &&
+    //   chromeFile.lastModifiedTime < defaultChrome.lastModifiedTime) {
+    //   chromeFile.remove(false);
+    // }
+
+    // Copy userChrome.css to <profile>/chrome/
+    if (!chromeFile.exists()) {
+      defaultChrome.copyTo(chromeDir, "userChrome.css");
+      updated = true;
+    }
+
+    // Create nsIFile objects for userContent.css in <profile>/chrome/ and in /etc/
+    var contentFile = chromeDir.clone();
+    contentFile.append("userContent.css");
+    var defaultContent = new FileUtils.File("${userContent}");
+
+    // No auto-upgrade. Should this be replaced with symlinking?
+    // // Remove the existing userContent.css if older than the installed one
+    // if (contentFile.exists() && defaultContent.exists() &&
+    //   contentFile.lastModifiedTime < defaultContent.lastModifiedTime) {
+    //   contentFile.remove(false);
+    // }
+
+    // Copy userContent.css to <profile>/chrome/
+    if (!contentFile.exists()) {
+      defaultContent.copyTo(chromeDir, "userContent.css");
+      updated = true;
+    }
+
+    // Restart Firefox immediately if one of the files got updated
+    if (updated === true) {
+        var appStartup = Cc["@mozilla.org/toolkit/app-startup;1"].getService(Ci.nsIAppStartup);
+        appStartup.quit(Ci.nsIAppStartup.eForceQuit | Ci.nsIAppStartup.eRestart);
+    }
+
+    defaultPref('general.useragent.override', 'Mozilla/5.0 (Android 11; Mobile; rv:96.0) Gecko/96.0 Firefox/96.0');
+    defaultPref('browser.urlbar.suggest.topsites', false);
+    defaultPref('browser.urlbar.suggest.engines', false);
+    defaultPref('browser.newtabpage.enabled', true);
+
+    // Enable android-style pinch-to-zoom
+    pref('dom.w3c.touch_events.enabled', true);
+    pref('apz.allow_zooming', true);
+    pref('apz.allow_double_tap_zooming', true);
+
+    // Save vertical space by hiding the titlebar
+    pref('browser.tabs.inTitlebar', 1);
+
+    // Disable search suggestions
+    pref('browser.search.suggest.enabled', false);
+
+    // Empty new tab page: faster, less distractions
+    pref('browser.newtabpage.enabled', false);
+
+    // Allow UI customizations with userChrome.css and userContent.css
+    pref('toolkit.legacyUserProfileCustomizations.stylesheets', true);
+
+    // Select the entire URL with one click
+    pref('browser.urlbar.clickSelectsAll', true);
+
+    // Disable cosmetic animations, save CPU
+    pref('toolkit.cosmeticAnimations.enabled', false);
+
+    // Disable download animations, save CPU
+    pref('browser.download.animateNotifications', false);
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28883,6 +28883,8 @@ with pkgs;
 
   firefox = wrapFirefox firefox-unwrapped { };
 
+  firefox-mobile = callPackage ../applications/networking/browsers/firefox/mobile-config.nix { };
+
   firefox-esr = firefox-esr-102;
   firefox-esr-102 = wrapFirefox firefox-esr-102-unwrapped { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds a ["mobile" configuration for firefox, by postmarketOS](https://gitlab.com/postmarketOS/mobile-config-firefox). This is just policy+css on for the regular firefox (since it now handles wayland natively).

Tested on mobile-nixos on pinephone

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
