### PR TITLE
rtw89: unstable-2021-10-21 -> unstable-2022-12-18; There was no support for 8852BE, and 8853CE devices.

### DIFF
--- a/pkgs/os-specific/linux/rtw89/default.nix
+++ b/pkgs/os-specific/linux/rtw89/default.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "rtw89";
-  version = "unstable-2021-10-21";
+  version = "unstable-2022-12-18";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw89";
-    rev = "0684157cba90e36bff5bc61a59e7e87c359b5e5c";
-    sha256 = "0cvawyi1ksw9xkr8pzwipsl7b8hnmrb17w5cblyicwih8fqaw632";
+    rev = "e834edfe8bee6e27e31c2f783817a9c13ff45665";
+    sha256 = "19ApYiEvA0E6qgf5XQc03paZ+ghjZL8JoC3vSYYw3xU=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -30,12 +30,12 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = " Driver for Realtek 8852AE, an 802.11ax device";
+    description = " Driver for Realtek 8852AE, 8852BE, and 8853CE, 802.11ax devices";
     homepage = "https://github.com/lwfinger/rtw89";
     license = with licenses; [ gpl2Only ];
     maintainers = with maintainers; [ tvorog ];
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "5.4";
+    broken = kernel.kernelOlder "5.7";
     priority = -1;
   };
 }


### PR DESCRIPTION
###### Description of changes
```
diff --git a/pkgs/os-specific/linux/rtw89/default.nix b/pkgs/os-specific/linux/rtw89/default.nix
index 6ff208fa6dd..1bb42860a8c 100644
--- a/pkgs/os-specific/linux/rtw89/default.nix
+++ b/pkgs/os-specific/linux/rtw89/default.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "rtw89";
-  version = "unstable-2021-10-21";
+  version = "unstable-2022-12-18";
 
   src = fetchFromGitHub {
     owner = "lwfinger";
     repo = "rtw89";
-    rev = "0684157cba90e36bff5bc61a59e7e87c359b5e5c";
-    sha256 = "0cvawyi1ksw9xkr8pzwipsl7b8hnmrb17w5cblyicwih8fqaw632";
+    rev = "e834edfe8bee6e27e31c2f783817a9c13ff45665";
+    sha256 = "19ApYiEvA0E6qgf5XQc03paZ+ghjZL8JoC3vSYYw3xU=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -30,12 +30,12 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = " Driver for Realtek 8852AE, an 802.11ax device";
+    description = " Driver for Realtek 8852AE, 8852BE, and 8853CE, 802.11ax devices";
     homepage = "https://github.com/lwfinger/rtw89";
     license = with licenses; [ gpl2Only ];
     maintainers = with maintainers; [ tvorog ];
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "5.4";
+    broken = kernel.kernelOlder "5.7";
     priority = -1;
   };
 }
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
