### PR TITLE
gimme-aws-creds: init at 2.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3601,6 +3601,13 @@
     githubId = 62989;
     name = "Demyan Rogozhin";
   };
+  dennajort = {
+    email = "gosselinjb@gmail.com";
+    matrix = "@dennajort:matrix.org";
+    github = "dennajort";
+    githubId = 1536838;
+    name = "Jean-Baptiste Gosselin";
+  };
   derchris = {
     email = "derchris@me.com";
     github = "derchrisuk";

--- a/pkgs/development/python-modules/ctap-keyring-device/default.nix
+++ b/pkgs/development/python-modules/ctap-keyring-device/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonRelaxDepsHook
+, setuptools-scm
+# install requirements
+, fido2
+, keyring
+, cryptography
+# test requirements
+, pytestCheckHook
+}:
+
+let
+  fido2_0 = fido2.overridePythonAttrs (oldAttrs: rec {
+    version = "0.9.3";
+    src = fetchPypi {
+      inherit (oldAttrs) pname;
+      inherit version;
+      hash = "sha256-tF6JphCc/Lfxu1E3dqotZAjpXEgi+DolORi5RAg0Zuw=";
+    };
+  });
+in
+buildPythonPackage rec {
+  pname = "ctap-keyring-device";
+  version = "1.0.6";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "sha256-pEJkuz0wxKt2PkowmLE2YC+HPYa2ZiENK7FAW14Ec/Y=";
+  };
+
+  # removing optional dependency needing pyobjc
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace "--flake8 --black --cov" ""
+  '';
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+    setuptools-scm
+  ];
+
+  pythonRemoveDeps = [
+    # This is a darwin requirement missing pyobjc
+    "pyobjc-framework-LocalAuthentication"
+  ];
+
+  propagatedBuildInputs = [
+    keyring
+    fido2_0
+    cryptography
+  ];
+
+  pythonImportsCheck = [ "ctap_keyring_device" ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # Disabled tests that needs pyobjc or windows
+    "touch_id_ctap_user_verifier"
+    "windows_hello_ctap_user_verifier"
+  ];
+
+  meta = with lib; {
+    description = "CTAP (client-to-authenticator-protocol) device backed by python's keyring library";
+    homepage = "https://github.com/dany74q/ctap-keyring-device";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dennajort ];
+  };
+}

--- a/pkgs/development/python-modules/okta/default.nix
+++ b/pkgs/development/python-modules/okta/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+# install requirements
+, pycryptodome
+, yarl
+, flatdict
+, python-jose
+, aenum
+, aiohttp
+, pydash
+, xmltodict
+, pyyaml
+# test requirements
+, pytestCheckHook
+, pytest-recording
+, pytest-asyncio
+, pytest-mock
+, pyfakefs
+}:
+
+buildPythonPackage rec {
+  pname = "okta";
+  version = "2.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-yIVJoKX9b9Y7Ydl28twHxgPbUa58LJ12Oz3tvpU7CAc=";
+  };
+
+  propagatedBuildInputs = [
+    pycryptodome
+    yarl
+    flatdict
+    python-jose
+    aenum
+    aiohttp
+    pydash
+    xmltodict
+    pyyaml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-mock
+    pytest-recording
+    pyfakefs
+  ];
+
+  pytestFlagsArray = [ "tests/" ];
+
+  disabledTests = [
+    "test_client_raise_exception"
+  ];
+
+  pythonImportsCheck = [
+    "okta"
+    "okta.cache"
+    "okta.client"
+    "okta.exceptions"
+    "okta.http_client"
+    "okta.models"
+    "okta.request_executor"
+  ];
+
+  meta = with lib; {
+    description = "Python SDK for the Okta Management API";
+    homepage = "https://github.com/okta/okta-sdk-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dennajort ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-recording/default.nix
+++ b/pkgs/development/python-modules/pytest-recording/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+# install dependencies
+, pytest
+, vcrpy
+, attrs
+# test dependencies
+, pytestCheckHook
+, pytest-httpbin
+, pytest-mock
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-recording";
+  version = "0.12.2";
+
+  src = fetchFromGitHub {
+    owner = "kiwicom";
+    repo = "pytest-recording";
+    rev = "v${version}";
+    hash = "sha256-nivwxaW8AIrBtPkzPJYfxlPxWn2NuYcaMry/IrBnnl0=";
+  };
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    vcrpy
+    attrs
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-httpbin
+    pytest-mock
+    requests
+  ];
+
+  disabledTests = [
+    "test_block_network_with_allowed_hosts"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Missing socket.AF_NETLINK
+    "test_other_socket"
+  ];
+
+  pytestFlagsArray = [
+    "tests"
+  ];
+
+  pythonImportsCheck = [
+    "pytest_recording"
+  ];
+
+  meta = with lib; {
+    description = "A pytest plugin that allows you recording of network interactions via VCR.py";
+    homepage = "https://github.com/kiwicom/pytest-recording";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dennajort ];
+  };
+}

