### PR TITLE
vbam: 2.1.4 -> 2.1.5 + add GUI

### DIFF
--- a/pkgs/applications/emulators/vbam/default.nix
+++ b/pkgs/applications/emulators/vbam/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   meta =  with lib; {
     description = "A merge of the original Visual Boy Advance forks";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ lassulus ];
+    maintainers = with maintainers; [ lassulus netali ];
     homepage = "https://vba-m.com/";
     platforms = lib.platforms.linux;
     badPlatforms = [ "aarch64-linux" ];

--- a/pkgs/applications/emulators/vbam/default.nix
+++ b/pkgs/applications/emulators/vbam/default.nix
@@ -5,6 +5,8 @@
 , fetchpatch
 , ffmpeg
 , gettext
+, wxGTK32
+, gtk3
 , libGLU, libGL
 , openal
 , pkg-config
@@ -16,12 +18,12 @@
 
 stdenv.mkDerivation rec {
   pname = "visualboyadvance-m";
-  version = "2.1.4";
+  version = "2.1.5";
   src = fetchFromGitHub {
     owner = "visualboyadvance-m";
     repo = "visualboyadvance-m";
     rev = "v${version}";
-    sha256 = "1kgpbvng3c12ws0dy92zc0azd94h0i3j4vm7b67zc8mi3pqsppdg";
+    sha256 = "1sc3gdn7dqkipjsvlzchgd98mia9ic11169dw8v341vr9ppb1b6m";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -30,12 +32,15 @@ stdenv.mkDerivation rec {
     cairo
     ffmpeg
     gettext
-    libGLU libGL
+    libGLU
+    libGL
     openal
     SDL2
     sfml
     zip
     zlib
+    wxGTK32
+    gtk3
   ];
 
   cmakeFlags = [
@@ -43,17 +48,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_FFMPEG='true'"
     "-DENABLE_LINK='true'"
     "-DSYSCONFDIR=etc"
-    "-DENABLE_WX='false'"
     "-DENABLE_SDL='true'"
-  ];
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/visualboyadvance-m/visualboyadvance-m/pull/793
-      name = "fix-build-SDL-2.0.14.patch";
-      url = "https://github.com/visualboyadvance-m/visualboyadvance-m/commit/619a5cce683ec4b1d03f08f316ba276d8f8cd824.patch";
-      sha256 = "099cbzgq4r9g83bvdra8a0swfl1vpfng120wf4q7h6vs0n102rk9";
-    })
   ];
 
   meta =  with lib; {


### PR DESCRIPTION
###### Description of changes

Update vbam from 2.1.4 to 2.1.5 + enable GUI (the GUI build was broken on 2.1.4) + add me as a maintainer of the vbam package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
