### PR TITLE
gnu-shepherd: 0.8.1 -> 0.9.3

### DIFF
--- a/pkgs/misc/gnu-shepherd/default.nix
+++ b/pkgs/misc/gnu-shepherd/default.nix
@@ -1,20 +1,18 @@
-{ stdenv, lib, fetchurl, guile, pkg-config }:
+{ stdenv, lib, fetchurl, guile, pkg-config, guile-fibers }:
 
 stdenv.mkDerivation rec {
   pname = "gnu-shepherd";
-  version = "0.8.1";
+  version = "0.9.3";
 
   src = fetchurl {
-    url = "https://ftp.gnu.org/gnu/shepherd/shepherd-${version}.tar.gz";
-    sha256 = "sha256-0y/lhpS7U1C1/HKFzwyg2cfSQiGqWWnWxGTuPjrIP3U=";
+    url = "mirror://gnu/shepherd/shepherd-${version}.tar.gz";
+    sha256 = "0qy2yq13xhf05an5ilz7grighdxicx56211yaarqq5qigiiybc32";
   };
 
-  configureFlags = [
-    "--localstatedir=/"
-  ];
+  configureFlags = [ "--localstatedir=/" ];
 
-  buildInputs = [ guile ];
-  nativeBuildInputs = [ pkg-config guile ];
+  buildInputs = [ guile guile-fibers ];
+  nativeBuildInputs = [ pkg-config ];
 
   meta = with lib; {
     homepage = "https://www.gnu.org/software/shepherd/";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes: https://git.savannah.gnu.org/cgit/shepherd.git/tree/NEWS?h=v0.9.3&id=1b0d50714ffb8d5f88674b4cbeb75e797e72aa19

Also swaps download url to mirror://

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
