### PR TITLE
decker: init at 1.31

### DIFF
--- a/pkgs/by-name/de/decker/package.nix
+++ b/pkgs/by-name/de/decker/package.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, SDL2
+, SDL2_image
+, unixtools
+, multimarkdown
+}:
+
+stdenv.mkDerivation rec {
+  pname = "decker";
+  version = "1.31";
+
+  src = fetchFromGitHub {
+    owner = "JohnEarnest";
+    repo = "Decker";
+    rev = "v${version}";
+    hash = "sha256-9utCIf7LO/ms46QqagkcXZ3BuvRuLa6nE78MgkbaEjA=";
+  };
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    multimarkdown
+    unixtools.xxd
+  ];
+
+  doCheck = true;
+
+  postPatch = ''
+    patchShebangs ./scripts
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make lilt
+    make decker
+    make docs
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 ./c/build/lilt -t $out/bin
+    install -Dm0755 ./c/build/decker -t $out/bin
+    install -Dm0644 ./syntax/vim/ftdetect/lil.vim -t $out/share/vim-plugins/decker/ftdetect
+    install -Dm0644 ./syntax/vim/syntax/lil.vim -t $out/share/vim-plugins/decker/syntax
+
+    # Fixing the permissions of the installed files on the documentation.
+    chmod a-x ./docs/images/* \
+              ./docs/*.md \
+              ./examples/decks/*.deck \
+              ./examples/lilt/*.lil
+
+    # This example has a shebang so we'll leave it as an executable.
+    chmod a+x ./examples/lilt/podcasts.lil
+
+    mkdir -p $out/share/doc/decker
+    cp -r ./docs/*.html ./docs/images ./examples $out/share/doc/decker
+
+    runHook postInstall
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    make test
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://beyondloom.com/decker";
+    description = "Multimedia platform for creating and sharing interactive documents";
+    license = licenses.mit;
+    mainProgram = "decker";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ foo-dogsquared ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add Decker, a multimedia sketchpad.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

There are some things I don't know how to do properly such as installing those Vim plugins (or could be added as a separate package if that is preferred).