### PR TITLE
python310Packages.appthreat-vulnerability-db: 4.1.12 -> 4.2.0, appthreat-depscan: 3.4.0 -> 3.5.0 

### DIFF
--- a/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
+++ b/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
@@ -3,19 +3,19 @@
 , buildPythonPackage
 , cvss
 , fetchFromGitHub
+, httpx
 , msgpack
 , orjson
 , packageurl-python
 , pytestCheckHook
 , pythonOlder
-, requests
 , semver
 , tabulate
 }:
 
 buildPythonPackage rec {
   pname = "appthreat-vulnerability-db";
-  version = "4.1.12";
+  version = "4.2.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -24,16 +24,16 @@ buildPythonPackage rec {
     owner = "AppThreat";
     repo = "vulnerability-db";
     rev = "refs/tags/v${version}";
-    hash = "sha256-DHjB8hT9rP1yyeo9I5D8JGIXq+17RYX+e6H7BBuWTw4=";
+    hash = "sha256-uZkPQYuF8EbX5+Qyj7CjxJhpT+DywCSwbORKXqaY0z8=";
   };
 
   propagatedBuildInputs = [
     appdirs
     cvss
+    httpx
     msgpack
     orjson
     packageurl-python
-    requests
     semver
     tabulate
   ];

--- a/pkgs/development/tools/appthreat-depscan/default.nix
+++ b/pkgs/development/tools/appthreat-depscan/default.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "appthreat-depscan";
-  version = "3.4.0";
+  version = "3.5.0";
 
   src = fetchFromGitHub {
     owner = "AppThreat";
     repo = "dep-scan";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Gp0JXjtU8TZl/k6HHWvMvdggIgyn4zqLyyBqiPtlkA8=";
+    hash = "sha256-kwur74jaAjGch4Jruq6OX1lWqX8b3NZYvxxNsp+n/TI=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [


### PR DESCRIPTION
Diff: https://github.com/AppThreat/vulnerability-db/compare/refs/tags/v4.1.12...v4.2.0

Changelog: https://github.com/AppThreat/vulnerability-db/releases/tag/v4.2.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
