### PR TITLE
stdenv: use `intersectAttrs` instead of `intersectLists`

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -483,7 +483,7 @@ else let
 
   checkedEnv =
     let
-      overlappingNames = lib.intersectLists (lib.attrNames env) (lib.attrNames derivationArg);
+      overlappingNames = lib.attrNames (builtins.intersectAttrs env derivationArg);
     in
     assert lib.assertMsg envIsExportable
       "When using structured attributes, `env` must be an attribute set of environment variables.";


### PR DESCRIPTION
Better complexity.

Will need to be retargeted to `staging-next` if the branch-off happens before this is merged.