### PR TITLE
scummvm: 2.5.1 -> 2.6.1

### DIFF
--- a/pkgs/games/scummvm/default.nix
+++ b/pkgs/games/scummvm/default.nix
@@ -1,15 +1,17 @@
-{ lib, stdenv, fetchurl, nasm
-, alsa-lib, curl, flac, fluidsynth, freetype, libjpeg, libmad, libmpeg2, libogg, libvorbis, libGLU, libGL, SDL2, zlib
+{ lib, stdenv, fetchFromGitHub, nasm
+, alsa-lib, curl, flac, fluidsynth, freetype, libjpeg, libmad, libmpeg2, libogg, libtheora, libvorbis, libGLU, libGL, SDL2, zlib
 , Cocoa, AudioToolbox, Carbon, CoreMIDI, AudioUnit, cctools
 }:
 
 stdenv.mkDerivation rec {
   pname = "scummvm";
-  version = "2.5.1";
+  version = "2.6.1";
 
-  src = fetchurl {
-    url = "http://scummvm.org/frs/scummvm/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-n9jbOORFYUS/jDTazffyBOdfGOjkSOwBzgjOgmoDXwE=";
+  src = fetchFromGitHub {
+    owner = "scummvm";
+    repo = "scummvm";
+    rev = "v${version}";
+    hash = "sha256-fqMMdHBVcXLsBDWxXH9UKXwfvlyIVbRsIPmrYqPGQ+g=";
   };
 
   nativeBuildInputs = [ nasm ];
@@ -19,7 +21,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     Cocoa AudioToolbox Carbon CoreMIDI AudioUnit
   ] ++ [
-    curl freetype flac fluidsynth libjpeg libmad libmpeg2 libogg libvorbis libGLU libGL SDL2 zlib
+    curl freetype flac fluidsynth libjpeg libmad libmpeg2 libogg libtheora libvorbis libGLU libGL SDL2 zlib
   ];
 
   dontDisableStatic = true;
@@ -28,7 +30,6 @@ stdenv.mkDerivation rec {
 
   configurePlatforms = [ "host" ];
   configureFlags = [
-    "--enable-c++11"
     "--enable-release"
   ];
 


### PR DESCRIPTION
###### Description of changes

Version bump which includes changes from ScummVM 1.6.0 ([see notes](https://github.com/scummvm/scummvm/releases/tag/v2.6.0)) and 1.6.1 ([see notes](https://github.com/scummvm/scummvm/releases/tag/v2.6.1)). This couldn't be automatically updated due to the deprecation of a configure flag.

Also fixed the absence of the `sword25` engine for Broken Sword 2.5. This engine was previously not included because of the absence of libtheora during the configuration phase. This meant that previous versions of the `broken-sword-25` package were actually broken, as it was running a build of ScummVM without the proper engine support.

Since all ScummVM docs now refer to the Github repo as the official repository, I've also switched over to `fetchFromGithub`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).