### PR TITLE
sile 0.14.7

### DIFF
--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv
-, gnumake42
 , darwin
 , fetchurl
 , makeWrapper
@@ -44,11 +43,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.14.5";
+  version = "0.14.7";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "01wf0rihksk2ldxgci5vzl3j575vnp6wgk12yd28mwzxkss6n39g";
+    sha256 = "01sx4368bws47989zdahhksgy5jgc1qw4hhvpib4qcz3fs6xpx9j";
   };
 
   configureFlags = [
@@ -60,7 +59,6 @@ stdenv.mkDerivation rec {
     gitMinimal
     pkg-config
     makeWrapper
-    gnumake42
   ];
   buildInputs = [
     luaEnv


### PR DESCRIPTION
Minor upstream release. Does include build system changes but the new configure defaults should be correct for packaging purposes.

See [upstream release notes](https://github.com/sile-typesetter/sile/releases/tag/v0.14.6).