### PR TITLE
home-assistant: support here_travel_time component

### DIFF
--- a/pkgs/development/python-modules/here-routing/default.nix
+++ b/pkgs/development/python-modules/here-routing/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, aiohttp
+, async-timeout
+, yarl
+, aresponses
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "here-routing";
+  version = "0.2.0";
+
+  disabled = pythonOlder "3.8";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "eifinger";
+    repo = "here_routing";
+    rev = "v${version}";
+    hash = "sha256-IXiYLDrPXc6YT8u0QT6f2GAjBNYhWwzkFxGhmAyiq5s=";
+  };
+
+  postPatch = ''
+    sed -i "/^addopts/d" pyproject.toml
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    yarl
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "here_routing" ];
+
+  meta = {
+    changelog = "https://github.com/eifinger/here_routing/blob/${src.rev}/CHANGELOG.md";
+    description = "Asynchronous Python client for the HERE Routing V8 API";
+    homepage = "https://github.com/eifinger/here_routing";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/here-transit/default.nix
+++ b/pkgs/development/python-modules/here-transit/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, aiohttp
+, async-timeout
+, yarl
+, aresponses
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "here-transit";
+  version = "1.2.0";
+
+  disabled = pythonOlder "3.8";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "eifinger";
+    repo = "here_transit";
+    rev = "v${version}";
+    hash = "sha256-C5HZZCmK9ILUUXyx1i/cUggSM3xbOzXiJ13hrT2DWAI=";
+  };
+
+  postPatch = ''
+    sed -i "/^addopts/d" pyproject.toml
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    yarl
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "here_transit" ];
+
+  meta = {
+    changelog = "https://github.com/eifinger/here_transit/blob/${src.rev}/CHANGELOG.md";
+    description = "Asynchronous Python client for the HERE Routing V8 API";
+    homepage = "https://github.com/eifinger/here_transit";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1349,7 +1349,9 @@
       pyheos
     ];
     "here_travel_time" = ps: with ps; [
-    ]; # missing inputs: here_routing here_transit
+      here-routing
+      here-transit
+    ];
     "hexaom" = ps: with ps; [
     ];
     "hi_kumo" = ps: with ps; [
@@ -4315,6 +4317,7 @@
     "hddtemp"
     "hdmi_cec"
     "heos"
+    "here_travel_time"
     "hisense_aehw4a1"
     "history"
     "history_stats"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4212,6 +4212,8 @@ self: super: with self; {
 
   hepunits = callPackage ../development/python-modules/hepunits { };
 
+  here-routing = callPackage ../development/python-modules/here-routing { };
+
   herepy = callPackage ../development/python-modules/herepy { };
 
   hetzner = callPackage ../development/python-modules/hetzner { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4214,6 +4214,8 @@ self: super: with self; {
 
   here-routing = callPackage ../development/python-modules/here-routing { };
 
+  here-transit = callPackage ../development/python-modules/here-transit { };
+
   herepy = callPackage ../development/python-modules/herepy { };
 
   hetzner = callPackage ../development/python-modules/hetzner { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
