### PR TITLE
[DRAFT] forgejo: init at 1.18.0-rc1-1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -587,6 +587,7 @@
   ./services/misc/etesync-dav.nix
   ./services/misc/exhibitor.nix
   ./services/misc/felix.nix
+  ./services/misc/forgejo.nix
   ./services/misc/freeswitch.nix
   ./services/misc/fstrim.nix
   ./services/misc/gammu-smsd.nix

--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -1,0 +1,663 @@
+{ config, lib, options, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.forgejo;
+  opt = options.services.forgejo;
+  forgejo = cfg.package;
+  pg = config.services.postgresql;
+  useMysql = cfg.database.type == "mysql";
+  usePostgresql = cfg.database.type == "postgres";
+  useSqlite = cfg.database.type == "sqlite3";
+  format = pkgs.formats.ini { };
+  configFile = pkgs.writeText "app.ini" ''
+    APP_NAME = ${cfg.appName}
+    RUN_USER = ${cfg.user}
+    RUN_MODE = prod
+
+    ${generators.toINI {} cfg.settings}
+
+    ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
+  '';
+in
+
+{
+  imports = [
+    (mkRenamedOptionModule [ "services" "forgejo" "cookieSecure" ] [ "services" "forgejo" "settings" "session" "COOKIE_SECURE" ])
+    (mkRenamedOptionModule [ "services" "forgejo" "disableRegistration" ] [ "services" "forgejo" "settings" "service" "DISABLE_REGISTRATION" ])
+    (mkRenamedOptionModule [ "services" "forgejo" "log" "level" ] [ "services" "forgejo" "settings" "log" "LEVEL" ])
+    (mkRenamedOptionModule [ "services" "forgejo" "log" "rootPath" ] [ "services" "forgejo" "settings" "log" "ROOT_PATH" ])
+    (mkRenamedOptionModule [ "services" "forgejo" "ssh" "clonePort" ] [ "services" "forgejo" "settings" "server" "SSH_PORT" ])
+
+    (mkRemovedOptionModule [ "services" "forgejo" "ssh" "enable" ] "services.forgejo.ssh.enable has been migrated into freeform setting services.forgejo.settings.server.DISABLE_SSH. Keep in mind that the setting is inverted")
+  ];
+
+  options = {
+    services.forgejo = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = lib.mdDoc "Enable Forgejo Service.";
+      };
+
+      package = mkOption {
+        default = pkgs.forgejo;
+        type = types.package;
+        defaultText = literalExpression "pkgs.forgejo";
+        description = lib.mdDoc "forgejo derivation to use";
+      };
+
+      useWizard = mkOption {
+        default = false;
+        type = types.bool;
+        description = lib.mdDoc "Do not generate a configuration and use forgejo' installation wizard instead. The first registered user will be administrator.";
+      };
+
+      stateDir = mkOption {
+        default = "/var/lib/forgejo";
+        type = types.str;
+        description = lib.mdDoc "forgejo data directory.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "forgejo";
+        description = lib.mdDoc "User account under which forgejo runs.";
+      };
+
+      database = {
+        type = mkOption {
+          type = types.enum [ "sqlite3" "mysql" "postgres" ];
+          example = "mysql";
+          default = "sqlite3";
+          description = lib.mdDoc "Database engine to use.";
+        };
+
+        host = mkOption {
+          type = types.str;
+          default = "127.0.0.1";
+          description = lib.mdDoc "Database host address.";
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = if !usePostgresql then 3306 else pg.port;
+          defaultText = literalExpression ''
+            if config.${opt.database.type} != "postgresql"
+            then 3306
+            else config.${options.services.postgresql.port}
+          '';
+          description = lib.mdDoc "Database host port.";
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "forgejo";
+          description = lib.mdDoc "Database name.";
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "forgejo";
+          description = lib.mdDoc "Database user.";
+        };
+
+        password = mkOption {
+          type = types.str;
+          default = "";
+          description = lib.mdDoc ''
+            The password corresponding to {option}`database.user`.
+            Warning: this is stored in cleartext in the Nix store!
+            Use {option}`database.passwordFile` instead.
+          '';
+        };
+
+        passwordFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/run/keys/forgejo-dbpassword";
+          description = lib.mdDoc ''
+            A file containing the password corresponding to
+            {option}`database.user`.
+          '';
+        };
+
+        socket = mkOption {
+          type = types.nullOr types.path;
+          default = if (cfg.database.createDatabase && usePostgresql) then "/run/postgresql" else if (cfg.database.createDatabase && useMysql) then "/run/mysqld/mysqld.sock" else null;
+          defaultText = literalExpression "null";
+          example = "/run/mysqld/mysqld.sock";
+          description = lib.mdDoc "Path to the unix socket file to use for authentication.";
+        };
+
+        path = mkOption {
+          type = types.str;
+          default = "${cfg.stateDir}/data/forgejo.db";
+          defaultText = literalExpression ''"''${config.${opt.stateDir}}/data/forgejo.db"'';
+          description = lib.mdDoc "Path to the sqlite3 database file.";
+        };
+
+        createDatabase = mkOption {
+          type = types.bool;
+          default = true;
+          description = lib.mdDoc "Whether to create a local database automatically.";
+        };
+      };
+
+      dump = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = lib.mdDoc ''
+            Enable a timer that runs forgejo dump to generate backup-files of the
+            current forgejo database and repositories.
+          '';
+        };
+
+        interval = mkOption {
+          type = types.str;
+          default = "04:31";
+          example = "hourly";
+          description = lib.mdDoc ''
+            Run a forgejo dump at this interval. Runs by default at 04:31 every day.
+
+            The format is described in
+            {manpage}`systemd.time(7)`.
+          '';
+        };
+
+        backupDir = mkOption {
+          type = types.str;
+          default = "${cfg.stateDir}/dump";
+          defaultText = literalExpression ''"''${config.${opt.stateDir}}/dump"'';
+          description = lib.mdDoc "Path to the dump files.";
+        };
+
+        type = mkOption {
+          type = types.enum [ "zip" "rar" "tar" "sz" "tar.gz" "tar.xz" "tar.bz2" "tar.br" "tar.lz4" ];
+          default = "zip";
+          description = lib.mdDoc "Archive format used to store the dump file.";
+        };
+
+        file = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = lib.mdDoc "Filename to be used for the dump. If `null` a default name is choosen by forgejo.";
+          example = "forgejo-dump";
+        };
+      };
+
+      lfs = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = lib.mdDoc "Enables git-lfs support.";
+        };
+
+        contentDir = mkOption {
+          type = types.str;
+          default = "${cfg.stateDir}/data/lfs";
+          defaultText = literalExpression ''"''${config.${opt.stateDir}}/data/lfs"'';
+          description = lib.mdDoc "Where to store LFS files.";
+        };
+      };
+
+      appName = mkOption {
+        type = types.str;
+        default = "forgejo: Forgejo Service";
+        description = lib.mdDoc "Application name.";
+      };
+
+      repositoryRoot = mkOption {
+        type = types.str;
+        default = "${cfg.stateDir}/repositories";
+        defaultText = literalExpression ''"''${config.${opt.stateDir}}/repositories"'';
+        description = lib.mdDoc "Path to the git repositories.";
+      };
+
+      domain = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = lib.mdDoc "Domain name of your server.";
+      };
+
+      rootUrl = mkOption {
+        type = types.str;
+        default = "http://localhost:3000/";
+        description = lib.mdDoc "Full public URL of forgejo server.";
+      };
+
+      httpAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        description = lib.mdDoc "HTTP listen address.";
+      };
+
+      httpPort = mkOption {
+        type = types.port;
+        default = 3000;
+        description = lib.mdDoc "HTTP listen port.";
+      };
+
+      enableUnixSocket = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Configure Forgejo to listen on a unix socket instead of the default TCP port.";
+      };
+
+      staticRootPath = mkOption {
+        type = types.either types.str types.path;
+        default = forgejo.data;
+        defaultText = literalExpression "package.data";
+        example = "/var/lib/forgejo/data";
+        description = lib.mdDoc "Upper level of template and static files path.";
+      };
+
+      mailerPasswordFile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "/var/lib/secrets/forgejo/mailpw";
+        description = lib.mdDoc "Path to a file containing the SMTP password.";
+      };
+
+      settings = mkOption {
+        default = { };
+        description = lib.mdDoc ''
+          Forgejo configuration. Refer to <https://docs.gitea.io/en-us/config-cheat-sheet/>
+          for details on supported values.
+        '';
+        example = literalExpression ''
+          {
+            "cron.sync_external_users" = {
+              RUN_AT_START = true;
+              SCHEDULE = "@every 24h";
+              UPDATE_EXISTING = true;
+            };
+            mailer = {
+              ENABLED = true;
+              MAILER_TYPE = "sendmail";
+              FROM = "do-not-reply@example.org";
+              SENDMAIL_PATH = "''${pkgs.system-sendmail}/bin/sendmail";
+            };
+            other = {
+              SHOW_FOOTER_VERSION = false;
+            };
+          }
+        '';
+        type = with types; submodule {
+          freeformType = format.type;
+          options = {
+            log = {
+              ROOT_PATH = mkOption {
+                default = "${cfg.stateDir}/log";
+                defaultText = literalExpression ''"''${config.${opt.stateDir}}/log"'';
+                type = types.str;
+                description = lib.mdDoc "Root path for log files.";
+              };
+              LEVEL = mkOption {
+                default = "Info";
+                type = types.enum [ "Trace" "Debug" "Info" "Warn" "Error" "Critical" ];
+                description = lib.mdDoc "General log level.";
+              };
+            };
+
+            server = {
+              DISABLE_SSH = mkOption {
+                type = types.bool;
+                default = false;
+                description = lib.mdDoc "Disable external SSH feature.";
+              };
+
+              SSH_PORT = mkOption {
+                type = types.port;
+                default = 22;
+                example = 2222;
+                description = lib.mdDoc ''
+                  SSH port displayed in clone URL.
+                  The option is required to configure a service when the external visible port
+                  differs from the local listening port i.e. if port forwarding is used.
+                '';
+              };
+            };
+
+            service = {
+              DISABLE_REGISTRATION = mkEnableOption (lib.mdDoc "the registration lock") // {
+                description = lib.mdDoc ''
+                  By default any user can create an account on this `forgejo` instance.
+                  This can be disabled by using this option.
+
+                  *Note:* please keep in mind that this should be added after the initial
+                  deploy unless [](#opt-services.forgejo.useWizard)
+                  is `true` as the first registered user will be the administrator if
+                  no install wizard is used.
+                '';
+              };
+            };
+
+            session = {
+              COOKIE_SECURE = mkOption {
+                type = types.bool;
+                default = false;
+                description = lib.mdDoc ''
+                  Marks session cookies as "secure" as a hint for browsers to only send
+                  them via HTTPS. This option is recommend, if forgejo is being served over HTTPS.
+                '';
+              };
+            };
+          };
+        };
+      };
+
+      extraConfig = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = lib.mdDoc "Configuration lines appended to the generated forgejo configuration file.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.database.createDatabase -> cfg.database.user == cfg.user;
+        message = "services.forgejo.database.user must match services.forgejo.user if the database is to be automatically provisioned";
+      }
+    ];
+
+    services.forgejo.settings = {
+      database = mkMerge [
+        {
+          DB_TYPE = cfg.database.type;
+        }
+        (mkIf (useMysql || usePostgresql) {
+          HOST = if cfg.database.socket != null then cfg.database.socket else cfg.database.host + ":" + toString cfg.database.port;
+          NAME = cfg.database.name;
+          USER = cfg.database.user;
+          PASSWD = "#dbpass#";
+        })
+        (mkIf useSqlite {
+          PATH = cfg.database.path;
+        })
+        (mkIf usePostgresql {
+          SSL_MODE = "disable";
+        })
+      ];
+
+      repository = {
+        ROOT = cfg.repositoryRoot;
+      };
+
+      server = mkMerge [
+        {
+          DOMAIN = cfg.domain;
+          STATIC_ROOT_PATH = toString cfg.staticRootPath;
+          LFS_JWT_SECRET = "#lfsjwtsecret#";
+          ROOT_URL = cfg.rootUrl;
+        }
+        (mkIf cfg.enableUnixSocket {
+          PROTOCOL = "unix";
+          HTTP_ADDR = "/run/forgejo/forgejo.sock";
+        })
+        (mkIf (!cfg.enableUnixSocket) {
+          HTTP_ADDR = cfg.httpAddress;
+          HTTP_PORT = cfg.httpPort;
+        })
+        (mkIf cfg.lfs.enable {
+          LFS_START_SERVER = true;
+          LFS_CONTENT_PATH = cfg.lfs.contentDir;
+        })
+
+      ];
+
+      session = {
+        COOKIE_NAME = lib.mkDefault "session";
+      };
+
+      security = {
+        SECRET_KEY = "#secretkey#";
+        INTERNAL_TOKEN = "#internaltoken#";
+        INSTALL_LOCK = true;
+      };
+
+      mailer = mkIf (cfg.mailerPasswordFile != null) {
+        PASSWD = "#mailerpass#";
+      };
+
+      oauth2 = {
+        JWT_SECRET = "#oauth2jwtsecret#";
+      };
+    };
+
+    services.postgresql = optionalAttrs (usePostgresql && cfg.database.createDatabase) {
+      enable = mkDefault true;
+
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensurePermissions = { "DATABASE ${cfg.database.name}" = "ALL PRIVILEGES"; };
+        }
+      ];
+    };
+
+    services.mysql = optionalAttrs (useMysql && cfg.database.createDatabase) {
+      enable = mkDefault true;
+      package = mkDefault pkgs.mariadb;
+
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
+        }
+      ];
+    };
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.dump.backupDir}' 0750 ${cfg.user} forgejo - -"
+      "z '${cfg.dump.backupDir}' 0750 ${cfg.user} forgejo - -"
+      "Z '${cfg.dump.backupDir}' - ${cfg.user} forgejo - -"
+      "d '${cfg.lfs.contentDir}' 0750 ${cfg.user} forgejo - -"
+      "z '${cfg.lfs.contentDir}' 0750 ${cfg.user} forgejo - -"
+      "Z '${cfg.lfs.contentDir}' - ${cfg.user} forgejo - -"
+      "d '${cfg.repositoryRoot}' 0750 ${cfg.user} forgejo - -"
+      "z '${cfg.repositoryRoot}' 0750 ${cfg.user} forgejo - -"
+      "Z '${cfg.repositoryRoot}' - ${cfg.user} forgejo - -"
+      "d '${cfg.stateDir}' 0750 ${cfg.user} forgejo - -"
+      "d '${cfg.stateDir}/conf' 0750 ${cfg.user} forgejo - -"
+      "d '${cfg.stateDir}/custom' 0750 ${cfg.user} forgejo - -"
+      "d '${cfg.stateDir}/custom/conf' 0750 ${cfg.user} forgejo - -"
+      "d '${cfg.stateDir}/log' 0750 ${cfg.user} forgejo - -"
+      "z '${cfg.stateDir}' 0750 ${cfg.user} forgejo - -"
+      "z '${cfg.stateDir}/.ssh' 0700 ${cfg.user} forgejo - -"
+      "z '${cfg.stateDir}/conf' 0750 ${cfg.user} forgejo - -"
+      "z '${cfg.stateDir}/custom' 0750 ${cfg.user} forgejo - -"
+      "z '${cfg.stateDir}/custom/conf' 0750 ${cfg.user} forgejo - -"
+      "z '${cfg.stateDir}/log' 0750 ${cfg.user} forgejo - -"
+      "Z '${cfg.stateDir}' - ${cfg.user} forgejo - -"
+
+      # If we have a folder or symlink with forgejo locales, remove it
+      # And symlink the current forgejo locales in place
+      "L+ '${cfg.stateDir}/conf/locale' - - - - ${forgejo.out}/locale"
+    ];
+
+    systemd.services.forgejo = {
+      description = "forgejo";
+      after = [ "network.target" ] ++ lib.optional usePostgresql "postgresql.service" ++ lib.optional useMysql "mysql.service";
+      wantedBy = [ "multi-user.target" ];
+      path = [ forgejo pkgs.git pkgs.gnupg ];
+
+      # In older versions the secret naming for JWT was kind of confusing.
+      # The file jwt_secret hold the value for LFS_JWT_SECRET and JWT_SECRET
+      # wasn't persistant at all.
+      # To fix that, there is now the file oauth2_jwt_secret containing the
+      # values for JWT_SECRET and the file jwt_secret gets renamed to
+      # lfs_jwt_secret.
+      # We have to consider this to stay compatible with older installations.
+      preStart =
+        let
+          runConfig = "${cfg.stateDir}/custom/conf/app.ini";
+          secretKey = "${cfg.stateDir}/custom/conf/secret_key";
+          oauth2JwtSecret = "${cfg.stateDir}/custom/conf/oauth2_jwt_secret";
+          oldLfsJwtSecret = "${cfg.stateDir}/custom/conf/jwt_secret"; # old file for LFS_JWT_SECRET
+          lfsJwtSecret = "${cfg.stateDir}/custom/conf/lfs_jwt_secret"; # new file for LFS_JWT_SECRET
+          internalToken = "${cfg.stateDir}/custom/conf/internal_token";
+          replaceSecretBin = "${pkgs.replace-secret}/bin/replace-secret";
+        in
+        ''
+          # copy custom configuration and generate a random secret key if needed
+          ${optionalString (!cfg.useWizard) ''
+            function forgejo_setup {
+              cp -f ${configFile} ${runConfig}
+
+              if [ ! -s ${secretKey} ]; then
+                  ${forgejo}/bin/forgejo generate secret SECRET_KEY > ${secretKey}
+              fi
+
+              # Migrate LFS_JWT_SECRET filename
+              if [[ -s ${oldLfsJwtSecret} && ! -s ${lfsJwtSecret} ]]; then
+                  mv ${oldLfsJwtSecret} ${lfsJwtSecret}
+              fi
+
+              if [ ! -s ${oauth2JwtSecret} ]; then
+                  ${forgejo}/bin/forgejo generate secret JWT_SECRET > ${oauth2JwtSecret}
+              fi
+
+              if [ ! -s ${lfsJwtSecret} ]; then
+                  ${forgejo}/bin/forgejo generate secret LFS_JWT_SECRET > ${lfsJwtSecret}
+              fi
+
+              if [ ! -s ${internalToken} ]; then
+                  ${forgejo}/bin/forgejo generate secret INTERNAL_TOKEN > ${internalToken}
+              fi
+
+              chmod u+w '${runConfig}'
+              ${replaceSecretBin} '#secretkey#' '${secretKey}' '${runConfig}'
+              ${replaceSecretBin} '#dbpass#' '${cfg.database.passwordFile}' '${runConfig}'
+              ${replaceSecretBin} '#oauth2jwtsecret#' '${oauth2JwtSecret}' '${runConfig}'
+              ${replaceSecretBin} '#lfsjwtsecret#' '${lfsJwtSecret}' '${runConfig}'
+              ${replaceSecretBin} '#internaltoken#' '${internalToken}' '${runConfig}'
+
+              ${lib.optionalString (cfg.mailerPasswordFile != null) ''
+                ${replaceSecretBin} '#mailerpass#' '${cfg.mailerPasswordFile}' '${runConfig}'
+              ''}
+              chmod u-w '${runConfig}'
+            }
+            (umask 027; forgejo_setup)
+          ''}
+
+          # run migrations/init the database
+          ${forgejo}/bin/forgejo migrate
+
+          # update all hooks' binary paths
+          ${forgejo}/bin/forgejo admin regenerate hooks
+
+          # update command option in authorized_keys
+          if [ -r ${cfg.stateDir}/.ssh/authorized_keys ]
+          then
+            ${forgejo}/bin/forgejo admin regenerate keys
+          fi
+        '';
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = "forgejo";
+        WorkingDirectory = cfg.stateDir;
+        ExecStart = "${forgejo}/bin/forgejo web --pid /run/forgejo/forgejo.pid";
+        Restart = "always";
+        # Runtime directory and mode
+        RuntimeDirectory = "forgejo";
+        RuntimeDirectoryMode = "0755";
+        # Access write directories
+        ReadWritePaths = [ cfg.dump.backupDir cfg.repositoryRoot cfg.stateDir cfg.lfs.contentDir ];
+        UMask = "0027";
+        # Capabilities
+        CapabilityBoundingSet = "";
+        # Security
+        NoNewPrivileges = true;
+        # Sandboxing
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_UNIX AF_INET AF_INET6" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        PrivateMounts = true;
+        # System Call Filtering
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "~@clock @cpu-emulation @debug @keyring @memlock @module @mount @obsolete @raw-io @reboot @setuid @swap";
+      };
+
+      environment = {
+        USER = cfg.user;
+        HOME = cfg.stateDir;
+        FORGEJO_WORK_DIR = cfg.stateDir;
+      };
+    };
+
+    users.users = mkIf (cfg.user == "forgejo") {
+      forgejo = {
+        description = "Forgejo Service";
+        home = cfg.stateDir;
+        useDefaultShell = true;
+        group = "forgejo";
+        isSystemUser = true;
+      };
+    };
+
+    users.groups.forgejo = { };
+
+    warnings =
+      optional (cfg.database.password != "") "config.services.forgejo.database.password will be stored as plaintext in the Nix store. Use database.passwordFile instead." ++
+      optional (cfg.extraConfig != null) ''
+        services.forgejo.`extraConfig` is deprecated, please use services.forgejo.`settings`.
+      '';
+
+    # Create database passwordFile default when password is configured.
+    services.forgejo.database.passwordFile =
+      mkDefault (toString (pkgs.writeTextFile {
+        name = "forgejo-database-password";
+        text = cfg.database.password;
+      }));
+
+    systemd.services.forgejo-dump = mkIf cfg.dump.enable {
+      description = "forgejo dump";
+      after = [ "forgejo.service" ];
+      wantedBy = [ "default.target" ];
+      path = [ forgejo ];
+
+      environment = {
+        USER = cfg.user;
+        HOME = cfg.stateDir;
+        FORGEJO_WORK_DIR = cfg.stateDir;
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        ExecStart = "${forgejo}/bin/forgejo dump --type ${cfg.dump.type}" + optionalString (cfg.dump.file != null) " --file ${cfg.dump.file}";
+        WorkingDirectory = cfg.dump.backupDir;
+      };
+    };
+
+    systemd.timers.forgejo-dump = mkIf cfg.dump.enable {
+      description = "Update timer for forgejo-dump";
+      partOf = [ "forgejo-dump.service" ];
+      wantedBy = [ "timers.target" ];
+      timerConfig.OnCalendar = cfg.dump.interval;
+    };
+  };
+  meta.maintainers = with lib.maintainers; [ infinidoge ];
+}

