### PR TITLE
xrootd: provide fuse support (xrootdfs) for Darwin and fix the tests

### DIFF
--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     curl
+    fuse
     libkrb5
     libuuid
     libxcrypt
@@ -56,7 +57,6 @@ stdenv.mkDerivation rec {
     zlib
   ]
   ++ lib.optionals stdenv.isLinux [
-    fuse
     systemd
     voms
   ]

--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -36,7 +36,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "out" "dev" "man" ];
 
-  passthru.tests = lib.optionalAttrs enableTests && stdenv.isLinux {
+  passthru.tests = lib.optionalAttrs enableTests {
+    test-xrdcp = callPackage ./test-xrdcp.nix {
+      url = "root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000138275/ESD/0000/AliESDs.root";
+      hash = "sha256-tIcs2oi+8u/Qr+P7AAaPTbQT+DEt26gEdc4VNerlEHY=";
+    };
+  } // lib.optionalAttrs stdenv.isLinux {
     test-runner = callPackage ./test-runner.nix { };
   };
 

--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "out" "dev" "man" ];
 
-  passthru.tests = lib.optionalAttrs enableTests {
+  passthru.tests = lib.optionalAttrs enableTests && stdenv.isLinux {
     test-runner = callPackage ./test-runner.nix { };
   };
 

--- a/pkgs/tools/networking/xrootd/test-xrdcp.nix
+++ b/pkgs/tools/networking/xrootd/test-xrdcp.nix
@@ -1,0 +1,19 @@
+{ lib
+, runCommandLocal
+, buildPlatform
+, xrootd
+, url
+, hash
+}: runCommandLocal (baseNameOf url)
+{
+  nativeBuildInputs = [ xrootd ];
+  outputHashAlgo = null;
+  outputHashMode = "flat";
+  outputHash = hash;
+  inherit url;
+}
+# Set [DY]LD_LIBRARY_PATH to workaround #169677
+# TODO: Remove the library path after #200830 get merged
+''
+  ${lib.optionalString buildPlatform.isDarwin "DY"}LD_LIBRARY_PATH=${lib.makeLibraryPath [ xrootd ]} xrdcp --force "$url" "$out"
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1514,7 +1514,12 @@ with pkgs;
 
   xpaste = callPackage ../tools/text/xpaste { };
 
-  xrootd = callPackage ../tools/networking/xrootd { };
+  xrootd = callPackage ../tools/networking/xrootd {
+    fuse =
+      if hostPlatform.isDarwin then osxfuse
+      else if hostPlatform.isLinux then fuse
+      else null;
+  };
 
   xtrt = callPackage ../tools/archivers/xtrt { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Pass `fuse` into `buildInputs` by defaults and use `fuse = osxfuse` on Darwin.

This should bring no change to the Linux package. However, the Linux package also rebuilds due to the change of the `buildInputs` order.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
