### PR TITLE
interpreters/lua: replace sourceVersion with lib.versions

### DIFF
--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -14,7 +14,7 @@
 , rockspecVersion ? version
 
 # by default prefix `name` e.g. "lua5.2-${name}"
-, namePrefix ? "${lua.pname}${lua.sourceVersion.major}.${lua.sourceVersion.minor}-"
+, namePrefix ? "${lua.pname}${lib.versions.majorMinor version}-"
 
 # Dependencies for building the package
 , buildInputs ? []

--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -1,5 +1,5 @@
 # similar to interpreters/python/default.nix
-{ stdenv, lib, callPackage, fetchurl, fetchpatch, makeBinaryWrapper }:
+{ stdenv, lib, callPackage, fetchFromGitHub, fetchurl, fetchpatch, makeBinaryWrapper }:
 
 
 let
@@ -8,7 +8,6 @@ let
   # copied from python
   passthruFun =
     { executable
-    , sourceVersion
     , luaversion
     , packageOverrides
     , luaOnBuildForBuild
@@ -67,7 +66,7 @@ let
         withPackages = import ./with-packages.nix { inherit buildEnv luaPackages;};
         pkgs = luaPackages;
         interpreter = "${self}/bin/${executable}";
-        inherit executable luaversion sourceVersion;
+        inherit executable luaversion;
         luaOnBuild = luaOnBuildForHost.override { inherit packageOverrides; self = luaOnBuild; };
 
         tests = callPackage ./tests { inherit (luaPackages) wrapLua; };
@@ -80,7 +79,7 @@ in
 rec {
   lua5_4 = callPackage ./interpreter.nix {
     self = lua5_4;
-    sourceVersion = { major = "5"; minor = "4"; patch = "4"; };
+    version = "5.4.4";
     hash = "sha256-Fkx4SWU7gK5nvsS3RzuIS/XMjS3KBWU0dewu0nuev2E=";
     makeWrapper = makeBinaryWrapper;
     inherit passthruFun;
@@ -112,7 +111,7 @@ rec {
 
   lua5_3 = callPackage ./interpreter.nix {
     self = lua5_3;
-    sourceVersion = { major = "5"; minor = "3"; patch = "6"; };
+    version = "5.3.6";
     hash = "0q3d8qhd7p0b7a4mh9g7fxqksqfs6mr1nav74vq26qvkp2dxcpzw";
     makeWrapper = makeBinaryWrapper;
     inherit passthruFun;
@@ -129,7 +128,7 @@ rec {
 
   lua5_2 = callPackage ./interpreter.nix {
     self = lua5_2;
-    sourceVersion = { major = "5"; minor = "2"; patch = "4"; };
+    version = "5.2.4";
     hash = "0jwznq0l8qg9wh5grwg07b5cy3lzngvl5m2nl1ikp6vqssmf9qmr";
     makeWrapper = makeBinaryWrapper;
     inherit passthruFun;
@@ -146,7 +145,7 @@ rec {
 
   lua5_1 = callPackage ./interpreter.nix {
     self = lua5_1;
-    sourceVersion = { major = "5"; minor = "1"; patch = "5"; };
+    version = "5.1.5";
     hash = "2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333";
     makeWrapper = makeBinaryWrapper;
     inherit passthruFun;
@@ -156,12 +155,12 @@ rec {
 
   luajit_2_0 = import ../luajit/2.0.nix {
     self = luajit_2_0;
-    inherit callPackage lib passthruFun;
+    inherit callPackage fetchFromGitHub lib passthruFun;
   };
 
   luajit_2_1 = import ../luajit/2.1.nix {
     self = luajit_2_1;
-    inherit callPackage passthruFun;
+    inherit callPackage fetchFromGitHub passthruFun;
   };
 
 }

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -9,19 +9,19 @@
 , pkgsBuildTarget
 , pkgsHostHost
 , pkgsTargetTarget
-, sourceVersion
+, version
 , hash
 , passthruFun
 , patches ? []
 , postConfigure ? null
 , postBuild ? null
 , staticOnly ? stdenv.hostPlatform.isStatic
-, luaAttr ? "lua${sourceVersion.major}_${sourceVersion.minor}"
+, luaAttr ? "lua${lib.versions.major version}_${lib.versions.minor version}"
 } @ inputs:
 let
   luaPackages = self.pkgs;
 
-  luaversion = with sourceVersion; "${major}.${minor}";
+  luaversion = lib.versions.majorMinor version;
 
 plat = if (stdenv.isLinux && lib.versionOlder self.luaversion "5.4") then "linux"
        else if (stdenv.isLinux && lib.versionAtLeast self.luaversion "5.4") then "linux-readline"
@@ -36,7 +36,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "lua";
-  version = "${luaversion}.${sourceVersion.patch}";
+  inherit version;
 
   src = fetchurl {
     url = "https://www.lua.org/ftp/${pname}-${version}.tar.gz";
@@ -136,7 +136,7 @@ stdenv.mkDerivation rec {
     inputs' = lib.filterAttrs (n: v: ! lib.isDerivation v && n != "passthruFun") inputs;
     override = attr: let lua = attr.override (inputs' // { self = lua; }); in lua;
   in passthruFun rec {
-    inherit self luaversion packageOverrides luaAttr sourceVersion;
+    inherit self luaversion packageOverrides luaAttr;
     executable = "lua";
     luaOnBuildForBuild = override pkgsBuildBuild.${luaAttr};
     luaOnBuildForHost = override pkgsBuildHost.${luaAttr};

--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -1,13 +1,18 @@
-{ self, callPackage, lib, passthruFun }:
+{ self, callPackage, fetchFromGitHub, lib, passthruFun }:
+
 callPackage ./default.nix {
-  sourceVersion = { major = "2"; minor = "0"; patch = "5"; };
-  inherit self passthruFun;
   version = "2.0.5-2022-09-13";
-  rev = "46e62cd963a426e83a60f691dcbbeb742c7b3ba2";
   isStable = true;
-  hash = "sha256-/XR9+6NjXs2TrUVKJNkH2h970BkDNFqMDJTWcy/bswU=";
+  src = fetchFromGitHub {
+    owner = "LuaJIT";
+    repo = "LuaJIT";
+    rev = "46e62cd963a426e83a60f691dcbbeb742c7b3ba2";
+    hash = "sha256-/XR9+6NjXs2TrUVKJNkH2h970BkDNFqMDJTWcy/bswU=";
+  };
+
   extraMeta = { # this isn't precise but it at least stops the useless Hydra build
     platforms = with lib; filter (p: !hasPrefix "aarch64-" p)
       (platforms.linux ++ platforms.darwin);
   };
+  inherit self passthruFun;
 }

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -1,9 +1,13 @@
-{ self, callPackage, passthruFun }:
+{ self, callPackage, fetchFromGitHub, passthruFun }:
 callPackage ./default.nix {
-  sourceVersion = { major = "2"; minor = "1"; patch = "0"; };
-  inherit self passthruFun;
   version = "2.1.0-2022-10-04";
-  rev = "6c4826f12c4d33b8b978004bc681eb1eef2be977";
   isStable = false;
-  hash = "sha256-GMgoSVHrfIuLdk8mW9XgdemNFsAkkQR4wiGGjaAXAKg=";
+  src = fetchFromGitHub {
+    owner = "LuaJIT";
+    repo = "LuaJIT";
+    rev = "6c4826f12c4d33b8b978004bc681eb1eef2be977";
+    hash = "sha256-GMgoSVHrfIuLdk8mW9XgdemNFsAkkQR4wiGGjaAXAKg=";
+  };
+
+  inherit self passthruFun;
 }

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -3,9 +3,8 @@
 , fetchFromGitHub
 , buildPackages
 , isStable
-, hash
-, rev
 , version
+, src
 , extraMeta ? { }
 , callPackage
 , self
@@ -15,7 +14,6 @@
 , pkgsBuildTarget
 , pkgsHostHost
 , pkgsTargetTarget
-, sourceVersion
 , passthruFun
 , enableFFI ? true
 , enableJIT ? true
@@ -28,7 +26,7 @@
 , enableAPICheck ? false
 , enableVMAssertions ? false
 , useSystemMalloc ? false
-, luaAttr ? "luajit_${sourceVersion.major}_${sourceVersion.minor}"
+, luaAttr ? "luajit_${lib.versions.major version}_${lib.versions.minor version}"
 } @ inputs:
 assert enableJITDebugModule -> enableJIT;
 assert enableGDBJITSupport -> enableJIT;
@@ -51,12 +49,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "luajit";
-  inherit version;
-  src = fetchFromGitHub {
-    owner = "LuaJIT";
-    repo = "LuaJIT";
-    inherit hash rev;
-  };
+  inherit version src;
 
   luaversion = "5.1";
 
@@ -113,7 +106,7 @@ stdenv.mkDerivation rec {
     inputs' = lib.filterAttrs (n: v: ! lib.isDerivation v && n != "passthruFun") inputs;
     override = attr: let lua = attr.override (inputs' // { self = lua; }); in lua;
   in passthruFun rec {
-    inherit self luaversion packageOverrides luaAttr sourceVersion;
+    inherit self luaversion packageOverrides luaAttr;
     executable = "lua";
     luaOnBuildForBuild = override pkgsBuildBuild.${luaAttr};
     luaOnBuildForHost = override pkgsBuildHost.${luaAttr};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
