### PR TITLE
tuner: init at 1.5.1

### DIFF
--- a/pkgs/applications/audio/tuner/default.nix
+++ b/pkgs/applications/audio/tuner/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, meson
+, ninja
+, vala
+, glib
+, itstool
+, wrapGAppsHook
+, desktop-file-utils
+, libsoup
+, json-glib
+, geoclue2
+, geocode-glib
+, libgee
+, gtk3
+, pantheon
+, gst_all_1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tuner";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "louis77";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-tG1AMEqHcp4jHNgWDy9fS2FtlxFTlpMD5MVbepIY+GY=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    vala
+    glib
+    itstool
+    wrapGAppsHook
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libsoup
+    json-glib
+    geoclue2
+    geocode-glib
+    libgee
+    glib
+    gtk3
+    pantheon.granite
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/louis77/tuner";
+    description = "An app to discover and play internet radio stations";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    mainProgram = "com.github.louis77.tuner";
+    maintainers = [ maintainers.abbe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38208,4 +38208,6 @@ with pkgs;
   widevine-cdm = callPackage ../applications/networking/browsers/misc/widevine-cdm.nix { };
 
   alsa-scarlett-gui = callPackage ../applications/audio/alsa-scarlett-gui { };
+
+  tuner = callPackage ../applications/audio/tuner { };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/louis77/tuner

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
