### PR TITLE
python310Packages.asyncio-mqtt: 0.14.0 -> 0.16.1

### DIFF
--- a/pkgs/development/python-modules/asyncio_mqtt/default.nix
+++ b/pkgs/development/python-modules/asyncio_mqtt/default.nix
@@ -49,17 +49,17 @@ buildPythonPackage rec {
   disabledTests = [
     # Tests require network access
     "test_client_filtered_messages"
-    "test_client_unfiltered_messages"
-    "test_client_unsubscribe"
-    "test_client_will"
-    "test_client_tls_context"
-    "test_client_tls_params"
-    "test_client_username_password "
     "test_client_logger"
     "test_client_max_concurrent_outgoing_calls"
-    "test_client_websockets"
-    "test_client_pending_calls_threshold"
     "test_client_no_pending_calls_warnings_with_max_concurrent_outgoing_calls"
+    "test_client_pending_calls_threshold"
+    "test_client_tls_context"
+    "test_client_tls_params"
+    "test_client_unfiltered_messages"
+    "test_client_unsubscribe"
+    "test_client_username_password "
+    "test_client_websockets"
+    "test_client_will"
     "test_multiple_messages_generators"
   ];
 
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     description = "Idomatic asyncio wrapper around paho-mqtt";
     homepage = "https://github.com/sbtinstruments/asyncio-mqtt";
     license = licenses.bsd3;
-    changelog = "https://github.com/sbtinstruments/asyncio-mqtt/blob/master/CHANGELOG.md";
+    changelog = "https://github.com/sbtinstruments/asyncio-mqtt/blob/v${version}/CHANGELOG.md";
     maintainers = with maintainers; [ hexa ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/sbtinstruments/asyncio-mqtt/compare/refs/tags/v0.14.0...v0.16.1

Changelog: https://github.com/sbtinstruments/asyncio-mqtt/blob/v0.16.1/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