--- a/pkgs/tools/admin/gimme-aws-creds/default.nix
+++ b/pkgs/tools/admin/gimme-aws-creds/default.nix
@@ -1,0 +1,106 @@
+{ lib
+, python3
+, fetchFromGitHub
+, nix-update-script
+, testers
+, gimme-aws-creds
+}:
+
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      fido2 = super.fido2.overridePythonAttrs (oldAttrs: rec {
+        version = "0.9.3";
+        src = self.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          hash = "sha256-tF6JphCc/Lfxu1E3dqotZAjpXEgi+DolORi5RAg0Zuw=";
+        };
+      });
+
+      okta = super.okta.overridePythonAttrs (oldAttrs: rec {
+        version = "0.0.4";
+        src = self.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          hash = "sha256-U+eSxo02hP9BQLTLHAKvOCEJA2j4EQ/eVMC9tjhEkzI=";
+        };
+        propagatedBuildInputs = [
+          self.six
+          self.python-dateutil
+          self.requests
+        ];
+        pythonImportsCheck = [ "okta" ];
+        doCheck = false; # no tests were included with this version
+      });
+    };
+  };
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "gimme-aws-creds";
+  version = "2.5.0"; # N.B: if you change this, check if overrides are still up-to-date
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "Nike-Inc";
+    repo = "gimme-aws-creds";
+    rev = "v${version}";
+    hash = "sha256-rU4guBXRRJOG3/JilvEF9DwXM5z2IUV80qj3YcV8Z/I=";
+  };
+
+  nativeBuildInputs = with python.pkgs; [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRemoveDeps = [
+    "configparser"
+  ];
+
+  propagatedBuildInputs = with python.pkgs; [
+    boto3
+    fido2
+    beautifulsoup4
+    ctap-keyring-device
+    requests
+    okta
+  ];
+
+  checkInputs = with python.pkgs; [
+    pytestCheckHook
+    nose
+    responses
+  ];
+
+  disabledTests = [
+    "test_build_factor_name_webauthn_registered"
+  ];
+
+  pythonImportsCheck = [
+    "gimme_aws_creds"
+  ];
+
+  postInstall = ''
+    rm $out/bin/gimme-aws-creds.cmd
+    chmod +x $out/bin/gimme-aws-creds
+  '';
+
+  passthru = {
+    inherit python;
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+    tests.version = testers.testVersion {
+      package = gimme-aws-creds;
+      command = ''touch tmp.conf && OKTA_CONFIG="tmp.conf" gimme-aws-creds --version'';
+      version = "gimme-aws-creds ${version}";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/Nike-Inc/gimme-aws-creds";
+    changelog = "https://github.com/Nike-Inc/gimme-aws-creds/releases";
+    description = "A CLI that utilizes Okta IdP via SAML to acquire temporary AWS credentials";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dennajort ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16997,6 +16997,8 @@ with pkgs;
 
   gImageReader = callPackage ../applications/misc/gImageReader { };
 
+  gimme-aws-creds = callPackage ../tools/admin/gimme-aws-creds { };
+
   guile_1_8 = callPackage ../development/interpreters/guile/1.8.nix { };
 
   # Needed for autogen

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6643,6 +6643,8 @@ self: super: with self; {
 
   oemthermostat = callPackage ../development/python-modules/oemthermostat { };
 
+  okta = callPackage ../development/python-modules/okta { };
+
   olefile = callPackage ../development/python-modules/olefile { };
 
   oletools = callPackage ../development/python-modules/oletools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9184,6 +9184,8 @@ self: super: with self; {
 
   pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };
 
+  pytest-recording = callPackage ../development/python-modules/pytest-recording { };
+
   pytest-regressions = callPackage ../development/python-modules/pytest-regressions { };
 
   pytest-relaxed = callPackage ../development/python-modules/pytest-relaxed { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2144,6 +2144,8 @@ self: super: with self; {
 
   csvw = callPackage ../development/python-modules/csvw { };
 
+  ctap-keyring-device = callPackage ../development/python-modules/ctap-keyring-device { };
+
   cu2qu = callPackage ../development/python-modules/cu2qu { };
 
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Add python application `gimme-aws-creds` https://github.com/Nike-Inc/gimme-aws-creds
- Add python library `okta` https://github.com/okta/okta-sdk-python
- Add python library `ctap-keyring-device` https://github.com/dany74q/ctap-keyring-device with patch for missing `pyobjc`
- Add python library `pytest-recording` https://github.com/kiwicom/pytest-recording

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
