### PR TITLE
datafusion-cli: unstable-2022-04-08 -> 15.0.0

### DIFF
--- a/pkgs/development/misc/datafusion/default.nix
+++ b/pkgs/development/misc/datafusion/default.nix
@@ -1,35 +1,38 @@
-{ stdenv
-, lib
+{ lib
 , rustPlatform
 , fetchFromGitHub
+, stdenv
+, darwin
 }:
-let
-  pname = "datafusion-cli";
-  version = "unstable-2022-04-08";
-in
-rustPlatform.buildRustPackage {
-  inherit pname version;
 
-  # TODO the crate has been yanked so not the best source
-  # the repo is a workspace with a lock inside a subdirectory, making
-  # compilation from github source not straightforward
-  # re-evaluate strategy on release after 7.0.0
+rustPlatform.buildRustPackage rec {
+  pname = "datafusion-cli";
+  version = "15.0.0";
+
   src = fetchFromGitHub {
     owner = "apache";
     repo = "arrow-datafusion";
-    rev = "9cbde6d0e30fd29f59b0a16e309bdb0843cc7c64";
-    sha256 = "sha256-XXd9jvWVivOBRS0PVOU9F4RQ6MrS/q78JF4S6Htd67w=";
+    rev = version;
+    sha256 = "sha256-s+gQoczTesJGOpz4W5hBPDdxo4eQnf+D10+V2kx65Io=";
   };
   sourceRoot = "source/datafusion-cli";
 
-  cargoSha256 = "sha256-Q0SjVofl1+sex15sSU9s7PgKeHG2b0gJPSqz7YZFOVs=";
+  cargoSha256 = "sha256-w+/5Ig+U8y4nwu7QisnZvc3UlZaEU/kovV6birOWndE=";
+
+  buildInputs = lib.optional stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  checkFlags = [
+    # fails even outside the Nix sandbox
+    "--skip=object_storage::tests::s3_region_validation"
+  ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "cli for Apache Arrow DataFusion";
     homepage = "https://arrow.apache.org/datafusion";
+    changelog = "https://github.com/apache/arrow-datafusion/blob/${version}/datafusion/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ happysalada ];
-    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/apache/arrow-datafusion/compare/9cbde6d0e30fd29f59b0a16e309bdb0843cc7c64...15.0.0
https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/CHANGELOG.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
