### PR TITLE
ashpd-demo: 0.2.2 → 0.3.0

### DIFF
--- a/pkgs/development/tools/ashpd-demo/default.nix
+++ b/pkgs/development/tools/ashpd-demo/default.nix
@@ -19,25 +19,20 @@
 , desktop-file-utils
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ashpd-demo";
-  version = "0.2.2";
+  version = "0.3.0";
 
-  src =
-    let
-      share = fetchFromGitHub {
-        owner = "bilelmoussaoui";
-        repo = "ashpd";
-        rev = version;
-        sha256 = "9O6XqM4oys/hXgztQQ8tTobJV8U52db/VY6FlTMUvGY=";
-      };
-    in
-    "${share}/ashpd-demo";
+  src = fetchFromGitHub {
+    owner = "bilelmoussaoui";
+    repo = "ashpd";
+    rev = "${finalAttrs.version}-demo";
+    hash = "sha256-isc0+Mke6XeCCLiuxnjHqrnlGqYuQnmcU1acM14UOno=";
+  };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
-    name = "${pname}-${version}";
-    hash = "sha256-eFq42m16zzrUBbAqv7BsAf4VxyO93WynLjvIzKbZwnQ=";
+    src = "${finalAttrs.src}/ashpd-demo";
+    hash = "sha256-9L/WFL2fLCRahjGCVdgV+3HfDMrntdIWcuuOJbzdPiI=";
   };
 
   nativeBuildInputs = [
@@ -64,13 +59,9 @@ stdenv.mkDerivation rec {
     libshumate
   ];
 
-  # FIXME: workaround for Pipewire 0.3.64 deprecated API change, remove when fixed upstream
-  # https://gitlab.freedesktop.org/pipewire/pipewire-rs/-/issues/55
-  env.NIX_CFLAGS_COMPILE = toString [ "-DPW_ENABLE_DEPRECATED" ];
-
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  postPatch = ''
+    cd ashpd-demo
+  '';
 
   meta = with lib; {
     description = "Tool for playing with XDG desktop portals";
@@ -79,4 +70,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

https://github.com/bilelmoussaoui/ashpd/compare/0.2.2...0.3.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
