### PR TITLE
gdal: 3.6.0.1 -> 3.6.1

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , bison
 , cmake
 , doxygen
@@ -62,23 +61,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gdal";
-  version = "3.6.0.1";
+  version = "3.6.1";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "gdal";
     rev = "v${version}";
-    hash = "sha256-Yx7tmj2Y26FE5rzN+w1gg/7yRckNo6gLudrAPRoCro4=";
+    hash = "sha256-hWuV73b7czmbxpnd82V2FHM+ak9JviDHVodVXAHh/pc=";
   };
-
-  patches = [
-    # https://github.com/OSGeo/gdal/pull/6754
-    (fetchpatch {
-      name = "skip-test-failing-on-macos.patch";
-      url = "https://github.com/OSGeo/gdal/commit/65b2b12fa6638653f54d3ca0f8066225597832b9.patch";
-      hash = "sha256-zpj4jMp01Oz+Zk1b59qdoVxhkwWmTN9bwoKwbau2ADY=";
-    })
-  ];
 
   nativeBuildInputs = [
     bison


### PR DESCRIPTION
###### Description of changes

Update gdal to the latest bug fix version. This PR is dropping [patch](https://github.com/OSGeo/gdal/pull/6754) which was applied in upstream.

List of changes: https://github.com/OSGeo/gdal/blob/v3.6.1/NEWS.md

Notable change:

"""
GDAL 3.6.1 is a bugfix release. It officially retracts GDAL 3.6.0 which could cause corruption of the spatial index of GeoPackage files it created (in tables with 100 000 features or more): cf qgis/QGIS#51188 and #6911. GDAL 3.6.1 fixes that issue. Setting OGR_GPKG_ALLOW_THREADED_RTREE=NO environment variable (at generation time) also works around the issue with GDAL 3.6.0. Users who have generated corrupted GeoPackage files with 3.6.0 can regnerate them with 3.6.1 with, for example, "ogr2ogr out_ok.gpkg in_corrupted.gpkg" (assuming a GeoPackage file with vector content only)
"""

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
