### PR TITLE
androidenv: use callPackage instead of import & fix infinite recursion

### DIFF
--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,10 +1,10 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgs_i686}:
+{deployAndroidPackage, lib, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux}:
 
 deployAndroidPackage {
   inherit package os;
   nativeBuildInputs = [ makeWrapper ]
     ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
-  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc pkgs.zlib pkgs.ncurses5 pkgs_i686.glibc pkgs_i686.zlib pkgs_i686.ncurses5 pkgs.libcxx ];
+  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc pkgs.zlib pkgs.ncurses5 pkgsi686Linux.glibc pkgsi686Linux.zlib pkgsi686Linux.ncurses5 pkgs.libcxx ];
   patchInstructions = ''
     ${lib.optionalString (os == "linux") ''
       addAutoPatchelfSearchPath $packageBaseDir/lib

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -1,4 +1,4 @@
-{ requireFile, autoPatchelfHook, pkgs, pkgsHostHost, pkgs_i686
+{ callPackage, stdenv, lib, fetchurl, ruby, writeText
 , licenseAccepted ? false
 }:
 
@@ -25,9 +25,6 @@
 }:
 
 let
-  inherit (pkgs) stdenv lib fetchurl;
-  inherit (pkgs.buildPackages) makeWrapper unzip;
-
   # Determine the Android os identifier from Nix's system identifier
   os = if stdenv.system == "x86_64-linux" then "linux"
     else if stdenv.system == "x86_64-darwin" then "macosx"
@@ -35,7 +32,7 @@ let
 
   # Uses mkrepo.rb to create a repo spec.
   mkRepoJson = { packages ? [], images ? [], addons ? [] }: let
-    mkRepoRuby = (pkgs.ruby.withPackages (pkgs: with pkgs; [ slop nokogiri ]));
+    mkRepoRuby = (ruby.withPackages (pkgs: with pkgs; [ slop nokogiri ]));
     mkRepoRubyArguments = lib.lists.flatten [
       (builtins.map (package: ["--packages" "${package}"]) packages)
       (builtins.map (image: ["--images" "${image}"]) images)
@@ -115,25 +112,24 @@ let
   ] ++ extraLicenses);
 in
 rec {
-  deployAndroidPackage = import ./deploy-androidpackage.nix {
-    inherit stdenv unzip;
+  deployAndroidPackage = callPackage ./deploy-androidpackage.nix {
   };
 
-  platform-tools = import ./platform-tools.nix {
-    inherit deployAndroidPackage autoPatchelfHook pkgs lib;
+  platform-tools = callPackage ./platform-tools.nix {
+    inherit deployAndroidPackage;
     os = if stdenv.system == "aarch64-darwin" then "macosx" else os; # "macosx" is a universal binary here
     package = packages.platform-tools.${platformToolsVersion};
   };
 
   build-tools = map (version:
-    import ./build-tools.nix {
-      inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgs_i686 lib;
+    callPackage ./build-tools.nix {
+      inherit deployAndroidPackage;
       package = packages.build-tools.${version};
     }
   ) buildToolsVersions;
 
-  emulator = import ./emulator.nix {
-    inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgs_i686 lib;
+  emulator = callPackage ./emulator.nix {
+    inherit deployAndroidPackage os;
     package = packages.emulator.${emulatorVersion};
   };
 
@@ -171,16 +167,16 @@ rec {
   ) platformVersions);
 
   cmake = map (version:
-    import ./cmake.nix {
-      inherit deployAndroidPackage os autoPatchelfHook pkgs lib stdenv;
+    callPackage ./cmake.nix {
+      inherit deployAndroidPackage os;
       package = packages.cmake.${version};
     }
   ) cmakeVersions;
 
   # Creates a NDK bundle.
   makeNdkBundle = ndkVersion:
-    import ./ndk-bundle {
-      inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgsHostHost lib platform-tools stdenv;
+    callPackage ./ndk-bundle {
+      inherit deployAndroidPackage os platform-tools;
       package = packages.ndk-bundle.${ndkVersion} or packages.ndk.${ndkVersion};
     };
 
@@ -253,8 +249,8 @@ rec {
     ${lib.concatMapStringsSep "\n" (str: "  - ${str}") licenseNames}
 
     by setting nixpkgs config option 'android_sdk.accept_license = true;'.
-  '' else import ./tools.nix {
-    inherit deployAndroidPackage requireFile packages toolsVersion autoPatchelfHook makeWrapper os pkgs pkgs_i686 lib;
+  '' else callPackage ./tools.nix {
+    inherit deployAndroidPackage packages toolsVersion;
 
     postInstall = ''
       # Symlink all requested plugins
@@ -323,7 +319,7 @@ rec {
       ${lib.concatMapStrings (licenseName:
         let
           licenseHashes = builtins.concatStringsSep "\n" (mkLicenseHashes licenseName);
-          licenseHashFile = pkgs.writeText "androidenv-${licenseName}" licenseHashes;
+          licenseHashFile = writeText "androidenv-${licenseName}" licenseHashes;
         in
         ''
           ln -s ${licenseHashFile} licenses/${licenseName}

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -1,21 +1,17 @@
-{ config, pkgs ? import <nixpkgs> {}, pkgsHostHost ? pkgs.pkgsHostHost
-, pkgs_i686 ? import <nixpkgs> { system = "i686-linux"; }
+{ config, pkgs ? import <nixpkgs> {}
 , licenseAccepted ? config.android_sdk.accept_license or false
 }:
 
 rec {
-  composeAndroidPackages = import ./compose-android-packages.nix {
-    inherit (pkgs) requireFile autoPatchelfHook;
-    inherit pkgs pkgsHostHost pkgs_i686 licenseAccepted;
+  composeAndroidPackages = pkgs.callPackage ./compose-android-packages.nix {
+    inherit licenseAccepted;
   };
 
-  buildApp = import ./build-app.nix {
-    inherit (pkgs) stdenv lib jdk ant gnumake gawk;
+  buildApp = pkgs.callPackage ./build-app.nix {
     inherit composeAndroidPackages;
   };
 
-  emulateApp = import ./emulate-app.nix {
-    inherit (pkgs) stdenv lib runtimeShell;
+  emulateApp = pkgs.callPackage ./emulate-app.nix {
     inherit composeAndroidPackages;
   };
 

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -1,4 +1,4 @@
-{ deployAndroidPackage, lib, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgs_i686 }:
+{ deployAndroidPackage, lib, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux }:
 
 deployAndroidPackage {
   inherit package os;
@@ -13,7 +13,7 @@ deployAndroidPackage {
       zlib
       ncurses5
       stdenv.cc.cc
-      pkgs_i686.glibc
+      pkgsi686Linux.glibc
       expat
       freetype
       nss

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -7,11 +7,11 @@
     sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
   }),
   pkgs ? import nixpkgsSource {},
-  pkgs_i686 ? import nixpkgsSource { system = "i686-linux"; },*/
+  pkgsi686Linux ? import nixpkgsSource { system = "i686-linux"; },*/
 
   # If you want to use the in-tree version of nixpkgs:
   pkgs ? import ../../../../.. {},
-  pkgs_i686 ? import ../../../../.. { system = "i686-linux"; },
+  pkgsi686Linux ? import ../../../../.. { system = "i686-linux"; },
 
   config ? pkgs.config
 }:
@@ -46,13 +46,13 @@ let
   };
 
   androidEnv = pkgs.callPackage "${androidEnvNixpkgs}/pkgs/development/mobile/androidenv" {
-    inherit config pkgs pkgs_i686;
+    inherit config pkgs pkgsi686Linux;
     licenseAccepted = true;
   };*/
 
   # Otherwise, just use the in-tree androidenv:
   androidEnv = pkgs.callPackage ./.. {
-    inherit config pkgs pkgs_i686;
+    inherit config pkgs pkgsi686Linux;
     licenseAccepted = true;
   };
 

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -2,7 +2,8 @@
 
 deployAndroidPackage {
   inherit package os;
-  buildInputs = lib.optionals (os == "linux") [ autoPatchelfHook pkgs.glibc pkgs.zlib pkgs.ncurses5 ];
+  nativeBuildInputs = lib.optionals (os == "linux") [ autoPatchelfHook ];
+  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc pkgs.zlib pkgs.ncurses5 ];
   patchInstructions = lib.optionalString (os == "linux") ''
     addAutoPatchelfSearchPath $packageBaseDir/lib64
     autoPatchelf --no-recurse $packageBaseDir/lib64

--- a/pkgs/development/mobile/androidenv/tools.nix
+++ b/pkgs/development/mobile/androidenv/tools.nix
@@ -1,7 +1,7 @@
-{deployAndroidPackage, requireFile, lib, packages, toolsVersion, autoPatchelfHook, makeWrapper, os, pkgs, pkgs_i686, postInstall ? ""}:
+{deployAndroidPackage, requireFile, lib, packages, toolsVersion, os, callPackage, postInstall ? ""}:
 
-if toolsVersion == "26.0.1" then import ./tools/26.nix {
-  inherit deployAndroidPackage lib autoPatchelfHook makeWrapper os pkgs pkgs_i686 postInstall;
+if toolsVersion == "26.0.1" then callPackage ./tools/26.nix {
+  inherit deployAndroidPackage lib os postInstall;
   package = {
     name = "tools";
     path = "tools";
@@ -17,10 +17,10 @@ if toolsVersion == "26.0.1" then import ./tools/26.nix {
       };
     };
   };
-} else if toolsVersion == "26.1.1" then import ./tools/26.nix {
-  inherit deployAndroidPackage lib autoPatchelfHook makeWrapper os pkgs pkgs_i686 postInstall;
+} else if toolsVersion == "26.1.1" then callPackage ./tools/26.nix {
+  inherit deployAndroidPackage lib os postInstall;
   package = packages.tools.${toolsVersion};
-} else import ./tools/25.nix {
-  inherit deployAndroidPackage lib autoPatchelfHook makeWrapper os pkgs pkgs_i686 postInstall;
+} else callPackage ./tools/25.nix {
+  inherit deployAndroidPackage lib os postInstall;
   package = packages.tools.${toolsVersion};
 }

--- a/pkgs/development/mobile/androidenv/tools/25.nix
+++ b/pkgs/development/mobile/androidenv/tools/25.nix
@@ -1,9 +1,9 @@
-{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgs_i686, postInstall ? ""}:
+{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, postInstall ? ""}:
 
 deployAndroidPackage {
   name = "androidsdk";
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
-  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc pkgs.xorg.libX11 pkgs.xorg.libXext pkgs.xorg.libXdamage pkgs.xorg.libxcb pkgs.xorg.libXfixes pkgs.xorg.libXrender pkgs.fontconfig.lib pkgs.freetype pkgs.libGL pkgs.zlib pkgs.ncurses5 pkgs.libpulseaudio pkgs_i686.glibc pkgs_i686.xorg.libX11 pkgs_i686.xorg.libXrender pkgs_i686.fontconfig pkgs_i686.freetype pkgs_i686.zlib ];
+  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc pkgs.xorg.libX11 pkgs.xorg.libXext pkgs.xorg.libXdamage pkgs.xorg.libxcb pkgs.xorg.libXfixes pkgs.xorg.libXrender pkgs.fontconfig.lib pkgs.freetype pkgs.libGL pkgs.zlib pkgs.ncurses5 pkgs.libpulseaudio pkgsi686Linux.glibc pkgsi686Linux.xorg.libX11 pkgsi686Linux.xorg.libXrender pkgsi686Linux.fontconfig pkgsi686Linux.freetype pkgsi686Linux.zlib ];
   inherit package os;
 
   patchInstructions = ''

--- a/pkgs/development/mobile/androidenv/tools/26.nix
+++ b/pkgs/development/mobile/androidenv/tools/26.nix
@@ -1,4 +1,4 @@
-{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgs_i686, postInstall ? ""}:
+{deployAndroidPackage, lib, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, postInstall ? ""}:
 
 deployAndroidPackage {
   name = "androidsdk";
@@ -8,7 +8,7 @@ deployAndroidPackage {
   buildInputs = lib.optional (os == "linux") (
       (with pkgs; [ glibc freetype fontconfig fontconfig.lib])
       ++ (with pkgs.xorg; [ libX11 libXrender libXext ])
-      ++ (with pkgs_i686; [ glibc xorg.libX11 xorg.libXrender xorg.libXext fontconfig.lib freetype zlib ])
+      ++ (with pkgsi686Linux; [ glibc xorg.libX11 xorg.libXrender xorg.libXext fontconfig.lib freetype zlib ])
     );
 
   patchInstructions = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3359,9 +3359,7 @@ with pkgs;
 
   anbox = callPackage ../os-specific/linux/anbox { };
 
-  androidenv = callPackage ../development/mobile/androidenv {
-    pkgs_i686 = pkgsi686Linux;
-  };
+  androidenv = callPackage ../development/mobile/androidenv { };
 
   androidndkPkgs = androidndkPkgs_21;
   androidndkPkgs_21 = (callPackage ../development/androidndk-pkgs {})."21";


### PR DESCRIPTION
infinite recursion was due to autoPatchelfHook being in buildInputs, i will add a lint for it in nix-community/nixpkgs-lint.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
