### PR TITLE
pythonPackages.pytest-postgresql: init at 4.1.1

### DIFF
--- a/pkgs/development/python-modules/mirakuru/default.nix
+++ b/pkgs/development/python-modules/mirakuru/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  psutil,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  pytest-cov,
+  netcat,
+  procps,
+  python-daemon,
+}:
+buildPythonPackage rec {
+  pname = "mirakuru";
+  version = "2.4.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "ClearcodeHQ";
+    repo = "mirakuru";
+    rev = "v${version}";
+    hash = "sha256-0z7Qq0BQV7criQqqK0I9/Rm0u1qa1EQJ+06+oXAl+M0=";
+  };
+
+  nativeBuildInputs = [setuptools];
+
+  propagatedBuildInputs = [psutil];
+
+  checkInputs = [pytestCheckHook pytest-cov python-daemon netcat procps];
+
+  pythonImportsCheck = ["mirakuru"];
+
+  meta = with lib; {
+    description = "Process executor (not only) for tests";
+    homepage = https://github.com/ClearcodeHQ/mirakuru;
+    license = licenses.lgpl3Only;
+    maintainers = [maintainers.apeschar];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/port-for/default.nix
+++ b/pkgs/development/python-modules/port-for/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  pytest-cov,
+}:
+buildPythonPackage rec {
+  pname = "port-for";
+  version = "0.6.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "kmike";
+    repo = "port-for";
+    rev = "v${version}";
+    hash = "sha256-1+wP7KHcfQOvOYdn9WaugVNthoDcSsUKKT+84vpG+/k=";
+  };
+
+  nativeBuildInputs = [setuptools];
+
+  checkInputs = [pytestCheckHook pytest-cov];
+
+  pythonImportsCheck = ["port_for"];
+
+  meta = with lib; {
+    description = "Utility that helps with local TCP ports management";
+    homepage = https://github.com/kmike/port-for/;
+    license = licenses.mit;
+    maintainers = [maintainers.apeschar];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/pytest-postgresql/default.nix
+++ b/pkgs/development/python-modules/pytest-postgresql/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytest,
+  port-for,
+  mirakuru,
+  pytestCheckHook,
+  pytest-cov,
+  pytest-xdist,
+  psycopg,
+  postgresql,
+  glibcLocales,
+}:
+buildPythonPackage rec {
+  pname = "pytest-postgresql";
+  version = "4.1.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "ClearcodeHQ";
+    repo = "pytest-postgresql";
+    rev = "v${version}";
+    hash = "sha256-ckwab7q5moPJRpx8+C7cx6exBneYwfk5XTbj3vgMhPE=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    pytest
+    port-for
+    mirakuru
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-cov
+    pytest-xdist
+    psycopg
+    postgresql
+    glibcLocales
+  ];
+
+  pytestFlagsArray = [
+    "--postgresql-exec=${postgresql}/bin/pg_ctl"
+    "--ignore=tests/docker/test_nooproc_docker.py"
+    "--ignore=tests/test_template_database.py"
+  ];
+
+  pythonImportsCheck = [
+    "pytest_postgresql"
+    "pytest_postgresql.factories"
+  ];
+
+  meta = with lib; {
+    description = "PostgreSQL fixtures and fixture factories for pytest";
+    homepage = https://github.com/ClearcodeHQ/pytest-postgresql;
+    license = licenses.lgpl3Only;
+    maintainers = [maintainers.apeschar];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/pytest-redis/default.nix
+++ b/pkgs/development/python-modules/pytest-redis/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytest,
+  port-for,
+  mirakuru,
+  redis,
+  pytestCheckHook,
+  pytest-cov,
+  pytest-xdist,
+  mock,
+  pkgs,
+}:
+buildPythonPackage rec {
+  pname = "pytest-redis";
+  version = "2.4.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "ClearcodeHQ";
+    repo = "pytest-redis";
+    rev = "v${version}";
+    hash = "sha256-0sYY7DMBFNosnJ6EEA06tCE2LKk8F8ER2rLLYIUxn8I=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    pytest
+    port-for
+    mirakuru
+    redis
+  ];
+
+  checkInputs = [pytestCheckHook pytest-cov pytest-xdist mock];
+
+  pytestFlagsArray = [
+    "--redis-exec=${pkgs.redis}/bin/redis-server"
+    "--basetemp=$(mktemp -d)"
+    "-k 'not test_second_redis'"
+  ];
+
+  pythonImportsCheck = [
+    "pytest_redis"
+    "pytest_redis.factories"
+  ];
+
+  meta = with lib; {
+    description = "Redis fixtures and fixture factories for pytest";
+    homepage = https://github.com/ClearcodeHQ/pytest-redis;
+    license = licenses.lgpl3Only;
+    maintainers = [maintainers.apeschar];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8913,6 +8913,8 @@ self: super: with self; {
 
   pytest-plt = callPackage ../development/python-modules/pytest-plt { };
 
+  pytest-postgresql = callPackage ../development/python-modules/pytest-postgresql { };
+
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
   pytest-qt = callPackage ../development/python-modules/pytest-qt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8931,6 +8931,8 @@ self: super: with self; {
 
   pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };
 
+  pytest-redis = callPackage ../development/python-modules/pytest-redis { };
+
   pytest-regressions = callPackage ../development/python-modules/pytest-regressions { };
 
   pytest-relaxed = callPackage ../development/python-modules/pytest-relaxed { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7292,6 +7292,8 @@ self: super: with self; {
 
   portend = callPackage ../development/python-modules/portend { };
 
+  port-for = callPackage ../development/python-modules/port-for { };
+
   portpicker = callPackage ../development/python-modules/portpicker { };
 
   posix_ipc = callPackage ../development/python-modules/posix_ipc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5787,6 +5787,8 @@ self: super: with self; {
     inherit (pkgs.darwin) cctools;
   };
 
+  mirakuru = callPackage ../development/python-modules/mirakuru { };
+
   misaka = callPackage ../development/python-modules/misaka { };
 
   misoc = callPackage ../development/python-modules/misoc { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
