### PR TITLE
open-stage-control: do not copy node_modules to reduce closure

### DIFF
--- a/pkgs/applications/audio/open-stage-control/default.nix
+++ b/pkgs/applications/audio/open-stage-control/default.nix
@@ -33,16 +33,13 @@ buildNpmPackage rec {
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 
-  # Override installPhase so we can copy the only folders that matter (app and node_modules)
+  # Override installPhase so we can copy the only directory that matters (app)
   installPhase = ''
     runHook preInstall
 
-    # prune unused deps
-    npm prune --omit dev --no-save $npmFlags
-
     # copy built app and node_modules directories
     mkdir -p $out/lib/node_modules/open-stage-control
-    cp -r app node_modules $out/lib/node_modules/open-stage-control/
+    cp -r app $out/lib/node_modules/open-stage-control/
 
     # copy icon
     install -Dm644 resources/images/logo.png $out/share/icons/hicolor/256x256/apps/open-stage-control.png


### PR DESCRIPTION
###### Description of changes

So when I packaged this initially, I forgot that `open-stage-control` has its own bundling logic as part of the build process that inlines all of the modules it needs into the built files in the `app` directory. So the `node_modules` directory isn't even needed in the output (and I confirmed this through testing basic functionality -- nothing was missing)

This reduces the closure of `open-stage-control` by like 500MiB

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).