### PR TITLE
mpd: fix dylib issue on darwin

### DIFF
--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -153,6 +153,11 @@ let
           --replace kAudioHardwareServiceDeviceProperty_Virtual{Main,Master}Volume
       '';
 
+      # Fix strange issue where the dylib path is doubled
+      postFixup = lib.optionalString stdenv.isDarwin ''
+        install_name_tool -change ${fluidsynth}/${fluidsynth}/lib/libfluidsynth.3.dylib ${fluidsynth}/lib/libfluidsynth.3.dylib $out/bin/mpd
+      '';
+
       # Otherwise, the meson log says:
       #
       #    Program zip found: NO


### PR DESCRIPTION
###### Description of changes

This fixes the follow strange dylib problem with mpd on darwin, where the dylib path for fluidsynth is doubled up, causing mpd not to start:
```
$ mpd
dyld[72101]: Library not loaded: '/nix/store/3b0ld5wqq1gjvlav8shafp0w2bmg32aa-fluidsynth-2.3.0//nix/store/3b0ld5wqq1gjvlav8shafp0w2bmg32aa-fluidsynth-2.3.0/lib/libfluidsynth.3.dylib'
Referenced from: '/nix/store/93xlnac731w45dywzqxrp2nfi3lxc436-mpd-0.23.11/bin/mpd'
Reason: tried: '/nix/store/3b0ld5wqq1gjvlav8shafp0w2bmg32aa-fluidsynth-2.3.0//nix/store/3b0ld5wqq1gjvlav8shafp0w2bmg32aa-fluidsynth-2.3.0/lib/libfluidsynth.3.dylib' (no such file), '/usr/local/lib/libfluidsynth.3.dylib' (no such file), '/usr/lib/libfluidsynth.3.dylib' (no such file)
zsh: abort      mpd
$ otool -L ~/.nix-profile/bin/mpd | grep '//'
/nix/store/3b0ld5wqq1gjvlav8shafp0w2bmg32aa-fluidsynth-2.3.0//nix/store/3b0ld5wqq1gjvlav8shafp0w2bmg32aa-fluidsynth-2.3.0/lib/libfluidsynth.3.dylib (compatibility version 3.0.0, current version 3.1.3)
```

The approach of using `install_name_tool -change` is copied from https://github.com/kalekseev/nixpkgs/blob/df61cc1c2a4e3768f45d6e2c7fa1eb5326b99498/pkgs/development/tools/analysis/radare2/default.nix#L66

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
