### PR TITLE
POC: devShell interface

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -6,7 +6,7 @@
 
 let
   # N.B. Keep in sync with default arg for stdenv/generic.
-  defaultMkDerivationFromStdenv = import ./generic/make-derivation.nix { inherit lib config; };
+  defaultMkDerivationFromStdenv = import ./generic/make-derivation.nix { inherit lib config; inherit (pkgs) defaultDevShell; };
 
   # Low level function to help with overriding `mkDerivationFromStdenv`. One
   # gives it the old stdenv arguments and a "continuation" function, and

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -1,5 +1,6 @@
 { lib
 , localSystem, crossSystem, config, overlays, crossOverlays ? []
+, defaultDevShell
 }:
 
 let
@@ -11,6 +12,8 @@ let
 
     # Ignore custom stdenvs when cross compiling for compatability
     config = builtins.removeAttrs config [ "replaceStdenv" ];
+
+    inherit defaultDevShell;
   };
 
 in lib.init bootStages ++ [

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -34,6 +34,7 @@
       cpio = fetch { file = "cpio"; sha256 = "sha256-SWkwvLaFyV44kLKL2nx720SvcL4ej/p2V/bX3uqAGO0="; };
       tarball = fetch { file = "bootstrap-tools.cpio.bz2"; sha256 = "sha256-kRC/bhCmlD4L7KAvJQgcukk7AinkMz4IwmG1rqlh5tA="; executable = false; };
     }
+, defaultDevShell
 }:
 
 assert crossSystem == localSystem;
@@ -149,7 +150,7 @@ rec {
       thisStdenv = import ../generic {
         name = "${name}-stdenv-darwin";
 
-        inherit config shell extraBuildInputs;
+        inherit config shell extraBuildInputs defaultDevShell;
 
         extraNativeBuildInputs = extraNativeBuildInputs ++ lib.optionals doUpdateAutoTools [
           last.pkgs.updateAutotoolsGnuConfigScriptsHook
@@ -668,7 +669,7 @@ rec {
     import ../generic rec {
       name = "stdenv-darwin";
 
-      inherit config;
+      inherit config defaultDevShell;
       inherit (pkgs.stdenv) fetchurlBoot;
 
       buildPlatform = localSystem;

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -8,6 +8,7 @@
   lib
   # Args to pass on to the pkgset builder, too
 , localSystem, crossSystem, config, overlays, crossOverlays ? []
+, defaultDevShell
 } @ args:
 
 let

--- a/pkgs/stdenv/devShell.nix
+++ b/pkgs/stdenv/devShell.nix
@@ -1,0 +1,23 @@
+{ pkgs }:
+{ drv, ... }:
+
+# stdenvDevShell only supports simple derivations, not generalized packages or anything else.
+assert drv?drvPath && drv.type or null == "derivation";
+
+# TODO: fork and improve nix-shell logic
+(pkgs.buildPackages.writeScriptBin "devShell" ''
+  #!${pkgs.buildPackages.runtimeShell}
+  ${pkgs.buildPackages.nix}/bin/nix-shell ${builtins.unsafeDiscardOutputDependency drv.drvPath}
+'').overrideAttrs (finalAttrs: prevAttrs: {
+  passthru = prevAttrs.passthru or {} // {
+    shellData = pkgs.runCommandLocal "devShell-data" {
+      # inputDerivation can only produce one file without breaking back compat
+      # hence, we only use its implementation and improve its interface.
+      # TODO: expose the structured attrs files?
+      inherit (drv) inputDerivation;
+    } ''
+      mkdir $out
+      cp $inputDerivation $out/environment.sh
+    '';
+  };
+})

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -52,7 +52,10 @@ argsStdenv@{ name ? "stdenv", preHook ? "", initialPath
 
 , # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
   # This is convient to have as a parameter so the stdenv "adapters" work better
-  mkDerivationFromStdenv ? import ./make-derivation.nix { inherit lib config; }
+  mkDerivationFromStdenv ? import ./make-derivation.nix { inherit lib config defaultDevShell; }
+
+, # See ./make-derivation.nix
+  defaultDevShell ? _: null
 }:
 
 let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -1,4 +1,8 @@
-{ lib, config }:
+{ lib,
+  config,
+  # Function to construct the default devShell attribute; when not set via passthru.
+  defaultDevShell ? _: null,
+}:
 
 stdenv:
 
@@ -473,6 +477,8 @@ else let
                    else true);
     };
 
+  drv = derivation derivationArg;
+
 in
 
 lib.extendDerivation
@@ -503,13 +509,18 @@ lib.extendDerivation
        args = [ "-c" "export > $out" ];
      });
 
