### PR TITLE
lean: 3.49.0 -> 3.50.3

### DIFF
--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lean";
-  version = "3.50.2";
+  version = "3.50.3";
 
   src = fetchFromGitHub {
     owner  = "leanprover-community";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     # from. this is then used to check whether an olean file should be
     # rebuilt. don't use a tag as rev because this will get replaced into
     # src/githash.h.in in preConfigure.
-    rev    = "a4f95b7ef008115baca425f5f0b5c7d0283a80ad";
-    sha256 = "sha256-LFCSFmUsiFMrhaETT8+Q3Btba4yc9KR5yQluNzOQOW0=";
+    rev    = "855e5b74e3a52a40552e8f067169d747d48743fd";
+    sha256 = "sha256-RH4w7PpzC+fhqCHikXQO2pUUvWD2qrA0mVMUGxpauwE=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lean";
-  version = "3.50.1";
+  version = "3.50.2";
 
   src = fetchFromGitHub {
     owner  = "leanprover-community";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     # from. this is then used to check whether an olean file should be
     # rebuilt. don't use a tag as rev because this will get replaced into
     # src/githash.h.in in preConfigure.
-    rev    = "87f1037e4941054d773387d855fd449c729a35f7";
-    sha256 = "sha256-T/P+DBu8HRLaGp9RaYeVar8b42zi0y+6b09grjbm3CE=";
+    rev    = "a4f95b7ef008115baca425f5f0b5c7d0283a80ad";
+    sha256 = "sha256-LFCSFmUsiFMrhaETT8+Q3Btba4yc9KR5yQluNzOQOW0=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lean";
-  version = "3.50.0";
+  version = "3.50.1";
 
   src = fetchFromGitHub {
     owner  = "leanprover-community";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     # from. this is then used to check whether an olean file should be
     # rebuilt. don't use a tag as rev because this will get replaced into
     # src/githash.h.in in preConfigure.
-    rev    = "ffe5a176d915a3a9657b2c7f5cdd6985756ecbcd";
-    sha256 = "sha256-OiuEe6+TLZsl1kjOcm0bBV8cV0CGlgM52gJb1f/bxLU=";
+    rev    = "87f1037e4941054d773387d855fd449c729a35f7";
+    sha256 = "sha256-T/P+DBu8HRLaGp9RaYeVar8b42zi0y+6b09grjbm3CE=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lean";
-  version = "3.49.1";
+  version = "3.50.0";
 
   src = fetchFromGitHub {
     owner  = "leanprover-community";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     # from. this is then used to check whether an olean file should be
     # rebuilt. don't use a tag as rev because this will get replaced into
     # src/githash.h.in in preConfigure.
-    rev    = "53e8520d8964c7632989880372d91ba0cecbaf00";
-    sha256 = "sha256-Y6y/dgwZS4PjCpFBf2GWvMNw9im6bXAHCq3UeUUoYpo=";
+    rev    = "ffe5a176d915a3a9657b2c7f5cdd6985756ecbcd";
+    sha256 = "sha256-OiuEe6+TLZsl1kjOcm0bBV8cV0CGlgM52gJb1f/bxLU=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lean";
-  version = "3.49.0";
+  version = "3.49.1";
 
   src = fetchFromGitHub {
     owner  = "leanprover-community";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     # from. this is then used to check whether an olean file should be
     # rebuilt. don't use a tag as rev because this will get replaced into
     # src/githash.h.in in preConfigure.
-    rev    = "acf633e01a8783a12060b0a1b7b5b5e15fd73e77";
-    sha256 = "sha256-KF13DlGEl6aICSp/haczo54gjLZaOxyzFRdzvyyiu5M=";
+    rev    = "53e8520d8964c7632989880372d91ba0cecbaf00";
+    sha256 = "sha256-Y6y/dgwZS4PjCpFBf2GWvMNw9im6bXAHCq3UeUUoYpo=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Description of changes

https://github.com/leanprover-community/lean/releases/tag/v3.49.1
https://github.com/leanprover-community/lean/releases/tag/v3.50.0
https://github.com/leanprover-community/lean/releases/tag/v3.50.1
https://github.com/leanprover-community/lean/releases/tag/v3.50.2
https://github.com/leanprover-community/lean/releases/tag/v3.50.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
