### PR TITLE
ocamlPackages.paf: 0.2.0 → 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/git/mirage.nix
+++ b/pkgs/development/ocaml-modules/git/mirage.nix
@@ -43,6 +43,7 @@ buildDunePackage {
   inherit (git) version src;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   buildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/git/paf.nix
+++ b/pkgs/development/ocaml-modules/git/paf.nix
@@ -26,6 +26,7 @@ buildDunePackage {
   inherit (git) version src;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     git

--- a/pkgs/development/ocaml-modules/git/unix.nix
+++ b/pkgs/development/ocaml-modules/git/unix.nix
@@ -15,6 +15,7 @@ buildDunePackage {
   inherit (git) version src;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   buildInputs = [
     awa awa-mirage cmdliner

--- a/pkgs/development/ocaml-modules/irmin/git.nix
+++ b/pkgs/development/ocaml-modules/irmin/git.nix
@@ -10,6 +10,7 @@ buildDunePackage {
   pname = "irmin-git";
 
   inherit (irmin) version src strictDeps;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     git

--- a/pkgs/development/ocaml-modules/irmin/graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/graphql.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   pname = "irmin-graphql";
 
   inherit (irmin) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ cohttp-lwt cohttp-lwt-unix graphql-cohttp graphql-lwt irmin git-unix ];
 

--- a/pkgs/development/ocaml-modules/irmin/http.nix
+++ b/pkgs/development/ocaml-modules/irmin/http.nix
@@ -9,6 +9,7 @@ buildDunePackage rec {
   pname = "irmin-http";
 
   inherit (irmin) version src strictDeps;
+  duneVersion = "3";
 
 
   propagatedBuildInputs = [ astring cohttp-lwt cohttp-lwt-unix fmt jsonm logs lwt uri irmin webmachine ];

--- a/pkgs/development/ocaml-modules/irmin/mirage-git.nix
+++ b/pkgs/development/ocaml-modules/irmin/mirage-git.nix
@@ -7,6 +7,7 @@ buildDunePackage {
   pname = "irmin-mirage-git";
 
   inherit (irmin-mirage) version src strictDeps;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     irmin-mirage

--- a/pkgs/development/ocaml-modules/irmin/mirage-graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/mirage-graphql.nix
@@ -6,6 +6,7 @@ buildDunePackage {
   pname = "irmin-mirage-graphql";
 
   inherit (irmin-mirage) version src strictDeps;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     irmin-mirage

--- a/pkgs/development/ocaml-modules/paf/cohttp.nix
+++ b/pkgs/development/ocaml-modules/paf/cohttp.nix
@@ -24,6 +24,8 @@ buildDunePackage {
     src
   ;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [
     paf
     cohttp-lwt

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -25,14 +25,15 @@
 
 buildDunePackage rec {
   pname = "paf";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchurl {
     url = "https://github.com/dinosaure/paf-le-chien/releases/download/${version}/paf-${version}.tbz";
-    sha256 = "sha256-TzhRxFTPkLMAsLPl0ONC8DRhJRGstF58+QRKbGuJZVE=";
+    sha256 = "sha256-+RkrmWJJREHg8BBdNe92vYhd2/Frvs7l5qOr9jBwymU=";
   };
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     mirage-stack

--- a/pkgs/development/ocaml-modules/paf/le.nix
+++ b/pkgs/development/ocaml-modules/paf/le.nix
@@ -19,6 +19,8 @@ buildDunePackage {
     src
   ;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [
     paf
     duration


### PR DESCRIPTION
###### Description of changes

Fixes & improvements: https://github.com/dinosaure/paf-le-chien/blob/0.3.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
