### PR TITLE
poac: 0.4.1 -> 0.5.1

### DIFF
--- a/pkgs/development/tools/poac/default.nix
+++ b/pkgs/development/tools/poac/default.nix
@@ -4,6 +4,7 @@
 , cmake
 , cpm-cmake
 , git
+, git2-cpp
 , cacert
 , boost179
 , fmt_8
@@ -11,38 +12,19 @@
 , libarchive
 , libgit2
 , lz4
+, mitama-cpp-result
 , ninja
 , openssl_3
+, package-project-cmake
 , spdlog
 }:
 
 let
-  git2Cpp = fetchFromGitHub {
-    owner = "ken-matsui";
-    repo = "git2-cpp";
-    rev = "v0.1.0-alpha.1";
-    sha256 = "sha256-Ub0wrBK5oMfWGv+kpq/W1PN3yzpcfg+XWRFF/lV9VCY=";
-  };
-
   glob = fetchFromGitHub {
     owner = "p-ranav";
     repo = "glob";
     rev = "v0.0.1";
     sha256 = "sha256-2y+a7YFBiYX8wbwCCWw1Cm+SFoXGB3ZxLPi/QdZhcdw=";
-  };
-
-  packageProjectCMake = fetchFromGitHub {
-    owner = "TheLartians";
-    repo = "PackageProject.cmake";
-    rev = "v1.3";
-    sha256 = "sha256-ZktftDrPo+JhBt0XKJekv0cyxIagvcgMcXZOBd4RtKs=";
-  };
-
-  mitamaCppResult = fetchFromGitHub {
-    owner = "LoliGothick";
-    repo = "mitama-cpp-result";
-    rev = "v9.3.0";
-    sha256 = "sha256-CWYVPpmPIZZTsqXKh+Ft3SlQ4C9yjUof1mJ8Acn5kmM=";
   };
 
   structopt = fetchFromGitHub {
@@ -61,13 +43,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "poac";
-  version = "0.4.1";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "poacpm";
     repo = pname;
     rev = version;
-    sha256 = "sha256-jXYPeI/rVuTr7OYV5sMgNr+U1OfN0XZtun6mihtlErY=";
+    sha256 = "sha256-JgGa7lomDvZG5HLxGJMALcezjnZprexJDTxyTUjLetg=";
   };
 
   preConfigure = ''
@@ -76,13 +58,13 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DCPM_USE_LOCAL_PACKAGES=ON"
+    "-DPOAC_BUILD_TESTING=OFF"
     "-DCPM_SOURCE_CACHE=${placeholder "out"}/share"
     "-DFETCHCONTENT_SOURCE_DIR_FMT=${fmt_8}"
-    "-DFETCHCONTENT_SOURCE_DIR_GIT2-CPP=${git2Cpp}"
+    "-DFETCHCONTENT_SOURCE_DIR_GIT2-CPP=${git2-cpp.src}"
     "-DFETCHCONTENT_SOURCE_DIR_GLOB=${glob}"
-    "-DFETCHCONTENT_SOURCE_DIR_PACKAGEPROJECT.CMAKE=${packageProjectCMake}"
-    "-DFETCHCONTENT_SOURCE_DIR_MITAMA-CPP-RESULT=${mitamaCppResult}"
+    "-DFETCHCONTENT_SOURCE_DIR_PACKAGEPROJECT.CMAKE=${package-project-cmake.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_MITAMA-CPP-RESULT=${mitama-cpp-result.src}"
     "-DFETCHCONTENT_SOURCE_DIR_NINJA=${ninja.src}"
     "-DFETCHCONTENT_SOURCE_DIR_STRUCTOPT=${structopt}"
     "-DFETCHCONTENT_SOURCE_DIR_TOML11=${toml11}"
@@ -95,10 +77,10 @@ stdenv.mkDerivation rec {
       enableStatic = !stdenv.isDarwin;
     })
     fmt_8
-    git2Cpp
+    git2-cpp
     glob
-    packageProjectCMake
-    mitamaCppResult
+    package-project-cmake
+    mitama-cpp-result
     ninja
     structopt
     toml11


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
