### PR TITLE
gimme-aws-creds: init at 2.4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3390,6 +3390,12 @@
     githubId = 62989;
     name = "Demyan Rogozhin";
   };
+  dennajort = {
+    email = "1536838+dennajort@users.noreply.github.com";
+    github = "dennajort";
+    githubId = 1536838;
+    name = "JB Gosselin";
+  };
   derchris = {
     email = "derchris@me.com";
     github = "derchrisuk";

--- a/pkgs/development/python-modules/ctap-keyring-device/default.nix
+++ b/pkgs/development/python-modules/ctap-keyring-device/default.nix
@@ -1,36 +1,43 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-# , six
-# , cryptography
-# , mock
-# , pyfakefs
-# , unittestCheckHook
+, fido2
+, keyring
+, cryptography
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "ctap-keyring-device";
   version = "1.0.6";
-  format = "wheel";
+  format = "pyproject";
 
   src = fetchPypi {
-    inherit version format;
-    pname = "ctap_keyring_device";
-    sha256 = "sha256-EsCKq9YDGL1CI+69EkY+l5uOv+w2xZQwWbLsoibtFCc=";
+    inherit version pname;
+    sha256 = "sha256-pEJkuz0wxKt2PkowmLE2YC+HPYa2ZiENK7FAW14Ec/Y=";
   };
 
-  # propagatedBuildInputs = [ six cryptography ];
+  # removing optional dependency needing pyobjc
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "pyobjc-framework-LocalAuthentication >= 7.1; platform_system=='Darwin'" ""
+  '';
 
-  # checkInputs = [ unittestCheckHook mock pyfakefs ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
-  # unittestFlagsArray = [ "-v" ];
+  propagatedBuildInputs = [
+    keyring
+    fido2
+    cryptography
+  ];
 
-  # pythonImportsCheck = [ "fido2" ];
+  pythonImportsCheck = [ "ctap_keyring_device" ];
 
   meta = with lib; {
     description = "CTAP (client-to-authenticator-protocol) device backed by python's keyring library";
     homepage = "https://github.com/dany74q/ctap-keyring-device";
     license = licenses.mit;
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = with maintainers; [ dennajort ];
   };
 }

--- a/pkgs/development/python-modules/ctap-keyring-device/default.nix
+++ b/pkgs/development/python-modules/ctap-keyring-device/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+# , six
+# , cryptography
+# , mock
+# , pyfakefs
+# , unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ctap-keyring-device";
+  version = "1.0.6";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit version format;
+    pname = "ctap_keyring_device";
+    sha256 = "sha256-EsCKq9YDGL1CI+69EkY+l5uOv+w2xZQwWbLsoibtFCc=";
+  };
+
+  # propagatedBuildInputs = [ six cryptography ];
+
+  # checkInputs = [ unittestCheckHook mock pyfakefs ];
+
+  # unittestFlagsArray = [ "-v" ];
+
+  # pythonImportsCheck = [ "fido2" ];
+
+  meta = with lib; {
+    description = "CTAP (client-to-authenticator-protocol) device backed by python's keyring library";
+    homepage = "https://github.com/dany74q/ctap-keyring-device";
+    license = licenses.mit;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/python-modules/okta/default.nix
+++ b/pkgs/development/python-modules/okta/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pycryptodome
+, yarl
+, flatdict
+, python-jose
+, aenum
+, aiohttp
+, pydash
+, xmltodict
+, pyyaml
+, pytest
+, pytest-recording
+, pytest-asyncio
+, pytest-mock
+, tox
+}:
+
+buildPythonPackage rec {
+  pname = "okta";
+  version = "2.8.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "sha256-yIVJoKX9b9Y7Ydl28twHxgPbUa58LJ12Oz3tvpU7CAc=";
+  };
+
+  propagatedBuildInputs = [
+    pycryptodome
+    yarl
+    flatdict
+    python-jose
+    aenum
+    aiohttp
+    pydash
+    xmltodict
+    pyyaml
+  ];
+
+  checkInputs = [
+    tox
+    pytest
+    pytest-asyncio
+    pytest-mock
+    pytest-recording
+  ];
+
+  checkPhase = ''
+    tox
+  '';
+
+  pythonImportsCheck = [
+    "okta"
+    "okta.cache"
+    "okta.client"
+    "okta.exceptions"
+    "okta.http_client"
+    "okta.models"
+    "okta.request_executor"
+  ];
+
+  meta = with lib; {
+    description = "Python SDK for the Okta Management API";
+    homepage = "https://github.com/okta/okta-sdk-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dennajort ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-recording/default.nix
+++ b/pkgs/development/python-modules/pytest-recording/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-recording";
+  version = "0.12.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5cd3289745ab3156d43eb9c8e7f7d00a926f3ae5c9cf425bec649b2fe15bad5b";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "A pytest plugin that allows you recording of network interactions via VCR.py";
+    homepage = "https://github.com/kiwicom/pytest-recording";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dennajort ];
+  };
+}