--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, buildGoPackage
+, fetchurl
+, makeWrapper
+, git
+, bash
+, gzip
+, openssh
+, pam
+, sqliteSupport ? true
+, pamSupport ? true
+, nixosTests
+}:
+
+buildGoPackage rec {
+  pname = "forgejo";
+  version = "1.18.0-rc1-1";
+
+  # not fetching directly from the git repo, because that lacks several vendor files for the web UI
+  # See https://codeberg.org/forgejo/forgejo/issues/128 about URL
+  src = fetchurl {
+    name = "forgejo-src-${version}.tar.gz";
+    url = "https://codeberg.org/attachments/976c426a-3e04-49ff-9762-47fab50624a3";
+    sha256 = "sha256-kreBMHlMVB1UeG67zMbszGrgjaROateCRswH7GrKnEw=";
+  };
+
+
+  patches = [
+    ./static-root-path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace modules/setting/setting.go --subst-var data
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = lib.optional pamSupport pam;
+
+  preBuild =
+    let
+      tags = lib.optional pamSupport "pam"
+        ++ lib.optional sqliteSupport "sqlite sqlite_unlock_notify";
+      tagsString = lib.concatStringsSep " " tags;
+    in
+    ''
+      export buildFlagsArray=(
+        -tags="${tagsString}"
+        -ldflags='-X "main.Version=${version}" -X "main.Tags=${tagsString}"'
+      )
+    '';
+
+  outputs = [ "out" "data" ];
+
+  postInstall = ''
+    mkdir $data
+    cp -R ./go/src/${goPackagePath}/{public,templates,options} $data
+    mkdir -p $out
+    cp -R ./go/src/${goPackagePath}/options/locale $out/locale
+
+    wrapProgram $out/bin/gitea \
+      --prefix PATH : ${lib.makeBinPath [ bash git gzip openssh ]}
+  '';
+
+  goPackagePath = "code.gitea.io/gitea";
+
+  passthru.tests = nixosTests.gitea;
+
+  meta = with lib; {
+    description = "Beyond coding. We forge.";
+    homepage = "https://forgejo.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/applications/version-management/forgejo/static-root-path.patch
+++ b/pkgs/applications/version-management/forgejo/static-root-path.patch
@@ -1,0 +1,13 @@
+diff --git a/modules/setting/setting.go b/modules/setting/setting.go
+index 45e55a2..9d18ee4 100644
+--- a/modules/setting/setting.go
++++ b/modules/setting/setting.go
+@@ -667,7 +667,7 @@ func NewContext() {
+ 	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
+ 	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
+ 	if len(StaticRootPath) == 0 {
+-		StaticRootPath = AppWorkPath
++		StaticRootPath = "@data@"
+ 	}
+ 	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(StaticRootPath)
+ 	StaticCacheTime = sec.Key("STATIC_CACHE_TIME").MustDuration(6 * time.Hour)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7305,6 +7305,8 @@ with pkgs;
 
   free42 = callPackage ../applications/misc/free42 { };
 
+  forgejo = callPackage ../applications/version-management/forgejo { };
+
   galen = callPackage ../development/tools/galen {};
 
   gallery-dl = python3Packages.callPackage ../applications/misc/gallery-dl { };


### PR DESCRIPTION
###### Description of changes

[Forgejo](https://forgejo.org) is a new fork of [Gitea](https://gitea.io) by the people at [Codeberg](https://codeberg.org), designed to try and make a new place where the Gitea community can come together and control their project again. Codeberg themselves have stated that once Forgejo releases its first stable version, they will be switching over.

Forgejo is a soft-fork as of currently, so it shares the vast majority of its code base with Gitea, so most of the work done in this PR is just duplicating the existing things for Gitea and editing text. That being said, since Forgejo has not yet released its first stable release, I intend on keeping this PR as a draft until that happens. (Also allows for time for feedback, and for making finishing touches.)

Announcement Blog Posts:
https://blog.codeberg.org/codeberg-launches-forgejo.html
https://forgejo.org/2022-12-15-hello-forgejo/

###### TODO
- [ ] Duplicate Gitea tests
- [ ] Add release notes entry for module
- [ ] Bump to first stable release when it happens
- [ ] Change URL to not need to be manually replaced each update (See https://codeberg.org/forgejo/forgejo/issues/128)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
