### PR TITLE
texlive.combine: no-effect clean up of script

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -143,7 +143,7 @@ in (buildEnv {
       [[ -e "$fname" ]] && sed -E -n -f '${script}' -i "$fname"
     done
     [[ -e "$out"/share/texmf/tex/generic/config/language.dat.lua ]] && sed -E -n -f '${scriptLua}' -i "$out"/share/texmf/tex/generic/config/language.dat.lua
-    [[ -e "$out"/share/texmf/web2c/fmtutil.cnf ]] && sed -E -n -f '${fmtutilSed}' -i "$out"/share/texmf/web2c/fmtutil.cnf
+    [[ -e "$TEXMFCNF"/fmtutil.cnf ]] && sed -E -n -f '${fmtutilSed}' -i "$TEXMFCNF"/fmtutil.cnf
   '') +
 
   # function to wrap created executables with required env vars
@@ -207,13 +207,13 @@ in (buildEnv {
 
     # tex intentionally ignores SOURCE_DATE_EPOCH even when FORCE_SOURCE_DATE=1
     # https://salsa.debian.org/live-team/live-build/-/blob/master/examples/hooks/reproducible/0139-reproducible-texlive-binaries-fmt-files.hook.chroot#L52
-    if [[ -f "$out"/share/texmf-var/web2c/tex/tex.fmt ]]
+    if [[ -f "$TEXMFSYSVAR"/web2c/tex/tex.fmt ]]
     then
-      faketime $(date --utc -d@$SOURCE_DATE_EPOCH --iso-8601=seconds) tex -output-directory "$out"/share/texmf-var/web2c/tex -ini -jobname=tex -progname=tex tex.ini
+      faketime $(date --utc -d@$SOURCE_DATE_EPOCH --iso-8601=seconds) tex -output-directory "$TEXMFSYSVAR"/web2c/tex -ini -jobname=tex -progname=tex tex.ini
     fi
-    if [[ -f "$out"/share/texmf-var/web2c/luahbtex/lualatex.fmt ]]
+    if [[ -f "$TEXMFSYSVAR"/web2c/luahbtex/lualatex.fmt ]]
     then
-      faketime $(date --utc -d@$SOURCE_DATE_EPOCH --iso-8601=seconds) luahbtex --output-directory="out"/share/texmf-var/web2c/luahbtex -ini -jobname=lualatex -progname=lualatex lualatex.ini
+      faketime $(date --utc -d@$SOURCE_DATE_EPOCH --iso-8601=seconds) luahbtex --output-directory="$TEXMFSYSVAR"/web2c/luahbtex -ini -jobname=lualatex -progname=lualatex lualatex.ini
     fi
 
     # Disable unavailable map files

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -193,9 +193,7 @@ in (buildEnv {
   '' +
   # texlive post-install actions
   ''
-    for tool in updmap; do
-      ln -sf "$out/share/texmf/scripts/texlive/$tool."* "$out/bin/$tool"
-    done
+    ln -sf "$out"/share/texmf/scripts/texlive/updmap.pl "$out"/bin/updmap
   '' +
     # now hack to preserve "$0" for mktexfmt
   ''

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -202,9 +202,9 @@ in (buildEnv {
     sed "1s|$| -I $out/share/texmf/scripts/texlive|" -i "$out/bin/fmtutil"
     ln -sf fmtutil "$out/bin/mktexfmt"
 
-    perl `type -P mktexlsr.pl` --sort ./share/texmf
+    perl "$out"/share/texmf/scripts/texlive/mktexlsr.pl --sort "$out"/share/texmf
     texlinks "$out/bin" && wrapBin
-    FORCE_SOURCE_DATE=1 perl `type -P fmtutil.pl` --sys --all | grep '^fmtutil' # too verbose
+    FORCE_SOURCE_DATE=1 fmtutil --sys --all | grep '^fmtutil' # too verbose
     #texlinks "$out/bin" && wrapBin # do we need to regenerate format links?
 
     # tex intentionally ignores SOURCE_DATE_EPOCH even when FORCE_SOURCE_DATE=1
@@ -223,14 +223,14 @@ in (buildEnv {
     fi
 
     # Disable unavailable map files
-    echo y | perl `type -P updmap.pl` --sys --syncwithtrees --force
+    echo y | updmap --sys --syncwithtrees --force
     # Regenerate the map files (this is optional)
-    perl `type -P updmap.pl` --sys --force
+    updmap --sys --force
 
     # sort entries to improve reproducibility
     [[ -f "$TEXMFSYSCONFIG"/web2c/updmap.cfg ]] && sort -o "$TEXMFSYSCONFIG"/web2c/updmap.cfg "$TEXMFSYSCONFIG"/web2c/updmap.cfg
 
-    perl `type -P mktexlsr.pl` --sort ./share/texmf-* # to make sure
+    perl "$out"/share/texmf/scripts/texlive/mktexlsr.pl --sort "$out"/share/texmf-* # to make sure
   '' +
     # install (wrappers for) scripts, based on a list from upstream texlive
   ''

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -246,9 +246,9 @@ in (buildEnv {
     #  * Copy is done to have a correct "$0" so that epstopdf enables the restricted mode
     #  * ./bin/repstopdf needs to be a symlink to be processed by wrapBin
   ''
-    if [[ -e ./bin/epstopdf ]]; then
-      cp $(realpath ./bin/epstopdf) ./share/texmf/scripts/repstopdf
-      ln -s "$out"/share/texmf/scripts/repstopdf ./bin/repstopdf
+    if [[ -e "$out"/bin/epstopdf ]]; then
+      cp "$out"/bin/epstopdf "$out"/share/texmf/scripts/repstopdf
+      ln -s "$out"/share/texmf/scripts/repstopdf "$out"/bin/repstopdf
     fi
   '' +
     # finish up the wrappers

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -305,16 +305,10 @@ in (buildEnv {
     done
   '' +
   # MkIV uses its own lookup mechanism and we need to initialize
-  # caches for it. Unsetting TEXMFCNF is needed to let mtxrun
-  # determine it from kpathsea so that the config path is given with
-  # "selfautodir:" as it will be in runtime. This is important because
-  # the cache is identified by a hash of this path.
+  # caches for it.
   ''
     if [[ -e "$out/bin/mtxrun" ]]; then
-      (
-        unset TEXMFCNF
-        mtxrun --generate
-      )
+      mtxrun --generate
     fi
   ''
     + bin.cleanBrokenLinks +

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -74,9 +74,8 @@ in (buildEnv {
   ''
     export PATH="$out/bin:$out/share/texmf/scripts/texlive:$PATH"
     export TEXMFCNF="$out/share/texmf/web2c"
-    export TEXMFDIST="$out/share/texmf"
-    export TEXMFSYSCONFIG="$out/share/texmf-config"
-    export TEXMFSYSVAR="$out/share/texmf-var"
+    TEXMFSYSCONFIG="$out/share/texmf-config"
+    TEXMFSYSVAR="$out/share/texmf-var"
     export PERL5LIB="$out/share/texmf/scripts/texlive:${bin.core.out}/share/texmf-dist/scripts/texlive"
   '' +
     # patch texmf-dist  -> $out/share/texmf

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -50,7 +50,7 @@ in (buildEnv {
     "/tex/generic/config" # make it a real directory for scheme-infraonly
   ];
 
-  nativeBuildInputs = [ makeWrapper libfaketime ];
+  nativeBuildInputs = [ makeWrapper libfaketime perl bin.texlinks ];
   buildInputs = pkgList.extraInputs;
 
   # This is set primarily to help find-tarballs.nix to do its job
@@ -73,7 +73,7 @@ in (buildEnv {
       pkgList.bin
     +
   ''
-    export PATH="$out/bin:$out/share/texmf/scripts/texlive:${perl}/bin:$PATH"
+    export PATH="$out/bin:$out/share/texmf/scripts/texlive:$PATH"
     export TEXMFCNF="$out/share/texmf/web2c"
     export TEXMFDIST="$out/share/texmf"
     export TEXMFSYSCONFIG="$out/share/texmf-config"
@@ -224,9 +224,9 @@ in (buildEnv {
     ln -sf fmtutil "$out/bin/mktexfmt"
 
     perl `type -P mktexlsr.pl` --sort ./share/texmf
-    ${bin.texlinks}/bin/texlinks "$out/bin" && wrapBin
+    texlinks "$out/bin" && wrapBin
     FORCE_SOURCE_DATE=1 perl `type -P fmtutil.pl` --sys --all | grep '^fmtutil' # too verbose
-    #${bin.texlinks}/bin/texlinks "$out/bin" && wrapBin # do we need to regenerate format links?
+    #texlinks "$out/bin" && wrapBin # do we need to regenerate format links?
 
     # tex intentionally ignores SOURCE_DATE_EPOCH even when FORCE_SOURCE_DATE=1
     # https://salsa.debian.org/live-team/live-build/-/blob/master/examples/hooks/reproducible/0139-reproducible-texlive-binaries-fmt-files.hook.chroot#L52


### PR DESCRIPTION
###### Description of changes
This is a minor clean up of the combine script, and not necessarily complete. My intention is to simplify things as much as possible before trying bigger improvements that would address the existing issues (e.g. I'd still like to split the texmf and texmf-var derivations, and eventually re-use the format files across different derivations, saving *a lot* of time).

As far as I can tell, this PR has no effect on the output, other than the usual non-reproducible changes caused by changing and rebuilding a derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
