### PR TITLE
Fix dcmkt build

### DIFF
--- a/pkgs/applications/science/medicine/dcmtk/0001-Fix-cmake.patch
+++ b/pkgs/applications/science/medicine/dcmtk/0001-Fix-cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/CMake/dcmtk.pc.in b/CMake/dcmtk.pc.in
+index 13c79c0d5..b1edf725c 100644
+--- a/CMake/dcmtk.pc.in
++++ b/CMake/dcmtk.pc.in
+@@ -1,6 +1,6 @@
+  prefix="@CMAKE_INSTALL_PREFIX@"
+  exec_prefix="${prefix}"
+- libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
++ libdir=@CMAKE_INSTALL_FULL_LIBDIR@"
+  includedir="${prefix}/include/"
+ 
+  Name: DCMTK

--- a/pkgs/applications/science/medicine/dcmtk/default.nix
+++ b/pkgs/applications/science/medicine/dcmtk/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, zlib, libtiff, libxml2, openssl, libiconv, libpng, cmake }:
+{ lib, stdenv, fetchFromGitHub, zlib, libtiff, libxml2, openssl, libiconv
+, libpng, cmake, fetchpatch }:
 
 with lib;
 stdenv.mkDerivation rec {
@@ -14,8 +15,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libpng zlib libtiff libxml2 openssl libiconv ];
 
+  # This is only needed until https://github.com/DCMTK/dcmtk/pull/75/files is merged
+  patches = [ ./0001-Fix-cmake.patch ];
+
   meta = {
-    description = "Collection of libraries and applications implementing large parts of the DICOM standard";
+    description =
+      "Collection of libraries and applications implementing large parts of the DICOM standard";
     longDescription = ''
       DCMTK is a collection of libraries and applications implementing large parts of the DICOM standard.
       It includes software for examining, constructing and converting DICOM image files, handling offline media,


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The package wouldn't build because of
```
The following lines have issues (specifically '//' in paths).
3: libdir="${prefix}//nix/store/w7psws13xvps8mzkmcz4m4wrvfaqgazr-dcmtk-3.6.7/lib"
It is very likely that paths are being joined improperly.
ex: "${prefix}/@CMAKE_INSTALL_LIBDIR@" should be "@CMAKE_INSTALL_FULL_LIBDIR@"
Please see https://github.com/NixOS/nixpkgs/issues/144170 for more details.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
