### PR TITLE
cinnamon.nemo-with-extensions: init

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -105,7 +105,7 @@ in
       services.dbus.packages = with pkgs.cinnamon; [
         cinnamon-common
         cinnamon-screensaver
-        nemo
+        nemo-with-extensions
         xapp
       ];
       services.cinnamon.apps.enable = mkDefault true;
@@ -154,7 +154,7 @@ in
         polkit_gnome
 
         # packages
-        nemo
+        nemo-with-extensions
         cinnamon-control-center
         cinnamon-settings-daemon
         libgnomekbd

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -15,6 +15,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   # Extensions added here will be shipped by default
   nemoExtensions = [
     nemo-fileroller
+    nemo-python
   ];
 
   # blueberry -> pkgs/tools/bluetooth/blueberry/default.nix
@@ -31,6 +32,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cjs = callPackage ./cjs { };
   nemo = callPackage ./nemo { };
   nemo-fileroller = callPackage ./nemo-extensions/nemo-fileroller { };
+  nemo-python = callPackage ./nemo-extensions/nemo-python { };
   nemo-with-extensions = callPackage ./nemo/wrapper.nix { };
   mint-artwork = callPackage ./mint-artwork { };
   mint-cursor-themes = callPackage ./mint-cursor-themes { };

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -12,6 +12,10 @@ lib.makeScope pkgs.newScope (self: with self; {
     installPhase = "mv svg $out/share/iso-flags-svg";
   });
 
+  # Extensions added here will be shipped by default
+  nemoExtensions = [
+  ];
+
   # blueberry -> pkgs/tools/bluetooth/blueberry/default.nix
   bulky = callPackage ./bulky { };
   cinnamon-common = callPackage ./cinnamon-common { };
@@ -25,6 +29,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cinnamon-settings-daemon = callPackage ./cinnamon-settings-daemon { };
   cjs = callPackage ./cjs { };
   nemo = callPackage ./nemo { };
+  nemo-with-extensions = callPackage ./nemo/wrapper.nix { };
   mint-artwork = callPackage ./mint-artwork { };
   mint-cursor-themes = callPackage ./mint-cursor-themes { };
   mint-themes = callPackage ./mint-themes { };

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -14,6 +14,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   # Extensions added here will be shipped by default
   nemoExtensions = [
+    folder-color-switcher
     nemo-fileroller
     nemo-python
   ];
@@ -30,6 +31,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cinnamon-session = callPackage ./cinnamon-session { };
   cinnamon-settings-daemon = callPackage ./cinnamon-settings-daemon { };
   cjs = callPackage ./cjs { };
+  folder-color-switcher = callPackage ./folder-color-switcher { };
   nemo = callPackage ./nemo { };
   nemo-fileroller = callPackage ./nemo-extensions/nemo-fileroller { };
   nemo-python = callPackage ./nemo-extensions/nemo-python { };

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -14,6 +14,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   # Extensions added here will be shipped by default
   nemoExtensions = [
+    nemo-fileroller
   ];
 
   # blueberry -> pkgs/tools/bluetooth/blueberry/default.nix
@@ -29,6 +30,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cinnamon-settings-daemon = callPackage ./cinnamon-settings-daemon { };
   cjs = callPackage ./cjs { };
   nemo = callPackage ./nemo { };
+  nemo-fileroller = callPackage ./nemo-extensions/nemo-fileroller { };
   nemo-with-extensions = callPackage ./nemo/wrapper.nix { };
   mint-artwork = callPackage ./mint-artwork { };
   mint-cursor-themes = callPackage ./mint-cursor-themes { };

--- a/pkgs/desktops/cinnamon/folder-color-switcher/default.nix
+++ b/pkgs/desktops/cinnamon/folder-color-switcher/default.nix
@@ -1,0 +1,44 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, gettext
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "folder-color-switcher";
+  version = "1.5.5";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    # They don't really do tags, this is just a named commit.
+    rev = "5e0b768b3a5bf88a828a2489b9428997b797c1ed";
+    sha256 = "sha256-DU75LM5v2/E/ZmqQgyiPsOOEUw9QQ/NXNtGDFzzYvyY=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+  ];
+
+  postPatch = ''
+    substituteInPlace usr/share/nemo-python/extensions/nemo-folder-color-switcher.py \
+      --replace "/usr/share" "$out/share"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    mv usr/share $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/linuxmint/folder-color-switcher";
+    description = "Change folder colors for Nemo and Caja";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
+}

--- a/pkgs/desktops/cinnamon/nemo-extensions/nemo-fileroller/default.nix
+++ b/pkgs/desktops/cinnamon/nemo-extensions/nemo-fileroller/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, pkg-config
+, ninja
+, glib
+, gtk3
+, nemo
+, gnome
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nemo-fileroller";
+  version = "5.6.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "nemo-extensions";
+    rev = "nemo-fileroller-${version}";
+    sha256 = "sha256-dPmAHuJ0ZRTAwhnMMZEu1e9+qZRYCnlaaoCdUP45W+s=";
+  };
+
+  sourceRoot = "${src.name}/nemo-fileroller";
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    nemo
+  ];
+
+  postPatch = ''
+    substituteInPlace src/nemo-fileroller.c \
+      --replace "file-roller" "${lib.getExe gnome.file-roller}"
+  '';
+
+  PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";
+
+  meta = with lib; {
+    homepage = "https://github.com/linuxmint/nemo-extensions/tree/master/nemo-fileroller";
+    description = "Nemo file roller extension";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
+}

