### PR TITLE
stdenv: add `developDerivation`

### DIFF
--- a/pkgs/stdenv/generic/get-env.sh.nix
+++ b/pkgs/stdenv/generic/get-env.sh.nix
@@ -1,0 +1,136 @@
+builtins.toFile "get-env.sh" ''
+
+  set -e
+  if [ -e .attrs.sh ]; then source .attrs.sh; fi
+
+  export IN_NIX_SHELL=impure
+  export dontAddDisableDepTrack=1
+
+  if [[ -n $stdenv ]]; then
+      source $stdenv/setup
+  fi
+
+  # Better to use compgen, but stdenv bash doesn't have it.
+  __vars="$(declare -p)"
+  __functions="$(declare -F)"
+
+  __dumpEnv() {
+      printf '{\n'
+
+      printf '  "bashFunctions": {\n'
+      local __first=1
+      while read __line; do
+          if ! [[ $__line =~ ^declare\ -f\ (.*) ]]; then continue; fi
+          __fun_name="''${BASH_REMATCH[1]}"
+          __fun_body="$(type $__fun_name)"
+          if [[ $__fun_body =~ \{(.*)\} ]]; then
+              if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
+              __fun_body="''${BASH_REMATCH[1]}"
+              printf "    "
+              __escapeString "$__fun_name"
+              printf ':'
+              __escapeString "$__fun_body"
+          else
+              printf "Cannot parse definition of function '%s'.\n" "$__fun_name" >&2
+              return 1
+          fi
+      done < <(printf "%s\n" "$__functions")
+      printf '\n  },\n'
+
+      printf '  "variables": {\n'
+      local __first=1
+      while read __line; do
+          if ! [[ $__line =~ ^declare\ (-[^ ])\ ([^=]*) ]]; then continue; fi
+          local type="''${BASH_REMATCH[1]}"
+          local __var_name="''${BASH_REMATCH[2]}"
+
+          if [[ $__var_name =~ ^BASH_ || \
+                $__var_name =~ ^COMP_ || \
+                $__var_name = _ || \
+                $__var_name = DIRSTACK || \
+                $__var_name = EUID || \
+                $__var_name = FUNCNAME || \
+                $__var_name = HISTCMD || \
+                $__var_name = HOSTNAME || \
+                $__var_name = GROUPS || \
+                $__var_name = PIPESTATUS || \
+                $__var_name = PWD || \
+                $__var_name = RANDOM || \
+                $__var_name = SHLVL || \
+                $__var_name = SECONDS || \
+                $__var_name = EPOCHREALTIME || \
+                $__var_name = EPOCHSECONDS \
+              ]]; then continue; fi
+
+          if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
+
+          printf "    "
+          __escapeString "$__var_name"
+          printf ': {'
+
+          # FIXME: handle -i, -r, -n.
+          if [[ $type == -x ]]; then
+              printf '"type": "exported", "value": '
+              __escapeString "''${!__var_name}"
+          elif [[ $type == -- ]]; then
+              printf '"type": "var", "value": '
+              __escapeString "''${!__var_name}"
+          elif [[ $type == -a ]]; then
+              printf '"type": "array", "value": ['
+              local __first2=1
+              __var_name="$__var_name[@]"
+              for __i in "''${!__var_name}"; do
+                  if [[ -z $__first2 ]]; then printf ', '; else __first2=; fi
+                  __escapeString "$__i"
+                  printf ' '
+              done
+              printf ']'
+          elif [[ $type == -A ]]; then
+              printf '"type": "associative", "value": {\n'
+              local __first2=1
+              declare -n __var_name2="$__var_name"
+              for __i in "''${!__var_name2[@]}"; do
+                  if [[ -z $__first2 ]]; then printf ',\n'; else __first2=; fi
+                  printf "      "
+                  __escapeString "$__i"
+                  printf ": "
+                  __escapeString "''${__var_name2[$__i]}"
+              done
+              printf '\n    }'
+          else
+              printf '"type": "unknown"'
+          fi
+
+          printf "}"
+      done < <(printf "%s\n" "$__vars")
+      printf '\n  }\n}'
+  }
+
+  __escapeString() {
+      local __s="$1"
+      __s="''${__s//\\/\\\\}"
+      __s="''${__s//\"/\\\"}"
+      __s="''${__s//$'\n'/\\n}"
+      __s="''${__s//$'\r'/\\r}"
+      __s="''${__s//$'\t'/\\t}"
+      printf '"%s"' "$__s"
+  }
+
+  # In case of `__structuredAttrs = true;` the list of outputs is an associative
+  # array with a format like `outname => /nix/store/hash-drvname-outname`, so `__olist`
+  # must contain the array's keys (hence `''${!...[@]}`) in this case.
+  if [ -e .attrs.sh ]; then
+      __olist="''${!outputs[@]}"
+  else
+      __olist=$outputs
+  fi
+
+  for __output in $__olist; do
+      if [[ -z $__done ]]; then
+          __dumpEnv > ''${!__output}
+          __done=1
+      else
+          echo -n >> "''${!__output}"
+      fi
+  done
+''

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -478,6 +478,19 @@ in
 lib.extendDerivation
   validity.handled
   ({
+     # a recreation in Nix of the derivation produced by the cli when calling `nix develop`
+     # one can call `nix print-dev-env` from a script on this derivations output to enter shell
+     # in a non-interactive script, and is also a way to guarantee we capture the devshell as a
+     # a build dependency for such a script.
+     developDerivation = let
+       argContext = builtins.getContext (toString derivationArg.args);
+       getEnvSh = import ./get-env.sh.nix;
+    in
+      derivation (derivationArg // {
+        name = "${derivationArg.name}-env";
+        args = [(builtins.appendContext getEnvSh argContext)];
+      });
+
      # A derivation that always builds successfully and whose runtime
      # dependencies are the original derivations build time dependencies
      # This allows easy building and distributing of all derivations


### PR DESCRIPTION
Once NixOS/nix#7480 is merged, this will be an exact hash equivalent of the derivation which `nix develop` creates directly in C++ code.

Being able to reference this in Nix expressions is essential to properly capturing it as a dependency for scripts, and for simply building the shell as a separate stage before executing it.


###### Description of changes

The implementation takes a copy of the upstream header. We could pull it directly out of the nix source, but doing so would require some post processing and induce IFD, so we really can't since IFD isn't allowed in nixpkgs.

A simple example script that might want to enter the build environment of the `zlib` derivation:
```nix
pkgs.writeShellScript "f.sh" ''

  eval "$(nix print-dev-env zlib.developDerivation)"
  # rest of the script inside the build environment of the `zlib` package ...
''
```

We may even want to emulate what `nix print-dev-env` does as a separate function so we can remove the dependency on the nix cli, if desired.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->