### PR TITLE
openrgb-plugin-hardwaresync,openrgb-plugin-effects: init at 0.8

### DIFF
--- a/pkgs/applications/misc/openrgb-plugins/effects/default.nix
+++ b/pkgs/applications/misc/openrgb-plugins/effects/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchpatch
+, qtbase
+, openrgb
+, glib
+, openal
+, qmake
+, pkg-config
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openrgb-plugin-effects";
+  version = "0.8";
+
+  src = fetchFromGitLab {
+    owner = "OpenRGBDevelopers";
+    repo = "OpenRGBEffectsPlugin";
+    rev = "release_${version}";
+    hash = "sha256-2F6yeLWgR0wCwIj75+d1Vdk45osqYwRdenK21lcRoOg=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # Add install rule
+    (fetchpatch {
+      url = "https://gitlab.com/OpenRGBDevelopers/OpenRGBEffectsPlugin/-/commit/75f1b3617d9cabfb3b04a7afc75ce0c1b8514bc0.patch";
+      hash = "sha256-X+zMNE3OCZNmUb68S4683r/RbE+CDrI/Jv4BMWPI47E=";
+    })
+  ];
+
+  postPatch = ''
+    # Use the source of openrgb from nixpkgs instead of the submodule
+    rm -r OpenRGB
+    ln -s ${openrgb.src} OpenRGB
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    glib
+    openal
+  ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/OpenRGBDevelopers/OpenRGBEffectsPlugin";
+    description = "An effects plugin for OpenRGB";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/openrgb-plugins/hardwaresync/default.nix
+++ b/pkgs/applications/misc/openrgb-plugins/hardwaresync/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchpatch
+, qtbase
+, openrgb
+, glib
+, libgtop
+, lm_sensors
+, qmake
+, pkg-config
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openrgb-plugin-hardwaresync";
+  version = "0.8";
+
+  src = fetchFromGitLab {
+    owner = "OpenRGBDevelopers";
+    repo = "OpenRGBHardwareSyncPlugin";
+    rev = "release_${version}";
+    hash = "sha256-P+IitP8pQLUkBdMfcNw4fOggqyFfg6lNlnSfUGjddzo=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "use-pkgconfig";
+      url = "https://gitlab.com/OpenRGBDevelopers/OpenRGBHardwareSyncPlugin/-/commit/df2869d679ea43119fb9b174cd0b2cb152022685.patch";
+      hash = "sha256-oBtrHwpvB8Z3xYi4ucDSuw+5WijPEbgBW7vLGELFjfw=";
+    })
+    (fetchpatch {
+      name = "add-install-rule";
+      url = "https://gitlab.com/OpenRGBDevelopers/OpenRGBHardwareSyncPlugin/-/commit/bfbaa0a32ed05112e0cc8b6b2a8229945596e522.patch";
+      hash = "sha256-76UMMzeXnyQRCEE1tGPNR5XSHTT480rQDnJ9hWhfIqY=";
+    })
+  ];
+
+  postPatch = ''
+    # Use the source of openrgb from nixpkgs instead of the submodule
+    rmdir OpenRGB
+    ln -s ${openrgb.src} OpenRGB
+    # Remove prebuilt stuff
+    rm -r dependencies/lhwm-cpp-wrapper
+  '';
+
+  buildInputs = [
+    qtbase
+    glib
+    libgtop
+    lm_sensors
+  ];
+
+  nativeBuildInputs = [
+    qmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/OpenRGBDevelopers/OpenRGBHardwareSyncPlugin";
+    description = "Sync your ARGB devices colors with hardware measures (CPU, GPU, fan speed, etc...)";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab, qmake, wrapQtAppsHook, libusb1, hidapi, pkg-config, coreutils, mbedtls_2, qtbase, qttools }:
+{ lib, stdenv, fetchFromGitLab, qmake, wrapQtAppsHook, libusb1, hidapi, pkg-config, coreutils, mbedtls_2, qtbase, qttools, symlinkJoin, openrgb }:
 
 stdenv.mkDerivation rec {
   pname = "openrgb";
@@ -24,6 +24,29 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     HOME=$TMPDIR $out/bin/openrgb --help > /dev/null
   '';
+
+  passthru.withPlugins = plugins:
+    let pluginsDir = symlinkJoin {
+      name = "openrgb-plugins";
+      paths = plugins;
+      # Remove all library version symlinks except one,
+      # or they will result in duplicates in the UI.
+      # We leave the one pointing to the actual library, usually the most
+      # qualified one (eg. libOpenRGBHardwareSyncPlugin.so.1.0.0).
+      postBuild = ''
+        for f in $out/lib/*; do
+          if [ "$(dirname $(readlink "$f"))" == "." ]; then
+            rm "$f"
+          fi
+        done
+      '';
+    };
+    in openrgb.overrideAttrs (old: {
+      qmakeFlags = old.qmakeFlags or [] ++ [
+        # Welcome to Escape Hell, we have backslashes
+        ''DEFINES+=OPENRGB_EXTRA_PLUGIN_DIRECTORY=\\\""${lib.escape ["\\" "\"" " "] (toString pluginsDir)}/lib\\\""''
+      ];
+    });
 
   meta = with lib; {
     description = "Open source RGB lighting control";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10333,7 +10333,12 @@ with pkgs;
 
   openrgb = libsForQt5.callPackage ../applications/misc/openrgb { };
 
-  openrgb-with-all-plugins = openrgb.withPlugins [ openrgb-plugin-hardwaresync ];
+  openrgb-with-all-plugins = openrgb.withPlugins [
+    openrgb-plugin-effects
+    openrgb-plugin-hardwaresync
+  ];
+
+  openrgb-plugin-effects = libsForQt5.callPackage ../applications/misc/openrgb-plugins/effects { };
 
   openrgb-plugin-hardwaresync = libsForQt5.callPackage ../applications/misc/openrgb-plugins/hardwaresync { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10333,6 +10333,8 @@ with pkgs;
 
   openrgb = libsForQt5.callPackage ../applications/misc/openrgb { };
 
+  openrgb-with-all-plugins = openrgb.withPlugins [ openrgb-plugin-hardwaresync ];
+
   openrgb-plugin-hardwaresync = libsForQt5.callPackage ../applications/misc/openrgb-plugins/hardwaresync { };
 
   openrussian-cli = callPackage ../misc/openrussian-cli {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10333,6 +10333,8 @@ with pkgs;
 
   openrgb = libsForQt5.callPackage ../applications/misc/openrgb { };
 
+  openrgb-plugin-hardwaresync = libsForQt5.callPackage ../applications/misc/openrgb-plugins/hardwaresync { };
+
   openrussian-cli = callPackage ../misc/openrussian-cli {
     lua = lua5_3;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Unfortunately openrgb imports a plugin by copying it into its config directory, so this only works until a garbage collection removes its dependencies. I don't see how to fix that without patching upstream. Replacing the imported plugin with a symlink to a static location (such as /etc) of the package works though.
edit: fixed, see comments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
