### PR TITLE
uair: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13906,6 +13906,12 @@
     githubId = 3268082;
     name = "Thibaut Marty";
   };
+  thled = {
+    name = "Thomas Le Duc";
+    email = "dev@tleduc.de";
+    github = "thled";
+    githubId = 28220902;
+  };
   thyol = {
     name = "thyol";
     email = "thyol@pm.me";

--- a/pkgs/tools/misc/uair/default.nix
+++ b/pkgs/tools/misc/uair/default.nix
@@ -1,0 +1,37 @@
+{ fetchFromGitHub
+, installShellFiles
+, lib
+, rustPlatform
+, scdoc
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "uair";
+  version = "v0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "metent";
+    repo = pname;
+    rev = version;
+    hash = "sha256-xGPc371Dfo455rnfacXVDgC9SXU5s8jqw4ttSCBqWyk=";
+  };
+
+  cargoHash = "sha256-tHcMR8ExIlzYZzacBYyyk2d5by20jG4ihM0yU0K6Xhg=";
+
+  nativeBuildInputs = [ installShellFiles scdoc ];
+
+  preFixup = ''
+    scdoc < docs/uair.1.scd > docs/uair.1
+    scdoc < docs/uair.5.scd > docs/uair.5
+    scdoc < docs/uairctl.1.scd > docs/uairctl.1
+
+    installManPage docs/*.[1-9]
+  '';
+
+  meta = with lib; {
+    description = "An extensible pomodoro timer";
+    homepage = "https://github.com/metent/uair";
+    license = licenses.mit;
+    maintainers = with maintainers; [ thled ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12498,6 +12498,8 @@ with pkgs;
 
   ua = callPackage ../tools/networking/ua { };
 
+  uair = callPackage ../tools/misc/uair { };
+
   ubidump = python3Packages.callPackage ../tools/filesystems/ubidump { };
 
   ubridge = callPackage ../tools/networking/ubridge { };


### PR DESCRIPTION
###### Description of changes

Add the pomodoro timer tool `uair` (https://github.com/metent/uair).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).