--- a/pkgs/tools/admin/gimme-aws-creds/default.nix
+++ b/pkgs/tools/admin/gimme-aws-creds/default.nix
@@ -1,0 +1,150 @@
+{ lib
+, python3
+# , groff
+# , less
+# , nix-update-script
+# , testers
+}:
+
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+      fido2 = super.fido2.overridePythonAttrs (oldAttrs: rec {
+        version = "0.9.3";
+        src = self.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          hash = "sha256-tF6JphCc/Lfxu1E3dqotZAjpXEgi+DolORi5RAg0Zuw=";
+        };
+      });
+
+      # awscrt = super.awscrt.overridePythonAttrs (oldAttrs: rec {
+      #   version = "0.14.0";
+      #   src = self.fetchPypi {
+      #     inherit (oldAttrs) pname;
+      #     inherit version;
+      #     hash = "sha256-MGLTFcsWVC/gTdgjny6LwyOO6QRc1QcLkVzy677Lqqw=";
+      #   };
+      # });
+
+      # prompt-toolkit = super.prompt-toolkit.overridePythonAttrs (oldAttrs: rec {
+      #   version = "3.0.28";
+      #   src = self.fetchPypi {
+      #     pname = "prompt_toolkit";
+      #     inherit version;
+      #     hash = "sha256-nxzRax6GwpaPJRnX+zHdnWaZFvUVYSwmnRTp7VK1FlA=";
+      #   };
+      # });
+    };
+  };
+
+  # py = python3;
+in
+with py.pkgs; buildPythonApplication rec {
+  pname = "gimme-aws-creds";
+  version = "2.4.4"; # N.B: if you change this, check if overrides are still up-to-date
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit version format;
+    pname = "gimme_aws_creds";
+    hash = "sha256-twD/hb1kPBKegNLifdH1Kk6f8Cf0bsvP/tkQNTccSEg=";
+  };
+
+  nativeBuildInputs = [
+    # flit-core
+  ];
+
+  propagatedBuildInputs = [
+    boto3
+    python-dateutil
+    fido2
+    beautifulsoup4
+    # awscrt
+    # bcdoc
+    # colorama
+    # cryptography
+    # distro
+    # docutils
+    # groff
+    # less
+    # prompt-toolkit
+    # pyyaml
+    # rsa
+    # ruamel-yaml
+    # python-dateutil
+    # jmespath
+    # urllib3
+  ];
+
+  checkInputs = [
+    # jsonschema
+    # mock
+    # pytestCheckHook
+  ];
+
+  # postPatch = ''
+  #   substituteInPlace pyproject.toml \
+  #     --replace "colorama>=0.2.5,<0.4.4" "colorama" \
+  #     --replace "distro>=1.5.0,<1.6.0" "distro" \
+  #     --replace "cryptography>=3.3.2,<=38.0.1" "cryptography>=3.3.2,<=38.0.3"
+  # '';
+
+  # postInstall = ''
+  #   mkdir -p $out/${python3.sitePackages}/awscli/data
+  #   ${python3.interpreter} scripts/gen-ac-index --index-location $out/${python3.sitePackages}/awscli/data/ac.index
+
+  #   mkdir -p $out/share/bash-completion/completions
+  #   echo "complete -C $out/bin/aws_completer aws" > $out/share/bash-completion/completions/aws
+
+  #   mkdir -p $out/share/zsh/site-functions
+  #   mv $out/bin/aws_zsh_completer.sh $out/share/zsh/site-functions
+
+  #   rm $out/bin/aws.cmd
+  # '';
+
+  # doCheck = true;
+
+  # preCheck = ''
+  #   export PATH=$PATH:$out/bin
+  #   export HOME=$(mktemp -d)
+  # '';
+
+  # pytestFlagsArray = [
+  #   "-Wignore::DeprecationWarning"
+  # ];
+
+  # disabledTestPaths = [
+  #   # Integration tests require networking
+  #   "tests/integration"
+
+  #   # Disable slow tests (only run unit tests)
+  #   "tests/backends"
+  #   "tests/functional"
+  # ];
+
+  # pythonImportsCheck = [
+  #   "awscli"
+  # ];
+
+  # passthru = {
+  #   python = py; # for aws_shell
+  #   updateScript = nix-update-script {
+  #     attrPath = pname;
+  #   };
+  #   tests.version = testers.testVersion {
+  #     package = awscli2;
+  #     command = "aws --version";
+  #     version = version;
+  #   };
+  # };
+
+  meta = with lib; {
+    homepage = "https://github.com/Nike-Inc/gimme-aws-creds";
+    changelog = "https://github.com/Nike-Inc/gimme-aws-creds/releases";
+    description = "A CLI that utilizes Okta IdP via SAML to acquire temporary AWS credentials";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bhipple davegallant bryanasdev000 devusb anthonyroussel ];
+    mainProgram = "gimme-aws-creds";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16354,6 +16354,8 @@ with pkgs;
 
   gImageReader = callPackage ../applications/misc/gImageReader { };
 
