### PR TITLE
[22.05] sqlite: add patch for CVE-2022-46908

### DIFF
--- a/pkgs/development/libraries/sqlite/3.39.4-autoconf-CVE-2022-46908.patch
+++ b/pkgs/development/libraries/sqlite/3.39.4-autoconf-CVE-2022-46908.patch
@@ -1,0 +1,25 @@
+adapted for preprocessed source files from upstream
+https://sqlite.org/src/vpatch?from=a60e56627fc0ef88&to=cefc032473ac5ad2
+
+diff --git a/shell.c b/shell.c
+index e66ae08..d423278 100644
+--- a/shell.c
++++ b/shell.c
+@@ -12921,7 +12921,7 @@ static int safeModeAuth(
+     "zipfile",
+     "zipfile_cds",
+   };
+-  UNUSED_PARAMETER(zA2);
++  UNUSED_PARAMETER(zA1);
+   UNUSED_PARAMETER(zA3);
+   UNUSED_PARAMETER(zA4);
+   switch( op ){
+@@ -12936,7 +12936,7 @@ static int safeModeAuth(
+     case SQLITE_FUNCTION: {
+       int i;
+       for(i=0; i<ArraySize(azProhibitedFunctions); i++){
+-        if( sqlite3_stricmp(zA1, azProhibitedFunctions[i])==0 ){
++        if( sqlite3_stricmp(zA2, azProhibitedFunctions[i])==0 ){
+           failIfSafeMode(p, "cannot use the %s() function in safe mode",
+                          azProhibitedFunctions[i]);
+         }

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -21,7 +21,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-WvB96YK6ZY/ZGgMXDJRfmclx9pVbx53zJmVENz45hpw=";
   };
 
-  patches = [ ./CVE-2022-35737.patch ];
+  patches = [
+    ./CVE-2022-35737.patch
+    ./3.39.4-autoconf-CVE-2022-46908.patch
+  ];
 
   outputs = [ "bin" "dev" "out" ];
   separateDebugInfo = stdenv.isLinux;


### PR DESCRIPTION
###### Description of changes

Backport of  #205966

https://nvd.nist.gov/vuln/detail/CVE-2022-46908

Built `passthru.tests`, `sqlite-interactive` on macos 10.15, nixos x86_64. (`pkgsStatic.`/`pkgsMusl.`/`pkgsCross.aarch64-multiplatform.`)(`sqlite`/`sqlite-interactive`)

Built `pkgsi686Linux.sqlite.tests` successfully too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
