### PR TITLE
fzf-git-sh: init at unstable-2022-09-30

### DIFF
--- a/pkgs/shells/fzf-git-sh/default.nix
+++ b/pkgs/shells/fzf-git-sh/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, lib
+, bash
+, bat
+, coreutils
+, fetchFromGitHub
+, findutils
+, fzf
+, gawk
+, git
+, gnugrep
+, gnused
+, tmux
+, util-linux
+, xdg-utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fzf-git-sh";
+  version = "unstable-2022-09-30";
+
+  src = fetchFromGitHub {
+    owner = "junegunn";
+    repo = "fzf-git.sh";
+    rev = "9190e1bf7273d85f435fa759a5c3b20e588e9f7e";
+    sha256 = "sha256-2CGjk1oTXip+eAJMuOk/X3e2KTwfwzcKTcGToA2xPd4=";
+  };
+
+  dontBuild = true;
+
+  postPatch = ''
+    sed -i \
+      -e "s,\bawk\b,${gawk}/bin/awk," \
+      -e "s,\bbash\b,${bash}/bin/bash," \
+      -e "s,\bbat\b,${bat}/bin/bat," \
+      -e "s,\bcat\b,${coreutils}/bin/cat," \
+      -e "s,\bcut\b,${coreutils}/bin/cut," \
+      -e "s,\bhead\b,${coreutils}/bin/head," \
+      -e "s,\buniq\b,${coreutils}/bin/uniq," \
+      -e "s,\bcolumn\b,${util-linux}/bin/column," \
+      -e "s,\bfzf-tmux\b,${fzf}/bin/fzf-tmux," \
+      -e "/display-message/!s,\bgit\b,${git}/bin/git,g" \
+      -e "s,\bgrep\b,${gnugrep}/bin/grep," \
+      -e "s,\bsed\b,${gnused}/bin/sed," \
+      -e "/fzf-tmux/!s,\btmux\b,${tmux}/bin/tmux," \
+      -e "s,\bxargs\b,${findutils}/bin/xargs," \
+      -e "s,\bxdg-open\b,${xdg-utils}/bin/xdg-open," \
+      -e "s,__fzf_git=.*BASH_SOURCE.*,__fzf_git=$out/share/${pname}/fzf-git.sh," \
+      -e "/__fzf_git=.*readlink.*/d" \
+      fzf-git.sh
+  '';
+
+  installPhase = ''
+    install -D fzf-git.sh $out/share/${pname}/fzf-git.sh
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/junegunn/fzf-git.sh";
+    description = "Bash and zsh key bindings for Git objects, powered by fzf";
+    license = licenses.mit;
+    maintainers = with maintainers; [ deejayem ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13540,6 +13540,8 @@ with pkgs;
 
   fishPlugins = recurseIntoAttrs (callPackage ../shells/fish/plugins { });
 
+  fzf-git-sh = callPackage ../shells/fzf-git-sh {};
+
   ion = callPackage ../shells/ion {
     inherit (darwin) Security;
   };


### PR DESCRIPTION
###### Description of changes

Add fzf-git.sh as fzf-git-sh.

https://github.com/junegunn/fzf-git.sh - "bash and zsh key bindings for Git objects, powered by fzf"

I'm not sure if this belongs here (`pkgs/shells/`), or in `pkgs/applications/version-management/git-and-tools/`, but as all it does is provide keybindings when the installed file is sourced, I thought this was a good place.

To test:
- With bash: `nix-build -A fzf-git-sh && source result/share/fzf-git-sh/fzf-git.sh`, then try hitting e.g. ctrl-g ctrl-f (files) or ctrl-g ctrl-b (branches).
- With zsh: the same approach will *probably* work, but some zsh config/plugins can cause odd behaviour where the shell exits after sourcing the file. For me, adding the source command to my `~/.zshrc` (rather than doing it interactively), and then running `exec zsh` to restart the shell resolves this. Alternatively, use `zsh -f` to start zsh without reading your config, and then sourcing `fzf-git.sh` should work fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
