### PR TITLE
broadcom_sta: fix build on linux 6.1

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation {
     ./linux-5.18.patch
     # source: https://gist.github.com/joanbm/207210d74637870c01ef5a3c262a597d
     ./linux-6.0.patch
+    # source: https://gist.github.com/joanbm/94323ea99eff1e1d1c51241b5b651549
+    ./linux-6.1.patch
     ./pedantic-fix.patch
     ./null-pointer-fix.patch
     ./gcc.patch

--- a/pkgs/os-specific/linux/broadcom-sta/linux-6.1.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-6.1.patch
@@ -1,0 +1,83 @@
+From a63a5f70e5cf05f6bce4cda2e0dd67462e1d76a5 Mon Sep 17 00:00:00 2001
+From: Joan Bruguera <joanbrugueram@gmail.com>
+Date: Mon, 29 Aug 2022 00:06:53 +0200
+Subject: [PATCH] Tentative patch for broadcom-wl 6.30.223.271 driver for Linux 6.1-rc1
+
+Applies on top of all the patches applied to broadcom-wl-dkms 6.30.223.271-35 on Arch Linux
+---
+ src/wl/sys/wl_cfg80211_hybrid.c | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index 4fef22a..50d1e34 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -105,20 +105,25 @@ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wd
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm);
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++#define MAYBE_INT_LINK_ID int link_id,
++#else
++#define MAYBE_INT_LINK_ID
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 38)
+ static s32 wl_cfg80211_config_default_key(struct wiphy *wiphy,
+-           struct net_device *dev, u8 key_idx, bool unicast, bool multicast);
++           struct net_device *dev, MAYBE_INT_LINK_ID u8 key_idx, bool unicast, bool multicast);
+ #else
+ static s32 wl_cfg80211_config_default_key(struct wiphy *wiphy,
+            struct net_device *dev, u8 key_idx);
+ #endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)
+ static s32 wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+-           u8 key_idx, bool pairwise, const u8 *mac_addr, struct key_params *params);
++           MAYBE_INT_LINK_ID u8 key_idx, bool pairwise, const u8 *mac_addr, struct key_params *params);
+ static s32 wl_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+-           u8 key_idx, bool pairwise, const u8 *mac_addr);
++           MAYBE_INT_LINK_ID u8 key_idx, bool pairwise, const u8 *mac_addr);
+ static s32 wl_cfg80211_get_key(struct wiphy *wiphy, struct net_device *dev,
+-           u8 key_idx, bool pairwise, const u8 *mac_addr,
++           MAYBE_INT_LINK_ID u8 key_idx, bool pairwise, const u8 *mac_addr,
+            void *cookie, void (*callback) (void *cookie, struct key_params *params));
+ #else
+ static s32 wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+@@ -1165,7 +1170,7 @@ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 38)
+ static s32
+ wl_cfg80211_config_default_key(struct wiphy *wiphy,
+-	struct net_device *dev, u8 key_idx, bool unicast, bool multicast)
++	struct net_device *dev, MAYBE_INT_LINK_ID u8 key_idx, bool unicast, bool multicast)
+ #else
+ static s32
+ wl_cfg80211_config_default_key(struct wiphy *wiphy,
+@@ -1190,7 +1195,7 @@ wl_cfg80211_config_default_key(struct wiphy *wiphy,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)
+ static s32
+ wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+-                    u8 key_idx, bool pairwise, const u8 *mac_addr, struct key_params *params)
++                    MAYBE_INT_LINK_ID u8 key_idx, bool pairwise, const u8 *mac_addr, struct key_params *params)
+ #else
+ static s32
+ wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+@@ -1311,7 +1316,7 @@ wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)
+ static s32
+ wl_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+-                    u8 key_idx, bool pairwise, const u8 *mac_addr)
++                    MAYBE_INT_LINK_ID u8 key_idx, bool pairwise, const u8 *mac_addr)
+ #else
+ static s32
+ wl_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+@@ -1354,7 +1359,7 @@ wl_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)
+ static s32
+ wl_cfg80211_get_key(struct wiphy *wiphy, struct net_device *dev,
+-                    u8 key_idx, bool pairwise, const u8 *mac_addr, void *cookie,
++                    MAYBE_INT_LINK_ID u8 key_idx, bool pairwise, const u8 *mac_addr, void *cookie,
+                     void (*callback) (void *cookie, struct key_params * params))
+ #else
+ static s32
+-- 
+2.37.2
+


### PR DESCRIPTION
###### Description of changes

Fix build issues when building against linux 6.1

Fixes #206867

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->