### PR TITLE
nixos/vim: fix example package

### DIFF
--- a/nixos/modules/programs/vim.nix
+++ b/nixos/modules/programs/vim.nix
@@ -19,7 +19,7 @@ in {
       type = types.package;
       default = pkgs.vim;
       defaultText = literalExpression "pkgs.vim";
-      example = literalExpression "pkgs.vimHugeX";
+      example = literalExpression "pkgs.vim-full";
       description = lib.mdDoc ''
         vim package to use.
       '';


### PR DESCRIPTION
vimHugeX is now an alias for vim-full after https://github.com/NixOS/nixpkgs/pull/204438.