### PR TITLE
ticktick: init at 1.0.40

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16208,4 +16208,10 @@
     github = "ziguana";
     githubId = 45833444;
   };
+  spebern = {
+    name = "spebern";
+    email = "sp33cht@googlemail.com";
+    github = "spebern";
+    githubId = 7761511;
+  };
 }

--- a/pkgs/applications/misc/ticktick/default.nix
+++ b/pkgs/applications/misc/ticktick/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, wrapGAppsHook
+, dpkg
+, alsa-lib
+, atk
+, cairo
+, cups
+, glib
+, nss
+, mesa
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.0.40";
+  name = "ticktick-${version}";
+
+  src = fetchurl {
+    url = "https://appest-public.s3.amazonaws.com/download/linux/linux_deb_x64/ticktick-${version}-amd64.deb";
+    sha256 = "sha256-9WltRL7DimSYqM7gaENc7OqVuoir6+pi2KxskgJdB0g=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    wrapGAppsHook
+  ];
+
+  runtimeDependencies = [
+    (lib.getLib systemd)
+  ];
+
+  buildInputs = [
+    alsa-lib
+    atk
+    cups
+    glib
+    mesa # for libgbm
+    nss
+    systemd
+  ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp -R "opt" "$out"
+    cp -R "usr/share" "$out/share"
+    chmod -R g-w "$out"
+
+    ln -s $out/opt/TickTick/ticktick $out/bin/ticktick
+
+    # Otherwise it looks "suspicious"
+    chmod -R g-w $out
+  '';
+
+  postFixup = ''
+    substituteInPlace \
+      $out/share/applications/ticktick.desktop \
+      --replace /opt/ $out/opt/
+  '';
+
+  meta = with lib; {
+    description = "The official TickTick app";
+    homepage = https://ticktick.com/;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ spebern ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38447,4 +38447,6 @@ with pkgs;
   alsa-scarlett-gui = callPackage ../applications/audio/alsa-scarlett-gui { };
 
   tuner = callPackage ../applications/audio/tuner { };
+
+  ticktick = callPackage ../applications/misc/ticktick { };
 }


### PR DESCRIPTION
###### Description of changes

Add ticktick package https://ticktick.com/about/download

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
