### PR TITLE
mbedtls: 3.2.1 -> 3.3.0, mbedtls_2: 2.28.1 -> 2.28.2 

### DIFF
--- a/pkgs/development/libraries/mbedtls/2.nix
+++ b/pkgs/development/libraries/mbedtls/2.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "2.28.1";
-  hash = "sha256-brbZB3fINDeVWXf50ct4bxYkoBVyD6bBBijZyFQSnyw=";
+  version = "2.28.2";
+  hash = "sha256-rbWvPrFoY31QyW/TbMndPXTzAJS6qT/bo6J0IL6jRvQ=";
 }

--- a/pkgs/development/libraries/mbedtls/3.nix
+++ b/pkgs/development/libraries/mbedtls/3.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "3.2.1";
-  hash = "sha256-+M36NvFe4gw2PRbld/2JV3yBGrqK6soWcmrSEkUNcrc=";
+  version = "3.3.0";
+  hash = "sha256-yb5migP5Tcw99XHFzJkCct4f5R6ztxPR43VQcfTGRtE=";
 }

--- a/pkgs/development/libraries/mbedtls/generic.nix
+++ b/pkgs/development/libraries/mbedtls/generic.nix
@@ -32,10 +32,14 @@ stdenv.mkDerivation rec {
     perl scripts/config.pl set MBEDTLS_THREADING_PTHREAD    # POSIX thread wrapper layer for the threading layer.
   '';
 
-  cmakeFlags = [ "-DUSE_SHARED_MBEDTLS_LIBRARY=on" ];
-  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [
-    "-Wno-error=format"
-    "-Wno-error=format-truncation"
+  cmakeFlags = [
+    "-DUSE_SHARED_MBEDTLS_LIBRARY=on"
+
+    # Avoid a dependency on jsonschema and jinja2 by not generating source code
+    # using python. In releases, these generated files are already present in
+    # the repository and do not need to be regenerated. See:
+    # https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.3.0 below "Requirement changes".
+    "-DGEN_FILES=off"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Changelog v3: https://github.com/Mbed-TLS/mbedtls/blob/mbedtls-3.3.0/ChangeLog
Changelog v2: https://github.com/Mbed-TLS/mbedtls/blob/mbedtls-2.28.2/ChangeLog

Removed NIX_CFLAGS_COMPILE which is not needed anymore, and disabled generation of source code by using the generated code that is already present in releases. This avoids new build-time dependencies for mbedtls 3.

I'm labelling this as security because the changelogs describe security related bugfixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) - just ./result/bin/selftest
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
