### PR TITLE
ocamlPackages.lwt_ppx: 2.0.2 → 2.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/dap/default.nix
+++ b/pkgs/development/ocaml-modules/dap/default.nix
@@ -5,13 +5,13 @@
 buildDunePackage rec {
   pname = "dap";
   version = "1.0.6";
-  useDune2 = true;
+  duneVersion = "3";
   src = fetchurl {
     url = "https://github.com/hackwaly/ocaml-dap/releases/download/${version}/dap-${version}.tbz";
     sha256 = "1zq0f8429m38a4x3h9n3rv7n1vsfjbs72pfi5902a89qwyilkcp0";
   };
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   buildInputs = [
     lwt_ppx

--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -11,9 +11,9 @@ buildDunePackage rec {
   pname = "earlybird";
   version = "1.1.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.11";
+  minimalOCamlVersion = "4.11";
 
   src = fetchFromGitHub {
     owner = "hackwaly";

--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -2,11 +2,10 @@
 
 buildDunePackage {
   pname = "lwt_ppx";
-  version = "2.0.2";
+  version = "2.1.0";
+  duneVersion = "3";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.04";
+  minimalOCamlVersion = "4.04";
 
   # `lwt_ppx` has a different release cycle than Lwt, but it's included in
   # one of its release bundles.
@@ -18,8 +17,8 @@ buildDunePackage {
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "lwt";
-    rev = "5.4.0";
-    sha256 = "sha256-rRivROVbQbXkHWen1n8+9AwrRJaOK0Fhyilw29T7was=";
+    rev = "5.6.0";
+    hash = "sha256-DLQupCkZ14kOuSQatbb7j07I+jvvDCKpdlaR3rijT4s=";
   };
 
   propagatedBuildInputs = [ lwt ppxlib ];

--- a/pkgs/development/ocaml-modules/ocsipersist/default.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/default.nix
@@ -5,7 +5,8 @@
 
 buildDunePackage {
   pname = "ocsipersist";
-  inherit (ocsipersist-lib) src version useDune2;
+  inherit (ocsipersist-lib) src version;
+  duneVersion = "3";
 
   buildInputs = [
     ocsipersist-pgsql

--- a/pkgs/development/ocaml-modules/ocsipersist/lib.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/lib.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
   pname = "ocsipersist-lib";
   version = "1.1.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "ocsigen";

--- a/pkgs/development/ocaml-modules/ocsipersist/pgsql.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/pgsql.nix
@@ -7,7 +7,8 @@
 
 buildDunePackage {
   pname = "ocsipersist-pgsql";
-  inherit (ocsipersist-lib) version src useDune2;
+  inherit (ocsipersist-lib) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     lwt_log

--- a/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
@@ -7,7 +7,8 @@
 
 buildDunePackage {
   pname = "ocsipersist-sqlite";
-  inherit (ocsipersist-lib) version src useDune2;
+  inherit (ocsipersist-lib) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     lwt_log

--- a/pkgs/tools/misc/flitter/default.nix
+++ b/pkgs/tools/misc/flitter/default.nix
@@ -11,7 +11,7 @@ ocamlPackages.buildDunePackage rec {
   # request to tag releases: https://github.com/alexozer/flitter/issues/34
   version = "unstable-2020-10-05";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "alexozer";


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
