### PR TITLE
gitlab-runner: 15.5.1 -> 15.7.1

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoModule, fetchFromGitLab, fetchurl, bash }:
 
 let
-  version = "15.5.1";
+  version = "15.7.1";
 in
 buildGoModule rec {
   inherit version;
@@ -17,13 +17,13 @@ buildGoModule rec {
   # For patchShebangs
   buildInputs = [ bash ];
 
-  vendorSha256 = "sha256-IcsYH1V3b5IUY2JqOADJrc4lkng1GS7lndfHObRQbxU=";
+  vendorSha256 = "sha256-GyhDns10eekU05D7SGbhYYlpK3OIajtUXXOcWgprBPc=";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     rev = "v${version}";
-    sha256 = "sha256-ZvQaA4DSuEIdHEoRKJg5tOnBQgf26paTAiWy6RLRG3o=";
+    sha256 = "sha256-YHqezwud+/osCiqeR3QUvANFRU/oR451act+Crh4CRE=";
   };
 
   patches = [
@@ -46,6 +46,7 @@ buildGoModule rec {
     rm executors/docker/terminal_test.go
     rm executors/docker/docker_test.go
     rm helpers/docker/auth/auth_test.go
+    rm executors/docker/services_test.go
   '';
 
   postInstall = ''

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/remove-bash-test.patch
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/remove-bash-test.patch
@@ -1,25 +1,23 @@
 diff --git a/shells/bash_test.go b/shells/bash_test.go
-index b8a48f85e..0e3173fc3 100644
+index 9ed9e65ff..02b6e6d5f 100644
 --- a/shells/bash_test.go
 +++ b/shells/bash_test.go
-@@ -4,12 +4,9 @@
- package shells
+@@ -4,11 +4,9 @@ package shells
  
  import (
+ 	"path"
 -	"runtime"
  	"testing"
  
  	"github.com/stretchr/testify/assert"
 -	"github.com/stretchr/testify/require"
--	"gitlab.com/gitlab-org/gitlab-runner/common"
+ 	"gitlab.com/gitlab-org/gitlab-runner/common"
  )
  
- func TestBash_CommandShellEscapesLegacy(t *testing.T) {
-@@ -84,62 +81,3 @@ func TestBash_CheckForErrors(t *testing.T) {
- 		})
+@@ -90,65 +88,6 @@ func TestBash_CheckForErrors(t *testing.T) {
  	}
  }
--
+ 
 -func TestBash_GetConfiguration(t *testing.T) {
 -	tests := map[string]struct {
 -		info common.ShellScriptInfo
@@ -78,3 +76,7 @@ index b8a48f85e..0e3173fc3 100644
 -		})
 -	}
 -}
+-
+ func Test_BashWriter_isTmpFile(t *testing.T) {
+ 	tmpDir := "/foo/bar"
+ 	bw := BashWriter{TemporaryPath: tmpDir}


### PR DESCRIPTION
###### Description of changes
https://gitlab.com/gitlab-org/gitlab-runner/blob/v15.7.1/CHANGELOG.md

They seemed to have refactored their codebase a little, so I had to adjust our patches accordingly.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
