### PR TITLE
python3Packages.autofaiss: init at 2.15.3

### DIFF
--- a/pkgs/development/python-modules/autofaiss/default.nix
+++ b/pkgs/development/python-modules/autofaiss/default.nix
@@ -1,0 +1,60 @@
+{ buildPythonPackage
+, embedding-reader
+, faiss
+, fetchFromGitHub
+, fire
+, fsspec
+, lib
+, numpy
+, pyarrow
+, pytestCheckHook
+, pythonRelaxDepsHook
+}:
+
+buildPythonPackage rec {
+  pname = "autofaiss";
+  version = "2.15.3";
+
+  src = fetchFromGitHub {
+    owner = "criteo";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-RJOOUMI4w1YPEjDKi0YkqTXU01AbVoPn2+Id6kdC5pA=";
+  };
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  pythonRemoveDeps = [
+    # The `dataclasses` packages is a python2-only backport, unnecessary in
+    # python3.
+    "dataclasses"
+    # We call it faiss, not faiss-cpu.
+    "faiss-cpu"
+  ];
+
+  pythonRelaxDeps = [
+    # As of v2.15.3, autofaiss asks for pyarrow<8 but we have pyarrow v9.0.0 in
+    # nixpkgs at the time of writing (2022-12-15).
+    "pyarrow"
+  ];
+
+  propagatedBuildInputs = [ embedding-reader fsspec numpy faiss fire pyarrow ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # Attempts to spin up a Spark cluster and talk to it which doesn't work in
+    # the Nix build environment.
+    "test_build_partitioned_indexes"
+    "test_index_correctness_in_distributed_mode_with_multiple_indices"
+    "test_index_correctness_in_distributed_mode"
+    "test_quantize_with_pyspark"
+  ];
+
+  meta = with lib; {
+    description = "Automatically create Faiss knn indices with the most optimal similarity search parameters";
+    homepage = "https://github.com/criteo/autofaiss";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/embedding-reader/default.nix
+++ b/pkgs/development/python-modules/embedding-reader/default.nix
@@ -1,0 +1,39 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, fsspec
+, lib
+, numpy
+, pandas
+, pyarrow
+, pytestCheckHook
+, pythonRelaxDepsHook
+}:
+
+buildPythonPackage rec {
+  pname = "embedding-reader";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "rom1504";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-uyeIcAW9O9PR4cqmifC6Lx+Hn6XPb1RH/ksmUWvbdtw=";
+  };
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  pythonRelaxDeps = [ "pyarrow" ];
+
+  propagatedBuildInputs = [ fsspec numpy pandas pyarrow ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "embedding_reader" ];
+
+  meta = with lib; {
+    description = "Efficiently read embedding in streaming from any filesystem";
+    homepage = "https://github.com/rom1504/embedding-reader";
+    license = licenses.mit;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2945,6 +2945,8 @@ self: super: with self; {
 
   email-validator = callPackage ../development/python-modules/email-validator { };
 
+  embedding-reader = callPackage ../development/python-modules/embedding-reader { };
+
   embrace = callPackage ../development/python-modules/embrace { };
 
   emcee = callPackage ../development/python-modules/emcee { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -780,6 +780,8 @@ self: super: with self; {
 
   autocommand = callPackage ../development/python-modules/autocommand { };
 
+  autofaiss = callPackage ../development/python-modules/autofaiss { };
+
   autograd = callPackage ../development/python-modules/autograd { };
 
   autoit-ripper = callPackage ../development/python-modules/autoit-ripper { };


### PR DESCRIPTION
###### Description of changes

Add the autofaiss package for the straightforward creating of faiss indices. Also requires packaging the embedding-reader package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
