### PR TITLE
xorg.xorgserver: apply CVE patches

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -814,6 +814,43 @@ self: super:
             url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/dd8caf39e9e15d8f302e54045dd08d8ebf1025dc.diff";
             sha256 = "rBiiXQRreMvexW9vOKblcfCYzul+9La01EAhir4FND8=";
           })
+        ]
+        # TODO: remove with xorgserver >= 21.1.5; https://www.mail-archive.com/xorg-announce@lists.x.org/msg01511.html
+        ++ [
+          (fetchpatch {
+            name = "CVE-2022-46340.diff";
+            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/b320ca0ffe4c0c872eeb3a93d9bde21f765c7c63.diff";
+            sha256 = "sha256-XPjLwZcJPLVv1ufgqnUxl73HKcJWWTDy2J/oxFiFnAU=";
+          })
+          (fetchpatch {
+            name = "CVE-2022-46341.diff";
+            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/51eb63b0ee1509c6c6b8922b0e4aa037faa6f78b.diff";
+            sha256 = "sha256-w+tzzoI1TfjjiFw5GNxVBgPc7M2lRY60zl+ySsyV59o=";
+          })
+          (fetchpatch {
+            name = "CVE-2022-46342.diff";
+            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/b79f32b57cc0c1186b2899bce7cf89f7b325161b.diff";
+            sha256 = "sha256-NytCsqRlqhs8xpOL8PGgluU0nKd7VIY26BXgpzN6WqE=";
+          })
+          (fetchpatch {
+            name = "CVE-2022-46343.diff";
+            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/842ca3ccef100ce010d1d8f5f6d6cc1915055900.diff";
+            sha256 = "sha256-oUwKwfN6lAvZ60dylm53+/yDeFnYTVdCINpBAfM6LoY=";
+          })
+          (fetchpatch {
+            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/b8a84cb0f2807b07ab70ca9915fcdee21301b8ca.diff";
+            sha256 = "sha256-Y2x9/P0SgwUAJRjIXivA32NnMso7gQAid+VjcwNUsa8=";
+          })
+          (fetchpatch {
+            name = "CVE-2022-46344.diff";
+            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/8f454b793e1f13c99872c15f0eed1d7f3b823fe8.diff";
+            sha256 = "sha256-Cr760UPwmm8Qr0o/R8/IlgggXQ6ENTHRz3bP/nsIwbU=";
+          })
+          (fetchpatch {
+            name = "CVE-2022-4283.diff";
+            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/ccdd431cd8f1cabae9d744f0514b6533c438908c.diff";
+            sha256 = "sha256-IGPsjS7KgRPLrs1ImBXvIFCa8Iu5ZiAHRZvHlBYP8KQ=";
+          })
         ];
         buildInputs = commonBuildInputs ++ [ libdrm mesa ];
         propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ libpciaccess libepoxy ] ++ commonPropagatedBuildInputs ++ lib.optionals stdenv.isLinux [


### PR DESCRIPTION
https://www.mail-archive.com/xorg-announce@lists.x.org/msg01511.html


rebuild count 913

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
