### PR TITLE
pulumiPackages.pulumi-language-nodejs: init at 3.49.0

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/default.nix
+++ b/pkgs/tools/admin/pulumi-packages/default.nix
@@ -6,6 +6,7 @@ in
 {
   pulumi-aws-native = callPackage' ./pulumi-aws-native.nix { };
   pulumi-azure-native = callPackage' ./pulumi-azure-native.nix { };
+  pulumi-language-nodejs = callPackage ./pulumi-language-nodejs.nix { };
   pulumi-language-python = callPackage ./pulumi-language-python.nix { };
   pulumi-random = callPackage' ./pulumi-random.nix { };
 }

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, pulumi
+}:
+buildGoModule rec {
+  inherit (pulumi) version src;
+
+  pname = "pulumi-language-nodejs";
+
+  sourceRoot = "${src.name}/sdk";
+
+  vendorHash = "sha256-gM3VpX6r/BScUyvk/XefAfbx0qYzdzSBGaWZN+89BS8=";
+
+  subPackages = [
+    "nodejs/cmd/pulumi-language-nodejs"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
+  ];
+
+  postInstall = ''
+    cp nodejs/dist/pulumi-resource-pulumi-nodejs $out/bin
+    cp nodejs/dist/pulumi-analyzer-policy        $out/bin
+  '';
+}


### PR DESCRIPTION
###### Description of changes

Added `pulumi-language-nodejs` binary, for use with `pulumi`, to allow execution of nodejs based pulumi projects.

###### Things done

This is my very first time trying to write any nix code, apart from very simple `shell.nix` definitions. And it's quite confusing truth be told.
That being said, by basically copying the existing `pulumi-language-python` code by @veehaitch , I got this build to work. However I would greatly appreciate any comments on what I have done wrong, since it's very likely to be the case.

I actually wanted to DRY up some of the code, like sharing the `vendorHash` and go version `ldflags` between `pulumi-language-python` and `pulumi-language-nodejs`, but I couldn't figure out how to do that due to the confusing nature of the language and code structure. Thus would appreciate hints on how I could do this code DRYing.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - with go tests from pulumi source repo
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - by adding this built binary to $PATH using it in an existing pulumi nodejs TS project. Successfully ran `pulumi preview` and `pulumi up`