+     devShell = defaultDevShell {
+       # TODO bring `finalPackage` into scope here.
+       drv = overrideAttrs (o: {});
+     };
+
      inherit meta passthru overrideAttrs;
    } //
    # Pass through extra attributes that are not inputs, but
    # should be made available to Nix expressions using the
    # derivation (e.g., in assertions).
    passthru)
-  (derivation derivationArg);
+  drv;
 
 in
   fnOrAttrs:

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -40,6 +40,7 @@
   files = archLookupTable.${localSystem.system} or (if getCompatibleTools != null then getCompatibleTools
     else (abort "unsupported platform for the pure Linux stdenv"));
   in files
+, defaultDevShell
 }:
 
 assert crossSystem == localSystem;
@@ -461,6 +462,8 @@ in
         inherit (prevStage) binutils binutils-unwrapped;
         gcc = cc;
       };
+
+      inherit defaultDevShell;
     };
   })
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -112,6 +112,10 @@ with pkgs;
 
   tests = callPackages ../test {};
 
+  stdenvDevShell = import ../stdenv/devShell.nix { inherit pkgs; };
+
+  defaultDevShell = stdenvDevShell;
+
   ### Nixpkgs maintainer tools
 
   nix-generate-from-cpan = callPackage ../../maintainers/scripts/nix-generate-from-cpan.nix { };

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -124,6 +124,7 @@ in let
 
   stages = stdenvStages {
     inherit lib localSystem crossSystem config overlays crossOverlays;
+    inherit (pkgs) defaultDevShell;
   };
 
   pkgs = boot stages;


### PR DESCRIPTION
The idea here is that future Nix first tries to "`nix run`" the `pkg.devShell` package, and only if that fails, fall back to the legacy `nix develop` (or `nix-shell`) behavior.

This allows the development shell to evolve with stdenv, and it allows packages to individually customize the `devShell` attribute, by setting `passthru.devShell`.

Furthermore, these shell behaviors will be pinned to the expressions, allowing changes to be made in a more agile manner, unlike Nix, which has to be very careful not to break old expressions, as users can not revert Nix.

To give it a try:

    nix run .#hello.devShell

In the future this will be equivalent to:

    nix develop .#hello

Isn't this the responsibility of Nix?

It is not. `nix-shell` and `nix develop` are a great user interface, that everyone loves, but their implementation is a pile of hacks on top of stdenv.
Instead of coercing stdenv to do what `nix-shell` needs it to, we can ask stdenv politely to provide a shell.
Now that Nix doesn't have to assume a package comes from stdenv, there's a possibility for experimental builders to provide shells too.

What does this break?

Only packages that define a `devShell` attribute (for some reason?) have to adapt to the suggested new Nix behavior. Note that a `devShell` value for the builder can be overridden by `passthru` without affecting the build or shell.
Packages and shells pinned to older versions can still be loaded because Nix keeps the legacy behavior as a fallback.

But this still relies on `nix-shell` to provide a shell???

Fair enough. This is only a proof of concept. The goal is to replace that invocation by a script or program with the same or better behavior, without relying on `nix-shell` as its implementation.

Does this solve the need for `.env` for Haskell package shells?

Not in this commit, but Haskell packages will be able to produce their own `devShell` attribute, which is derived from the .env derivation rather than the regular derivation.

Refs
 - https://github.com/NixOS/nix/issues/7468 and a bunch of other issues where I've written about this idea.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
