### PR TITLE
drone-runner-docker: 1.8.1 -> 1.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6053,6 +6053,12 @@
     githubId = 37965;
     name = "Léo Stefanesco";
   };
+  indeednotjames = {
+    email = "nix@indeednotjames.com";
+    github = "IndeedNotJames";
+    githubId = 55066419;
+    name = "Emily Lange";
+  };
   infinidoge = {
     name = "Infinidoge";
     email = "infinidoge@inx.moe";

--- a/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
@@ -2,19 +2,19 @@
 
 buildGoModule rec {
   pname = "drone-runner-docker";
-  version = "1.8.1";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
     owner = "drone-runners";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-3SbvnW+mCwaBCF77rAnDMqZRHX9wDCjXvFGq9w0E5Qw=";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-ZpkVfzqeltZSYrKYB6dXtlVjl1uFpQdl2fa+c5ApiW4=";
   };
 
-  vendorSha256 = "sha256-E18ykjQc1eoHpviYok+NiLaeH01UMQmigl9JDwtR+zo=";
+  vendorSha256 = "sha256-KcNp3VdJ201oxzF0bLXY4xWHqHNz54ZrVSI96cfhU+k=";
 
   meta = with lib; {
-    maintainers = with maintainers; [ endocrimes ];
+    maintainers = with maintainers; [ endocrimes indeednotjames ];
     license = licenses.unfreeRedistributable;
     homepage = "https://github.com/drone-runners/drone-runner-docker";
     description = "Drone pipeline runner that executes builds inside Docker containers";


### PR DESCRIPTION
###### Description of changes

https://github.com/drone-runners/drone-runner-docker/releases/tag/v1.8.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

I had to change the `rev` in `fetchFromGitHub` to `"refs/tags/v${version}"`, because of an ambiguity in the upstream repository (#187570).
For whatever reason, it contains [a branch](https://github.com/drone-runners/drone-runner-docker/tree/v1.8.2) and [a tag](https://github.com/drone-runners/drone-runner-docker/releases/tag/v1.8.2) with the same name (`v1.8.2`).
Which might be the reason why @r-ryantm didn't create a PR yet ([`v1.8.2`](https://github.com/drone-runners/drone-runner-docker/releases/tag/v1.8.2) has been released Jun 14, as mentioned in https://github.com/NixOS/nixpkgs/pull/169777#issuecomment-1182507525).

Also added myself as maintainer :)