### PR TITLE
cavalier: init at 2023.01.29

### DIFF
--- a/pkgs/applications/audio/cavalier/default.nix
+++ b/pkgs/applications/audio/cavalier/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, python3
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, glib
+, gtk4
+, librsvg
+, libadwaita
+, wrapGAppsHook4
+, appstream-glib
+, desktop-file-utils
+, cava
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "cavalier";
+  version = "2023.01.29";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "fsobolev";
+    repo = pname;
+    rev = version;
+    hash = "sha256-6bvi73cFQHtIyD4d4+mqje0qkmG4wkahZ2ohda5RvRQ=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    wrapGAppsHook4
+    appstream-glib
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    librsvg
+    libadwaita
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+  ];
+
+  # Prevent double wrapping
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH ":" "${lib.makeBinPath [ cava ]}"
+    )
+  '';
+
+  meta = with lib; {
+    description = "Audio visualizer based on CAVA with customizable LibAdwaita interface";
+    homepage = "https://github.com/fsobolev/cavalier";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27895,6 +27895,8 @@ with pkgs;
 
   cava = callPackage ../applications/audio/cava { };
 
+  cavalier = callPackage ../applications/audio/cavalier { };
+
   cb2bib = libsForQt5.callPackage ../applications/office/cb2bib { };
 
   cbatticon = callPackage ../applications/misc/cbatticon { };


### PR DESCRIPTION
###### Description of changes

https://github.com/fsobolev/cavalier

Audio visualizer based on CAVA. Written in Python using LibAdwaita. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
