### PR TITLE
rustc: 1.65.0 -> 1.66.0

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -134,6 +134,7 @@ stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoUpdateHook" "carg
   ];
 
   buildInputs = buildInputs
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
     ++ lib.optionals stdenv.hostPlatform.isMinGW [ windows.pthreads ];
 
   patches = cargoPatches ++ patches;

--- a/pkgs/development/compilers/rust/1_66.nix
+++ b/pkgs/development/compilers/rust/1_66.nix
@@ -20,8 +20,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.65.0";
-  rustcSha256 = "sha256-WCi7Z/Z36r+MOEAgWCsM56+IThyEOJSE9/jQDdgsADg=";
+  rustcVersion = "1.66.0";
+  rustcSha256 = "sha256-OzzT6lqCombnXQs18LVMFgIVdtnreNOEBSF1p3KTWkg=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
@@ -37,25 +37,25 @@ import ./default.nix {
 
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.64.0";
+  bootstrapVersion = "1.65.0";
 
   # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
   bootstrapHashes = {
-    i686-unknown-linux-gnu = "177b4f95c8cdaa34bb29e69950cbfe236e123757078af4792779c43ee3818199";
-    x86_64-unknown-linux-gnu = "a893977f238291370ab96726a74b6b9ae854dc75fbf5730954d901a93843bf9b";
-    x86_64-unknown-linux-musl = "d5c4293a8fe1b34d857bec4124229c39711f8759aa2f6108c8b6c22a308f96bb";
-    arm-unknown-linux-gnueabihf = "0d7c9c746f7b98f1f99e4cf720f9a32b2f5cdf22cb1d9f677b41c1dca62f14f8";
-    armv7-unknown-linux-gnueabihf = "0be29740f565ca8835ba260691274585733a7f4130ec872bfa37654a08013828";
-    aarch64-unknown-linux-gnu = "7d8860572431bd4ee1b9cd0cd77cf7ff29fdd5b91ed7c92a820f872de6ced558";
-    aarch64-unknown-linux-musl = "9e7cfd960fb8ad3e1f51ef667c56032d3d4d9d9f573a06bbcf65a7c7a96ab430";
-    x86_64-apple-darwin = "b6003d49fb857ff8dc105a3ccba98b851cd3e7d874005acb92284fd1113adc0d";
-    aarch64-apple-darwin = "e1a37dc5991304716e260144311fd291d8fb514042e45c244c582b3454477038";
-    powerpc64le-unknown-linux-gnu = "9d4591033eac22093d107991a68fffccea087b26bb54115d46cc544fbf5ef66c";
-    riscv64gc-unknown-linux-gnu = "f63981d9c1057cb20cf30871757d42475a1cd0c187b3dcce5fabb0cce0f80c5b";
-    mips64el-unknown-linux-gnuabi64 = "47488e4c53cca5c99b5837474a880f6c2368a7fe8368560dd8077bddb94959b5";
+    i686-unknown-linux-gnu = "b29869f8e2c7029150a929b2c4e26843f363846ad99253a25be6abcfa8e84f46";
+    x86_64-unknown-linux-gnu = "8f754fdd5af783fe9020978c64e414cb45f3ad0a6f44d045219bbf2210ca3cb9";
+    x86_64-unknown-linux-musl = "716984def5509a844c2dde1c7be42bfadeb179f751d5c1a30c9c7198c8c089cd";
+    arm-unknown-linux-gnueabihf = "e27f835c16bfcb66ad022a17d5c4602899e021e483a432ca4cc2cb4ecd39e938";
+    armv7-unknown-linux-gnueabihf = "5376d467a29b32cacb771e0c76dc280bd623852709e7ffd92caabab076d5475f";
+    aarch64-unknown-linux-gnu = "f406136010e6a1cdce3fb6573506f00d23858af49dd20a46723c3fa5257b7796";
+    aarch64-unknown-linux-musl = "4b701dc3cbac04ebf0e336cff2f4ce5fc1a1984c183226863c9ed911eb00b07e";
+    x86_64-apple-darwin = "139087a3937799415fd829e5a88162a69a32c23725a44457f9c96b98e4d64a7c";
+    aarch64-apple-darwin = "7ddc335bd10fc32d3039ef36248a5d0c4865db2437c8aad20a2428a6cf41df09";
+    powerpc64le-unknown-linux-gnu = "3f1d0d5bb13213348dc65e373f8c412fc0a12ee55abc1c864f7e0300932fc687";
+    riscv64gc-unknown-linux-gnu = "aac7067348d218faa452b4bdc735778a51570a310ad645313ec767b5d7c88492";
+    mips64el-unknown-linux-gnuabi64 = "d91ed3857c5256720da890f6533684b684e880bf9006dc4e4f4181213a5c4a09";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_65;
+  selectRustPackage = pkgs: pkgs.rust_1_66;
 
   rustcPatches = [
   ];

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, pkgsHostHost
 , file, curl, pkg-config, python3, openssl, cmake, zlib
 , installShellFiles, makeWrapper, cacert, rustPlatform, rustc
-, libiconv, CoreFoundation, Security
+, CoreFoundation, Security
 , auditable ? false # TODO: change to true when this is the default
 }:
 
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage {
     (lib.getDev pkgsHostHost.curl)
   ];
   buildInputs = [ cacert file curl python3 openssl zlib ]
-    ++ lib.optionals stdenv.isDarwin [ libiconv CoreFoundation Security ];
+    ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security ];
 
   # cargo uses git-rs which is made for a version of libgit2 from recent master that
   # is not compatible with the current version in nixpkgs.

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -163,6 +163,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ openssl ]
+    # TODO: remove libiconv once 1.66 is used to bootstrap
     ++ optionals stdenv.isDarwin [ libiconv Security ]
     ++ optional (!withBundledLLVM) llvmShared;
 

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -163,10 +163,8 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ openssl ]
-    ++ optionals stdenv.isDarwin [ Security ]
+    ++ optionals stdenv.isDarwin [ libiconv Security ]
     ++ optional (!withBundledLLVM) llvmShared;
-
-  depsTargetTargetPropagated = optionals stdenv.isDarwin [ libiconv ];
 
   outputs = [ "out" "man" "doc" ];
   setOutputFlags = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15214,11 +15214,11 @@ with pkgs;
     inherit (darwin) apple_sdk;
   };
 
-  rust_1_65 = callPackage ../development/compilers/rust/1_65.nix {
+  rust_1_66 = callPackage ../development/compilers/rust/1_66.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_14 = llvmPackages_14.libllvm;
   };
-  rust = rust_1_65;
+  rust = rust_1_66;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -15227,8 +15227,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  rustPackages_1_65 = rust_1_65.packages.stable;
-  rustPackages = rustPackages_1_65;
+  rustPackages_1_66 = rust_1_66.packages.stable;
+  rustPackages = rustPackages_1_66;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;
 


### PR DESCRIPTION
###### Description of changes

https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html

built and tested fd on master (x86_64-linux)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
