### PR TITLE
nixos/goeland: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -85,6 +85,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/slurdge/goeland">goeland</link>,
+          an alternative to rss2email written in golang with many
+          filters. Available as
+          <link linkend="opt-services.goeland.enable">services.goeland</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/ellie/atuin">atuin</link>,
           a sync server for shell history. Available as
           <link linkend="opt-services.atuin.enable">services.atuin</link>.

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -30,6 +30,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [stevenblack-blocklist](https://github.com/StevenBlack/hosts), A unified hosts file with base extensions for blocking unwanted websites. Available as [networking.stevenblack](options.html#opt-networking.stevenblack.enable).
 
+- [goeland](https://github.com/slurdge/goeland), an alternative to rss2email written in golang with many filters. Available as [services.goeland](#opt-services.goeland.enable).
+
 - [atuin](https://github.com/ellie/atuin), a sync server for shell history. Available as [services.atuin](#opt-services.atuin.enable).
 
 - [mmsd](https://gitlab.com/kop316/mmsd), a lower level daemon that transmits and recieves MMSes. Available as [services.mmsd](#opt-services.mmsd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -530,6 +530,7 @@
   ./services/mail/dovecot.nix
   ./services/mail/dspam.nix
   ./services/mail/exim.nix
+  ./services/mail/goeland.nix
   ./services/mail/listmonk.nix
   ./services/mail/maddy.nix
   ./services/mail/mail.nix

--- a/nixos/modules/services/mail/goeland.nix
+++ b/nixos/modules/services/mail/goeland.nix
@@ -34,14 +34,15 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [ "d ${cfg.databaseDirectory} 0750 goeland goeland -" ];
-
     services.goeland.settings.database = "${cfg.databaseDirectory}/goeland.db";
 
     systemd.services.goeland = {
       serviceConfig = let confFile = tomlFormat.generate "config.toml" cfg.settings; in {
         ExecStart = "${pkgs.goeland}/bin/goeland run -c ${confFile}";
         User = "goeland";
+        Group = "goeland";
+        StateDirectory = "goeland";
+        StateDirectoryMode = "0750";
       };
       startAt = cfg.schedule;
     };

--- a/nixos/modules/services/mail/goeland.nix
+++ b/nixos/modules/services/mail/goeland.nix
@@ -40,13 +40,17 @@ in
     services.goeland.settings.database = "${cfg.stateDir}/goeland.db";
 
     systemd.services.goeland = {
-      serviceConfig = let confFile = tomlFormat.generate "config.toml" cfg.settings; in {
-        ExecStart = "${pkgs.goeland}/bin/goeland run -c ${confFile}";
-        User = "goeland";
-        Group = "goeland";
-        StateDirectory = "goeland";
-        StateDirectoryMode = "0750";
-      };
+      serviceConfig = let confFile = tomlFormat.generate "config.toml" cfg.settings; in mkMerge [
+        {
+          ExecStart = "${pkgs.goeland}/bin/goeland run -c ${confFile}";
+          User = "goeland";
+          Group = "goeland";
+        }
+        (mkIf (cfg.stateDir == "/var/lib/goeland") {
+          StateDirectory = "goeland";
+          StateDirectoryMode = "0750";
+        })
+      ];
       startAt = cfg.schedule;
     };
 

--- a/nixos/modules/services/mail/goeland.nix
+++ b/nixos/modules/services/mail/goeland.nix
@@ -16,25 +16,28 @@ in
         See the [example config file](https://github.com/slurdge/goeland/blob/master/cmd/asset/config.default.toml) for the available options.
       '';
       default = { };
-      type = types.submodule {
-        freeformType = tomlFormat.type;
-      };
+      type = tomlFormat.type;
     };
     schedule = mkOption {
       type = types.str;
       default = "12h";
       example = "Mon, 00:00:00";
-      description = mdDoc "How often to run goeland, in systemd time format";
+      description = mdDoc "How often to run goeland, in systemd time format.";
     };
-    databaseDirectory = mkOption {
+    stateDir = mkOption {
       type = types.path;
       default = "/var/lib/goeland";
-      description = mdDoc "Directory where the goeland database will reside if using the `unseen` filter";
+      description = mdDoc ''
+        The data directory for goeland where the database will reside if using the unseen filter.
+        If left as the default value this directory will automatically be created before the goeland
+        server starts, otherwise you are responsible for ensuring the directory exists with
+        appropriate ownership and permissions.
+      '';
     };
   };
 
   config = mkIf cfg.enable {
-    services.goeland.settings.database = "${cfg.databaseDirectory}/goeland.db";
+    services.goeland.settings.database = "${cfg.stateDir}/goeland.db";
 
     systemd.services.goeland = {
       serviceConfig = let confFile = tomlFormat.generate "config.toml" cfg.settings; in {

--- a/nixos/modules/services/mail/goeland.nix
+++ b/nixos/modules/services/mail/goeland.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.goeland;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.services.goeland = {
+    enable = mkEnableOption (mdDoc "goeland");
+
+    settings = mkOption {
+      description = mdDoc ''
+        Configuration of goeland.
+        See the [example config file](https://github.com/slurdge/goeland/blob/master/cmd/asset/config.default.toml) for the available options.
+      '';
+      default = { };
+      type = types.submodule {
+        freeformType = tomlFormat.type;
+      };
+    };
+    schedule = mkOption {
+      type = types.str;
+      default = "12h";
+      example = "Mon, 00:00:00";
+      description = mdDoc "How often to run goeland, in systemd time format";
+    };
+    databaseDirectory = mkOption {
+      type = types.path;
+      default = "/var/lib/goeland";
+      description = mdDoc "Directory where the goeland database will reside if using the `unseen` filter";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [ "d ${cfg.databaseDirectory} 0750 goeland goeland -" ];
+
+    services.goeland.settings.database = "${cfg.databaseDirectory}/goeland.db";
+
+    systemd.services.goeland = {
+      serviceConfig = let confFile = tomlFormat.generate "config.toml" cfg.settings; in {
+        ExecStart = "${pkgs.goeland}/bin/goeland run -c ${confFile}";
+        User = "goeland";
+      };
+      startAt = cfg.schedule;
+    };
+
+    users.users.goeland = {
+      description = "goeland user";
+      group = "goeland";
+      isSystemUser = true;
+    };
+    users.groups.goeland = { };
+  };
+
+  meta.maintainers = with maintainers; [ sweenu ];
+}

--- a/nixos/modules/services/mail/goeland.nix
+++ b/nixos/modules/services/mail/goeland.nix
@@ -60,6 +60,17 @@ in
       isSystemUser = true;
     };
     users.groups.goeland = { };
+
+    warnings =
+      if hasAttr "password" cfg.settings.email
+      then [
+        ''
+          It is not recommended to set the "services.goeland.settings.email.password"
+          option as it will be in cleartext in the Nix store.
+          Please use "services.goeland.settings.email.password_file" instead.
+        ''
+      ]
+      else [ ];
   };
 
   meta.maintainers = with maintainers; [ sweenu ];

--- a/nixos/modules/services/mail/goeland.nix
+++ b/nixos/modules/services/mail/goeland.nix
@@ -61,16 +61,13 @@ in
     };
     users.groups.goeland = { };
 
-    warnings =
-      if hasAttr "password" cfg.settings.email
-      then [
-        ''
-          It is not recommended to set the "services.goeland.settings.email.password"
-          option as it will be in cleartext in the Nix store.
-          Please use "services.goeland.settings.email.password_file" instead.
-        ''
-      ]
-      else [ ];
+    warnings = optionals (hasAttr "password" cfg.settings.email) [
+      ''
+        It is not recommended to set the "services.goeland.settings.email.password"
+        option as it will be in cleartext in the Nix store.
+        Please use "services.goeland.settings.email.password_file" instead.
+      ''
+    ];
   };
 
   meta.maintainers = with maintainers; [ sweenu ];

--- a/pkgs/applications/networking/feedreaders/goeland/default.nix
+++ b/pkgs/applications/networking/feedreaders/goeland/default.nix
@@ -23,14 +23,15 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    description = "An alternative to RSS2Email written in golang with many filters.";
+    description = "An alternative to rss2email written in golang with many filters";
     longDescription = ''
-      Goeland excels at creating beautiful emails from RSS,
-      tailored for daily or weekly digest. It include a number of
+      Goeland excels at creating beautiful emails from RSS feeds,
+      tailored for daily or weekly digest. It includes a number of
       filters that can transform the RSS content along the way.
-      It can also consume other sources, such as a Imgur tag.
+      It can also consume other sources, such as Imgur tags.
     '';
     homepage = "https://github.com/slurdge/goeland";
+    changelog = "https://github.com/slurdge/goeland/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ mit ];
     maintainers = [ maintainers.sweenu ];
   };


### PR DESCRIPTION
###### Description of changes
New PR after this one was closed: https://github.com/NixOS/nixpkgs/pull/199755
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
