### PR TITLE
ta-lib: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11524,6 +11524,15 @@
     githubId = 131856;
     name = "Arnout Engelen";
   };
+  rafael = {
+    name = "Rafael";
+    email = "pr9@tuta.io";
+    github = "rafa-dot-el";
+    githubId = 104688305;
+    keys = [{
+      fingerprint = "5F0B 3EAC F1F9 8155 0946 CDF5 469E 3255 A40D 2AD6";
+    }];
+  };
   RaghavSood = {
     email = "r@raghavsood.com";
     github = "RaghavSood";

--- a/pkgs/development/libraries/ta-lib/default.nix
+++ b/pkgs/development/libraries/ta-lib/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config }:
+
+stdenv.mkDerivation rec {
+  name = "ta-lib";
+  version = "0.4.0";
+  src = fetchFromGitHub {
+    owner = "rafa-dot-el";
+    repo = "talib";
+    rev = "${version}";
+    sha256 = "sha256-bIzN8f9ZiOLaVzGAXcZUHUh/v9z1U+zY+MnyjJr1lSw=";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  hardeningDisable = [ "format" ];
+
+  meta = with lib; {
+    description =
+      "TA-Lib is a library that provides common functions for the technical analysis of financial market data.";
+    homepage = "https://ta-lib.org/";
+    license = lib.licenses.bsd3;
+
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rafael ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22851,6 +22851,8 @@ with pkgs;
 
   tageditor = libsForQt5.callPackage ../applications/audio/tageditor { };
 
+  ta-lib = callPackage ../development/libraries/ta-lib { };
+
   taglib = callPackage ../development/libraries/taglib { };
 
   taglib_extras = callPackage ../development/libraries/taglib-extras { };


### PR DESCRIPTION
Added TA-Lib, a library used for technical analysis.

Homepage: https://ta-lib.org/

This library is a mandatory dependency for financial and trading tools, for example:
 - https://github.com/twopirllc/pandas-ta
 - https://mrjbq7.github.io/ta-lib/


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
