### PR TITLE
xorg.xorgserver: 1.20.14 → 21.1.7

### DIFF
--- a/pkgs/desktops/gnome/core/mutter/42/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/42/default.nix
@@ -17,6 +17,7 @@
 , ninja
 , xvfb-run
 , xkeyboard_config
+, libxcvt
 , libxkbfile
 , libXdamage
 , libxkbcommon
@@ -93,6 +94,7 @@ let self = stdenv.mkDerivation rec {
   nativeBuildInputs = [
     desktop-file-utils
     gettext
+    libxcvt
     mesa # needed for gbm
     meson
     ninja
@@ -100,7 +102,7 @@ let self = stdenv.mkDerivation rec {
     pkg-config
     python3
     wrapGAppsHook
-    xorgserver # for cvt command
+    xorgserver
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -17,6 +17,7 @@
 , ninja
 , xvfb-run
 , xkeyboard_config
+, libxcvt
 , libxkbfile
 , libXdamage
 , libxkbcommon
@@ -97,6 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     desktop-file-utils
     gettext
+    libxcvt
     mesa # needed for gbm
     meson
     ninja
@@ -105,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     wrapGAppsHook
     gi-docgen
-    xorgserver # for cvt command
+    xorgserver
   ];
 
   buildInputs = [

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3322,18 +3322,18 @@ self: with self; {
   }) {};
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xorgserver = callPackage ({ stdenv, pkg-config, fetchurl, xorgproto, openssl, libX11, libXau, libXaw, libxcb, xcbutil, xcbutilwm, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, libXdmcp, libXfixes, libxkbfile, libXmu, libXpm, libXrender, libXres, libXt }: stdenv.mkDerivation {
+  xorgserver = callPackage ({ stdenv, pkg-config, fetchurl, xorgproto, openssl, libX11, libXau, libxcb, xcbutil, xcbutilwm, xcbutilimage, xcbutilkeysyms, xcbutilrenderutil, libXdmcp, libXfixes, libxkbfile }: stdenv.mkDerivation {
     pname = "xorg-server";
-    version = "1.20.14";
+    version = "21.1.7";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/xserver/xorg-server-1.20.14.tar.xz";
-      sha256 = "0sx18vsxr0dg9z7b9ph1gz6q4pmxc1n6b4sbb7i47578kc5vgiaw";
+      url = "mirror://xorg/individual/xserver/xorg-server-21.1.7.tar.xz";
+      sha256 = "sha256-2cYLLdDsUjJspqsg2w5JCx/09Wb1nKdC1lMuknlYd7s=";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     strictDeps = true;
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ xorgproto openssl libX11 libXau libXaw libxcb xcbutil xcbutilwm xcbutilimage xcbutilkeysyms xcbutilrenderutil libXdmcp libXfixes libxkbfile libXmu libXpm libXrender libXres libXt ];
+    buildInputs = [ xorgproto openssl libX11 libXau libxcb xcbutil xcbutilwm xcbutilimage xcbutilkeysyms xcbutilrenderutil libXdmcp libXfixes libxkbfile ];
     meta.platforms = lib.platforms.unix;
   }) {};
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -790,75 +790,8 @@ self: super:
           #
           # We set it to /var/log which can't be touched from inside the sandbox causing the build to hard-fail
           ./dont-create-logdir-during-build.patch
-
-          # Fix e.g. xorg.xf86videovmware with libdrm 2.4.108
-          # TODO: remove with xorgserver >= 1.21
-          (fetchpatch {
-            name = "stdbool.patch";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/454b3a826edb5fc6d0fea3a9cfd1a5e8fc568747.diff";
-            sha256 = "1l9qg905jvlw3r0kx4xfw5m12pbs0782v2g3267d1m6q4m6fj1zy";
-          })
-        ]
-        # TODO: remove with xorgserver >= 21.1.4; https://lists.x.org/archives/xorg/2022-July/061035.html
-        ++ [
-          (fetchpatch {
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/f1070c01d616c5f21f939d5ebc533738779451ac.diff";
-            sha256 = "5hcreV3ND8Lklvo7QMpB0VWQ2tifIamRlCr6J82qXt8=";
-          })
-          (fetchpatch {
-            name = "CVE-2022-2319.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/6907b6ea2b4ce949cb07271f5b678d5966d9df42.diff";
-            sha256 = "gWXCalWj2SF4U7wSFGIgK396B0Fs3EtA/EL+34m3FWY=";
-          })
-          (fetchpatch {
-            name = "CVE-2022-2320.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/dd8caf39e9e15d8f302e54045dd08d8ebf1025dc.diff";
-            sha256 = "rBiiXQRreMvexW9vOKblcfCYzul+9La01EAhir4FND8=";
-          })
-        ]
-        # TODO: remove with xorgserver >= 21.1.5; https://www.mail-archive.com/xorg-announce@lists.x.org/msg01511.html
-        ++ [
-          (fetchpatch {
-            name = "CVE-2022-46340.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/b320ca0ffe4c0c872eeb3a93d9bde21f765c7c63.diff";
-            sha256 = "sha256-XPjLwZcJPLVv1ufgqnUxl73HKcJWWTDy2J/oxFiFnAU=";
-          })
-          (fetchpatch {
-            name = "CVE-2022-46341.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/51eb63b0ee1509c6c6b8922b0e4aa037faa6f78b.diff";
-            sha256 = "sha256-w+tzzoI1TfjjiFw5GNxVBgPc7M2lRY60zl+ySsyV59o=";
-          })
-          (fetchpatch {
-            name = "CVE-2022-46342.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/b79f32b57cc0c1186b2899bce7cf89f7b325161b.diff";
-            sha256 = "sha256-NytCsqRlqhs8xpOL8PGgluU0nKd7VIY26BXgpzN6WqE=";
-          })
-          (fetchpatch {
-            name = "CVE-2022-46343.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/842ca3ccef100ce010d1d8f5f6d6cc1915055900.diff";
-            sha256 = "sha256-oUwKwfN6lAvZ60dylm53+/yDeFnYTVdCINpBAfM6LoY=";
-          })
-          (fetchpatch {
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/b8a84cb0f2807b07ab70ca9915fcdee21301b8ca.diff";
-            sha256 = "sha256-Y2x9/P0SgwUAJRjIXivA32NnMso7gQAid+VjcwNUsa8=";
-          })
-          (fetchpatch {
-            name = "CVE-2022-46344.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/8f454b793e1f13c99872c15f0eed1d7f3b823fe8.diff";
-            sha256 = "sha256-Cr760UPwmm8Qr0o/R8/IlgggXQ6ENTHRz3bP/nsIwbU=";
-          })
-          (fetchpatch {
-            name = "CVE-2022-4283.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/ccdd431cd8f1cabae9d744f0514b6533c438908c.diff";
-            sha256 = "sha256-IGPsjS7KgRPLrs1ImBXvIFCa8Iu5ZiAHRZvHlBYP8KQ=";
-          })
-          (fetchpatch {
-            name = "CVE-2023-0494.diff";
-            url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/0ba6d8c37071131a49790243cdac55392ecf71ec.diff";
-            sha256 = "sha256-/+IuGk09OYVEIB/Y+DTKf7kfHyukEFX/6u1FDIGJieY=";
-          })
         ];
-        buildInputs = commonBuildInputs ++ [ libdrm mesa ];
+        buildInputs = commonBuildInputs ++ [ libdrm libxcvt mesa ];
         propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ libpciaccess ] ++ commonPropagatedBuildInputs ++ lib.optionals stdenv.isLinux [
           udev
         ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -217,4 +217,4 @@ mirror://xorg/individual/util/lndir-1.0.4.tar.xz
 mirror://xorg/individual/util/makedepend-1.0.6.tar.bz2
 mirror://xorg/individual/util/util-macros-1.19.3.tar.bz2
 mirror://xorg/individual/util/xorg-cf-files-1.0.7.tar.bz2
-mirror://xorg/individual/xserver/xorg-server-1.20.14.tar.xz
+mirror://xorg/individual/xserver/xorg-server-21.1.7.tar.xz


### PR DESCRIPTION
###### Description of changes

Diff:
https://github.com/freedesktop/xorg-xserver/compare/xorg-server-1.20.14...xorg-server-21.1.7

This reverts the revert on https://github.com/NixOS/nixpkgs/pull/174140

###### Things done

Built and booted into NixOS unstable on a gcc-12 branch on top of current staging-next. (nvidia proprietary drivers on gnome/mutter, no segfault)

https://github.com/NixOS/nixpkgs/issues/170856

https://github.com/NixOS/nixpkgs/issues/206663

However, would appreciate some runtime testing from other users, specially those for known issues.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
