### PR TITLE
python310Packages.trustme: remove aarch64-darwin workarounds

### DIFF
--- a/pkgs/development/python-modules/trustme/default.nix
+++ b/pkgs/development/python-modules/trustme/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , buildPythonPackage
 , fetchPypi
 , isPy3k
@@ -21,10 +20,9 @@ buildPythonPackage rec {
   };
 
   checkInputs = [
-    service-identity
-    pytestCheckHook
-  ] ++ lib.optionals (!stdenv.isDarwin || !stdenv.isAarch64) [
     pyopenssl
+    pytestCheckHook
+    service-identity
   ];
 
   propagatedBuildInputs = [
@@ -33,17 +31,6 @@ buildPythonPackage rec {
   ] ++ lib.optionals (!isPy3k) [
     futures
   ];
-
-  # aarch64-darwin forbids W+X memory, but this tests depends on it:
-  # * https://github.com/pyca/pyopenssl/issues/873
-  disabledTests = lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
-    "test_pyopenssl_end_to_end"
-  ];
-
-  postPatch = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
-    substituteInPlace "tests/test_trustme.py" \
-      --replace "import OpenSSL.SSL" ""
-  '';
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
These are no longer necessary now that pyopenssl is no longer broken on aarch64-darwin.

This reverts the fixes done in https://github.com/NixOS/nixpkgs/pull/200717 and https://github.com/NixOS/nixpkgs/pull/203584 since https://github.com/NixOS/nixpkgs/pull/204002 has marked pyopenssl unbroken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
