### PR TITLE
dumb-init: fix musl

### DIFF
--- a/pkgs/applications/virtualization/dumb-init/default.nix
+++ b/pkgs/applications/virtualization/dumb-init/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-aRh0xfmp+ToXIYjYaducTpZUHndZ5HlFZpFhzJ3yKgs=";
   };
 
-  buildInputs = [ glibc.static ];
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isMusl) [ glibc.static ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
dumb-init: fix musl

Tested in `linux-x86_64` as: `nix build .#pkgsMusl.dumb-init`

Without this patch master fails as:
![image](https://user-images.githubusercontent.com/5861043/208156742-078a9f3d-064f-475d-9de1-946d622e4109.png)

Musl is supported: https://github.com/Yelp/dumb-init#building-with-musl

---
This PR is ready for review. Feel free to review it.