### PR TITLE
python3Packages.meshcat: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/meshcat/default.nix
+++ b/pkgs/development/python-modules/meshcat/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ipython
+, u-msgpack-python
+, numpy
+, tornado
+, pyzmq
+, pyngrok
+, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "meshcat";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-LP4XzeT+hdByo94Bip2r9WJvgMJV//LOY7JqSNJIStk=";
+  };
+
+  postPatch = ''
+    sed -i '/PYTHONPATH/d' src/meshcat/servers/zmqserver.py
+  '';
+
+  propagatedBuildInputs = [
+    ipython
+    u-msgpack-python
+    numpy
+    tornado
+    pyzmq
+    pyngrok
+    pillow
+  ];
+
+  pythonImportsCheck = [ "meshcat" ];
+
+  # requires a running MeshCat viewer
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/rdeits/meshcat-python";
+    description = "WebGL-based 3D visualizer for Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wegank ];
+  };
+}

--- a/pkgs/development/python-modules/pyngrok/default.nix
+++ b/pkgs/development/python-modules/pyngrok/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "pyngrok";
+  version = "5.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-dws4Z4LzgkkOGTS5LZn/MU8ZKr70n4PWocezsDhxeT4=";
+  };
+
+  propagatedBuildInputs = [
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "pyngrok" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/alexdlaird/pyngrok";
+    description = "A Python wrapper for ngrok";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wegank ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7094,6 +7094,8 @@ self: super: with self; {
 
   pylddwrap = callPackage ../development/python-modules/pylddwrap { };
 
+  pyngrok = callPackage ../development/python-modules/pyngrok { };
+
   pynndescent = callPackage ../development/python-modules/pynndescent { };
 
   pynobo = callPackage ../development/python-modules/pynobo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5727,6 +5727,8 @@ self: super: with self; {
 
   mesa = callPackage ../development/python-modules/mesa { };
 
+  meshcat = callPackage ../development/python-modules/meshcat { };
+
   meshio = callPackage ../development/python-modules/meshio { };
 
   meshlabxml = callPackage ../development/python-modules/meshlabxml { };


### PR DESCRIPTION
###### Description of changes

MeshCat is a remotely-controllable 3D viewer, built on top of three.js.

https://github.com/rdeits/meshcat-python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
