### PR TITLE
pulumiPackages.pulumi-language-nodejs: 3.47.0 -> 3.49.0

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/default.nix
+++ b/pkgs/tools/admin/pulumi-packages/default.nix
@@ -6,7 +6,7 @@ in
 {
   pulumi-aws-native = callPackage' ./pulumi-aws-native.nix { };
   pulumi-azure-native = callPackage' ./pulumi-azure-native.nix { };
-  pulumi-language-python = callPackage ./pulumi-language-python.nix { };
   pulumi-language-nodejs = callPackage ./pulumi-language-nodejs.nix { };
+  pulumi-language-python = callPackage ./pulumi-language-python.nix { };
   pulumi-random = callPackage' ./pulumi-random.nix { };
 }

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
@@ -4,13 +4,13 @@
 , nodejs
 }:
 buildGoModule rec {
-  inherit (pulumi) version src;
+  inherit (pulumi) version src sdkVendorHash;
 
   pname = "pulumi-language-nodejs";
 
   sourceRoot = "${src.name}/sdk";
 
-  vendorHash = "sha256-IZIdLmNGMFjRdkLPoE9UyON3pX/GBIgz/rv108v8iLY=";
+  vendorHash = sdkVendorHash;
 
   subPackages = [
     "nodejs/cmd/pulumi-language-nodejs"

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
@@ -4,13 +4,13 @@
 , python3
 }:
 buildGoModule rec {
-  inherit (pulumi) version src;
+  inherit (pulumi) version src sdkVendorHash;
 
   pname = "pulumi-language-python";
 
   sourceRoot = "${src.name}/sdk";
 
-  vendorHash = "sha256-gM3VpX6r/BScUyvk/XefAfbx0qYzdzSBGaWZN+89BS8=";
+  vendorHash = sdkVendorHash;
 
   postPatch = ''
     # Requires network

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -16,6 +16,9 @@ buildGoModule rec {
   pname = "pulumi";
   version = "3.49.0";
 
+  # Used in pulumi-language packages, which inherit this prop
+  sdkVendorHash = "sha256-gM3VpX6r/BScUyvk/XefAfbx0qYzdzSBGaWZN+89BS8=";
+
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;


### PR DESCRIPTION
Recently this PR was merged https://github.com/NixOS/nixpkgs/pull/202462
which introduced pulumiPackages.pulumi-language-nodejs at version 3.47.0.

However, because it relies on the inherited `version` from the `pulumi` package,
which is now 3.49.0, there is an issue at build time.  
The source, which is pulled based on the version, no longer matches the expected `vendorHash`, and you get the following error at build time:
```
error: hash mismatch in fixed-output derivation '/nix/store/fz8kd3dr9mg2f8f2nwq9kjvnyp1cs5c6-pulumi-language-nodejs-3.49.0-go-modules.drv':
         specified: sha256-IZIdLmNGMFjRdkLPoE9UyON3pX/GBIgz/rv108v8iLY=
            got:    sha256-gM3VpX6r/BScUyvk/XefAfbx0qYzdzSBGaWZN+89BS8=
error: 1 dependencies of derivation '/nix/store/vsadbgf0ljch4dz16q58w99z6gdvz005-pulumi-language-nodejs-3.49.0.drv' failed to build
```

Thus I fixed it, by specifying the expected hash.

Also. I changed the ordering in `pkgs/tools/admin/pulumi-packages/default.nix`, to match the alphabetical ordering which was present before the `pulumi-language-nodejs` package was introduced.