### PR TITLE
mdbook: 0.4.21 -> 0.4.24

### DIFF
--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -2,24 +2,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook";
-  version = "0.4.21";
+  version = "0.4.24";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "mdBook";
-    rev = "v${version}";
-    sha256 = "sha256-ggcyOsA4cyo5l87cZmOMI0w1gCzmWy9NRJiWxjBdB1E=";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-Y7ZbgRX0ZaYtLA20fD/L9eNMbARI1f7g6O4Yl/UDO5E=";
   };
 
-  cargoSha256 = "sha256-KVoMC8ypikABVkIj5dCSHzYZ9CV8UMuAFxSEYLaQTSk=";
+  cargoSha256 = "sha256-74LyxlDx9tVjw0KGPml6EZbAIbDiW3tvM/CEj5BW7pI=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
-
-  # Tests rely on unset 'RUST_LOG' value to emit INFO messages.
-  # 'RUST_LOG=' nixpkgs default enables warnings only and breaks tests.
-  # Can be removed when https://github.com/rust-lang/mdBook/pull/1777
-  # is released.
-  logLevel = "info";
 
   passthru = {
     tests = {
@@ -30,6 +24,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Create books from MarkDown";
     homepage = "https://github.com/rust-lang/mdBook";
+    changelog = "https://github.com/rust-lang/mdBook/blob/v${version}/CHANGELOG.md";
     license = [ licenses.mpl20 ];
     maintainers = [ maintainers.havvy ];
   };

--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/rust-lang/mdBook";
     changelog = "https://github.com/rust-lang/mdBook/blob/v${version}/CHANGELOG.md";
     license = [ licenses.mpl20 ];
-    maintainers = [ maintainers.havvy ];
+    maintainers = with maintainers; [ havvy Frostman ];
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/rust-lang/mdBook/releases/tag/v0.4.22
https://github.com/rust-lang/mdBook/releases/tag/v0.4.23
https://github.com/rust-lang/mdBook/releases/tag/v0.4.24

https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0422
https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0423
https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0424

closes #204423

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
