### PR TITLE
kiwix-tools: init at 3.4.0

### DIFF
--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -40,7 +40,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "An offline reader for Web content";
     homepage = "https://kiwix.org";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ajs124 ];
   };

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -1,5 +1,5 @@
 { lib, mkDerivation, fetchFromGitHub
-, callPackage
+, libkiwix
 , pkg-config
 , qmake
 , qtbase
@@ -26,11 +26,11 @@ mkDerivation rec {
   ];
 
   buildInputs = [
+    libkiwix
     qtbase
     qtwebengine
     qtsvg
     qtimageformats
-    (callPackage ./lib.nix {})
   ];
 
   qtWrapperArgs = [

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -11,13 +11,13 @@
 
 mkDerivation rec {
   pname = "kiwix";
-  version = "2.2.1";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = "${pname}-desktop";
     rev = version;
-    sha256 = "sha256-ks2d/guMp5pb2tiwGxNp3htQVm65MsYvZ/6tNjGXNr8=";
+    sha256 = "sha256-ghx4pW6IkWPzZXk0TtMGeQZIzm9HEN3mR4XQFJ1xHDo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/kiwix/lib.nix
+++ b/pkgs/applications/misc/kiwix/lib.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub
 , meson, ninja, pkg-config
 , python3
 , curl
@@ -51,4 +51,12 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs scripts
   '';
+
+  meta = with lib; {
+    description = "Common code base for all Kiwix ports";
+    homepage = "https://kiwix.org";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ colinsane ];
+  };
 }

--- a/pkgs/applications/misc/kiwix/lib.nix
+++ b/pkgs/applications/misc/kiwix/lib.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Common code base for all Kiwix ports";
     homepage = "https://kiwix.org";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ colinsane ];
   };

--- a/pkgs/applications/misc/kiwix/lib.nix
+++ b/pkgs/applications/misc/kiwix/lib.nix
@@ -3,8 +3,8 @@
 , python3
 , curl
 , icu
+, libzim
 , pugixml
-, zimlib
 , zlib
 , libmicrohttpd
 , mustache-hpp
@@ -12,14 +12,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "kiwix-lib";
-  version = "10.1.1";
+  pname = "libkiwix";
+  version = "12.0.0";
 
   src = fetchFromGitHub {
     owner = "kiwix";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ECvdraN1J5XJQLeZDngxO5I7frwZ8+W8tFpbB7o8UeM=";
+    sha256 = "sha256-4FxLxJxVhqbeNqX4vorHkROUuRURvE6AXlteIZCEBtc=";
   };
 
   nativeBuildInputs = [
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     curl
     libmicrohttpd
+    libzim
     pugixml
-    zimlib
   ];
 
   checkInputs = [

--- a/pkgs/applications/misc/kiwix/tools.nix
+++ b/pkgs/applications/misc/kiwix/tools.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchFromGitHub
+, icu
+, libkiwix
+, meson
+, ninja
+, pkg-config
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kiwix-tools";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "kiwix";
+    repo = "kiwix-tools";
+    rev = version;
+    sha256 = "sha256-r3/aTH/YoDuYpKLPakP4toS3OtiRueTUjmR34rdmr+w=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    icu
+    libkiwix
+  ];
+
+  meta = with lib; {
+    description = "Command line Kiwix tools: kiwix-serve, kiwix-manage, ...";
+    homepage = "https://kiwix.org";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ colinsane ];
+  };
+}
+

--- a/pkgs/development/libraries/libzim/default.nix
+++ b/pkgs/development/libraries/libzim/default.nix
@@ -5,6 +5,8 @@
 , meson
 , ninja
 , pkg-config
+, python3
+, xapian
 , xz
 , zstd
 }:
@@ -24,19 +26,27 @@ stdenv.mkDerivation rec {
     ninja
     meson
     pkg-config
+    python3
   ];
 
   buildInputs = [
     icu
-    xz
     zstd
   ];
+
+  propagatedBuildInputs = [
+    xapian
+    xz
+  ];
+
+  postPatch = ''
+    patchShebangs scripts
+  '';
 
   mesonFlags = [
     # Tests are located at https://github.com/openzim/zim-testing-suite
     # "...some tests need up to 16GB of memory..."
     "-Dtest_data_dir=none"
-    "-Dwith_xapian=false"
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30172,6 +30172,8 @@ with pkgs;
 
   leo-editor = libsForQt5.callPackage ../applications/editors/leo-editor { };
 
+  libkiwix = callPackage ../applications/misc/kiwix/lib.nix { };
+
   libowfat = callPackage ../development/libraries/libowfat { };
 
   libowlevelzs = callPackage ../development/libraries/libowlevelzs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29952,6 +29952,8 @@ with pkgs;
 
   kiwix = libsForQt5.callPackage ../applications/misc/kiwix { };
 
+  kiwix-tools = callPackage ../applications/misc/kiwix/tools.nix { };
+
   klayout = libsForQt5.callPackage ../applications/misc/klayout { };
 
   klee = callPackage ../applications/science/logic/klee (with llvmPackages_11; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

this provides the `kiwix-serve` tool asked for in
<https://github.com/NixOS/nixpkgs/issues/35009>,    
but does not implement the systemd service requested.    
    
package contents:    
- bin/kiwix-manage    
- bin/kiwix-search    
- bin/kiwix-serve    
    
tested by invoking `kiwix-serve` and connecting to it in a web browser:    
    
```sh    
nix build '.#kiwix-tools'    
wget 'https://dumps.wikimedia.org/other/kiwix/zim/wikipedia/wikipedia_en_simple_all_mini_2022-11.zim'    
./result/bin/kiwix-serve -p 1080 ./wikipedia_en_simple_all_mini_2022-11.zim    
curl http://localhost:1080    
```

necessary to this work was to also bump libkiwix 10.1.1 -> 12.0.0, and i updated kiwix (kiwix-desktop) 2.2.1 -> 2.3.1 to keep them in sync. see the individual commits for more details (e.g. changelogs).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
