### PR TITLE
paperless-ngx: 1.9.2 -> 1.10.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1474,12 +1474,12 @@
     }];
   };
   babariviere = {
-    email = "babathriviere@gmail.com";
+    email = "me@babariviere.com";
     github = "babariviere";
     githubId = 12128029;
     name = "Bastien Rivière";
     keys = [{
-      fingerprint = "2F85 B362 B274 0012 37E2  81EE F202 AD3B 6EDF 4BD1";
+      fingerprint = "74AA 9AB4 E6FF 872B 3C5A  CB3E 3903 5CC0 B75D 1142";
     }];
   };
   babbaj = {

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -20,20 +20,6 @@ let
     packageOverrides = self: super: {
       django = super.django_4;
 
-      # use paperless-ngx version of django-q
-      # see https://github.com/paperless-ngx/paperless-ngx/pull/1014
-      django-q = super.django-q.overridePythonAttrs (oldAttrs: {
-        src = fetchFromGitHub {
-          owner = "paperless-ngx";
-          repo = "django-q";
-          hash = "sha256-alu7tZwUn77xhUF9c/aGmwRwO//mR/FucXjvXUl/6ek=";
-          rev = "8b5289d8caf36f67fb99448e76ead20d5b498c1b";
-        };
-        # due to paperless-ngx modification of the pyproject.toml file
-        # the patch is not needed any more
-        patches = [ ];
-      });
-
       aioredis = super.aioredis.overridePythonAttrs (oldAttrs: rec {
         version = "1.3.1";
         src = oldAttrs.src.override {
@@ -93,12 +79,12 @@ let
 in
 python.pkgs.pythonPackages.buildPythonApplication rec {
   pname = "paperless-ngx";
-  version = "1.9.2";
+  version = "1.10.2";
 
-  # Fetch the release tarball instead of a git ref because it contains the prebuilt fontend
+  # Fetch the release tarball instead of a git ref because it contains the prebuilt frontend
   src = fetchurl {
     url = "https://github.com/paperless-ngx/paperless-ngx/releases/download/v${version}/${pname}-v${version}.tar.xz";
-    hash = "sha256-fafjVXRfzFrINzI/Ivfm1VY4YpemHkHwThBP54XoXM4=";
+    hash = "sha256-uOrRHHNqIYsDbzKcA7EsYZjadpLyAB4Ks+PU+BNsTWE=";
   };
 
   format = "other";
@@ -112,6 +98,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     autobahn
     automat
     blessed
+    celery
     certifi
     cffi
     channels-redis
@@ -124,11 +111,11 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     cryptography
     daphne
     dateparser
+    django-celery-results
     django-cors-headers
     django-extensions
     django-filter
     django-picklefield
-    django-q
     django
     djangorestframework
     filelock
@@ -171,6 +158,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     pytz
     pyyaml
     pyzbar
+    rapidfuzz
     redis
     regex
     reportlab
@@ -198,13 +186,6 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     whoosh
     zope_interface
   ];
-
-  # paperless-ngx includes the bundled django-q version. This will
-  # conflict with the tests and is not needed since we overrode the
-  # django-q version with the paperless-ngx version
-  postPatch = ''
-    rm -rf src/django-q
-  '';
 
   # Compile manually because `pythonRecompileBytecodeHook` only works for
   # files in `python.sitePackages`
@@ -246,8 +227,19 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     # Disable unneeded code coverage test
     substituteInPlace src/setup.cfg \
       --replace "--cov --cov-report=html" ""
+    # OCR on NixOS recognizes the space in the picture, upstream CI doesn't.
+    # See https://github.com/paperless-ngx/paperless-ngx/pull/2216
+    substituteInPlace src/paperless_tesseract/tests/test_parser.py \
+      --replace "this is awebp document" "this is a webp document"
   '';
 
+  disabledTests = [
+    # FileNotFoundError(2, 'No such file or directory'): /build/tmp...
+    "test_script_with_output"
+    # AssertionError: 10 != 4 (timezone/time issue)
+    # Due to getting local time from modification date in test_consumer.py
+    "testNormalOperation"
+  ];
 
   passthru = {
     inherit python path;

--- a/pkgs/development/python-modules/django-celery-results/default.nix
+++ b/pkgs/development/python-modules/django-celery-results/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, celery
+, django
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "django_celery_results";
+  version = "2.4.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-dapRlw21aRy/JCxqD/UMjN9BniZc0Om3cjNdBkNsS5k=";
+  };
+
+  propagatedBuildInputs = [
+    celery
+    django
+  ];
+
+  # Tests need access to a database.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Celery result back end with django";
+    homepage = "https://github.com/celery/django-celery-results";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ babariviere ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2489,6 +2489,8 @@ self: super: with self; {
 
   django-celery-email = callPackage ../development/python-modules/django-celery-email { };
 
+  django-celery-results = callPackage ../development/python-modules/django-celery-results { };
+
   django_classytags = callPackage ../development/python-modules/django_classytags { };
 
   django-cleanup = callPackage ../development/python-modules/django-cleanup { };


### PR DESCRIPTION
###### Description of changes

Update paperless-ngx to 1.10.2.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
