### PR TITLE
package-project-cmake: init at 1.10.0

### DIFF
--- a/pkgs/development/tools/package-project-cmake/default.nix
+++ b/pkgs/development/tools/package-project-cmake/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "package-project-cmake";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "TheLartians";
+    repo = "PackageProject.cmake";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-tDjWknwqN8NLx6GX16WOn0JUDAyaGU9HA7fTsHNLx9s=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/{,doc/}package-project-cmake
+    install -Dm644 CMakeLists.txt $out/share/package-project-cmake/
+    install -Dm644 README.md $out/share/doc/package-project-cmake/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/TheLartians/PackageProject.cmake";
+    description = "A CMake script for packaging C/C++ projects";
+    longDescription = ''
+      Help other developers use your project. A CMake script for packaging
+      C/C++ projects for simple project installation while employing
+      best-practices for maximum compatibility. Creating installable
+      CMake scripts always requires a large amount of boilerplate code
+      to get things working. This small script should simplify the CMake
+      packaging process into a single, easy-to-use command.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ ken-matsui ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17723,6 +17723,8 @@ with pkgs;
     libiberty_static = libiberty.override { staticBuild = true; };
   };
 
+  package-project-cmake = callPackage ../development/tools/package-project-cmake { };
+
   pactorio = callPackage ../development/tools/pactorio {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Related to
* https://github.com/NixOS/nixpkgs/pull/178258
* https://github.com/NixOS/nixpkgs/pull/206482