### PR TITLE
 luaPlugins.lua-resty-lrucache: init at 0.13;  luaPlugins.lua-resty-core: init at 0.1.24 

### DIFF
--- a/pkgs/development/lua-modules/generic/default.nix
+++ b/pkgs/development/lua-modules/generic/default.nix
@@ -2,6 +2,7 @@
 
 { disabled ? false
 , propagatedBuildInputs ? [ ]
+, makeFlags ? [ ]
 , ...
 } @ attrs:
 
@@ -9,18 +10,16 @@ if disabled then
   throw "${attrs.name} not supported by interpreter lua-${lua.luaversion}"
 else
   toLuaModule (lua.stdenv.mkDerivation (
-    {
+    attrs // {
+      name = "lua${lua.luaversion}-" + attrs.pname + "-" + attrs.version;
+
       makeFlags = [
         "PREFIX=$(out)"
-        "LUA_LIBDIR=$(out)/lib/lua/${lua.luaversion}"
         "LUA_INC=-I${lua}/include"
-      ];
-    }
-    //
-    attrs
-    //
-    {
-      name = "lua${lua.luaversion}-" + attrs.pname + "-" + attrs.version;
+        "LUA_LIBDIR=$(out)/lib/lua/${lua.luaversion}"
+        "LUA_VERSION=${lua.luaversion}"
+      ] ++ makeFlags;
+
       propagatedBuildInputs = propagatedBuildInputs ++ [
         lua # propagate it for its setup-hook
       ];

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -59,6 +59,27 @@ rec {
   # a fork of luarocks used to generate nix lua derivations from rockspecs
   luarocks-nix = callPackage ../development/tools/misc/luarocks/luarocks-nix.nix { };
 
+ lua-resty-core = callPackage ({ fetchFromGitHub }: buildLuaPackage rec {
+    pname = "lua-resty-core";
+    version = "0.1.24";
+
+    src = fetchFromGitHub {
+      owner = "openresty";
+      repo = "lua-resty-core";
+      rev = "v${version}";
+      sha256 = "sha256-obwyxHSot1Lb2c1dNqJor3inPou+UIBrqldbkNBCQQk=";
+    };
+
+    propagatedBuildInputs = [ lua-resty-lrucache ];
+
+    meta = with lib; {
+      description = "New FFI-based API for lua-nginx-module";
+      homepage = "https://github.com/openresty/lua-resty-core";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ SuperSandro2000 ];
+    };
+  }) {};
+
  lua-resty-lrucache = callPackage ({ fetchFromGitHub }: buildLuaPackage rec {
     pname = "lua-resty-lrucache";
     version = "0.13";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -30,7 +30,7 @@ let
     lib.concatMapStringsSep ";" (path: "${drv}/${path}") pathListForVersion;
 
 in
-{
+rec {
 
   # Dont take luaPackages from "global" pkgs scope to avoid mixing lua versions
   luaPackages = self;
@@ -58,6 +58,25 @@ in
 
   # a fork of luarocks used to generate nix lua derivations from rockspecs
   luarocks-nix = callPackage ../development/tools/misc/luarocks/luarocks-nix.nix { };
+
+ lua-resty-lrucache = callPackage ({ fetchFromGitHub }: buildLuaPackage rec {
+    pname = "lua-resty-lrucache";
+    version = "0.13";
+
+    src = fetchFromGitHub {
+      owner = "openresty";
+      repo = "lua-resty-lrucache";
+      rev = "v${version}";
+      sha256 = "sha256-J8RNAMourxqUF8wPKd8XBhNwGC/x1KKvrVnZtYDEu4Q=";
+    };
+
+    meta = with lib; {
+      description = "Lua-land LRU Cache based on LuaJIT FFI";
+      homepage = "https://github.com/openresty/lua-resty-lrucache";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ SuperSandro2000 ];
+    };
+  }) {};
 
   luxio = callPackage ({ fetchurl, which, pkg-config }: buildLuaPackage rec {
     pname = "luxio";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
