### PR TITLE
cmake: 3.24.3 -> 3.25.1

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/002-application-services.diff
+++ b/pkgs/development/tools/build-managers/cmake/002-application-services.diff
@@ -1,20 +1,18 @@
-diff --git a/Source/CMakeLists.txt b/Source/CMakeLists.txt
-index 9a18184fd3..278d146dd1 100644
---- a/Source/CMakeLists.txt
-+++ b/Source/CMakeLists.txt
-@@ -933,7 +933,6 @@ endif()
+diff -Naur cmake-3.25.1-old/Source/CMakeLists.txt cmake-3.25.1-new/Source/CMakeLists.txt
+--- cmake-3.25.1-old/Source/CMakeLists.txt	2022-11-30 10:57:03.000000000 -0300
++++ cmake-3.25.1-new/Source/CMakeLists.txt	2022-12-19 01:00:08.412064304 -0300
+@@ -916,7 +916,6 @@
  # On Apple we need CoreFoundation and CoreServices
  if(APPLE)
-   target_link_libraries(CMakeLib "-framework CoreFoundation")
--  target_link_libraries(CMakeLib "-framework CoreServices")
+   target_link_libraries(CMakeLib PUBLIC "-framework CoreFoundation")
+-  target_link_libraries(CMakeLib PUBLIC "-framework CoreServices")
  endif()
  
  if(WIN32 AND NOT UNIX)
-diff --git a/Source/cmGlobalXCodeGenerator.cxx b/Source/cmGlobalXCodeGenerator.cxx
-index 77403b076a..d5aac95e1e 100644
---- a/Source/cmGlobalXCodeGenerator.cxx
-+++ b/Source/cmGlobalXCodeGenerator.cxx
-@@ -49,10 +49,6 @@ struct cmLinkImplementation;
+diff -Naur cmake-3.25.1-old/Source/cmGlobalXCodeGenerator.cxx cmake-3.25.1-new/Source/cmGlobalXCodeGenerator.cxx
+--- cmake-3.25.1-old/Source/cmGlobalXCodeGenerator.cxx	2022-11-30 10:57:03.000000000 -0300
++++ cmake-3.25.1-new/Source/cmGlobalXCodeGenerator.cxx	2022-12-19 01:00:56.065135169 -0300
+@@ -56,10 +56,6 @@
  
  #if !defined(CMAKE_BOOTSTRAP) && defined(__APPLE__)
  #  include <CoreFoundation/CoreFoundation.h>
@@ -25,19 +23,17 @@ index 77403b076a..d5aac95e1e 100644
  #endif
  
  #if !defined(CMAKE_BOOTSTRAP)
-diff --git a/Utilities/cmlibarchive/CMakeLists.txt b/Utilities/cmlibarchive/CMakeLists.txt
-index 79452ffff6..a848731b7e 100644
---- a/Utilities/cmlibarchive/CMakeLists.txt
-+++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -2013,11 +2013,6 @@ IF(ENABLE_TEST)
+diff -Naur cmake-3.25.1-old/Utilities/cmlibarchive/CMakeLists.txt cmake-3.25.1-new/Utilities/cmlibarchive/CMakeLists.txt
+--- cmake-3.25.1-old/Utilities/cmlibarchive/CMakeLists.txt	2022-11-30 10:57:03.000000000 -0300
++++ cmake-3.25.1-new/Utilities/cmlibarchive/CMakeLists.txt	2022-12-19 01:01:43.392205981 -0300
+@@ -2041,10 +2041,6 @@
+   ADD_CUSTOM_TARGET(run_all_tests)
  ENDIF(ENABLE_TEST)
- ENDIF()
  
 -# We need CoreServices on Mac OS.
 -IF(APPLE)
 -  LIST(APPEND ADDITIONAL_LIBS "-framework CoreServices")
 -ENDIF(APPLE)
--
+ 
  add_subdirectory(libarchive)
  IF(0) # CMake does not build libarchive's command-line tools.
- add_subdirectory(cat)

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -40,11 +40,11 @@ stdenv.mkDerivation rec {
     + lib.optionalString isBootstrap "-boot"
     + lib.optionalString cursesUI "-cursesUI"
     + lib.optionalString qt5UI "-qt5UI";
-  version = "3.24.3";
+  version = "3.25.1";
 
   src = fetchurl {
     url = "https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
-    sha256 = "sha256-tTqhD6gr/4TM21kGWSe3LTvuSfTYYmEkn8CYSzs2cpE=";
+    sha256 = "sha256-HFEdCVFq9JNpTtm68TxVlHo2OJZ01lei1eDM7caykdg=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
