### PR TITLE
vulkan-tools-lunarg: fix CMake include path

### DIFF
--- a/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
@@ -81,6 +81,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  patches = [ ./gtest.patch ];
+
   # Same as vulkan-validation-layers
   dontPatchELF = true;
 

--- a/pkgs/tools/graphics/vulkan-tools-lunarg/gtest.patch
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/gtest.patch
@@ -1,0 +1,34 @@
+diff --git a/external/googletest/googlemock/CMakeLists.txt b/external/googletest/googlemock/CMakeLists.txt
+index e7df8ec53d..869bfcb716 100644
+--- a/external/googletest/googlemock/CMakeLists.txt
++++ b/external/googletest/googlemock/CMakeLists.txt
+@@ -111,10 +111,10 @@ endif()
+ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+   target_include_directories(gmock SYSTEM INTERFACE
+     "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
+-    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
++    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>")
+   target_include_directories(gmock_main SYSTEM INTERFACE
+     "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
+-    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
++    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>")
+ endif()
+ 
+ ########################################################################
+diff --git a/external/googletest/googletest/CMakeLists.txt b/external/googletest/googletest/CMakeLists.txt
+index abdd98b79a..7ae174d566 100644
+--- a/external/googletest/googletest/CMakeLists.txt
++++ b/external/googletest/googletest/CMakeLists.txt
+@@ -138,10 +138,10 @@ set_target_properties(gtest_main PROPERTIES VERSION ${GOOGLETEST_VERSION})
+ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+   target_include_directories(gtest SYSTEM INTERFACE
+     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
+-    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
++    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>")
+   target_include_directories(gtest_main SYSTEM INTERFACE
+     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
+-    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
++    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>")
+ endif()
+ target_link_libraries(gtest_main PUBLIC gtest)
+


### PR DESCRIPTION
###### Description of changes

Fix invalid include path in `external/googletest/googlemock/CMakeLists.txt`.

```diff
   target_include_directories(gmock SYSTEM INTERFACE
     "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
-    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
