### PR TITLE
bambu-studio: init at 01.06.02.04

### DIFF
--- a/pkgs/applications/misc/bambu-studio/0001-not-for-upstream-CMakeLists-Link-against-webkit2gtk-.patch
+++ b/pkgs/applications/misc/bambu-studio/0001-not-for-upstream-CMakeLists-Link-against-webkit2gtk-.patch
@@ -1,0 +1,34 @@
+From 7eed499898226222a949a792e0400ec10db4a1c9 Mon Sep 17 00:00:00 2001
+From: Zhaofeng Li <hello@zhaofeng.li>
+Date: Tue, 22 Nov 2022 13:00:39 -0700
+Subject: [PATCH] [not for upstream] CMakeLists: Link against webkit2gtk in
+ libslic3r_gui
+
+WebView.cpp uses symbols from webkitgtk directly. Upstream setup
+links wxGTK statically so webkitgtk is already pulled in.
+
+> /nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: slic3r/liblibslic3r_gui.a(WebView.cpp.o): undefined reference to symbol 'webkit_web_view_run_javascript_finish'
+> /nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/8yvy428jy2nwq4dhmrcs7gj5r27a2pv6-webkitgtk-2.38.2+abi=4.0/lib/libwebkit2gtk-4.0.so.37: error adding symbols: DSO missing from command line
+---
+ src/CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9c5cb96..e92a0e3 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -175,6 +175,11 @@ if (WIN32)
+     target_link_libraries(BambuStudio_app_gui PRIVATE boost_headeronly)
+ endif ()
+ 
++# We link against webkit2gtk symbols in src/slic3r/GUI/Widgets/WebView.cpp
++if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
++    target_link_libraries(libslic3r_gui "-lwebkit2gtk-4.0")
++endif ()
++
+ # Link the resources dir to where Slic3r GUI expects it
+ set(output_dlls_Release "")
+ set(output_dlls_Debug "")
+-- 
+2.38.1
+

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -1,0 +1,175 @@
+{ stdenv
+, lib
+, binutils
+, fetchFromGitHub
+, cmake
+, pkg-config
+, wrapGAppsHook
+, boost
+, cereal
+, cgal_5
+, curl
+, dbus
+, eigen
+, expat
+, gcc-unwrapped
+, glew
+, glfw
+, glib
+, glib-networking
+, gmp
+, gstreamer
+, gst-plugins-base
+, gst-plugins-bad
+, gtest
+, gtk3
+, hicolor-icon-theme
+, ilmbase
+, libpng
+, mesa
+, mpfr
+, nlopt
+, opencascade-occt
+, openvdb
+, pcre
+, qhull
+, systemd
+, tbb
+, webkitgtk
+, wxGTK31
+, xorg
+, fetchpatch
+, withSystemd ? stdenv.isLinux
+}:
+let
+  wxGTK31' = wxGTK31.overrideAttrs (old: {
+    configureFlags = old.configureFlags ++ [
+      # Disable noisy debug dialogs
+      "--enable-debug=no"
+    ];
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "bambu-studio";
+  version = "01.06.02.04";
+
+  src = fetchFromGitHub {
+    owner = "bambulab";
+    repo = "BambuStudio";
+    rev = "v${version}";
+    hash = "sha256-k2/0ukIVjGhUUKhaJCldTRsQcHwX/mL2ROVaiTkv/eg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    binutils
+    boost
+    cereal
+    cgal_5
+    curl
+    dbus
+    eigen
+    expat
+    gcc-unwrapped
+    glew
+    glfw
+    glib
+    glib-networking
+    gmp
+    gstreamer
+    gst-plugins-base
+    gst-plugins-bad
+    gtk3
+    hicolor-icon-theme
+    ilmbase
+    libpng
+    mesa.osmesa
+    mpfr
+    nlopt
+    opencascade-occt
+    openvdb
+    pcre
+    tbb
+    webkitgtk
+    wxGTK31'
+    xorg.libX11
+  ] ++ lib.optionals withSystemd [
+    systemd
+  ] ++ checkInputs;
+
+  patches = [
+    # Fix for webkitgtk linking
+    ./0001-not-for-upstream-CMakeLists-Link-against-webkit2gtk-.patch
+
+    # Fix null pointer deref with wxTranslations::Get()
+    #
+    # https://github.com/bambulab/BambuStudio/pull/1906
+    (fetchpatch {
+      name = "Initialize-locale-before-wxTranslations-Get.patch";
+      url = "https://github.com/zhaofengli/BambuStudio/commit/04728a14433ebd3b36032210c1ef806c63101166.patch";
+      hash = "sha256-9rk/qaDMqqN9aaK0E1ElKz1qUkznOEBlgeMSE48wQh8=";
+    })
+  ];
+
+  doCheck = true;
+  checkInputs = [ gtest ];
+
+  separateDebugInfo = true;
+
+  # The build system uses custom logic - defined in
+  # cmake/modules/FindNLopt.cmake in the package source - for finding the nlopt
+  # library, which doesn't pick up the package in the nix store.  We
+  # additionally need to set the path via the NLOPT environment variable.
+  NLOPT = nlopt;
+
+  # Disable compiler warnings that clutter the build log.
+  # It seems to be a known issue for Eigen:
+  # http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
+  NIX_CFLAGS_COMPILE = "-Wno-ignored-attributes";
+
+  # prusa-slicer uses dlopen on `libudev.so` at runtime
+  NIX_LDFLAGS = lib.optionalString withSystemd "-ludev";
+
+  # TODO: macOS
+  prePatch = ''
+    # Since version 2.5.0 of nlopt we need to link to libnlopt, as libnlopt_cxx
+    # now seems to be integrated into the main lib.
+    sed -i 's|nlopt_cxx|nlopt|g' cmake/modules/FindNLopt.cmake
+  '';
+
+  cmakeFlags = [
+    "-DSLIC3R_STATIC=0"
+    "-DSLIC3R_FHS=1"
+    "-DSLIC3R_GTK=3"
+
+    # BambuStudio-specific
+    "-DBBL_RELEASE_TO_PUBLIC=1"
+    "-DBBL_INTERNAL_TESTING=0"
+    "-DDEP_WX_GTK3=ON"
+    "-DSLIC3R_BUILD_TESTS=0"
+    "-DCMAKE_CXX_FLAGS=-DBOOST_LOG_DYN_LINK"
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "$out/lib"
+
+      # Fixes intermittent crash
+      # The upstream setup links in glew statically
+      --prefix LD_PRELOAD : "${glew.out}/lib/libGLEW.so"
+    )
+  '';
+
+  meta = with lib; {
+    description = "PC Software for BambuLab's 3D printers";
+    homepage = "https://github.com/bambulab/BambuStudio";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ zhaofengli ];
+    mainProgram = "bambu-studio";
+  };
+}

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -51,13 +51,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bambu-studio";
-  version = "01.06.02.04";
+  version = "01.07.00.65";
 
   src = fetchFromGitHub {
     owner = "bambulab";
     repo = "BambuStudio";
     rev = "v${version}";
-    hash = "sha256-k2/0ukIVjGhUUKhaJCldTRsQcHwX/mL2ROVaiTkv/eg=";
+    hash = "sha256-IYkfKumi9gy1pQ5FnOzbbozTbjd1HY/xu19hrv8Bs6s=";
   };
 
   nativeBuildInputs = [
@@ -105,15 +105,6 @@ stdenv.mkDerivation rec {
   patches = [
     # Fix for webkitgtk linking
     ./0001-not-for-upstream-CMakeLists-Link-against-webkit2gtk-.patch
-
-    # Fix null pointer deref with wxTranslations::Get()
-    #
-    # https://github.com/bambulab/BambuStudio/pull/1906
-    (fetchpatch {
-      name = "Initialize-locale-before-wxTranslations-Get.patch";
-      url = "https://github.com/zhaofengli/BambuStudio/commit/04728a14433ebd3b36032210c1ef806c63101166.patch";
-      hash = "sha256-9rk/qaDMqqN9aaK0E1ElKz1qUkznOEBlgeMSE48wQh8=";
-    })
   ];
 
   doCheck = true;

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -1,11 +1,14 @@
 { stdenv
 , lib
+, openexr
+, jemalloc
+, c-blosc
 , binutils
 , fetchFromGitHub
 , cmake
 , pkg-config
 , wrapGAppsHook
-, boost
+, boost179
 , cereal
 , cgal_5
 , curl
@@ -34,7 +37,7 @@
 , pcre
 , qhull
 , systemd
-, tbb
+, tbb_2021_8
 , webkitgtk
 , wxGTK31
 , xorg
@@ -48,16 +51,19 @@ let
       "--enable-debug=no"
     ];
   });