--- a/pkgs/desktops/cinnamon/nemo-extensions/nemo-python/default.nix
+++ b/pkgs/desktops/cinnamon/nemo-extensions/nemo-python/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, pkg-config
+, ninja
+, glib
+, gtk3
+, nemo
+, python3
+, substituteAll
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nemo-python";
+  version = "5.6.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "nemo-extensions";
+    rev = version;
+    sha256 = "sha256-cxutiz5bc/dZ9D7XzvMWodWNYvNJPj+5IhJDPJwnb5I=";
+  };
+
+  sourceRoot = "${src.name}/nemo-python";
+
+  patches = [
+    # Load extensions from NEMO_PYTHON_EXTENSION_DIR environment variable
+    # https://github.com/NixOS/nixpkgs/issues/78327
+    ./load-extensions-from-env.patch
+
+    # Required for pygobject_init ().
+    (substituteAll {
+      src = ./python-path.patch;
+      env = "${python3.pkgs.pygobject3}/${python3.sitePackages}";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    nemo
+    python3
+    python3.pkgs.pygobject3
+  ];
+
+  postPatch = ''
+    # Tries to load libpython3.so via g_module_open ().
+    substituteInPlace meson.build \
+      --replace "get_option('prefix'), get_option('libdir')" "'${python3}/lib'"
+  '';
+
+  PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";
+
+  meta = with lib; {
+    homepage = "https://github.com/linuxmint/nemo-extensions/tree/master/nemo-python";
+    description = "Python bindings for the Nemo extension library";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = teams.cinnamon.members;
+  };
+}

--- a/pkgs/desktops/cinnamon/nemo-extensions/nemo-python/load-extensions-from-env.patch
+++ b/pkgs/desktops/cinnamon/nemo-extensions/nemo-python/load-extensions-from-env.patch
@@ -1,0 +1,27 @@
+diff --git a/src/nemo-python.c b/src/nemo-python.c
+index 8d2acdb..900811b 100644
+--- a/src/nemo-python.c
++++ b/src/nemo-python.c
+@@ -255,6 +255,7 @@ nemo_module_initialize(GTypeModule *module)
+ {
+ 	gchar *user_extensions_dir;
+ 	const gchar *env_string;
++	const gchar *python_extensiondir;
+ 
+ 	env_string = g_getenv("NEMO_PYTHON_DEBUG");
+ 	if (env_string != NULL)
+@@ -269,8 +270,12 @@ nemo_module_initialize(GTypeModule *module)
+ 
+ 	all_types = g_array_new(FALSE, FALSE, sizeof(GType));
+ 
+-	// Look in the new global path, $DATADIR/nemo-python/extensions
+-	nemo_python_load_dir(module, PYTHON_EXTENSION_DIR);
++	// Look in NEMO_PYTHON_EXTENSION_DIR
++	python_extensiondir = g_getenv("NEMO_PYTHON_EXTENSION_DIR");
++	if (python_extensiondir == NULL) {
++		python_extensiondir = PYTHON_EXTENSION_DIR;
++	}
++	nemo_python_load_dir(module, python_extensiondir);
+ 
+ 	// Look in XDG_DATA_DIR, ~/.local/share/nemo-python/extensions
+ 	user_extensions_dir = g_build_filename(g_get_user_data_dir(), 

--- a/pkgs/desktops/cinnamon/nemo-extensions/nemo-python/python-path.patch
+++ b/pkgs/desktops/cinnamon/nemo-extensions/nemo-python/python-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/nemo-python.c b/src/nemo-python.c
+index 8d2acdb..ee24143 100644
+--- a/src/nemo-python.c
++++ b/src/nemo-python.c
+@@ -197,7 +197,7 @@ nemo_python_init_python (void)
+ 	}
+ 	
+ 	debug("Sanitize the python search path");
+-	PyRun_SimpleString("import sys; sys.path = [path for path in sys.path if path]");
++	PyRun_SimpleString("import sys; sys.path = [path for path in sys.path if path]; sys.path.append('@env@')");
+ 	if (PyErr_Occurred())
+ 	{
+ 		PyErr_Print();

--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
   pname = "nemo";
   version = "5.6.1";
 
-  # TODO: add plugins support (see https://github.com/NixOS/nixpkgs/issues/78327)
-
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = pname;
@@ -35,6 +33,10 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Load extensions from NEMO_EXTENSION_DIR environment variable
+    # https://github.com/NixOS/nixpkgs/issues/78327
+    ./load-extensions-from-env.patch
+
     # Don't populate nemo actions from /run/current-system/sw/share
     # They should only be loaded exactly once from $out/share
     # https://github.com/NixOS/nixpkgs/issues/190781
@@ -70,12 +72,16 @@ stdenv.mkDerivation rec {
     "--localedir=${cinnamon-translations}/share/locale"
   ];
 
+  # Taken from libnemo-extension.pc.
+  passthru.extensiondir = "lib/nemo/extensions-3.0";
+
   meta = with lib; {
     homepage = "https://github.com/linuxmint/nemo";
     description = "File browser for Cinnamon";
     license = [ licenses.gpl2 licenses.lgpl2 ];
     platforms = platforms.linux;
     maintainers = teams.cinnamon.members;
+    mainProgram = "nemo";
   };
 }
 

--- a/pkgs/desktops/cinnamon/nemo/load-extensions-from-env.patch
+++ b/pkgs/desktops/cinnamon/nemo/load-extensions-from-env.patch
@@ -1,0 +1,40 @@
+diff --git a/libnemo-private/nemo-module.c b/libnemo-private/nemo-module.c
+index 92bcff5..ecadcd8 100644
+--- a/libnemo-private/nemo-module.c
++++ b/libnemo-private/nemo-module.c
+@@ -209,11 +209,16 @@ void
+ nemo_module_setup (void)
+ {
+ 	static gboolean initialized = FALSE;
++	const gchar *extensiondir = NULL;
+ 
+ 	if (!initialized) {
+ 		initialized = TRUE;
+ 		
+-		load_module_dir (NEMO_EXTENSIONDIR);
++		extensiondir = g_getenv ("NEMO_EXTENSION_DIR");
++		if (extensiondir == NULL) {
++			extensiondir = NEMO_EXTENSIONDIR;
++		}
++		load_module_dir (extensiondir);
+ 
+ 		eel_debug_call_at_shutdown (free_module_objects);
+ 	}
+diff --git a/src/nemo-extensions-list.c b/src/nemo-extensions-list.c
+index 944fc5f..983c396 100644
+--- a/src/nemo-extensions-list.c
++++ b/src/nemo-extensions-list.c
+@@ -129,7 +129,12 @@ module_get_extensions_for_type (GType type)
+ int
+ main (int argc, char *argv[])
+ {
+-    populate_from_directory (NEMO_EXTENSIONDIR);
++    const gchar *extensiondir = NULL;
++    extensiondir = g_getenv ("NEMO_EXTENSION_DIR");
++    if (extensiondir == NULL) {
++        extensiondir = NEMO_EXTENSIONDIR;
++    }
++    populate_from_directory (extensiondir);
+ 
+     GList *nd_providers;
+     GList *l;

--- a/pkgs/desktops/cinnamon/nemo/wrapper.nix
+++ b/pkgs/desktops/cinnamon/nemo/wrapper.nix
@@ -20,7 +20,8 @@ symlinkJoin {
   postBuild = ''
     for f in $(find $out/bin/ $out/libexec/ -type l -not -path "*/.*"); do
       wrapProgram "$f" \
-        --set "NEMO_EXTENSION_DIR" "$out/${nemo.extensiondir}"
+        --set "NEMO_EXTENSION_DIR" "$out/${nemo.extensiondir}" \
+        --set "NEMO_PYTHON_EXTENSION_DIR" "$out/share/nemo-python/extensions"
     done
 
     # Point to wrapped binary in all service files

--- a/pkgs/desktops/cinnamon/nemo/wrapper.nix
+++ b/pkgs/desktops/cinnamon/nemo/wrapper.nix
@@ -1,0 +1,37 @@
+{ symlinkJoin
+, lib
+, makeWrapper
+, nemo
+, nemoExtensions
+, extensions ? [ ]
+, useDefaultExtensions ? true
+}:
+
+let
+  selectedExtensions = extensions ++ (lib.optionals useDefaultExtensions nemoExtensions);
+in
+symlinkJoin {
+  name = "nemo-with-extensions-${nemo.version}";
+
+  paths = [ nemo ] ++ selectedExtensions;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    for f in $(find $out/bin/ $out/libexec/ -type l -not -path "*/.*"); do
+      wrapProgram "$f" \
+        --set "NEMO_EXTENSION_DIR" "$out/${nemo.extensiondir}"
+    done
+
+    # Point to wrapped binary in all service files
+    for file in "share/dbus-1/services/nemo.FileManager1.service" \
+      "share/dbus-1/services/nemo.service"
+    do
+      rm "$out/$file"
+      substitute "${nemo}/$file" "$out/$file" \
+        --replace "${nemo}" "$out"
+    done
+  '';
+
+  inherit (nemo) meta;
+}


### PR DESCRIPTION
###### Description of changes

This PR adds initial support for nemo extensions. Also adds a regular extension (`nemo-fileroller`), a python extension loader (`nemo-python`) and a python extension (`folder-color-switcher`).

I assume other extensions are basically a matter of fixing FHS paths and hardcoding gsettings, to make this PR easier to review let's do that later™ 

Closes https://github.com/NixOS/nixpkgs/issues/78327

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
