### PR TITLE
kent: restore building version 404

### DIFF
--- a/pkgs/applications/science/biology/kent/default.nix
+++ b/pkgs/applications/science/biology/kent/default.nix
@@ -10,6 +10,7 @@
 , bash
 , fetchFromGitHub
 , which
+, fetchpatch
 }:
 stdenv.mkDerivation rec {
   pname = "kent";
@@ -24,13 +25,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpng libuuid zlib bzip2 xz openssl curl libmysqlclient ];
 
-  patchPhase = ''
+  prePatch = ''
     substituteInPlace ./src/checkUmask.sh \
       --replace "/bin/bash" "${bash}/bin/bash"
 
     substituteInPlace ./src/hg/sqlEnvTest.sh \
       --replace "which mysql_config" "${which}/bin/which ${libmysqlclient}/bin/mysql_config"
+
   '';
+  patches = [(fetchpatch { url = "https://github.com/ucscGenomeBrowser/kent/commit/316e4fd40f53c96850128fd65097a42623d1e736.patch"; sha256 = "sha256-wr3NP5qoSonKz1TLKtQyrTPErCOk2gC1RimcX0tE7cM="; })];
 
   buildPhase = ''
     export MACHTYPE=$(uname -m)


### PR DESCRIPTION
###### Description of changes

This restores building kent version 404, and closes #195704.

This is affecting unstable and 22.11.

See https://github.com/ucscGenomeBrowser/kent/pull/54

###### Things done

Patching 'jmp_buf htmlRecover' to 'extern jmp_buf htmlRecover'.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [ ] Tested, as applicable:
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
      (they do print their help)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


