### PR TITLE
simplescreenrecorder: Make available on more platforms

### DIFF
--- a/pkgs/applications/video/simplescreenrecorder/default.nix
+++ b/pkgs/applications/video/simplescreenrecorder/default.nix
@@ -13,7 +13,10 @@ mkDerivation rec {
     sha256 = "0mrx8wprs8bi42fwwvk6rh634ic9jnn0gkfpd6q9pcawnnbz3vq8";
   };
 
-  cmakeFlags = [ "-DWITH_QT5=TRUE" ];
+  cmakeFlags = [
+    "-DWITH_QT5=TRUE"
+    "-DWITH_GLINJECT=${if stdenv.hostPlatform.isx86 then "TRUE" else "FALSE"}"
+  ];
 
   patches = [ ./fix-paths.patch ];
 
@@ -35,7 +38,7 @@ mkDerivation rec {
     description = "A screen recorder for Linux";
     homepage = "https://www.maartenbaert.be/simplescreenrecorder";
     license = licenses.gpl3Plus;
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Only thing that seems to have kept this from working on aarch64-linux was glinject:

```
building
build flags: -j2
[1/83] Building C object glinject/CMakeFiles/ssr-glinject.dir/elfhacks.c.o
FAILED: glinject/CMakeFiles/ssr-glinject.dir/elfhacks.c.o 
/nix/store/jm6gqq369d0vd9pz3b7swn2vyycygdb9-gcc-wrapper-9.5.0/bin/gcc -Dssr_glinject_EXPORTS  -O3 -DNDEBUG -fPIC -MD -MT glinject/CMakeFiles/ssr-glinject.dir/elfhacks.c.o -MF glinject/CMakeFiles/ssr-glinject.dir/elfhacks.c.o.d -o glinject/CMakeFiles/ssr-glinject.dir/elfhacks.c.o -c /build/source/glinject/elfhacks.c
In file included from /build/source/glinject/elfhacks.c:20:
/build/source/glinject/elfhacks.h:67:3: error: #error neither __elf32 nor __elf64 is defined
   67 | # error neither __elf32 nor __elf64 is defined
      |   ^~~~~
/build/source/glinject/elfhacks.c:34:37: error: unknown type name 'ElfW_Sword'; did you mean 'Elf64_Sword'?
   34 | int eh_find_next_dyn(eh_obj_t *obj, ElfW_Sword tag, int i, ElfW(Dyn) **next);
      |                                     ^~~~~~~~~~
      |                                     Elf64_Sword
/build/source/glinject/elfhacks.c:422:37: error: unknown type name 'ElfW_Sword'; did you mean 'Elf64_Sword'?
  422 | int eh_find_next_dyn(eh_obj_t *obj, ElfW_Sword tag, int i, ElfW(Dyn) **next)
      |                                     ^~~~~~~~~~
      |                                     Elf64_Sword
/build/source/glinject/elfhacks.c: In function 'eh_set_rela_plt':
/build/source/glinject/elfhacks.c:456:6: warning: implicit declaration of function 'eh_find_next_dyn' [-Wimplicit-function-declaration]
  456 |  if (eh_find_next_dyn(obj, DT_PLTRELSZ, p, &relasize))
      |      ^~~~~~~~~~~~~~~~
/build/source/glinject/elfhacks.c:460:20: warning: implicit declaration of function 'ELFW_R_SYM'; did you mean 'ELF64_R_SYM'? [-Wimplicit-function-declaration]
  460 |   if (!obj->symtab[ELFW_R_SYM(rela[i].r_info)].st_name)
      |                    ^~~~~~~~~~
      |                    ELF64_R_SYM
[2/83] Building CXX object glinject/CMakeFiles/ssr-glinject.dir/GLInject.cpp.o
ninja: build stopped: subcommand failed.
```

This isn't a crucial functionality and can be disabled with a CMake option, so doing just that on non-x86 (which mirrors what upstream's `simpple-build-and-install` script does). The platform restriction to just x86_64-linux specifically seemed abit too harsh to me, instead of adding aarch64-linux to that I've opted for `platforms.linux` instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  
  https://user-images.githubusercontent.com/23431373/208311064-ac2f063a-7409-468c-aab8-6b13d39f96b3.mp4
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
