### PR TITLE
sof-firmware: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/sof-firmware/default.nix
@@ -1,38 +1,34 @@
 { lib
+, fetchurl
 , stdenvNoCC
-, fetchFromGitHub
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "sof-firmware";
-  version = "2.2.2";
+  version = "2.2.3";
 
-  src = fetchFromGitHub {
-    owner = "thesofproject";
-    repo = "sof-bin";
-    rev = "v${version}";
-    sha256 = "sha256-ztewE/8Mc0bbKbxmbJ2sBn3TysuM9hoaSgqrboy77oI=";
+  src = fetchurl {
+    url = "https://github.com/thesofproject/sof-bin/releases/download/v${version}/sof-bin-v${version}.tar.gz";
+    sha256 = "sha256-WR/9ZvHisycDjJHt88hQK0FywdyFDP5EBQ6t+OT620I=";
   };
 
   dontFixup = true; # binaries must not be stripped or patchelfed
 
-  # There is no proper structure in the upstream repo.
-  # This needs to be adapted by hand for every new release.
   installPhase = ''
     runHook preInstall
-    cd "v2.2.x"
-    mkdir -p $out/lib/firmware/intel/sof{,-tplg}
-    cp -a sof-v2.2/* $out/lib/firmware/intel/sof
-    cp -a sof-v2.2.2/* $out/lib/firmware/intel/sof
-    cp -a sof-tplg-v2.2.1/* $out/lib/firmware/intel/sof-tplg
+    mkdir -p $out/lib/firmware/intel
+    cp -av sof-v${version} $out/lib/firmware/intel/sof
+    cp -av sof-tplg-v${version} $out/lib/firmware/intel/sof-tplg
     runHook postInstall
   '';
 
   meta = with lib; {
+    changelog = "https://github.com/thesofproject/sof-bin/releases/tag/v${version}";
     description = "Sound Open Firmware";
     homepage = "https://www.sofproject.org/";
     license = with licenses; [ bsd3 isc ];
     maintainers = with maintainers; [ lblasc evenbrenden hmenke ];
     platforms = with platforms; linux;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New upstream release adding support for more Alder Lake chipsets.
https://github.com/thesofproject/sof-bin/releases/tag/v2.2.3

I think I've also finally found a way to have somewhat reliable package updates that do not require human intervention and reading the release notes for every version bump.

Tested working on NixOS 22.11 on my laptop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
