### PR TITLE
[22.11] openjdk/openjfx: bumps

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -11,8 +11,8 @@
 let
   major = "11";
   minor = "0";
-  update = "15";
-  build = "10";
+  update = "17";
+  build = "8";
 
   openjdk = stdenv.mkDerivation rec {
     pname = "openjdk" + lib.optionalString headless "-headless";
@@ -22,7 +22,7 @@ let
       owner = "openjdk";
       repo = "jdk${major}u";
       rev = "jdk-${version}";
-      sha256 = "le2JDxPJPSuga4JxLJNRZwCaodptSb2kh4TsJXumTXs=";
+      sha256 = "sha256-kvgLYqQZPqyuigVyzbDHc3TMff0clvzM8IdzYLYcxPU=";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -20,7 +20,7 @@ let
     powerpc64le-linux = "ppc64le";
   }.${stdenv.system} or (throw "Unsupported platform ${stdenv.system}");
 
-  update = "322";
+  update = "352";
   build = "ga";
 
   openjdk8 = stdenv.mkDerivation rec {
@@ -31,7 +31,7 @@ let
       owner = "openjdk";
       repo = "jdk8u";
       rev = "jdk${version}";
-      sha256 = "sha256-e39Yv+NDQG7z6fGmpKEnkKd5MoHZ50SXlq/Q7lzWcDA=";
+      sha256 = "sha256-xDiiALDjStD9IPhbBr997rm/v2Q/WdS10cILBCmdJIQ=";
     };
     outputs = [ "out" "jre" ];
 

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, writeText, gradle_4, pkg-config, perl, cmake
-, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4, python2, ruby
+, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python2, ruby
 , openjdk11-bootstrap }:
 
 let
@@ -19,7 +19,7 @@ let
       sha256 = "1h7qsylr7rnwnbimqjyn3whszp9kv4h3gpicsrb3mradxc9yv194";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 ];
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python2 ruby ];
 
     dontUseCmakeConfigure = true;

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,26 +1,28 @@
-{ stdenv, lib, fetchurl, writeText, gradle_4, pkg-config, perl, cmake
-, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python2, ruby
+{ stdenv, lib, fetchFromGitHub, writeText, gradle_7, pkg-config, perl, cmake
+, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python3, ruby, icu68
 , openjdk11-bootstrap }:
 
 let
   major = "11";
-  update = ".0.3";
+  update = ".0.17";
   build = "1";
   repover = "${major}${update}+${build}";
-  gradle_ = (gradle_4.override {
+  gradle_ = (gradle_7.override {
     java = openjdk11-bootstrap;
   });
 
   makePackage = args: stdenv.mkDerivation ({
     version = "${major}${update}-${build}";
 
-    src = fetchurl {
-      url = "https://hg.openjdk.java.net/openjfx/${major}/rt/archive/${repover}.tar.gz";
-      sha256 = "1h7qsylr7rnwnbimqjyn3whszp9kv4h3gpicsrb3mradxc9yv194";
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jfx${major}u";
+      rev = repover;
+      sha256 = "sha256-uKb6k+tIFdwy1BYiHWeGmKNz82X4CZjFlGYqLDpSFY0=";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];
-    nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python2 ruby ];
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];
+    nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;
 
@@ -33,9 +35,6 @@ let
       CONF = Release
       JDK_HOME = ${openjdk11-bootstrap.home}
     '' + args.gradleProperties or "");
-
-    #avoids errors about deprecation of GTypeDebugFlags, GTimeVal, etc.
-    NIX_CFLAGS_COMPILE = [ "-DGLIB_DISABLE_DEPRECATION_WARNINGS" ];
 
     buildPhase = ''
       runHook preBuild
@@ -65,11 +64,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    # Downloaded AWT jars differ by platform.
-    outputHash = {
-      i686-linux = "0mjlyf6jvbis7nrm5d394sjv4hjw6k3753hr1nwdxk8skwc3ry08";
-      x86_64-linux = "0d4msxswdav1xsfkpr0qd3xgqkcbxzf47v1zdy5jmg5w4bs6a78a";
-    }.${stdenv.system} or (throw "Unsupported platform");
+    outputHash = "sha256-syceJMUEknBDCHK8eGs6rUU3IQn+HnQfURfCrDxYPa9=";
   };
 
 in makePackage {
@@ -77,7 +72,7 @@ in makePackage {
 
   gradleProperties = ''
     COMPILE_MEDIA = true
-    COMPILE_WEBKIT = true
+    COMPILE_WEBKIT = false
   '';
 
   preBuild = ''
@@ -90,12 +85,6 @@ in makePackage {
   installPhase = ''
     cp -r build/modular-sdk $out
   '';
-
-  # glib-2.62 deprecations
-  # -fcommon: gstreamer workaround for -fno-common toolchains:
-  #   ld: gsttypefindelement.o:(.bss._gst_disable_registry_cache+0x0): multiple definition of
-  #     `_gst_disable_registry_cache'; gst.o:(.bss._gst_disable_registry_cache+0x0): first defined here
-  NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS -fcommon";
 
   stripDebugList = [ "." ];
 

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk11_headless, gradle_5
 , pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
-, ffmpeg_4, python3, ruby }:
+, ffmpeg_4-headless, python3, ruby }:
 
 let
   major = "15";
@@ -21,7 +21,7 @@ let
       sha256 = "019glq8rhn6amy3n5jc17vi2wpf1pxpmmywvyz1ga8n09w7xscq1";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 ];
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;

--- a/pkgs/development/compilers/openjdk/openjfx/15.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/15.nix
@@ -121,6 +121,9 @@ in makePackage {
     license = licenses.gpl2;
     description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    knownVulnerabilities = [
+      "This OpenJFX version has reached its end of life."
+    ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -4,7 +4,7 @@
 
 let
   major = "17";
-  update = ".0.0.1";
+  update = ".0.5";
   build = "+1";
   repover = "${major}${update}${build}";
   gradle_ = (gradle_7.override {
@@ -16,9 +16,9 @@ let
 
     src = fetchFromGitHub {
       owner = "openjdk";
-      repo = "jfx";
+      repo = "jfx${major}u";
       rev = repover;
-      sha256 = "sha256-PSiE9KbF/4u9VyBl9PAMLGzKyGFB86/XByeh7vhL6Kw=";
+      sha256 = "sha256-jzLOlWuhkUS0/4+nXtjd1/IYbAHHnJrusFRTh7aPt8U=";
     };
 
     buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];

--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless, gradle_7
 , pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
-, ffmpeg_4, python3, ruby, icu68 }:
+, ffmpeg_4-headless, python3, ruby, icu68 }:
 
 let
   major = "17";
@@ -21,7 +21,7 @@ let
       sha256 = "sha256-PSiE9KbF/4u9VyBl9PAMLGzKyGFB86/XByeh7vhL6Kw=";
     };
 
-    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 icu68 ];
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backport of PR: https://github.com/NixOS/nixpkgs/pull/205169

Did not backport the `openjfx15: gradle_5 -> gradle_6` changes. Not needed to `release-22.11` though, since the reason for it is the future `gradle_5` [removal](https://github.com/NixOS/nixpkgs/issues/205455). Also, `openjfx15` will be marked as EOL anyway after the merge of this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
