### PR TITLE
luajit_openresty: init at 2.1-20220915

### DIFF
--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -163,4 +163,8 @@ rec {
     inherit callPackage fetchFromGitHub passthruFun;
   };
 
+  luajit_openresty = import ../luajit/openresty.nix {
+    self = luajit_openresty;
+    inherit callPackage fetchFromGitHub passthruFun;
+  };
 }

--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -2,7 +2,7 @@
 
 callPackage ./default.nix {
   version = "2.0.5-2022-09-13";
-  isStable = true;
+
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -1,7 +1,8 @@
 { self, callPackage, fetchFromGitHub, passthruFun }:
+
 callPackage ./default.nix {
   version = "2.1.0-2022-10-04";
-  isStable = false;
+
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , buildPackages
-, isStable
 , version
 , src
 , extraMeta ? { }
@@ -71,7 +70,7 @@ stdenv.mkDerivation rec {
     } >> src/luaconf.h
   '';
 
-  configurePhase = false;
+  dontConfigure = true;
 
   buildInputs = lib.optional enableValgrindSupport valgrind;
 
@@ -91,8 +90,9 @@ stdenv.mkDerivation rec {
   postInstall = ''
     ( cd "$out/include"; ln -s luajit-*/* . )
     ln -s "$out"/bin/luajit-* "$out"/bin/lua
-  '' + lib.optionalString (!isStable) ''
-    ln -s "$out"/bin/luajit-* "$out"/bin/luajit
+    if [[ ! -e "$out"/bin/luajit ]]; then
+      ln -s "$out"/bin/luajit* "$out"/bin/luajit
+    fi
   '';
 
   LuaPathSearchPaths    = luaPackages.luaLib.luaPathList;
@@ -117,7 +117,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "High-performance JIT compiler for Lua 5.1";
-    homepage = "http://luajit.org";
+    homepage = "https://luajit.org/";
     license = licenses.mit;
     platforms = platforms.linux ++ platforms.darwin;
     # See https://github.com/LuaJIT/LuaJIT/issues/628

--- a/pkgs/development/interpreters/luajit/openresty.nix
+++ b/pkgs/development/interpreters/luajit/openresty.nix
@@ -1,0 +1,14 @@
+{ self, callPackage, fetchFromGitHub, passthruFun }:
+
+callPackage ./default.nix rec {
+  version = "2.1-20220915";
+
+  src = fetchFromGitHub {
+    owner = "openresty";
+    repo = "luajit2";
+    rev = "v${version}";
+    hash = "sha256-kMHE4iQtm2CujK9TVut1jNhY2QxYP514jfBsxOCyd4s=";
+  };
+
+  inherit self passthruFun;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15993,7 +15993,7 @@ with pkgs;
 
   ### LUA interpreters
   luaInterpreters = callPackage ./../development/interpreters/lua-5 {};
-  inherit (luaInterpreters) lua5_1 lua5_2 lua5_2_compat lua5_3 lua5_3_compat lua5_4 lua5_4_compat luajit_2_1 luajit_2_0;
+  inherit (luaInterpreters) lua5_1 lua5_2 lua5_2_compat lua5_3 lua5_3_compat lua5_4 lua5_4_compat luajit_2_1 luajit_2_0 luajit_openresty;
 
   lua5 = lua5_2_compat;
   lua = lua5;


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/206807

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
