### PR TITLE
firefox: fix build by using newer `rustc` and `nss`

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -35,6 +35,7 @@
 , python3
 , runCommand
 , rustPackages_1_61
+, rustPackages_1_64
 , rust-cbindgen
 , unzip
 , which
@@ -142,7 +143,8 @@ assert pipewireSupport -> !waylandSupport || !webrtcSupport -> throw "${pname}: 
 let
   flag = tf: x: [(if tf then "--enable-${x}" else "--disable-${x}")];
 
-  inherit (rustPackages_1_61) cargo rustc rustPlatform;
+  inherit (if lib.versionAtLeast version "108" then rustPackages_1_64 else rustPackages_1_61)
+    cargo rustc rustPlatform;
 
   # Target the LLVM version that rustc is built with for LTO.
   llvmPackages0 = rustc.llvmPackages;

--- a/pkgs/development/compilers/rust/1_64.nix
+++ b/pkgs/development/compilers/rust/1_64.nix
@@ -1,0 +1,64 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+# 3. Firefox and Thunderbird should still build on x86_64-linux.
+
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security, SystemConfiguration
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
+, makeRustPlatform
+, llvmPackages_11
+, llvmPackages_14, llvm_14
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.64.0";
+  rustcSha256 = "sha256-s82fSB4aKQG/bzgI0wxpzE6oDZPEzE4u1SJYsYA4EgU=";
+
+  llvmSharedForBuild = pkgsBuildBuild.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
+
+  llvmBootstrapForDarwin = llvmPackages_11;
+
+  # For use at runtime
+  llvmShared = llvm_14.override { enableSharedLibraries = true; };
+
+  # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
+  llvmPackages = llvmPackages_14;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapVersion = "1.63.0";
+
+  # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+  bootstrapHashes = {
+    i686-unknown-linux-gnu = "6ac6ca18f119e099749d67c6dc25ce3f70542b43cc05062d5138fc1052e44c54";
+    x86_64-unknown-linux-gnu = "536bcf16807a4ff49b7b29af6e573a2f1821055bfad72c275c60e56edc693984";
+    x86_64-unknown-linux-musl = "4516f1fa2a0d9ec9176cc734e5faaa0a3d439bd49f75553a484b6c3c6d7905ab";
+    arm-unknown-linux-gnueabihf = "8847d8482e1d5ec962e092a63c95618dc7e17a079a9bf58bec1da39cac0ba4ce";
+    armv7-unknown-linux-gnueabihf = "d9227bf6d93f49889c698d35adc7ab3e042988740b9d9d9c81fb54fc0f854474";
+    aarch64-unknown-linux-gnu = "26745b57500da293a8147122a5998926301350a610c164f053107cbe026d3a51";
+    aarch64-unknown-linux-musl = "8fee65f2bd7e010259763939cbef8ed0794773ec8959c5ef90273cf39dcba180";
+    x86_64-apple-darwin = "37f76a45b8616e764c2663850758ce822c730e96af60168a46b818f528c1467d";
+    aarch64-apple-darwin = "25c3f43459da9b8683292999c3522d88980b0ca3244fe830f5a87a8092aac5a6";
+    powerpc64le-unknown-linux-gnu = "781662048caa48b78540c2fb22f0aa7c06d6d8e81aede0f6ef900c11428056cf";
+    riscv64gc-unknown-linux-gnu = "a7f398b45229c5cca833f75421c32897174e365fbbdf78e19b87612736c918aa";
+    mips64el-unknown-linux-gnuabi64 = "19f04c576c9d6b171acba65cfe44edcbcf6134a75a853d2f1538fdb2128ec654";
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_64;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_11" "llvmPackages_14" "llvm_14"])

--- a/pkgs/development/libraries/nss/85_security_load_3.85+.patch
+++ b/pkgs/development/libraries/nss/85_security_load_3.85+.patch
@@ -12,13 +12,13 @@ index ad8f3b84e..74676d039 100644
      if (!lib) {
          PR_fprintf(PR_STDERR, "loading softokn3 failed");
 diff --git nss/lib/pk11wrap/pk11load.c nss/lib/pk11wrap/pk11load.c
-index 9e7a0a546..a0a23a1a4 100644
+index 119c8c512..720d39ccc 100644
 --- nss/lib/pk11wrap/pk11load.c
 +++ nss/lib/pk11wrap/pk11load.c
-@@ -466,6 +466,15 @@ secmod_LoadPKCS11Module(SECMODModule *mod, SECMODModule **oldModule)
-          * unload the library if anything goes wrong from here on out...
-          */
+@@ -486,6 +486,15 @@ secmod_LoadPKCS11Module(SECMODModule *mod, SECMODModule **oldModule)
+ #else
          library = PR_LoadLibrary(mod->dllName);
+ #endif // defined(_WIN32)
 +#ifndef NSS_STATIC_SOFTOKEN
 +        if ((library == NULL) &&
 +            !rindex(mod->dllName, PR_GetDirectorySeparator())) {
@@ -32,7 +32,7 @@ index 9e7a0a546..a0a23a1a4 100644
  
          if (library == NULL) {
 diff --git nss/lib/util/secload.c nss/lib/util/secload.c
-index 12efd2f75..8b74478f6 100644
+index 1cebae4e2..9194bb761 100644
 --- nss/lib/util/secload.c
 +++ nss/lib/util/secload.c
 @@ -70,9 +70,14 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
@@ -66,8 +66,8 @@ index 12efd2f75..8b74478f6 100644
 @@ -89,6 +99,10 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
                                                         | PR_LD_ALT_SEARCH_PATH
  #endif
-                                           );
-+            if (! dlh) {
+             );
++            if (!dlh) {
 +                strcpy(fullName + referencePathSize, name);
 +                dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL);
 +            }

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -40,10 +40,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Based on http://patch-tracker.debian.org/patch/series/dl/nss/2:3.15.4-1/85_security_load.patch
-    (if (lib.versionOlder version "3.77") then
-      ./85_security_load.patch
-    else
+    (if (lib.versionOlder version "3.84") then
       ./85_security_load_3.77+.patch
+    else
+      ./85_security_load_3.85+.patch
     )
     ./fix-cross-compilation.patch
   ];

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,6 +5,6 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.84";
-  hash = "sha256-mjh//jUP8U8AHZQ/lswMBkiRVR1x4al6Xdv/5/EgeiU=";
+  version = "3.85";
+  hash = "sha256-r9nWRRCxFU3rvWyrNXHp/2SjNziY4DSD5Mhc2toT0pc=";
 }

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,6 +5,6 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.85";
-  hash = "sha256-r9nWRRCxFU3rvWyrNXHp/2SjNziY4DSD5Mhc2toT0pc=";
+  version = "3.86";
+  hash = "sha256-PzhfxoZHa7uoEQNfpoIbVCR11VdHsYwgwiHU1mVzuXU=";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13783,6 +13783,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_14 = llvmPackages_14.libllvm;
   };
+  rust_1_64 = callPackage ../development/compilers/rust/1_64.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
+    llvm_14 = llvmPackages_14.libllvm;
+  };
   rust = rust_1_60;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -13791,6 +13795,7 @@ with pkgs;
 
   rustPackages_1_60 = rust_1_60.packages.stable;
   rustPackages_1_61 = rust_1_61.packages.stable;
+  rustPackages_1_64 = rust_1_64.packages.stable;
   rustPackages = rustPackages_1_60;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;


### PR DESCRIPTION
FF 108 needs rustc >= 1.63 and nss >= 3.85
https://hydra.nixos.org/build/201985872/nixlog/1/tail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
