### PR TITLE
lima: 0.13.0 -> 0.14.2

### DIFF
--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -11,16 +11,16 @@
 
 buildGoModule rec {
   pname = "lima";
-  version = "0.14.1";
+  version = "0.14.2";
 
   src = fetchFromGitHub {
     owner = "lima-vm";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-C1qJ3SAxtFSxbGrDlLvYDzUwdiJDcegzx5uXCSYNVJQ=";
+    sha256 = "sha256-g4FvkjBviI1m8zlc+GK/09dIqVkTQ2MqqK1Wkyu4qBc=";
   };
 
-  vendorSha256 = "sha256-MaAdX7TKfBzvzz8r+cfKCSul/QZ0/AgHnBwhu0ZR0gY=";
+  vendorSha256 = "sha256-l53MTxLY/uid+0U/eY96l0aBWKImST1gN2BARilh2K0=";
 
   nativeBuildInputs = [ makeWrapper installShellFiles ]
     ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun sigtool ];

--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -27,8 +27,9 @@ buildGoModule rec {
 
   # clean fails with read only vendor dir
   postPatch = ''
-    substituteInPlace Makefile --replace 'binaries: clean' 'binaries:'
-    substituteInPlace Makefile --replace 'codesign --entitlements vz.entitlements -s -' 'codesign --force --entitlements vz.entitlements -s -'
+    substituteInPlace Makefile \
+      --replace 'binaries: clean' 'binaries:' \
+      --replace 'codesign --entitlements vz.entitlements -s -' 'codesign --force --entitlements vz.entitlements -s -'
   '';
 
   # It attaches entitlements with codesign and strip removes those,

--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -1,30 +1,38 @@
 { lib
+, stdenv
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
 , qemu
+, xcbuild
+, sigtool
 , makeWrapper
 }:
 
 buildGoModule rec {
   pname = "lima";
-  version = "0.13.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lima-vm";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-alE7fUVxJRkLMtdia5ruHxh9nlWIubM0J6iIrmpreRM=";
+    sha256 = "sha256-C1qJ3SAxtFSxbGrDlLvYDzUwdiJDcegzx5uXCSYNVJQ=";
   };
 
-  vendorSha256 = "sha256-Kb2R8USWOWRFMjQO3tjdl5UHOzzb2B3ld+5vO2gF3KY=";
+  vendorSha256 = "sha256-MaAdX7TKfBzvzz8r+cfKCSul/QZ0/AgHnBwhu0ZR0gY=";
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ]
+    ++ lib.optionals stdenv.isDarwin [ xcbuild.xcrun sigtool ];
 
   # clean fails with read only vendor dir
   postPatch = ''
     substituteInPlace Makefile --replace 'binaries: clean' 'binaries:'
   '';
+
+  # It attaches entitlements with codesign and strip removes those,
+  # voiding the entitlements and making it non-operational.
+  dontStrip = stdenv.isDarwin;
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -28,6 +28,7 @@ buildGoModule rec {
   # clean fails with read only vendor dir
   postPatch = ''
     substituteInPlace Makefile --replace 'binaries: clean' 'binaries:'
+    substituteInPlace Makefile --replace 'codesign --entitlements vz.entitlements -s -' 'codesign --force --entitlements vz.entitlements -s -'
   '';
 
   # It attaches entitlements with codesign and strip removes those,
@@ -36,7 +37,6 @@ buildGoModule rec {
 
   buildPhase = ''
     runHook preBuild
-    rm -rf _output
     make "VERSION=v${version}" binaries
     runHook postBuild
   '';

--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -36,6 +36,7 @@ buildGoModule rec {
 
   buildPhase = ''
     runHook preBuild
+    rm -rf _output
     make "VERSION=v${version}" binaries
     runHook postBuild
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36777,7 +36777,9 @@ with pkgs;
 
   colima = callPackage ../applications/virtualization/colima { };
 
-  lima = callPackage ../applications/virtualization/lima { };
+  lima = callPackage ../applications/virtualization/lima {
+    inherit (darwin) sigtool;
+  };
 
   logtop = callPackage ../tools/misc/logtop { };
 


### PR DESCRIPTION
###### Description of changes

Updates performed
- Golang update
- Added dependency to xcrun on darwin to detect if can compile with [Virtualization.framework](https://developer.apple.com/documentation/virtualization)
- Added dependency to sigtool on darwin for needed `codesign` command
- Modify Makefile to `--force` `codesign` due to golang signing `aarch64-darwin` binaries by default

To inspect upstream changes
- [Release on GitHub](https://github.com/lima-vm/lima/releases/tag/v0.14.1)
- [Compare changes on GitHub](https://github.com/lima-vm/lima/compare/v0.13.0...v0.14.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
