### PR TITLE
ruffle: nightly-2022-09-26 -> nightly-2022-12-16

### DIFF
--- a/pkgs/applications/emulators/ruffle/default.nix
+++ b/pkgs/applications/emulators/ruffle/default.nix
@@ -19,13 +19,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ruffle";
-  version = "nightly-2022-09-26";
+  version = "nightly-2022-12-16";
 
   src = fetchFromGitHub {
     owner = "ruffle-rs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-o0geKXODFRPKN4JgW+Sg16uPhBS5rrlMCmFSc9AcNPQ=";
+    sha256 = "sha256-VOaXn/dJB0AbuZ8owBbUYEPrL/H8DM73MhwhBjxq2Pg=";
   };
 
   nativeBuildInputs = [
@@ -71,7 +71,7 @@ rustPlatform.buildRustPackage rec {
       "''${gappsWrapperArgs[@]}"
   '';
 
-  cargoSha256 = "sha256-erqBuU66k7SGG9ueyYEINjeXbyC7A2I/r1bBqdsJemY=";
+  cargoSha256 = "sha256-h5qshincT48zYvbNLMXcvxw7Ovupnn9c93lpqY7oNtc=";
 
   meta = with lib; {
     description = "An Adobe Flash Player emulator written in the Rust programming language.";


### PR DESCRIPTION
###### Description of changes

It's been a few months since we've updated the version of Ruffle. This time it's very straight-forward, and I did individually test the scanner, exporter and desktop player, and all seemed to be functioning correctly.

Ruffle doesn't have a proper changelog, so I've compiled a list of some of the activity between the two releases. Changes since nightly-2022-09-26:

- Many AVM2 (ActionScript 3) improvements:
    - Native method names in stack traces.
    - Stubs for `UrlRequest`, `LocalConnection`, `Graphics.beginBitmapFill`, `Graphics.beginBitmapGradient`, `tabChildren`, `tabIndex`, `tabEnabled`, `SharedObject.close`, `SharedObject.clear`, `SharedObject.size`, `DropShadowFilter`, and more.
    - Implementations for `flash.net.navigateToURL`, `DisplayObject.cacheAsBitmap`, `Stage3D` for wgpu backend (partially), `TextField.numLines`, `TextField.getLineMetrics`, `Bitmap.perlinNoise`, `SoundMixer.computeSpectrum` and more.
    -  Various clean-ups, refactors, fixes.
- AVM1 improvements, including implementing more functionality, cleanups, etc.
- Many dependency version bumps across the board
- A multitude of other fixes and improvements in rendering, the webgl backend, CI, etc.

I've posted a [complete shortlog here][1] for your convenience.

[1]: https://gist.github.com/jchv/1e8eaf64b2a99a7855f434d816997387 (Output of running `git shortlog nightly-2022-09-26..nightly-2022-12-16`)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
