### PR TITLE
box64: More platforms, dynarec option, hello test, extra maintainer

### DIFF
--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -5,7 +5,14 @@
 , gitUpdater
 , cmake
 , python3
+, withDynarec ? stdenv.hostPlatform.isAarch64
+, runCommand
+, hello-x86_64
+, box64
 }:
+
+# Currently only supported on ARM
+assert withDynarec -> stdenv.hostPlatform.isAarch64;
 
 stdenv.mkDerivation rec {
   pname = "box64";
@@ -33,49 +40,57 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DNOGIT=1"
-  ] ++ (
-    if stdenv.hostPlatform.system == "aarch64-linux" then
-      [
-        "-DARM_DYNAREC=ON"
-      ]
-    else [
-      "-DLD80BITS=1"
-      "-DNOALIGN=1"
-    ]
-  );
+    "-DNOGIT=ON"
+    "-DARM_DYNAREC=${if withDynarec then "ON" else "OFF"}"
+    "-DRV64=${if stdenv.hostPlatform.isRiscV64 then "ON" else "OFF"}"
+    "-DPPC64LE=${if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then "ON" else "OFF"}"
+  ] ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+    "-DLD80BITS=ON"
+    "-DNOALIGN=ON"
+  ];
 
   installPhase = ''
     runHook preInstall
+
     install -Dm 0755 box64 "$out/bin/box64"
+
     runHook postInstall
   '';
 
   doCheck = true;
 
-  checkPhase = ''
-    runHook preCheck
-    ctest
-    runHook postCheck
-  '';
-
   doInstallCheck = true;
 
   installCheckPhase = ''
     runHook preInstallCheck
+
+    echo Checking if it works
     $out/bin/box64 -v
+
+    echo Checking if Dynarec option was respected
+    $out/bin/box64 -v | grep ${lib.optionalString (!withDynarec) "-v"} Dynarec
+
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
+  passthru = {
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+    };
+    tests.hello = runCommand "box64-test-hello" {
+      nativeBuildInputs = [ box64 hello-x86_64 ];
+    } ''
+      # There is no actual "Hello, world!" with any of the logging enabled, and with all logging disabled it's hard to
+      # tell what problems the emulator has run into.
+      BOX64_NOBANNER=0 BOX64_LOG=1 box64 ${hello-x86_64}/bin/hello --version | tee $out
+    '';
   };
 
   meta = with lib; {
     homepage = "https://box86.org/";
     description = "Lets you run x86_64 Linux programs on non-x86_64 Linux systems";
     license = licenses.mit;
-    maintainers = with maintainers; [ gador ];
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ gador OPNA2608 ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "riscv64-linux" "powerpc64le-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1932,7 +1932,12 @@ with pkgs;
     wxGTK = wxGTK32;
   };
 
-  box64 = callPackage ../applications/emulators/box64 { };
+  box64 = callPackage ../applications/emulators/box64 {
+    hello-x86_64 = if stdenv.hostPlatform.isx86_64 then
+      hello
+    else
+      pkgsCross.gnu64.hello;
+  };
 
   caprice32 = callPackage ../applications/emulators/caprice32 { };
 


### PR DESCRIPTION
###### Description of changes

- box64 also supports 64-bit riscv and powerpc64le, I lack the hardware to test but `pkgsCross.riscv64.box64` works and there should be no harm in adding platforms upstream says they support. If they end up being broken on our end, we'll add them to `meta.broken` instead.
- Removed custom `checkPhase`, a `make` call with the same outcome should happen as long as `doCheck = true`
- Added an option for controlling if dynamic recompilation is enabled, and a corresponding test in `installCheckPhase` to make sure the setting was honoured
- Added a test that runs `hello` for x86_64-linux via box64. This required moving most of the derivation into the `let` so the `withDynarec` option is correctly honoured even when overridden
- Added myself as maintainer, if you don't mind. I have a game I'm currently invested in, for which I need to use box64 when I want to play it on my aarch64-linux laptop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
