### PR TITLE
libarchive: refactor

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -22,43 +22,47 @@
 , cmake
 , nix
 , samba
+, buildPackages
 }:
 
+let
+  autoreconfHook = buildPackages.autoreconfHook269;
+in
 assert xarSupport -> libxml2 != null;
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libarchive";
   version = "3.6.2";
 
   src = fetchFromGitHub {
     owner = "libarchive";
     repo = "libarchive";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-wQbA6vlXH8pnpY7LJLkjrRFEBpcaPR1SqxnK71UVwxg=";
   };
 
-  postPatch = ''
+  outputs = [ "out" "lib" "dev" ];
+
+  postPatch = let
+    skipTestPaths = [
+      # test won't work in nix sandbox
+      "libarchive/test/test_write_disk_perms.c"
+      # the filesystem does not necessarily have sparse capabilities
+      "libarchive/test/test_sparse_basic.c"
+      # the filesystem does not necessarily have hardlink capabilities
+      "libarchive/test/test_write_disk_hardlink.c"
+      # access-time-related tests flakey on some systems
+      "cpio/test/test_option_a.c"
+      "cpio/test/test_option_t.c"
+    ];
+    removeTest = testPath: ''
+      substituteInPlace Makefile.am --replace "${testPath}" ""
+      rm "${testPath}"
+    '';
+  in ''
     substituteInPlace Makefile.am --replace '/bin/pwd' "$(type -P pwd)"
 
-    declare -a skip_test_paths=(
-      # test won't work in nix sandbox
-      'libarchive/test/test_write_disk_perms.c'
-      # can't be sure builder will have sparse-capable fs
-      'libarchive/test/test_sparse_basic.c'
-      # can't even be sure builder will have hardlink-capable fs
-      'libarchive/test/test_write_disk_hardlink.c'
-      # access-time-related tests flakey on some systems
-      'cpio/test/test_option_a.c'
-      'cpio/test/test_option_t.c'
-    )
-
-    for test_path in "''${skip_test_paths[@]}" ; do
-      substituteInPlace Makefile.am --replace "$test_path" ""
-      rm "$test_path"
-    done
+    ${lib.concatStringsSep "\n" (map removeTest skipTestPaths)}
   '';
-
-  outputs = [ "out" "lib" "dev" ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -105,7 +109,7 @@ stdenv.mkDerivation rec {
       includes implementations of the common tar, cpio, and zcat command-line
       tools that use the libarchive library.
     '';
-    changelog = "https://github.com/libarchive/libarchive/releases/tag/v${version}";
+    changelog = "https://github.com/libarchive/libarchive/releases/tag/v${finalAttrs.version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ jcumming AndersonTorres ];
     platforms = platforms.all;
@@ -114,4 +118,4 @@ stdenv.mkDerivation rec {
   passthru.tests = {
     inherit cmake nix samba;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20172,9 +20172,7 @@ with pkgs;
 
   libargs = callPackage ../development/libraries/libargs { };
 
-  libarchive = callPackage ../development/libraries/libarchive {
-    autoreconfHook = buildPackages.autoreconfHook269;
-  };
+  libarchive = callPackage ../development/libraries/libarchive { };
 
   libarchive-qt = libsForQt5.callPackage ../development/libraries/libarchive-qt { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
