### PR TITLE
devd: 0.9 -> unstable-2020-04-27

### DIFF
--- a/pkgs/development/tools/devd/default.nix
+++ b/pkgs/development/tools/devd/default.nix
@@ -1,16 +1,30 @@
-{ buildGoPackage, fetchFromGitHub, lib }:
+{ buildGoModule, fetchFromGitHub, fetchpatch, lib }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "devd";
-  version = "0.9";
+  version = "unstable-2020-04-27";
+
   src = fetchFromGitHub {
     owner = "cortesi";
     repo = "devd";
-    rev = "v${version}";
-    sha256 = "1b02fj821k68q7xl48wc194iinqw9jiavzfl136hlzvg4m07p1wf";
+    rev = "c1a3bfba27d8e028de90fb24452374412a4cffb3";
+    hash = "sha256-k0zj7fiYbaHnNUUI7ruD0vXiT4c1bxPuR4I0dRouCbU=";
   };
-  goPackagePath = "github.com/cortesi/devd";
+
+  vendorHash = "sha256-o7MbN/6n7fkp/yqYyQbfWBUqI09/JYh5jtV31gjNf6w=";
+
+  patches = [
+    # Update x/sys to support go 1.17.
+    (fetchpatch {
+      url = "https://github.com/cortesi/devd/commit/5f4720bf41399736b4e7e1a493da6c87a583d0b2.patch";
+      hash = "sha256-WDN08XNsDPuZwBCE8iDXgGAWFwx2UTwqRkhzKMtPKR8=";
+    })
+  ];
+
   subPackages = [ "cmd/devd" ];
+
+  ldflags = [ "-s" "-w" ];
+
   meta = with lib; {
     description = "A local webserver for developers";
     homepage = "https://github.com/cortesi/devd";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
