### PR TITLE
feat(checkexec): add tool

### DIFF
--- a/pkgs/tools/misc/checkexec/default.nix
+++ b/pkgs/tools/misc/checkexec/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  owner = "kurtbuilds";
+  pname = "checkexec";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = owner;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-osLtyVXR4rASwRJmbu6jD8o3h12l/Ty4O8/XTl5UzB4=";
+  };
+
+  cargoHash = "sha256-ivNhvd+Diq54tmJfveJoW8F/YN294/zRCbsQPwpufak=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  meta = with lib; {
+    description =
+      "checkexec is a tool to conditionally execute commands only when files in a dependency list have been updated";
+    homepage = "https://github.com/kurtbuilds/checkexec";
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.jceb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -376,6 +376,8 @@ with pkgs;
 
   cewl = callPackage ../tools/security/cewl { };
 
+  checkexec = callPackage ../tools/misc/checkexec { };
+
   checkov = callPackage ../development/tools/analysis/checkov {};
 
   chrysalis = callPackage ../applications/misc/chrysalis { };


### PR DESCRIPTION
###### Description of changes

Add `checkexec` tool.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).