### PR TITLE
dbeaver: 22.2.2 -> 22.3.0

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -19,20 +19,25 @@
 , javaPackages
 }:
 
-(javaPackages.mavenfod.override {
-  inherit maven; # use overridden maven version (see dbeaver's entry in all-packages.nix)
-}) rec {
+javaPackages.mavenfod rec {
   pname = "dbeaver";
-  version = "22.2.2"; # When updating also update mvnSha256
+  version = "22.3.0"; # When updating also update mvnHash and ./pin-deps.diff
 
   src = fetchFromGitHub {
     owner = "dbeaver";
     repo = "dbeaver";
     rev = version;
-    sha256 = "sha256-TUdtrhQ1JzqZx+QNauNA1P/+WDSSeOGIgGX3SdS0JTI=";
+    hash = "sha256-ynIpgecJy8mtywpNVTC6+Ws+uFcJC5xcPsjrMZtBxLo=";
   };
 
-  mvnSha256 = "uu7UNRIuAx2GOh4+YxxoGRcV5QO8C72q32e0ynJdgFo=";
+  mvnPatches = [
+    # https://github.com/NixOS/nixpkgs/pull/198222#pullrequestreview-1190679686
+    ./pin-deps.diff
+    # https://github.com/dbeaver/dbeaver/issues/18481
+    ./fix-api-mismatch.diff
+  ];
+
+  mvnHash = "sha256-cvSk/yUYNwWK5jaoxzUB562swMcnZY6rTIDCoAaKIi0=";
   mvnParameters = "-P desktop,all-platforms";
 
   nativeBuildInputs = [
@@ -134,5 +139,6 @@
     license = licenses.asl20;
     platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
     maintainers = with maintainers; [ jojosch mkg20001 ];
+    changelog = "https://github.com/dbeaver/dbeaver/releases/tag/${version}";
   };
 }

--- a/pkgs/applications/misc/dbeaver/fix-api-mismatch.diff
+++ b/pkgs/applications/misc/dbeaver/fix-api-mismatch.diff
@@ -1,0 +1,24 @@
+diff '--color=auto' -ur a/pom.xml c/pom.xml
+--- a/pom.xml	2022-12-19 16:48:05.022375943 -0300
++++ c/pom.xml	2022-12-19 16:48:59.122024363 -0300
+@@ -11,7 +11,7 @@
+     <properties>
+         <dbeaver-version>22.3.0</dbeaver-version>
+         <dbeaver-product>DBeaver</dbeaver-product>
+-        <tycho-version>3.0.0</tycho-version>
++        <tycho-version>3.0.1</tycho-version>
+         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+ 
+diff '--color=auto' -ur a/product/localRepository/pom.xml c/product/localRepository/pom.xml
+--- a/product/localRepository/pom.xml	2022-12-19 16:48:43.677839089 -0300
++++ c/product/localRepository/pom.xml	2022-12-19 16:49:15.780224352 -0300
+@@ -9,7 +9,7 @@
+ 	<name>DBeaver - 3rd party dependencies</name>
+ 
+ 	<properties>
+-		<tycho-version>3.0.0</tycho-version>
++		<tycho-version>3.0.1-SNAPSHOT</tycho-version>
+ 		<reficio-p2-version>1.4.1</reficio-p2-version>
+ 		<repo-name>DBeaver CE Update</repo-name>
+ 	</properties>

--- a/pkgs/applications/misc/dbeaver/pin-deps.diff
+++ b/pkgs/applications/misc/dbeaver/pin-deps.diff
@@ -1,0 +1,30 @@
+diff '--color=auto' -ur a/product/localRepository/pom.xml b/product/localRepository/pom.xml
+--- a/product/localRepository/pom.xml	2022-12-19 16:48:43.677839089 -0300
++++ b/product/localRepository/pom.xml	2022-12-19 13:56:10.608836334 -0300
+@@ -46,21 +46,21 @@
+ 								<artifact><id>org.eclipse.gef3.plugins:org.eclipse.gef3:3.12.100-SNAPSHOT</id></artifact>
+ 
+ 								<!-- POI and dependencies -->
+-								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.apache.poi:LATEST</id></artifact>
++								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.apache.poi:4.1.1</id></artifact>
+ 
+ 								<!-- GIS -->
+-								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.gis:LATEST</id></artifact>
++								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.gis:2.0.5</id></artifact>
+ 
+ 								<!-- JFreeChart -->
+-								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.jfreechart:LATEST</id></artifact>
++								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.jfreechart:1.0.23</id></artifact>
+ 
+ 								<!-- SSH and BouncyCastle -->
+-								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.sshj:LATEST</id></artifact>
++								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.sshj:0.34.0</id></artifact>
+ 								<!-- Ant minimized -->
+ 								<artifact><id>org.jkiss.bundle:org.apache.ant:1.10.0</id></artifact>
+ 
+ 								<!-- Batik -->
+-								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.apache.batik:LATEST</id></artifact>
++								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.apache.batik:1.14.0</id></artifact>
+ 								<!-- GraphQL -->
+ 								<artifact><id>org.jkiss.bundle:org.jkiss.bundle.graphql.java:LATEST</id></artifact>
+ 								<!-- DBCP -->

--- a/pkgs/development/java-modules/maven-fod.nix
+++ b/pkgs/development/java-modules/maven-fod.nix
@@ -5,6 +5,7 @@
 
 { src
 , patches ? []
+, mvnPatches ? []
 , pname
 , version
 , mvnSha256 ? "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
@@ -25,6 +26,8 @@ stdenv.mkDerivation (rec {
     buildInputs = [
       maven
     ];
+
+    patches = mvnPatches;
 
     buildPhase = ''
       mvn package -Dmaven.repo.local=$out/.m2 ${mvnParameters}


### PR DESCRIPTION
###### Description of changes

- Latest version bump;
- Includes hotfixes to build against latest eclipse;
- Pinned versions for the dependencies that were using "LATEST" as revision.

Full changelog: https://github.com/dbeaver/dbeaver/compare/22.2.2...22.3.0

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
