### PR TITLE
python310Packages.nianet: init at 1.1.4

### DIFF
--- a/pkgs/development/python-modules/nianet/default.nix
+++ b/pkgs/development/python-modules/nianet/default.nix
@@ -13,7 +13,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "NiaNet";
+  pname = "nianet";
   version = "1.1.4";
   format = "pyproject";
 

--- a/pkgs/development/python-modules/nianet/default.nix
+++ b/pkgs/development/python-modules/nianet/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "SasoPavlic";
     repo = pname;
-    rev = "version_1.1.4";
+    rev = "version_${version}";
     sha256 = "sha256-FZipl6Z9AfiL6WH0kvUn8bVxt8JLdDVlmTSqnyxe0nY=";
   };
 

--- a/pkgs/development/python-modules/nianet/default.nix
+++ b/pkgs/development/python-modules/nianet/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, matplotlib
+, niapy
+, numpy
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, scikit-learn
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "nianet";
+  version = "1.1.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "SasoPavlic";
+    repo = pname;
+    rev = "Latest";
+    sha256 = "sha256-df3kOWs17fT74dyKF2ZqPNOhMeH8yDEDkJOsMtFNHsM=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    niapy
+    numpy
+    scikit-learn
+    torch
+  ];
+
+  # no serious tests | some tests are incorrect | skip for now
+  # reported to the upstream
+  #checkInputs = [
+  #  pytestCheckHook
+  #];
+
+  pythonImportsCheck = [
+    "nianet"
+  ];
+
+  meta = with lib; {
+    description = "Designing and constructing neural network topologies using nature-inspired algorithms";
+    homepage = "https://github.com/SasoPavlic/NiaNet";
+    changelog = "https://github.com/SasoPavlic/NiaNet/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ firefly-cpp ];
+  };
+}

--- a/pkgs/development/python-modules/nianet/default.nix
+++ b/pkgs/development/python-modules/nianet/default.nix
@@ -8,12 +8,13 @@
 , pytestCheckHook
 , pythonOlder
 , scikit-learn
+, toml-adapt
 , torch
 }:
 
 buildPythonPackage rec {
-  pname = "nianet";
-  version = "1.1.1";
+  pname = "NiaNet";
+  version = "1.1.4";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -21,11 +22,12 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "SasoPavlic";
     repo = pname;
-    rev = "Latest";
-    sha256 = "sha256-df3kOWs17fT74dyKF2ZqPNOhMeH8yDEDkJOsMtFNHsM=";
+    rev = "version_1.1.4";
+    sha256 = "sha256-FZipl6Z9AfiL6WH0kvUn8bVxt8JLdDVlmTSqnyxe0nY=";
   };
 
   nativeBuildInputs = [
+    toml-adapt
     poetry-core
   ];
 
@@ -36,11 +38,15 @@ buildPythonPackage rec {
     torch
   ];
 
-  # no serious tests | some tests are incorrect | skip for now
-  # reported to the upstream
-  #checkInputs = [
-  #  pytestCheckHook
-  #];
+  # create niapy and torch dep version consistent
+  preBuild = ''
+    toml-adapt -path pyproject.toml -a change -dep niapy -ver X
+    toml-adapt -path pyproject.toml -a change -dep torch -ver X
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [
     "nianet"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6211,6 +6211,8 @@ self: super: with self; {
 
   niaaml = callPackage ../development/python-modules/niaaml { };
 
+  nianet = callPackage ../development/python-modules/nianet { };
+
   niaarm = callPackage ../development/python-modules/niaarm { };
 
   niapy = callPackage ../development/python-modules/niapy { };


### PR DESCRIPTION
###### Description of changes

Python package for designing and constructing neural network topologies using nature-inspired algorithms: [LINK](https://github.com/SasoPavlic/NiaNet) 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
