### PR TITLE
awscli2: 2.9.6 -> 2.9.8,python310Packages.awscrt: 0.15.1 -> 0.16.1

### DIFF
--- a/pkgs/development/python-modules/awscrt/default.nix
+++ b/pkgs/development/python-modules/awscrt/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "awscrt";
-  version = "0.15.1";
+  version = "0.16.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-2VBdad9NL19eW2Djot2gkynyjSCUvG4f0KnEub6M0vg=";
+    hash = "sha256-j9++euxSsvf6ZLkVJtyGdlOx6WWrAXEOczqwypYZkXA=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [
@@ -32,11 +32,6 @@ buildPythonPackage rec {
   hardeningDisable = lib.optionals stdenv.cc.isClang [
     "strictoverflow"
   ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "extra_link_args += ['-Wl,-fatal_warnings']" ""
-  '';
 
   # gcc <10 is not supported, LLVM on darwin is just fine
   nativeBuildInputs = [
@@ -58,6 +53,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/awslabs/aws-crt-python";
+    changelog = "https://github.com/awslabs/aws-crt-python/releases/tag/v${version}";
     description = "Python bindings for the AWS Common Runtime";
     license = licenses.asl20;
     maintainers = with maintainers; [ davegallant ];

--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -34,14 +34,14 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli2";
-  version = "2.9.6"; # N.B: if you change this, check if overrides are still up-to-date
+  version = "2.9.8"; # N.B: if you change this, check if overrides are still up-to-date
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-cli";
     rev = version;
-    hash = "sha256-3zB0Uy2pmkrOLb+/mXZGs/pnzo6zi2zVPyeNPGPVQJM=";
+    hash = "sha256-Q1iHGwkFg0rkunwEgWQIqLEPAGfOLfqA1UpjmCe2x8M=";
   };
 
   nativeBuildInputs = [
@@ -120,6 +120,8 @@ with py.pkgs; buildPythonApplication rec {
     python = py; # for aws_shell
     updateScript = nix-update-script {
       attrPath = pname;
+      # Excludes 1.x versions from the Github tags list
+      extraArgs = [ "--version-regex" "^(2\.(.*))" ];
     };
     tests.version = testers.testVersion {
       package = awscli2;

--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -11,15 +11,6 @@
 let
   py = python3.override {
     packageOverrides = self: super: {
-      awscrt = super.awscrt.overridePythonAttrs (oldAttrs: rec {
-        version = "0.14.0";
-        src = self.fetchPypi {
-          inherit (oldAttrs) pname;
-          inherit version;
-          hash = "sha256-MGLTFcsWVC/gTdgjny6LwyOO6QRc1QcLkVzy677Lqqw=";
-        };
-      });
-
       prompt-toolkit = super.prompt-toolkit.overridePythonAttrs (oldAttrs: rec {
         version = "3.0.28";
         src = self.fetchPypi {


### PR DESCRIPTION
###### Description of changes

* Upgrade awscli2 to 2.9.8
  * See https://github.com/aws/aws-cli/blob/2.9.8/CHANGELOG.rst

* Upgrade python310Packages.awscrt to 0.16.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
