### PR TITLE
gnome.cheese: 43.alpha → 43.0

### DIFF
--- a/pkgs/desktops/gnome/apps/cheese/default.nix
+++ b/pkgs/desktops/gnome/apps/cheese/default.nix
@@ -34,13 +34,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cheese";
-  version = "43.alpha";
+  version = "43.0";
 
   outputs = [ "out" "man" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/cheese/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "utrp972m+lch2regi4I3p15TJcDJpmlJj/VPdyFG5M8=";
+    sha256 = "dFdMSjwycyfxotbQs/k3vir7B6YVm21425wZLeZmfws=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/clutter-gst/default.nix
+++ b/pkgs/development/libraries/clutter-gst/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, lib, stdenv, pkg-config, clutter, gtk3, glib, cogl, gnome, gdk-pixbuf }:
+{ fetchurl, fetchpatch, lib, stdenv, pkg-config, clutter, gtk3, glib, cogl, gnome, gdk-pixbuf }:
 
 stdenv.mkDerivation rec {
   pname = "clutter-gst";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "17czmpl92dzi4h3rn5rishk015yi3jwiw29zv8qan94xcmnbssgy";
   };
+
+  patches = [
+    # Add patch from Arch Linux to fix corrupted display with Cheese
+    # https://gitlab.gnome.org/GNOME/cheese/-/issues/51
+    # https://github.com/archlinux/svntogit-packages/tree/packages/clutter-gst/trunk
+    (fetchpatch {
+      url = "https://github.com/archlinux/svntogit-packages/raw/c4dd0bbda35aa603ee790676f6e15541f71b6d36/trunk/0001-video-sink-Remove-RGBx-BGRx-support.patch";
+      sha256 = "sha256-k1fCiM/u7q81UrDYgbqhN/C+q9DVQ+qOyq6vmA3hbSQ=";
+    })
+  ];
 
   propagatedBuildInputs = [ clutter gtk3 glib cogl gdk-pixbuf ];
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION


###### Description of changes

https://gitlab.gnome.org/GNOME/cheese/-/compare/43.alpha...43.0

~~Change log is still TODO~~ The only non-translation change is "Remove glibc debug environment variables".




Also patch clutter-gst with a mostly-patched-in-every-downstream [^1][^2][^3][^4] patch to resolve [an old cheese issue](https://gitlab.gnome.org/GNOME/cheese/-/issues/51).

[^1]: https://build.opensuse.org/package/view_file/openSUSE:Factory/clutter-gst/0001-video-sink-Remove-RGBx-BGRx-support.patch
[^2]: https://github.com/archlinux/svntogit-packages/blob/packages/clutter-gst/trunk/0001-video-sink-Remove-RGBx-BGRx-support.patch
[^3]: https://salsa.debian.org/gnome-team/clutter-gst/-/blob/debian/master/debian/patches/video-sink-Remove-RGBx-BGRx-support.patch
[^4]: https://src.fedoraproject.org/rpms/clutter-gst3/blob/rawhide/f/remove-rgbx-bgrx-support.patch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
