### PR TITLE
nginxMainline: 1.23.2 -> 1.23.3

### DIFF
--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.23.2";
-  sha256 = "sha256-qAzCctPXKq7nCqi1F7SGKmNcAlZ5BDTb/E1hipmbC0Y=";
+  version = "1.23.3";
+  sha256 = "sha256-dctXh9u5+uGLFIEPkcxDQ/ZM5MJOJzAhNvtSSYBCulQ=";
 }


### PR DESCRIPTION
###### Description of changes

https://nginx.org/en/CHANGES

> Changes with nginx 1.23.3                                        13 Dec 2022
> 
>     *) Bugfix: an error might occur when reading PROXY protocol version 2
>        header with large number of TLVs.
> 
>     *) Bugfix: a segmentation fault might occur in a worker process if SSI
>        was used to process subrequests created by other modules.
>        Thanks to Ciel Zhao.
> 
>     *) Workaround: when a hostname used in the "listen" directive resolves
>        to multiple addresses, nginx now ignores duplicates within these
>        addresses.
> 
>     *) Bugfix: nginx might hog CPU during unbuffered proxying if SSL
>        connections to backends were used.
> 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
