### PR TITLE
tree-sitter/update: use `unionOfDisjoints`

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -375,19 +375,7 @@ let
           knownTreeSitterOrgGrammarRepos);
 
     in
-    mergeAttrsUnique otherGrammars treeSitterOrgaGrammars;
-
-  # TODO: move to lib
-  mergeAttrsUnique = left: right:
-    let intersect = lib.intersectLists (lib.attrNames left) (lib.attrNames right); in
-    assert
-    lib.assertMsg (intersect == [ ])
-      (lib.concatStringsSep "\n" [
-        "mergeAttrsUnique: keys in attrset overlapping:"
-        "left: ${lib.generators.toPretty {} (lib.getAttrs intersect left)}"
-        "right: ${lib.generators.toPretty {} (lib.getAttrs intersect right)}"
-      ]);
-    left // right;
+    lib.attrsets.unionOfDisjoint otherGrammars treeSitterOrgaGrammars;
 
 
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/2b534fee3d5bbee6944de149b312dbf3b4b71052/lib/attrsets.nix#L919-L931

The semantics are slightly different (`unionOfDisjoint` is lazy: it won't fail until an overlapping attribute is accessed), but this doesn't matter because `allGrammars` is consumed strictly.

This has better complexity than `intersectLists`.