### PR TITLE
cinnamon.nemo: Workaround duplicate right-click menu items

### DIFF
--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -34,6 +34,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ztx3Y+n9Bpzuz06mbkis3kdlM/0JrOaMDbRF5glzkDE=";
   };
 
+  patches = [
+    # Don't populate nemo actions from /run/current-system/sw/share
+    # They should only be loaded exactly once from $out/share
+    # https://github.com/NixOS/nixpkgs/issues/190781
+    ./fix-nemo-actions-duplicate-menu-items.patch
+  ];
+
   outputs = [ "out" "dev" ];
 
   buildInputs = [

--- a/pkgs/desktops/cinnamon/nemo/fix-nemo-actions-duplicate-menu-items.patch
+++ b/pkgs/desktops/cinnamon/nemo/fix-nemo-actions-duplicate-menu-items.patch
@@ -1,0 +1,48 @@
+diff --git a/libnemo-private/nemo-action-manager.c b/libnemo-private/nemo-action-manager.c
+index 4dac198..b671421 100644
+--- a/libnemo-private/nemo-action-manager.c
++++ b/libnemo-private/nemo-action-manager.c
+@@ -146,6 +146,8 @@ set_up_actions_directories (NemoActionManager *action_manager)
+     data_dirs = (gchar **) g_get_system_data_dirs ();
+ 
+     for (i = 0; i < g_strv_length (data_dirs); i++) {
++        if (g_strcmp0 (data_dirs[i], "/run/current-system/sw/share") == 0)
++            continue;
+         path = g_build_filename (data_dirs[i], "nemo", "actions", NULL);
+         uri = g_filename_to_uri (path, NULL, NULL);
+ 
+diff --git a/src/nemo-action-config-widget.c b/src/nemo-action-config-widget.c
+index fc4075e..6e1c837 100644
+--- a/src/nemo-action-config-widget.c
++++ b/src/nemo-action-config-widget.c
+@@ -221,6 +221,8 @@ refresh_widget (NemoActionConfigWidget *widget)
+     data_dirs = (gchar **) g_get_system_data_dirs ();
+ 
+     for (i = 0; i < g_strv_length (data_dirs); i++) {
++        if (g_strcmp0 (data_dirs[i], "/run/current-system/sw/share") == 0)
++            continue;
+         path = g_build_filename (data_dirs[i], "nemo", "actions", NULL);
+         populate_from_directory (widget, path);
+         g_clear_pointer (&path, g_free);
+@@ -390,6 +392,8 @@ static void setup_dir_monitors (NemoActionConfigWidget *widget)
+ 
+     guint i;
+     for (i = 0; i < g_strv_length (data_dirs); i++) {
++        if (g_strcmp0 (data_dirs[i], "/run/current-system/sw/share") == 0)
++            continue;
+         gchar *path = g_build_filename (data_dirs[i], "nemo", "actions", NULL);
+         try_monitor_path (widget, path);
+         g_free (path);
+diff --git a/src/nemo-script-config-widget.c b/src/nemo-script-config-widget.c
+index 3a2d349..b8a85b4 100644
+--- a/src/nemo-script-config-widget.c
++++ b/src/nemo-script-config-widget.c
+@@ -288,6 +288,8 @@ static void setup_dir_monitors (NemoScriptConfigWidget *widget)
+ 
+     guint i;
+     for (i = 0; i < g_strv_length (data_dirs); i++) {
++        if (g_strcmp0 (data_dirs[i], "/run/current-system/sw/share") == 0)
++            continue;
+         gchar *path = g_build_filename (data_dirs[i], "nemo", "actions", NULL);
+         try_monitor_path (widget, path);
+         g_free (path);


### PR DESCRIPTION
###### Description of changes

Don't populate nemo actions from `/run/current-system/sw/share`, they should only be loaded **exactly** once as `$out/share`.

- Helps https://github.com/NixOS/nixpkgs/issues/190781 (don't close it for now).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