+  gimme-aws-creds = callPackage ../tools/admin/gimme-aws-creds { };
+
   guile_1_8 = callPackage ../development/interpreters/guile/1.8.nix { };
 
   # Needed for autogen

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6453,6 +6453,8 @@ self: super: with self; {
 
   oemthermostat = callPackage ../development/python-modules/oemthermostat { };
 
+  okta = callPackage ../development/python-modules/okta { };
+
   olefile = callPackage ../development/python-modules/olefile { };
 
   oletools = callPackage ../development/python-modules/oletools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2091,6 +2091,8 @@ self: super: with self; {
 
   csvw = callPackage ../development/python-modules/csvw { };
 
+  ctap-keyring-device = callPackage ../development/python-modules/ctap-keyring-device { };
+
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };
 
   cufflinks = callPackage ../development/python-modules/cufflinks { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8935,6 +8935,8 @@ self: super: with self; {
 
   pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };
 
+  pytest-recording = callPackage ../development/python-modules/pytest-recording { };
+
   pytest-regressions = callPackage ../development/python-modules/pytest-regressions { };
 
   pytest-relaxed = callPackage ../development/python-modules/pytest-relaxed { };


### PR DESCRIPTION
###### Description of changes

- Add python application `gimme-aws-creds` https://github.com/Nike-Inc/gimme-aws-creds
- Add python library `okta` https://github.com/okta/okta-sdk-python
- Add python library `ctap-keyring-device` https://github.com/dany74q/ctap-keyring-device with patch for missing `pyobjc`
- Add python library `pytest-recording` https://github.com/kiwicom/pytest-recording

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
