### PR TITLE
Prometheus aggregate exporter

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -21,6 +21,7 @@ let
   #  `serviceOpts.script` or `serviceOpts.serviceConfig.ExecStart`
 
   exporterOpts = genAttrs [
+    "aggregate"
     "apcupsd"
     "artifactory"
     "bind"

--- a/nixos/modules/services/monitoring/prometheus/exporters/aggregate.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/aggregate.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+}:
+with lib; let
+  cfg = config.services.prometheus.exporters.aggregate;
+
+  enabledExporters = lib.filterAttrs (name: value: value.enable) (lib.filterAttrs (name: value: name != "aggregate" && name != "assertions" && name != "warnings") config.services.prometheus.exporters);
+in {
+  port = 9999;
+  extraOpts = {
+    enableLocalExporters = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Enables aggregation for all locally enabled exporters
+      '';
+    };
+    exporters = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = ["http://localhost:8080/metrics"];
+      description = lib.mdDoc ''
+        Addresses of additional exporters to be aggregated.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = let
+        aggregates = lib.concatStringsSep "," ((lib.attrValues (lib.mapAttrs (name: value: "${name}=http://localhost:${builtins.toString value.port}/metrics") enabledExporters)) ++ cfg.exporters);
+      in ''
+        ${pkgs.prometheus-aggregate-exporter}/bin/aggregate_exporter \
+          -targets "${aggregates}" \
+          -server.bind ${cfg.listenAddress}:${toString cfg.port} ${concatStringsSep " " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -59,6 +59,19 @@ let
   */
 
   exporterTests = {
+    aggregate = {
+      exporterConfig = {
+        enable = true;
+      };
+      metricProvider = {
+        services.prometheus.exporters.node.enable = true;
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-aggregate-exporter.service")
+        wait_for_open_port(9999)
+        succeed("curl -sSf http://localhost:9999/metrics | grep 'node_procs_running'")
+      '';
+    };
     apcupsd = {
       exporterConfig = {
         enable = true;

--- a/pkgs/servers/monitoring/prometheus/aggregate-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/aggregate-exporter.nix
@@ -1,0 +1,38 @@
+{ lib, buildGoModule, fetchFromGitHub, nixosTests, fetchpatch
+}:
+buildGoModule rec {
+  pname = "prometheus-aggregate-exporter";
+  version = "3.0.0";
+
+  patches = [(fetchpatch {
+    url = "https://github.com/kampka/prometheus-aggregate-exporter/commit/723520f41773fff9ff1c0d0db71c0f3aa4ce55d1.patch";
+    sha256 = "sha256-j2niNPsL9y7g0bZ/LRSNSU2neKrTzcUcsuwiR+xQ7sI=";
+  })];
+
+  src = fetchFromGitHub {
+    owner = "warmans";
+    repo = "prometheus-aggregate-exporter";
+    rev = "v${version}";
+    sha256 = "sha256-514Ti07HQLBife2lqGmISsAgN+EJLF8KLL7rwBG6Amo=";
+  };
+
+  vendorSha256 = "sha256-EejTaOq/25q5cA10IiWFOhB0GplnS4oiKSjt7DJAo/I=";
+
+  postBuild = ''
+    mv $GOPATH/bin/cmd $GOPATH/bin/aggregate_exporter
+    rm $GOPATH/bin/fixture
+  '';
+  ldflags = [
+    "-X main.Version=${version}"
+  ];
+  doCheck = false;
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) aggregate; };
+
+  meta = with lib; {
+    description = "Aggregate prometheus exporters into a single endpoint";
+    homepage = "https://github.com/warmans/prometheus-aggregate-exporter";
+    changelog = "https://github.com/warmans/prometheus-aggregate-exporter/releases";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24524,6 +24524,7 @@ with pkgs;
   prom2json = callPackage ../servers/monitoring/prometheus/prom2json.nix { };
   prometheus = callPackage ../servers/monitoring/prometheus { };
   prometheus-alertmanager = callPackage ../servers/monitoring/prometheus/alertmanager.nix { };
+  prometheus-aggregate-exporter = callPackage ../servers/monitoring/prometheus/aggregate-exporter.nix { };
   prometheus-apcupsd-exporter = callPackage ../servers/monitoring/prometheus/apcupsd-exporter.nix { };
   prometheus-artifactory-exporter = callPackage ../servers/monitoring/prometheus/artifactory-exporter.nix { };
   prometheus-aws-s3-exporter = callPackage ../servers/monitoring/prometheus/aws-s3-exporter.nix { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).