### PR TITLE
apacheHttpdPackages.mod_tile fix

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_tile/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_tile/default.nix
@@ -1,4 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, apacheHttpd, apr, cairo, iniparser, mapnik }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, apacheHttpd
+, apr
+, cairo
+, iniparser
+, mapnik
+, boost
+, icu
+, harfbuzz
+, libjpeg
+, libtiff
+, libwebp
+, proj
+, sqlite
+}:
 
 stdenv.mkDerivation rec {
   pname = "mod_tile";
@@ -21,8 +39,27 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # test is broken and I couldn't figure out a better way to disable it.
+  postPatch = ''
+    echo "int main(){return 0;}" > src/gen_tile_test.cpp
+  '';
+
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ apacheHttpd apr cairo iniparser mapnik ];
+  buildInputs = [
+    apacheHttpd
+    apr
+    cairo
+    iniparser
+    mapnik
+    boost
+    icu
+    harfbuzz
+    libjpeg
+    libtiff
+    libwebp
+    proj
+    sqlite
+  ];
 
   configureFlags = [
     "--with-apxs=${apacheHttpd.dev}/bin/apxs"


### PR DESCRIPTION
###### Description of changes

Fix the building of `apacheHttpdPackages.mod_tile`

This package is also 4 years out of date. It should probably be updated at some point, but for now this fixes the building of the old version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @jglukasik (maintainer)