+  openvdb_tbb_2021_8 = openvdb.overrideAttrs (old: rec {
+    buildInputs = [ openexr boost179 tbb_2021_8 jemalloc c-blosc ilmbase ];
+  });
 in
 stdenv.mkDerivation rec {
   pname = "bambu-studio";
-  version = "01.07.06.92";
+  version = "01.08.00.62";
 
   src = fetchFromGitHub {
     owner = "bambulab";
     repo = "BambuStudio";
     rev = "v${version}";
-    hash = "sha256-6GpPBVPXPcdZ/YvG1RNaBS1DMNp7nbRH5IP1/Z4CJCc=";
+    hash = "sha256-Rb8YNf+ZQ8+9jAP/ZLze0PfY/liE7Rr2bJX33AENsbg=";
   };
 
   nativeBuildInputs = [
@@ -68,7 +74,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     binutils
-    boost
+    boost179
     cereal
     cgal_5
     curl
@@ -92,9 +98,9 @@ stdenv.mkDerivation rec {
     mpfr
     nlopt
     opencascade-occt
-    openvdb
+    openvdb_tbb_2021_8
     pcre
-    tbb
+    tbb_2021_8
     webkitgtk
     wxGTK31'
     xorg.libX11

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -51,13 +51,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bambu-studio";
-  version = "01.07.00.65";
+  version = "01.07.06.92";
 
   src = fetchFromGitHub {
     owner = "bambulab";
     repo = "BambuStudio";
     rev = "v${version}";
-    hash = "sha256-IYkfKumi9gy1pQ5FnOzbbozTbjd1HY/xu19hrv8Bs6s=";
+    hash = "sha256-6GpPBVPXPcdZ/YvG1RNaBS1DMNp7nbRH5IP1/Z4CJCc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/wxwidgets/wxGTK31.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK31.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, curl
 , gst_all_1
 , gtk3
 , libGL
@@ -14,6 +15,7 @@
 , compat28 ? false
 , compat30 ? true
 , unicode ? true
+, withCurl ? false
 , withEGL ? true
 , withMesa ? !stdenv.isDarwin
 , withWebKit ? stdenv.isDarwin
@@ -59,6 +61,7 @@ stdenv.mkDerivation rec {
     libXxf86vm
     xorgproto
   ]
+  ++ lib.optional withCurl curl
   ++ lib.optional withMesa libGLU
   ++ lib.optional (withWebKit && !stdenv.isDarwin) webkitgtk
   ++ lib.optional (withWebKit && stdenv.isDarwin) WebKit
@@ -85,6 +88,7 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional (!withEGL) "--disable-glcanvasegl"
   ++ lib.optional unicode "--enable-unicode"
+  ++ lib.optional withCurl "--enable-webrequest"
   ++ lib.optional withMesa "--with-opengl"
   ++ lib.optionals stdenv.isDarwin [
     "--with-osx_cocoa"

--- a/pkgs/development/libraries/wxwidgets/wxGTK31.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK31.nix
@@ -16,6 +16,7 @@
 , compat30 ? true
 , unicode ? true
 , withCurl ? false
+, withPrivateFonts ? false
 , withEGL ? true
 , withMesa ? !stdenv.isDarwin
 , withWebKit ? stdenv.isDarwin
@@ -89,6 +90,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional (!withEGL) "--disable-glcanvasegl"
   ++ lib.optional unicode "--enable-unicode"
   ++ lib.optional withCurl "--enable-webrequest"
+  ++ lib.optional withPrivateFonts "--enable-privatefonts"
   ++ lib.optional withMesa "--with-opengl"
   ++ lib.optionals stdenv.isDarwin [
     "--with-osx_cocoa"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35487,15 +35487,9 @@ with pkgs;
   bambu-studio = callPackage ../applications/misc/bambu-studio {
     inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-bad;
 
-    # Needs to be the same version as in the closed-source networking plugin.
-    curl = curl.override { openssl = openssl_1_1; };
-
     glew = glew-egl;
 
     wxGTK31 = wxGTK31.override {
-      # https://github.com/supermerill/SuperSlicer/issues/1093
-      #withEGL = false;
-
       withCurl = true;
       withPrivateFonts = true;
       withWebKit = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35484,6 +35484,24 @@ with pkgs;
 
   super-slicer-latest = super-slicer.latest;
 
+  bambu-studio = callPackage ../applications/misc/bambu-studio {
+    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-bad;
+
+    # Needs to be the same version as in the closed-source networking plugin.
+    curl = curl.override { openssl = openssl_1_1; };
+
+    glew = glew-egl;
+
+    wxGTK31 = wxGTK31.override {
+      # https://github.com/supermerill/SuperSlicer/issues/1093
+      #withEGL = false;
+
+      withCurl = true;
+      withPrivateFonts = true;
+      withWebKit = true;
+    };
+  };
+
   snapmaker-luban = callPackage ../applications/misc/snapmaker-luban { };
 
   robustirc-bridge = callPackage ../servers/irc/robustirc-bridge { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[BambuStudio](https://github.com/bambulab/BambuStudio) is a slicer for 3D printers made by Bambu Lab, based on PrusaSlicer.

~~This isn't ready to be merged yet. There are still missing functionalities in the Linux version (e.g., camera livestream) and the slicer sometimes crashes upon startup. Previously building the package with libraries shipped by Nixpkgs required [some invasive patches](https://github.com/bambulab/BambuStudio/pull/696) which have since been merged. Upstream has promised better Linux support so let's wait a bit.~~ (camera stream is now working and slicer no longer crashes intermittently)

~~The last commit is bandaid from #206221. I will remove it once the mpfr fixes land in master.~~ (done)

Ref: https://github.com/bambulab/BambuStudio/issues/12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
