### PR TITLE
spotdl: 3.9.6 -> 4.0.6

### DIFF
--- a/pkgs/tools/audio/spotdl/default.nix
+++ b/pkgs/tools/audio/spotdl/default.nix
@@ -6,27 +6,39 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "spotdl";
-  version = "3.9.6";
+  version = "4.0.6";
+
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "spotDL";
     repo = "spotify-downloader";
     rev = "refs/tags/v${version}";
-    hash = "sha256-JoeNVMuEslz7A7G4ZvikimZrG75YrH5Mx3Oamtfy4cM=";
+    hash = "sha256-oZyEh76nNKMeEenz0dNLQ5Hd9jRaot6He8toxDSZZ/8=";
   };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = true;
 
   propagatedBuildInputs = with python3.pkgs; [
     spotipy
-    pytube
-    rich
-    rapidfuzz
-    mutagen
     ytmusicapi
+    pytube
     yt-dlp
+    mutagen
+    rich
     beautifulsoup4
     requests
-    unidecode
-    setuptools
+    rapidfuzz
+    python-slugify
+    uvicorn
+    pydantic
+    fastapi
+    platformdirs
   ];
 
   checkInputs = with python3.pkgs; [
@@ -37,8 +49,36 @@ python3.pkgs.buildPythonApplication rec {
     pytest-subprocess
   ];
 
-  # requires networking
-  doCheck = false;
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  disabledTestPaths = [
+    # require networking
+    "tests/test_init.py"
+    "tests/test_matching.py"
+    "tests/utils/test_m3u.py"
+    "tests/utils/test_metadata.py"
+    "tests/utils/test_search.py"
+  ];
+
+  disabledTests = [
+    # require networking
+    "test_album_from_string"
+    "test_album_from_url"
+    "test_album_length"
+    "test_artist_from_url"
+    "test_artist_from_string"
+    "test_convert"
+    "test_download_ffmpeg"
+    "test_download_song"
+    "test_playlist_from_string"
+    "test_playlist_from_url"
+    "test_playlist_length"
+    "test_preload_song"
+    "test_song_from_search_term"
+    "test_song_from_url"
+  ];
 
   makeWrapperArgs = [
     "--prefix" "PATH" ":" (lib.makeBinPath [ ffmpeg ])


### PR DESCRIPTION
###### Description of changes

https://github.com/spotDL/spotify-downloader/releases/tag/v4.0.0 https://github.com/spotDL/spotify-downloader/releases/tag/v4.0.1 https://github.com/spotDL/spotify-downloader/releases/tag/v4.0.2 https://github.com/spotDL/spotify-downloader/releases/tag/v4.0.3 https://github.com/spotDL/spotify-downloader/releases/tag/v4.0.4 https://github.com/spotDL/spotify-downloader/releases/tag/v4.0.5 https://github.com/spotDL/spotify-downloader/releases/tag/v4.0.6


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
