### PR TITLE
python310Packages.docformatter: 1.5.0 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/docformatter/default.nix
+++ b/pkgs/development/python-modules/docformatter/default.nix
@@ -2,6 +2,9 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
+, poetry-core
+, charset-normalizer
+, tomli
 , untokenize
 , mock
 , pytestCheckHook
@@ -9,20 +12,37 @@
 
 buildPythonPackage rec {
   pname = "docformatter";
-  version = "1.5.0";
+  version = "1.5.1";
 
   disabled = pythonOlder "3.6";
 
-  format = "setuptools";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-GSfsM6sPSLOIH0YJYFVTB3SigI62/ps51mA2iZ7GOEg=";
+    hash = "sha256-r+8FOl9Rrfi3V8f8wD41bRsaqDb+UrOBWuR3goK43xY=";
   };
 
+  patches = [
+    ./test-path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'charset_normalizer = "^2.0.0"' 'charset_normalizer = ">=2.0.0"'
+    substituteInPlace tests/conftest.py \
+      --subst-var-by docformatter $out/bin/docformatter
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
   propagatedBuildInputs = [
+    charset-normalizer
+    tomli
     untokenize
   ];
 
@@ -34,6 +54,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "docformatter" ];
 
   meta = {
+    changelog = "https://github.com/PyCQA/docformatter/blob/${src.rev}/CHANGELOG.md";
     description = "Formats docstrings to follow PEP 257";
     homepage = "https://github.com/myint/docformatter";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/docformatter/test-path.patch
+++ b/pkgs/development/python-modules/docformatter/test-path.patch
@@ -1,0 +1,29 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 5f5a9aa..3289222 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -92,21 +92,9 @@ def run_docformatter(arguments, temporary_file):
+ 
+     Return subprocess object.
+     """
+-    if "DOCFORMATTER_COVERAGE" in os.environ and int(
+-            os.environ["DOCFORMATTER_COVERAGE"]
+-    ):
+-        DOCFORMATTER_COMMAND = [
+-            "coverage",
+-            "run",
+-            "--branch",
+-            "--parallel",
+-            "--omit=*/site-packages/*",
+-            os.environ["VIRTUAL_ENV"] + "/bin/docformatter",
+-        ]
+-    else:
+-        DOCFORMATTER_COMMAND = [
+-            os.environ["VIRTUAL_ENV"] + "/bin/docformatter",
+-        ]  # pragma: no cover
++    DOCFORMATTER_COMMAND = [
++        "@docformatter@"
++    ]
+ 
+     if "-" not in arguments:
+         arguments.append(temporary_file)

--- a/pkgs/development/python-modules/xsdata/default.nix
+++ b/pkgs/development/python-modules/xsdata/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
+, fetchpatch
 , click
 , click-default-group
 , docformatter
@@ -24,6 +25,16 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-o9Xxt7b/+MkW94Jcg26ihaTn0/OpTcu+0OY7oV3JRGY=";
   };
+
+  patches = [
+    # https://github.com/tefra/xsdata/pull/741
+    (fetchpatch {
+      name = "use-docformatter-1.5.1.patch";
+      url = "https://github.com/tefra/xsdata/commit/040692db47e6e51028fd959c793e757858c392d7.patch";
+      excludes = [ "setup.cfg" ];
+      hash = "sha256-ncecMJLJUiUb4lB8ys+nyiGU/UmayK++o89h3sAwREQ=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace setup.cfg \


### PR DESCRIPTION
~This breaks xsdata: https://github.com/tefra/xsdata/issues/728~

###### Description of changes
https://github.com/PyCQA/docformatter/blob/v1.5.1/CHANGELOG.md

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
