### PR TITLE
vulkan-sdk: 1.3.231.0 -> 1.3.236.0

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -10,13 +10,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "glslang";
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
     rev = "sdk-${version}";
-    hash = "sha256-huPrQr+lPi7QCF8CufAavHEKGDDimGrcskiojhH9QYk=";
+    hash = "sha256-iVcx1j7OMJEU4cPydNwQSFufTUiqq7GKp69Y6pEt7Wc=";
   };
 
   # These get set at all-packages, keep onto them for child drvs
@@ -28,12 +28,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 bison jq ];
 
   patches = [
-    # https://github.com/NixOS/nixpkgs/pull/201747
-    (fetchpatch {
-      name = "Fix-locations-of-cmake-files-in-side-compat-shims.patch";
-      url = "https://github.com/KhronosGroup/glslang/commit/88fd417b0bb7d91755961c70e846d274c182f2b0.patch";
-      hash = "sha256-rjeaPX5Ieem6zkICNvPd2SjvvLzG5wBERZfDLZEJsAk=";
-    })
     (fetchpatch {
       name = "Use-CMAKE_INSTALL_FULL_LIBDIR-in-compat-cmake-files.patch";
       url = "https://github.com/KhronosGroup/glslang/commit/7627bd89583c5aafb8b38c81c15494019271fabf.patch";

--- a/pkgs/development/libraries/spirv-headers/default.nix
+++ b/pkgs/development/libraries/spirv-headers/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-headers";
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
     rev = "sdk-${version}";
-    hash = "sha256-lUWgZYGPu+IaLUrbtyC7R0o3Hq/q7C7BE8r7DAsiC30=";
+    hash = "sha256-eWI1MyIWxcg1JepRsnHBmitehDigDa+dR8kXvIkYejY=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "vulkan-headers";
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   nativeBuildInputs = [ cmake ];
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "sdk-${version}";
-    hash = "sha256-EoD48jBoJmIet4BDC6bYxOsKK2358SZ/NcZeM61q/5g=";
+    hash = "sha256-b1q9QugFH4lieS8CTOyZ3uoQ7bd44G8NPEwRtUPD+24=";
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -3,14 +3,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-loader";
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-Loader";
       rev = "sdk-${version}";
-      hash = "sha256-HWaa3JT0znhvqbvZdcsAwy8Dr6HDQp4rgpVmMOuCo0s=";
+      hash = "sha256-Y6OakowZlb40ZatITQCFBK/qSZqSdgTNew1XUFD/jMo=";
     });
 
   patches = [ ./fix-pkgconfig.patch ];

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-tools";
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   src = (assert version == spirv-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "SPIRV-Tools";
       rev = "sdk-${version}";
-      hash = "sha256-sqjQoz9v9alSPc0ujEcWZxDAWh2S6oAPP1+JZmNCpA0=";
+      hash = "sha256-BV7V/jS782zdvtuw/wNY5fyAdx8Z2niWSocNaW0Atho=";
     }
   );
 

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -22,7 +22,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   # If we were to use "dev" here instead of headers, the setupHook would be
   # placed in that output instead of "out".
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       owner = "KhronosGroup";
       repo = "Vulkan-ValidationLayers";
       rev = "sdk-${version}";
-      hash = "sha256-5bzUauu8081zyRaWmRUtOxHjUU4gc1GWoJtU783Msh0=";
+      hash = "sha256-+VbiXtxzYaF5o+wIrJ+09LmgBdaLv/0VJGFDnBkrXms=";
     });
 
   # Include absolute paths to layer libraries in their associated

--- a/pkgs/tools/graphics/vulkan-extension-layer/default.nix
+++ b/pkgs/tools/graphics/vulkan-extension-layer/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-extension-layer";
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-ExtensionLayer";
       rev = "sdk-${version}";
-      hash = "sha256-8Z9w+3WFPYp8QKEUVkEQCGy9LXMWYlZDgGt8i34T5DU=";
+      hash = "sha256-NlBS7UuV2AZPY5VyoqTnTf63M7fHIPQDZRtMZ4XwMzA=";
     });
 
   nativeBuildInputs = [ cmake jq ];

--- a/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
@@ -11,6 +11,7 @@
 , libffi
 , libxcb
 , wayland
+, which
 , xcbutilkeysyms
 , xcbutilwm
 , vulkan-headers
@@ -23,18 +24,18 @@
 stdenv.mkDerivation rec {
   pname = "vulkan-tools-lunarg";
   # The version must match that in vulkan-headers
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "LunarG";
       repo = "VulkanTools";
       rev = "sdk-${version}";
-      hash = "sha256-qomhouuKVv4Dat9Sv7X68Dw6bRnaUjj6iEXC9pCqX4E=";
+      hash = "sha256-0dGD3InmEd9hO8+uVGMqBHXXfyX8tswyuOaZCftudz0=";
       fetchSubmodules = true;
     });
 
-  nativeBuildInputs = [ cmake python3 jq ];
+  nativeBuildInputs = [ cmake python3 jq which ];
 
   buildInputs = [
     expat

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools";
-  version = "1.3.231.0";
+  version = "1.3.236.0";
 
   # It's not strictly necessary to have matching versions here, however
   # since we're using the SDK version we may as well be consistent with
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       owner = "KhronosGroup";
       repo = "Vulkan-Tools";
       rev = "sdk-${version}";
-      hash = "sha256-6oimP4ISa0dX4bLU3Nch8Ur6MzEMQscnL8EfRrqT/Es=";
+      hash = "sha256-PmNTpdAkXJkARLohRtUOuKTZPoKgeVF4DAo1wsAq5xE=";
     });
 
   nativeBuildInputs = [


### PR DESCRIPTION
**NOTE**: I've cherry-picked the commit from https://github.com/NixOS/nixpkgs/pull/206364, so it would be cool to review+merge it first, and then I drop the commit here.

###### Description of changes

- Bumps to latest tags, check changelog: https://vulkan.lunarg.com/doc/sdk/1.3.236.0/linux/release_notes.html

- One of the patches of https://github.com/NixOS/nixpkgs/pull/201747 were upstreamed and now removed.

###### Things done

Tested building `vulkan-tools`, which built `vulkan-headers`, `vulkan-loader`, and `glslang`. Building `vulkan-tools-lunarg` builds `vulkan-validation-layers`, that builds the spirv stack. I've built `vulkan-extension-layer` and that closed the testing. All of this in `x86-64-linux`.
