### PR TITLE
nasmfmt: unstable-2021-04-24 -> unstable-2022-09-15

### DIFF
--- a/pkgs/development/tools/nasmfmt/default.nix
+++ b/pkgs/development/tools/nasmfmt/default.nix
@@ -1,22 +1,27 @@
-{ lib, buildGoPackage, fetchFromGitHub, go }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "nasmfmt";
-  version = "unstable-2021-04-24";
+  version = "unstable-2022-09-15";
 
   src = fetchFromGitHub {
     owner = "yamnikov-oleg";
     repo = "nasmfmt";
-    rev = "efba220c5252eb717f080d266dcc8304efdeab40";
-    sha256 = "sha256-snhXF+IP0qzl43rKQ0Ugfo1zv3RyNfjxnMpjZEBgPQg=";
+    rev = "127dbe8e72376c67d7dff89010ccfb49fc7b533e";
+    hash = "sha256-1c7ZOdoM0/Us7cnTT3sds2P5pcCedrCfl0GqQBnf9Rk=";
   };
 
-  goPackagePath = "github.com/yamnikov-oleg/nasmfmt";
+  vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+
+  preBuild = ''
+    cp ${./go.mod} go.mod
+  '';
+
+  ldflags = [ "-s" "-w" ];
 
   meta = with lib; {
     description = "Formatter for NASM source files";
     homepage = "https://github.com/yamnikov-oleg/nasmfmt";
-    platforms = go.meta.platforms;
     license = licenses.mit;
     maintainers = with maintainers; [ ckie ];
   };

--- a/pkgs/development/tools/nasmfmt/go.mod
+++ b/pkgs/development/tools/nasmfmt/go.mod
@@ -1,0 +1,3 @@
+module github.com/yamnikov-oleg/nasmfmt
+
+go 1.18


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
