### PR TITLE
dotnet-sdk_3.1: 3.1.425 -> 3.1.426

### DIFF
--- a/pkgs/development/compilers/dotnet/versions/3.1.nix
+++ b/pkgs/development/compilers/dotnet/versions/3.1.nix
@@ -1,137 +1,137 @@
 { buildAspNetCore, buildNetRuntime, buildNetSdk, icu }:
 
-# v3.1 (maintenance)
+# v3.1 (eol)
 {
   aspnetcore_3_1 = buildAspNetCore {
     inherit icu;
-    version = "3.1.31";
+    version = "3.1.32";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/2fc0069c-e99a-4296-99ee-a422b3cf50de/df8aee91eeaf50a12c810c3845341eb3/aspnetcore-runtime-3.1.31-linux-x64.tar.gz";
-        sha512  = "9ea1fb4c9a656de8392b8f92c608c2f927fd03ad8e8b195f3f0b69c1433cfbf2679827b1ce2fac783f8ef77307c7b1b36563d0813f914b75b025b5cca6c773f9";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/39c3ef4c-73c7-4248-8c54-0865d5feb8b2/3420b1ff6b0f36e63044d6f7a794b579/aspnetcore-runtime-3.1.32-linux-x64.tar.gz";
+        sha512  = "0aa2aceda3d0b9f6bf02456d4e4b917c221c4f18eff30c8b6418e7514681baa9bb9ccc6b8c78949a92664922db4fb2b2a0dac9da11f775aaef618d9c491bb319";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/216fe20f-6c45-4a87-b206-6c22360567fd/902208836df9ddcf4eb177771b2c6fea/aspnetcore-runtime-3.1.31-linux-arm64.tar.gz";
-        sha512  = "970def9298bfe39c00054ae45231e2c632d4364a311349b3594bef5dd3739af2db33329f314f29a3956c271745948df88076e39bd2fa80e8a4dbb9723e3493ec";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/7a713b60-c2fb-4dc9-ad35-df86c4bfac0c/fff24659d0a2ad9c6b622be1722b8f72/aspnetcore-runtime-3.1.32-linux-arm64.tar.gz";
+        sha512  = "34b9ec241cd0047cb23f0b8416d3a009476e511c3dd5854636c11cfd078117faf095f32f06e7c97d810af94fde43621117414f983d3b2041ad40260f50dc330d";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/25282f2c-c43e-4c0f-aa09-f72c565e009e/b581cf1c97879ca4913a1763c7d1fe8d/aspnetcore-runtime-3.1.31-osx-x64.tar.gz";
-        sha512  = "25d395435ddc17b8155c6d9b06c6b280e462da3e86a8c2b0b0549cfb80d2770b0df33a0a87845b442e89295000a872fce12a5949b4f1b123f802e8e2d071d504";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/70cd4d7b-0186-4ce2-a710-f50d6dec246f/84c5b21b8a487127589095336c5158b5/aspnetcore-runtime-3.1.32-osx-x64.tar.gz";
+        sha512  = "21f77b64b527af41bbba0f8887c71be631f37d7bbabe9119fe39961c2600a90075f60768173097c9fffe32e40f8db309544837055cb70fe428195682b85fb9a0";
       };
     };
   };
 
   runtime_3_1 = buildNetRuntime {
     inherit icu;
-    version = "3.1.31";
+    version = "3.1.32";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/046afe25-7b88-48ad-a06c-1c3625115c63/6814f9ca777bc7e2cb4b373027dcdd76/dotnet-runtime-3.1.31-linux-x64.tar.gz";
-        sha512  = "fb2ac1a1e3b9b1eceb37587535d96a5a3c0b01edd07182ed57d4725e067678988a3fcdf22f3f49d21bc35760d69398af85a6449e6c3a8ed401ad85df920be4df";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/fea239ad-fd47-4764-aa71-6a147a82f632/20ee58b0bf08ae9f6e76e37ba3765c57/dotnet-runtime-3.1.32-linux-x64.tar.gz";
+        sha512  = "a1de9bbc3d2e3a4f5f52b7742c678b182a58a724d36232997511e390027044d60144a7e010a29d6ee016ec91f2911daef28ac5712a827fff8bdde73314b7e002";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/dbdcd07a-e519-470a-a03e-702f4cbf65d7/e1bc1991aa91cc52582d446ae4b63691/dotnet-runtime-3.1.31-linux-arm64.tar.gz";
-        sha512  = "bb9594cdf3b1f8005005d12055fe5e1ae6ba40ed56c2f6f41e36b2c04c9a7fa4630da594c7d93fe587d75d9a00638818fb14228e188fb7f1b7b5eff96d53bc7f";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/edfb706e-83fe-4a81-804c-23d80b041b70/4f98b067bd2817976a4362c25fbf70e7/dotnet-runtime-3.1.32-linux-arm64.tar.gz";
+        sha512  = "ff311df0db488f3b5cc03c7f6724f8442de7e60fa0a503ec8f536361ce7a357ad26d09d2499d68c50ebdfa751a5520bba4aaa77a38b191c892d5a018561ce422";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/3a01bc5f-4deb-4cf5-bbdd-19a1dc406b2c/1c66b68807fe87cda620898c088000c4/dotnet-runtime-3.1.31-osx-x64.tar.gz";
-        sha512  = "8890441bd64911656e34a824f3d4abdbcbe4337887efc90fc8eba62189be161bcedd0d0f0e1168dadbc25bc616c462ab1c8499b9a52f05be19173f2af8ea09e7";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/09f14240-76bf-43df-bdf1-636aa56cbd5c/4898c400f81d0bac651bcf84dc487b6f/dotnet-runtime-3.1.32-osx-x64.tar.gz";
+        sha512  = "9fd385812e770525856d734ca62e5d01ddb534ff317bb09e1091ded38ce2c16dc4bd02b5eebad8ea6e01b21755fe6f5ce6ca5183ebbbee04fa1aed956da4c58a";
       };
     };
   };
 
   sdk_3_1 = buildNetSdk {
     inherit icu;
-    version = "3.1.425";
+    version = "3.1.426";
     srcs = {
       x86_64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/c2574deb-9c23-4851-89bd-211243ecd85b/046fc7e68a8e7e6e5854fc0b3b56e59c/dotnet-sdk-3.1.425-linux-x64.tar.gz";
-        sha512  = "3d31c6bb578f668111d0f124db6a1222b5d186450380bfd4f42bc8030f156055b025697eabc8c2672791c96e247f6fc499ff0281388e452fcc16fbd1f8a36de1";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/e89c4f00-5cbb-4810-897d-f5300165ee60/027ace0fdcfb834ae0a13469f0b1a4c8/dotnet-sdk-3.1.426-linux-x64.tar.gz";
+        sha512  = "6c3f9541557feb5d5b93f5c10b28264878948e8540f2b8bb7fb966c32bd38191e6b310dcb5f87a4a8f7c67a7046fa932cde3cce9dc8341c1365ae6c9fcc481ec";
       };
       aarch64-linux = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/d4a8d050-e3d0-4f07-b222-5cadb21320f2/05d4d832757a78ec88fb56d8f9f4cc65/dotnet-sdk-3.1.425-linux-arm64.tar.gz";
-        sha512  = "f3c18acc094c19f3887f6598c34c9a2e1cfa94055f77aa4deae7e51e8d760ca87af7185cc9ed102e08f04d35f9a558894f04f7a44fa56b91232ccc895f4e5a5c";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/79f1cf3e-ccc7-4de4-9f4c-1a6e061cb867/68cab78b3f9a5a8ce2f275b983204376/dotnet-sdk-3.1.426-linux-arm64.tar.gz";
+        sha512  = "300e154fba3123644910bbb89a6e61f67569677efa359aa110871cbbb62afad059709dc362f0af27ece0b9a30bc3e6ef57c3cb7c6f75377b20d48636605f30f7";
       };
       x86_64-darwin = {
-        url     = "https://download.visualstudio.microsoft.com/download/pr/8d52dd3a-13f9-4b1e-ae1b-7afc8896bf08/f01ed5a9f1eb3d425daec9e900a334cf/dotnet-sdk-3.1.425-osx-x64.tar.gz";
-        sha512  = "dbe560c6d052333f2922c8337ca84cb4cd1de614de53be8bc3c52537c32bc4d074b8af832f5a1660bf0bc07204c74b3f0610a12ce6b192eae6503f76bb5ce40a";
+        url     = "https://download.visualstudio.microsoft.com/download/pr/e45c25b7-623f-4b98-8918-13a671884860/d6e4526d0dd31d388b36a749f90ae6e2/dotnet-sdk-3.1.426-osx-x64.tar.gz";
+        sha512  = "be1c29ffe8ddec6051d7529796dae35fe18036af89d5e7285fcdad46316fec557f4b15c15eed4d676071d187b363c2e16cb3bcbf708b920b5614340a6e51ab3d";
       };
     };
     packages = { fetchNuGet }: [
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm"; version = "3.1.31"; sha256 = "0s8rnj81b04w1lbgwirsv9xzmpkx9ffr8wyzgwwyvb2y2r39w6pg"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm64"; version = "3.1.31"; sha256 = "12w3gka0k2z309jaxwhrqlhjfhag0pn26k44528k6039r5vrc62r"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"; version = "3.1.31"; sha256 = "1gbiwdhsfns4pkcpvl1kdpzynkplal0binfawxhzx0mjp66447rf"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"; version = "3.1.31"; sha256 = "1k5zjvak7pp4rzcv3p4jp2ic23xyk89342mna3i9kp20qn4c36mv"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "3.1.31"; sha256 = "0kilp89vmcqs6yznvx2wpxafhpjbzybrvdbfqpmlxjbbbbsgfi7v"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-x64"; version = "3.1.31"; sha256 = "021a8xn4haa8vha9ypvldnmp8v519snjm9za67vscd2kkvifcxnl"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm"; version = "3.1.31"; sha256 = "1qmd1zx54khnsqwrlq76m70xbw6dv1qrz3f9nva89prjgkqmqag4"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm64"; version = "3.1.31"; sha256 = "0dm0prvl1qsws22rwgkbdbb8jkgvgxw8zf88rf7rw3xp1dnhql74"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x64"; version = "3.1.31"; sha256 = "1i6ldw55wqck3nxh9bpw0czv2y7zqbckxky8ih1r35nf08yw6dld"; })
-      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x86"; version = "3.1.31"; sha256 = "0pyssa4mhm3ik9w261kkmnhxri4l6kli20qg3fmfp5rb9yp99faz"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm"; version = "3.1.31"; sha256 = "14hrfingvks7x5y796dsfkhpjp4zszv7gvmd4ycczjfhrywfxzis"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm64"; version = "3.1.31"; sha256 = "1savp0v2b63sj6qj4qq30vbjgx8bynvvgadmgbgj42sk2p6sgll9"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm64"; version = "3.1.31"; sha256 = "13plrsf4bgdqv5v8jha1n2jz0nj7jdggjpc7w7ipc3gxw42w0z1a"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-x64"; version = "3.1.31"; sha256 = "1r59z5nwdxrwsqy2k4bvisqs2q0chr6wv9kxgsniqsz26vdp163w"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-x64"; version = "3.1.31"; sha256 = "176575973yg2b6ls2c02ysb101xxamlgqkrbxhgbdkfh4w5clf6k"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-x64"; version = "3.1.31"; sha256 = "0nvirb5hfk0swxm92isg3r9czcbsa95lb071k3adfqw7lfz8mqzz"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm"; version = "3.1.31"; sha256 = "09akjvppv6xvg3yyc84jx0yrcxn3kfg27vls71zxa539yvjkh29d"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm64"; version = "3.1.31"; sha256 = "03dsvrfb3jyrfril4d6w9z25rgl7ldbiqab5n6s7fjajz6qpmgj8"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x64"; version = "3.1.31"; sha256 = "0j2p5110qagrl5lb1j6zll9h0x3d17ad7r2h89ndjfrzs8awj9sp"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x86"; version = "3.1.31"; sha256 = "1s5fkl5102ar9kl6w5nibkc71q49yx9jdqr5dgx8zmh88klaqc6s"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm"; version = "3.1.31"; sha256 = "1p74kp59a6f8gvnkqvl9qfgav08lisjdsi882i4dpipxmsizbvn6"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm64"; version = "3.1.31"; sha256 = "00vlrk33nrxdjvjxrb1ck5hxv8ybjwscx9v3y3vnffias9dmg5dc"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm64"; version = "3.1.31"; sha256 = "037npznm0b3i4dl5ciif0l2cx98b4010633xjsahyfsnzszz6rxb"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-x64"; version = "3.1.31"; sha256 = "0626jfv9f0rbqp25x8sqdjcpqbbrr0mn7zlggz8lzkdfw3nj91pm"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-x64"; version = "3.1.31"; sha256 = "1rnvh65wav9ah7qs5a5anqb35z04wqp2lf1awzmam4jsmfqd666x"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-x64"; version = "3.1.31"; sha256 = "0zgwx8yl2y7hdc0xdlbmni55gq2fl1ni8xhdzknzyz5pwzr5fghl"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm"; version = "3.1.31"; sha256 = "1n85hrndj8kb9hi95jb7mfd197d17a79gl9mzv0xfb4zwfd3jb26"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm64"; version = "3.1.31"; sha256 = "19ssb0366lcs8w3wfq7nvbc2ja8530vfhps7yrwy3j46p2jl0x1m"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x64"; version = "3.1.31"; sha256 = "1i2das9gpk6lbvc4bjaarrgrmk29086zpqxkasgswqd17kdvpyfq"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x86"; version = "3.1.31"; sha256 = "0s2x3ybfkj65p9b5wm0bvn2gfj442ylc44hbp2r4zgxabq0lghh4"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "0j31jicc7107wfims5f7sgwi97vywcmdrqc7y6qc5gkc2djqbslr"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "0afclz46pdy9pbfjzlg9vkyyacy8ymmsq3jp6r161x0d5k2444vw"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "0c7yhq57gy004k6fhsl3adb9nqz8cn019dy9gaddp6qlkiidirg9"; })
-      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "01qirfj6ydwyasr7ggbhymv8c9bmk61vl44cdz9xq8cfvd6yq5bl"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "00x9ldx2906b2z35diihb7z8q5a3a537rak1yyif27pw5s20s6iw"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "0kpnlygnah6761iiqsdixzgb1sgfrvsqv0jjraz8bdda1778f22d"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "1y9w7yzq47sd9i1wz1hl91s3yzz6vlhb3acwm58yv91r73h6dgy2"; })
-      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "0fpqmin2mx99ndzzf2l633dlq8xxwgnn7qws3rcsn6kid7hn1kw3"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "02hyzxi4414z1clxhfni5x9dwmih5aww9wpcv8vjp9r33xigi6d9"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "0mi3rwjjsgrr8c5yci1sg1yg57f8vhmmcdcyr9zsgwnq8rwrqn91"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "1xbxgsi75xg0yrrpymkvh7fplrrrlw8k47knbgh8824bd7hvdq1b"; })
-      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "0r12z7z5pkwcjm1zq6dav3axnahl9nvp72lg4a6ds39jz6a94mds"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "15vann79nyz4iayx10gcqwlf0frqqsmw26v9xakfbckha4pjhy1x"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "13j2graqr5a5jimvzsvd1i5cnnmrzqxfcvax8r385gbav0xr0d0s"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "0v6h1rj25i0cpvk78845wzxa4yffwjcnqkhpwdafj8glac633242"; })
-      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "0qbn4zzx8fxap4546y3i5zwl6rv0rfdphkns4gmh1fjnkfb7zvjw"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "1ix4w2v5ajq6c4n6l7jrjxky7mx9lynsarfx0byxj4x5qlps1z56"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "1bkvz6n741dgrh9q57db9jdnlgccp9gcsivw8555n4zqkwx3bwkc"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "0zfhjqya1lnqz1zd9pw9c9w6ldvv8hgg76rh3qaxwfgmnp808vn0"; })
-      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "1fx08byahkjv797jnql3c7j9ldgb2w4pm9vhb326mpna28x3qgmm"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "0m339qyn21782x2fr73bbxk6aa6dngfav0aqlpbx1gpr0k6xb26b"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "1wwnzqb9xjadkgz4h6fmi7n0prp8v56cjfx1si79v96f3l9qrasd"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "0zwvrnqn4w38xgall1791msd9z0nr9xv6rk2xy6i1qbkavz4fn8p"; })
-      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "0dyvsidj5g6rj0khakzimzn193vkgzzciyfs6jqa03mp99zvdl8p"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "0ch5a8xpw89maq8lhncwp1izy16mwpjn1x60bfhzyskib9w931vw"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "0zxfclfjjcxr33ialjxwihpxvp28by1zrv6cmja0jp71kr882lq1"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "1is7azrlb222wfljhhnrwyhmrrc16d5hy8dadrx3s3h73bnmfl7g"; })
-      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "101ws6l12rcf08r80d02bya2wmwsaajnhvl4bjprakfiy4pz4laz"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "0k4fx1bnkh3420234pnqm227l30rih8s9ld0zpb7rzpby14dclar"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "1lsf021hw8ikwic1wdv0r1sdm4bypia9xcl7j01mllihs1idkadb"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "1ccf8zdc1h6ri79qhj7gnclw7pyi08qa5kb2fr0m26zdd8xsgqbb"; })
-      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "19ffjzqvdfmz5pfrk5pya2wvw6734mn5dg424sxgpbr1228bayai"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "0pra9gpjlndzh8hhjpxsqjl2awqb7lkp868jiljbv7a0hhrj7aiq"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "0yj7lw8w74cfc2q2dsz1qhqdw9glxs6narsqk48r80ahfvrbc5kr"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "1mh44i5b204q8kf70ywvhgggqf68b48j9y0d06wvzadnswakqd56"; })
-      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "11rysifqiysmajaipjg3hcrp3glwf6zg6ijvld0nsxwf3w4pxlvj"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "15hz945p1wr4j9b7qp2vqwd5mah464l938d14ldckhjr3di5c6si"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "0y7mqvxyhhannk11ky2i4gr60wcxaybv3ni4y7ydfd31k2baywf3"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "1njd0xvn780rg2jvlyvsw7kaxi80qfx1crhsbihhgjnjx4199vgn"; })
-      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "162589081jp4nn8f2cq2d8mnzppmdw1zclnd66ablxm4dwz2xrij"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"; version = "3.1.31"; sha256 = "0nnd9kcz05j83qyyz9xbsyxmc6x872ai4bc45ificxh0rqa7zk9n"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHost"; version = "3.1.31"; sha256 = "1s5p5iby2866zzfmzd0x35aclgzmdmghp9yqn5am7bklhza4dls8"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.31"; sha256 = "0h1nhmmjs55alphb1x51namkaivr64611bn0080hi3kizrmiwnxf"; })
-      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.31"; sha256 = "0sijpj15qjamyc9s8rxbqazi469525fzc7q81v9jw866x4laj4ms"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm"; version = "3.1.32"; sha256 = "06ws70zb4p4wbxx6f9bxk8dmighk8h57m82bnsss5cajabhrs9ss"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-arm64"; version = "3.1.32"; sha256 = "00ha2sl4gvqv68mbrsizd6ngqy0vv6vamngzjxr338k1w7a276dx"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"; version = "3.1.32"; sha256 = "0rvyv3mnb2fgj619rnqixfngzybhgqfr5mnw3s43v9mlg45la8hp"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"; version = "3.1.32"; sha256 = "06xbkmplw7vkcsacrcddnma3hawqgdk2hj9ayjs0mhb31n407j3j"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "3.1.32"; sha256 = "0ywz63q8vrdp25ix2j9b7h2jp5grc68hqfl64c6lqk26q9xwhp9r"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.osx-x64"; version = "3.1.32"; sha256 = "1crk54a1wvj76s9gnh46pi7wk8ryympm9xh2jq4s4rpp329fqgic"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm"; version = "3.1.32"; sha256 = "148pspjlx85yk95i6svhv37g483wmbinngd460p1ak2di26qbvk8"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-arm64"; version = "3.1.32"; sha256 = "17hbn0qvnclhhp6pdygia124qi46lm7r3ixkgsnbsmh7a5l02f84"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x64"; version = "3.1.32"; sha256 = "0m6qq8va2fd1zns85wlm5arhcg57hf1rfj3801v27hvijfsmcad3"; })
+      (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.win-x86"; version = "3.1.32"; sha256 = "0868nlkxi7sy74g6xrvlaiqzs2h846gq52wcmgapsq202lirnjzh"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm"; version = "3.1.32"; sha256 = "1yip3i79ljg2p23r8ph6p77rdmwm6h6gnlc3q2cikz07vib41042"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-arm64"; version = "3.1.32"; sha256 = "1zygp70xrk5zggs3q4a6yc6jfdwzcsjjsapqpwn6qyx35m69b72p"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-arm64"; version = "3.1.32"; sha256 = "1cj8wspslr17pbkh50xfbmwcicy9n2z9ha027ssfrah8r488d9sx"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-musl-x64"; version = "3.1.32"; sha256 = "0r5m0837zx2shp9bfgllnhz85h5792pbsacnk7lmmpgld32crzdx"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.linux-x64"; version = "3.1.32"; sha256 = "08sar3s7j6z1q5prjmz2jrbsq5ms81mrsi1c1zbfrkplkfjpld3a"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.osx-x64"; version = "3.1.32"; sha256 = "186gjn8sbhp4z6pq8fw4g8nqk9dwyaplwvdz2y3fbbvg36lggsh0"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm"; version = "3.1.32"; sha256 = "1pbrqyd43b3fmd6vk2wph726z6yddazp04ycyxbn5dh9zw8f2k55"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-arm64"; version = "3.1.32"; sha256 = "0i7vv4zvv4aixgdkskza8x8js4bnj5q4mnw0qdb7dmdypf34s2fm"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x64"; version = "3.1.32"; sha256 = "0fk77ij5k33gjydk51gw7k639mppqkyhgarch2701i5wciap2h32"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Host.win-x86"; version = "3.1.32"; sha256 = "1q36zbrkbgwg5wl7gpzmac79xvwd74zzqg13hrsldwfajmnwvdkj"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm"; version = "3.1.32"; sha256 = "16pgzx3gxgvcgb54z2sd48x8jlz4w242gf68s10ghlnqiiggpl4v"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-arm64"; version = "3.1.32"; sha256 = "13pcn74z1swz73s72zjl07f118j35wacnzgk7kbjqn83nwgqdgvq"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-arm64"; version = "3.1.32"; sha256 = "1lxvj597rw4srkhmx83p1hnf71dcmgg93k982vnvv89xmyvvyy42"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-musl-x64"; version = "3.1.32"; sha256 = "07rmk5l0k66x2ilm3r2cpl7icgdzpqjcnrhw89afm9z9w06zz78g"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-x64"; version = "3.1.32"; sha256 = "0mmc57dl8plrspdxwb7209wz29vhiwqds4nfbdfws7zg35yy70c7"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.osx-x64"; version = "3.1.32"; sha256 = "06bk39zcv27cwshjsxfg5d6wzkkzdhfk08sipdc7mr1s8pk7ihi1"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm"; version = "3.1.32"; sha256 = "00n05mi9zws7v88jklyw1a8cjjslx8nnbby1nyxmi6p2acbx6pxp"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-arm64"; version = "3.1.32"; sha256 = "035rs89y8j9v0mshqhaiyydv979x3w1204gcdp2kv2zhvfx1gnp2"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x64"; version = "3.1.32"; sha256 = "0qsm03gx86fqx8vadnq3nsin3m3falidib94pc3mb3fy87mapvqw"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.win-x86"; version = "3.1.32"; sha256 = "09r2776wbcmn5jh3nksd5ilzv6rrlic938b87xy77awqg251y017"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "1q09dbbx9kd3k4v8wg75llvz4332b5qsvblva7mhslbmyv47vfiq"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "0biy6p7kvcjxdn67wcmwyrfvv7pmd5249fj3410pw4xi8svjpxnj"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "1hs2czpqwa92x11d49m5dprjzr8n8zi5cx6cq8rcnacpynr19ldm"; })
+      (fetchNuGet { pname = "Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "1kk8116pvl1jc8k59338hqhbhs8mbnb7kv108xmzbqzygsfgcvb5"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "05yqaxrd981aw4mjg80n19506ls6ni3sy3w0fwiygblaffidj8h3"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "0p82n92njjahhndawz40jq8bf2smw1c61zm4hq3zi6m5f3x0qc4l"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "0x43pjvd7c58c7230i6ga7d4hidd258aahd9d1z9590z4d32v320"; })
+      (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "05mm56j8391rh8zghrdyrnxnbxvrmwqxy3gn4blyf8rb9xgsy78j"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "1pz1p935k4y06q8v9z44qwnc96anmg1r2kfrs3a0fbyqn0qkc4i3"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "0vznqq540gb9idxb4f0l26c2g8500z2fkx0sxrmnla91c3yf9f6c"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "0844r0h1pvb5mvl5939z37nxjb380kbjjf92g64d110bs8397dw3"; })
+      (fetchNuGet { pname = "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "0zr31wppl255hwlhrab78h7r2l4pfz8nz20s66j3xi2w9pvlsprd"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "1g3gxzn035gyq7kq2xwn51vz6wk0473qcq0yi3blakfrmjwdbiax"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "0a3kq34dk5lj0w7g3v3x78vkcs4jw4wjdxigyc3xwwc29rjwmy0x"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "0gygjx90ibi3xi514mll2jfnq8siy8gvmkj9ckwc904pvzy3q5z5"; })
+      (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "0cg209fkmmm0jfr1vj4454v482y4s4971xcnfsyx5ldvqhvq1nj0"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "05qrs75q38x0r542cgjyjm2l9nxbxmqp75nd3m2zny2wbm9zfqcl"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "0zb3qlb2c8s953ja4s8a3q26ips96czxm9xd16mair3fb8z4yvf2"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "05z3rxm7fgsmjmx5lzlihxhfyzvp16r888i4jj5v4kb5hb6y3xfw"; })
+      (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "17xyhgf0d3lhvyb0j6mzfv278l9iy800l1l0i5a72ihvjm4ld40r"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "0k0fng7fxssqkcywf4czpiqrfv60qmjf8pw686rmn9gqyd9y6wbw"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "1hjxa5rld8b1qx8avkc1gd7492vz51r6zqmbqadv1kklg4bf68zq"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "1kdcjy2c02qm0rkqq262iky40vmn1gnz0p1817js4b8a0ha13nl1"; })
+      (fetchNuGet { pname = "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "1q31a7gwl5nl0m4wizbqdd67k0xgrmdbf2wdsx9vx9i3xfcjj7js"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "11p5g8ar7x1czkl32f2s046zlibqqx28b499yiv7snngjcs9fgzq"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "1paagjfdsg9q0aknwipcds4chn8nfk2y83yhcz3qhi28pzpgih53"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "028kccjihxlyfv2i988g88fw98lhsidf7jj525w96wf9rgkl3m2d"; })
+      (fetchNuGet { pname = "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "1jc46wlga8r2nlmy0rhqcrxa2vp677340wiwl8nskp1sb3ci0p8m"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "1m92b4z727178lnvyh9sq1gx2ncs74q5vwaz4nivjh3fdq1qn9dz"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "0grk5axlpzwks3p42km6jy0r82ahcmgybgq1vh61xj1nzna1l3fs"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "0hhk71dqy5plq64ml3jc810y2lyq404k4aynv6y4g5j5y1wycx3s"; })
+      (fetchNuGet { pname = "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "0j50g2gjb6qsm1mp6g9bkvjjrih6jbisns74mghx92hk8q9cbq6v"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "042bjis2yrvsnaviijlpfi0lgp2ds8igsy8cdhbk3mzi9hcgmilg"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "1y7m9awpcg2ilwkn712sg2hbhqq97yf5s0j9bvrpgb6xh0pzk1f3"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "04rspzr88n1dy86v2n5i8vxkyyxqvw9qfgizzxav8dqsvd9yja41"; })
+      (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "105zgdvfx7w1wxbxjxhwjai72gwk1hhi0hjjrky261ga63j5akgg"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "08mizsssb84saw1sd51qvh8inacf6m6xbhpp6dfnmxszpamrzc09"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "02k2fhdb9p6vrn1v4d8fjpqy6a89gmrmlpf477i0pir42kwx7766"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "07jx0syqg5833g3rlmca692cry24iq9mxh6fa3w3p76qxx8aqlmg"; })
+      (fetchNuGet { pname = "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "1lhjckbf4679k8fmg7piqizix6d9rs9dgm83kjd3c9cd3m7xg0ky"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"; version = "3.1.32"; sha256 = "03s5x7b38mx5s4684jmdlrh6cj5pjyxhs37bwq5jdsip9a24yk5g"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHost"; version = "3.1.32"; sha256 = "0pa43dy3fmsgwmhp8xxsdvfbm3qagj4wlqcbcdm3rhk4i3ww88p3"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"; version = "3.1.32"; sha256 = "1mhzxyahgqabc4gxmnxfyjpb7bp4asac1qcjja891fp23w4fg0gn"; })
+      (fetchNuGet { pname = "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"; version = "3.1.32"; sha256 = "0c80n8gwzj5dp1ss1hcb8ah8ah0acx2k277pxzji6i7jxaq9wpdv"; })
     ];
   };
 }


### PR DESCRIPTION
###### Description of changes

version update via `update.sh`

NOTE: .NET Core 3.1 is now EOL as of 13th December 2022 and should no longer be built, however I'd like to make this final update before making it throw.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
