### PR TITLE
julia_18: use more bundle libraries to avoid failing version checks

### DIFF
--- a/pkgs/development/compilers/julia/1.8.nix
+++ b/pkgs/development/compilers/julia/1.8.nix
@@ -12,19 +12,13 @@
 , libwhich
 , libxml2
 , libunwind
-, libgit2
 , curl
-, nghttp2
-, mbedtls_2
-, libssh2
 , gmp
-, mpfr
 , suitesparse
 , utf8proc
 , zlib
 , p7zip
 , ncurses
-, pcre2
 }:
 
 stdenv.mkDerivation rec {
@@ -41,15 +35,6 @@ stdenv.mkDerivation rec {
       path = name: "https://raw.githubusercontent.com/archlinux/svntogit-community/6fd126d089d44fdc875c363488a7c7435a223cec/trunk/${name}";
     in
     [
-      # Pull upstream fix to fix tests mpfr-4.1.1
-      #   https://github.com/JuliaLang/julia/pull/47659
-      (fetchpatch {
-        name = "mfr-4.1.1.patch";
-        url = "https://github.com/JuliaLang/julia/commit/59965205ccbdffb4e25e1b60f651ca9df79230a4.patch";
-        hash = "sha256-QJ5wxZMhz+or8BqcYv/5fNSTxDAvdSizTYqt7630kcw=";
-        includes = [ "stdlib/MPFR_jll/test/runtests.jl" ];
-      })
-
       (fetchurl {
         url = path "julia-hardcoded-libs.patch";
         sha256 = "sha256-kppSpVA7bRohd0wXDs4Jgct9ocHnpbeiiSz7ElFom1U=";
@@ -77,17 +62,11 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libxml2
     libunwind
-    libgit2
     curl
-    nghttp2
-    mbedtls_2
-    libssh2
     gmp
-    mpfr
     utf8proc
     zlib
     p7zip
-    pcre2
   ];
 
   JULIA_RPATH = lib.makeLibraryPath (buildInputs ++ [ stdenv.cc.cc gfortran.cc ncurses ]);
@@ -106,29 +85,27 @@ stdenv.mkDerivation rec {
     "USE_SYSTEM_CSL=1"
     "USE_SYSTEM_LLVM=0" # a patched version is required
     "USE_SYSTEM_LIBUNWIND=1"
-    "USE_SYSTEM_PCRE=1"
+    "USE_SYSTEM_PCRE=0" # version checks
     "USE_SYSTEM_LIBM=0"
     "USE_SYSTEM_OPENLIBM=0"
     "USE_SYSTEM_DSFMT=0" # not available in nixpkgs
     "USE_SYSTEM_LIBBLASTRAMPOLINE=0" # not available in nixpkgs
     "USE_SYSTEM_BLAS=0" # test failure
     "USE_SYSTEM_LAPACK=0" # test failure
-    "USE_SYSTEM_GMP=1"
-    "USE_SYSTEM_MPFR=1"
+    "USE_SYSTEM_GMP=1" # version checks, but bundled version fails build
+    "USE_SYSTEM_MPFR=0" # version checks
     "USE_SYSTEM_LIBSUITESPARSE=0" # test failure
     "USE_SYSTEM_LIBUV=0" # a patched version is required
     "USE_SYSTEM_UTF8PROC=1"
-    "USE_SYSTEM_MBEDTLS=1"
-    "USE_SYSTEM_LIBSSH2=1"
-    "USE_SYSTEM_NGHTTP2=1"
+    "USE_SYSTEM_MBEDTLS=0" # version checks
+    "USE_SYSTEM_LIBSSH2=0" # version checks
+    "USE_SYSTEM_NGHTTP2=0" # version checks
     "USE_SYSTEM_CURL=1"
-    "USE_SYSTEM_LIBGIT2=1"
+    "USE_SYSTEM_LIBGIT2=0" # version checks
     "USE_SYSTEM_PATCHELF=1"
     "USE_SYSTEM_LIBWHICH=1"
-    "USE_SYSTEM_ZLIB=1"
+    "USE_SYSTEM_ZLIB=1" # version checks, but the system zlib is used anyway
     "USE_SYSTEM_P7ZIP=1"
-
-    "PCRE_INCL_PATH=${pcre2.dev}/include/pcre2.h"
   ];
 
   doInstallCheck = true;

--- a/pkgs/development/compilers/julia/1.8.nix
+++ b/pkgs/development/compilers/julia/1.8.nix
@@ -106,6 +106,11 @@ stdenv.mkDerivation rec {
     "USE_SYSTEM_LIBWHICH=1"
     "USE_SYSTEM_ZLIB=1" # version checks, but the system zlib is used anyway
     "USE_SYSTEM_P7ZIP=1"
+  ] ++ lib.optionals stdenv.isx86_64 [
+    # https://github.com/JuliaCI/julia-buildbot/blob/master/master/inventory.py
+    "JULIA_CPU_TARGET=generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    "JULIA_CPU_TERGET=generic;cortex-a57;thunderx2t99;armv8.2-a,crypto,fullfp16,lse,rdm"
   ];
 
   doInstallCheck = true;

--- a/pkgs/development/compilers/julia/patches/1.8/0001-skip-symlink-system-libraries.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0001-skip-symlink-system-libraries.patch
@@ -1,4 +1,4 @@
-From 1faa30525c9671ffd3a08901896b521a040d7e5c Mon Sep 17 00:00:00 2001
+From b2a58160fd194858267c433ae551f24840a0b3f4 Mon Sep 17 00:00:00 2001
 From: Nick Cao <nickcao@nichi.co>
 Date: Tue, 20 Sep 2022 18:42:08 +0800
 Subject: [PATCH 1/4] skip symlink system libraries

--- a/pkgs/development/compilers/julia/patches/1.8/0002-skip-building-doc.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0002-skip-building-doc.patch
@@ -1,4 +1,4 @@
-From 05c008dcabaf94f5623f2f7e267005eef0a8c5fc Mon Sep 17 00:00:00 2001
+From ddf422a97973a1f4d2d4d32272396c7165580702 Mon Sep 17 00:00:00 2001
 From: Nick Cao <nickcao@nichi.co>
 Date: Tue, 20 Sep 2022 18:42:31 +0800
 Subject: [PATCH 2/4] skip building doc
@@ -8,10 +8,10 @@ Subject: [PATCH 2/4] skip building doc
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index d38311dce..a775d36e1 100644
+index 57b595310..563be74c9 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -227,7 +227,7 @@ define stringreplace
+@@ -229,7 +229,7 @@ define stringreplace
  endef
  
  

--- a/pkgs/development/compilers/julia/patches/1.8/0003-skip-failing-and-flaky-tests.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0003-skip-failing-and-flaky-tests.patch
@@ -1,14 +1,14 @@
-From f91c8c6364eb321dd5e66fa443472fca6bcda7d6 Mon Sep 17 00:00:00 2001
+From ed596b33005a438109f0078ed0ba30ebe464b4b5 Mon Sep 17 00:00:00 2001
 From: Nick Cao <nickcao@nichi.co>
 Date: Tue, 20 Sep 2022 18:42:59 +0800
-Subject: [PATCH 3/4] skip failing tests
+Subject: [PATCH 3/4] skip failing and flaky tests
 
 ---
  test/Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/test/Makefile b/test/Makefile
-index 24e137a5b..2b30ab392 100644
+index 24e137a5b..553d9d095 100644
 --- a/test/Makefile
 +++ b/test/Makefile
 @@ -23,7 +23,7 @@ default:
@@ -16,7 +16,7 @@ index 24e137a5b..2b30ab392 100644
  $(TESTS):
  	@cd $(SRCDIR) && \
 -	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
-+	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --skip MozillaCACerts_jll --skip NetworkOptions --skip Zlib_jll --skip GMP_jll $@)
++	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --skip MozillaCACerts_jll --skip NetworkOptions --skip Zlib_jll --skip GMP_jll --skip channels $@)
  
  $(addprefix revise-, $(TESTS)): revise-% :
  	@cd $(SRCDIR) && \

--- a/pkgs/development/compilers/julia/patches/1.8/0004-ignore-absolute-path-when-loading-library.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0004-ignore-absolute-path-when-loading-library.patch
@@ -1,4 +1,4 @@
-From c0e587f4c50bd7bedfe6e5102e9b47c9704fac9b Mon Sep 17 00:00:00 2001
+From 4bd87f2f3151ad07d311f7d33c2b890977aca93d Mon Sep 17 00:00:00 2001
 From: Nick Cao <nickcao@nichi.co>
 Date: Tue, 20 Sep 2022 18:43:15 +0800
 Subject: [PATCH 4/4] ignore absolute path when loading library


### PR DESCRIPTION
###### Description of changes
julia expects many of its libraries to be of a very specific or even patched version
using system libraries has never been a supported setup and causes numerous issues on our side
replaces https://github.com/NixOS/nixpkgs/pull/206301 and future ones
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
