### PR TITLE
openafs: 1.8.8.1 → 1.8.9

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -37,64 +37,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ libkrb5 ];
 
-  patches = [
-    # Import of code from autoconf-archive
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=d8205bbb482554812fbe66afa3c337d991a247b6";
-      hash = "sha256-ohkjSux+S3+6slh6uZIw5UJXlvhy9UUDpDlP0YFRwmw=";
-    })
-    # Use autoconf-archive m4 from src/external
-    (fetchBase64Patch {
-      url = "https://gerrit.openafs.org/changes/14944/revisions/ea2a0e128d71802f61b8da2e44de3c6325c5f328/patch";
-      hash = "sha256-PAUk/MXL5p8xwhn40/UGmo3UIhvl1PB2FwgqhmqsjJ4=";
-    })
-    # cf: Use common macro to test compiler flags
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=790824ff749b6ee01c4d7101493cbe8773ef41c6";
-      hash = "sha256-Zc7AjCsH7eTmZJWCrx7ci1tBjEAgcFXS9lY1YBeboLA=";
-    })
-    # Linux-5.17: kernel func complete_and_exit renamed
-    (fetchBase64Patch {
-      url = "https://gerrit.openafs.org/changes/14945/revisions/a714e865efe41aa1112f6f9c8479112660dacd6f/patch";
-      hash = "sha256-zvyR/GOPJeAbG6ySRRMp44oT5tPujUwybyU0XR/5Xyc=";
-    })
-    # Linux-5.17: Kernel build uses -Wcast-function-type
-    (fetchBase64Patch {
-      url = "https://gerrit.openafs.org/changes/14946/revisions/449d1faf87e2841e80be38cf2b4a5cf5ff4df2d8/patch";
-      hash = "sha256-3bRTHYeMRIleLhob56m2Xt0dWzIMDo3QrytY0K1/q7c=";
-    })
-    # afs: Introduce afs_IsDCacheFresh
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=0d8ce846ab2e6c45166a61f04eb3af271cbd27db";
-      hash = "sha256-+xgRYVXz8XpT5c4Essc4VEn9Fj53vasAYhcFkK0oCBc=";
-    })
-    # LINUX: Don't panic on some file open errors
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=af73b9a3b1fc625694807287c0897391feaad52d";
-      hash = "sha256-k0d+Gav1LApU24SaMI0pmR3gGfWyicqdCpTpVJLcx7U=";
-    })
-    # Linux-5.18 replace set_page_dirty with dirty_folio
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=6aa129e743e882cf30c35afd67eabf82274c5fca";
-      hash = "sha256-8R0rdKYs7+Zl1sdizOZzpBjy6e9J+42R9HzsNUa/PQ4=";
-    })
-    # afs: introduce afs_alloc_ncr/afs_free_ncr
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=209eb92448001e59525413610356070d8e4f10a0";
-      hash = "sha256-t455gTaK5U+m0qcyKjTqnWTOb4qz6VN/JYZzRAAV8kM=";
-    })
-    # afs: introduce get_dcache_readahead
-    (fetchpatch {
-      url = "https://git.openafs.org/?p=openafs.git;a=patch;h=44e24ae5d7dc41e54d23638d5f64ab2e81e43ad0";
-      hash = "sha256-gtUNDSHAq+RY1Rm17YcxcUALy7FEBQf9k8/ELQlPORU=";
-    })
-    # Linux-5.18: replace readpages with readahead
-    (fetchBase64Patch {
-      url = "https://gerrit.openafs.org/changes/14953/revisions/0497b0cd7bffb6335ab9bcbf5a1310b8c6a4b299/patch";
-      hash = "sha256-a5pd+CHHPr1mGxsF7tSlaBqoiKw2IGr1mJ7EaDHDJSw=";
-    })
-  ];
-
   hardeningDisable = [ "pic" ];
 
   configureFlags = [
@@ -102,7 +44,6 @@ stdenv.mkDerivation {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--with-gssapi"
-    "--disable-linux-d_splice-alias-extra-iput"
   ];
 
   preConfigure = ''
@@ -133,6 +74,6 @@ stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = with maintainers; [ andersk maggesi spacefrogg ];
-    broken = kernel.isHardened || kernel.kernelAtLeast "5.19";
+    broken = kernel.isHardened;
   };
 }

--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -1,16 +1,16 @@
 { fetchurl }:
 rec {
-  version = "1.8.8.1";
+  version = "1.8.9";
   src = fetchurl {
     url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "sha256-58S+1wdbzWQC4/DC1bnb52rS7jxf1d3DlzozVsoj70Q=";
+    hash = "sha256-0SYXi+H0LMoYy3wMJpGsNUUY43kBcBUKdrvSX00VHwY=";
   };
 
   srcs = [
     src
     (fetchurl {
       url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      sha256 = "sha256-y17O3C4WS+o7SMayydbxw2v96R0GikxiqciF30j+jms=";
+      hash = "sha256-75HoVOq0qnQmhSWVSkHCoq0KLq9TDqoiu55L9FOxWTk=";
     })
   ];
 }


### PR DESCRIPTION
###### Description of changes

This is needed for new Linux kernel support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
