### PR TITLE
groonga: 12.0.7 -> 12.1.0

### DIFF
--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoreconfHook, mecab, kytea, libedit, pkg-config, libxcrypt
+{ lib, stdenv, fetchurl, mecab, kytea, libedit, pkg-config, libxcrypt
 , suggestSupport ? false, zeromq, libevent, msgpack, openssl
 , lz4Support  ? false, lz4
 , zlibSupport ? true, zlib
@@ -7,17 +7,12 @@
 stdenv.mkDerivation rec {
 
   pname = "groonga";
-  version = "12.0.7";
+  version = "12.1.0";
 
   src = fetchurl {
     url    = "https://packages.groonga.org/source/groonga/${pname}-${version}.tar.gz";
-    sha256 = "sha256-Eaei4Zi0Rg9zu7DInLAcaRo8Fyu2mqBblcYNRaS46c8=";
+    sha256 = "sha256-pLU1ifcm8jfqr9jQMjNbccNprDz6uZ9zNcXRJ5IBOdc=";
   };
-
-  preConfigure = ''
-    # To avoid problems due to libc++abi 11 using `#include <version>`.
-    rm version
-  '';
 
   buildInputs = with lib;
      [ mecab kytea libedit openssl libxcrypt ]
@@ -25,7 +20,7 @@ stdenv.mkDerivation rec {
     ++ optional zlibSupport zlib
     ++ optionals suggestSupport [ zeromq libevent msgpack ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  nativeBuildInputs = [ pkg-config ];
 
   configureFlags = with lib;
        optional zlibSupport "--with-zlib"
@@ -38,7 +33,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://groonga.org/";
     description = "An open-source fulltext search engine and column store";
     license     = licenses.lgpl21;
-    maintainers = [ maintainers.ericsagnes ];
+    maintainers = with maintainers; [ ericsagnes ivan ];
     platforms   = platforms.unix;
     longDescription = ''
       Groonga is an open-source fulltext search engine and column store.


### PR DESCRIPTION
###### Description of changes

https://github.com/groonga/groonga/compare/v12.0.7...v12.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested this only through pgroonga on PostgreSQL 14.6, which kept working on x86_64 NixOS 22.11.

cc maintainer @ericsagnes