### PR TITLE
hotspot: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/tools/analysis/hotspot/default.nix
+++ b/pkgs/development/tools/analysis/hotspot/default.nix
@@ -9,6 +9,7 @@
 , kio
 , kitemmodels
 , kitemviews
+, kparts
 , kwindowsystem
 , libelf
 , qtbase
@@ -21,13 +22,13 @@
 
 mkDerivation rec {
   pname = "hotspot";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "KDAB";
     repo = "hotspot";
     rev = "v${version}";
-    sha256 = "1f68bssh3p387hkavfjkqcf7qf7w5caznmjfjldicxphap4riqr5";
+    hash = "sha256-7GuIe8F3QqosW/XaN3KC1WeWcI7woUiEc9Nw0b+fSk0=";
     fetchSubmodules = true;
   };
 
@@ -36,12 +37,13 @@ mkDerivation rec {
     extra-cmake-modules
   ];
   buildInputs = [
-    elfutils
+    (elfutils.override { enableDebuginfod = true; }) # perfparser needs to find debuginfod.h
     kconfigwidgets
     ki18n
     kio
     kitemmodels
     kitemviews
+    kparts
     kwindowsystem
     libelf
     qtbase
@@ -59,11 +61,6 @@ mkDerivation rec {
   postPatch = ''
     mkdir -p 3rdparty/{perfparser,PrefixTickLabels}/.git
   '';
-
-  cmakeFlags = [
-    "-DRUSTC_DEMANGLE_INCLUDE_DIR=${rustc-demangle}/include"
-    "-DRUSTC_DEMANGLE_LIBRARY=${rustc-demangle}/lib/librustc_demangle.so"
-  ];
 
   meta = {
     description = "A GUI for Linux perf";


### PR DESCRIPTION
###### Description of changes

- Hotspot now depends on kparts.
- Enable debuginfod for elfutils, because perfparser needs to find debuginfod.h
- Remove rust demangle cmake flags, because it is found at runtime now, see https://github.com/KDAB/hotspot/issues/269

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).