### PR TITLE
rocm-related: implement more derivations

### DIFF
--- a/pkgs/development/compilers/hip-common/default.nix
+++ b/pkgs/development/compilers/hip-common/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hip-common";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";
     repo = "HIP";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-JpHWTsR2Z8pXp1gNjO29pDYvH/cJvd5Dlpeig33UD28=";
+    hash = "sha256-44CZWk6EsP5EduzBCBbOh2kshS89qOm4v3mx/xNDzV0=";
   };
 
   patches = [

--- a/pkgs/development/compilers/hip-common/default.nix
+++ b/pkgs/development/compilers/hip-common/default.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -49,7 +49,7 @@ let
   ];
 in stdenv.mkDerivation (finalAttrs: {
   pname = "hip-${hipPlatform}";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"
@@ -61,7 +61,7 @@ in stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm-Developer-Tools";
     repo = "hipamd";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-VL0vZVv099pZPX0J2pXPFvrhkVO/b6X+ZZDaD9B1hYI=";
+    hash = "sha256-FcuylhkG7HqLYXH1J6ND6IVEIbDzHp7h7jg2ZZ4XoFM=";
   };
 
   patches = [

--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -189,6 +189,9 @@ in stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
     # Tests require GPU, also include issues
-    broken = finalAttrs.version != hip-common.version || finalAttrs.version != hipcc.version || buildTests;
+    broken =
+      versions.minor finalAttrs.version != versions.minor hip-common.version ||
+      versions.minor finalAttrs.version != versions.minor hipcc.version ||
+      buildTests;
   };
 })

--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -160,10 +160,26 @@ in stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/hipconfig.pl ${lib.concatStringsSep " " wrapperArgs}
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    owner = finalAttrs.src.owner;
-    repo = finalAttrs.src.repo;
+  passthru = {
+    # All known and valid general GPU targets
+    # We cannot use this for each ROCm library, as each defines their own supported targets
+    # See: https://github.com/RadeonOpenCompute/ROCm/blob/77cbac4abab13046ee93d8b5bf410684caf91145/README.md#library-target-matrix
+    gpuTargets = lib.forEach [
+      "803"
+      "900"
+      "906"
+      "908"
+      "90a"
+      "1010"
+      "1012"
+      "1030"
+    ] (target: "gfx${target}");
+
+    updateScript = rocmUpdateScript {
+      name = finalAttrs.pname;
+      owner = finalAttrs.src.owner;
+      repo = finalAttrs.src.repo;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/compilers/hipcc/default.nix
+++ b/pkgs/development/compilers/hipcc/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipcc";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";

--- a/pkgs/development/compilers/hipcc/default.nix
+++ b/pkgs/development/compilers/hipcc/default.nix
@@ -57,6 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/compilers/hipify/default.nix
+++ b/pkgs/development/compilers/hipify/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, cmake
+, libxml2
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hipify";
+  version = "5.4.1";
+
+  src = fetchFromGitHub {
+    owner = "ROCm-Developer-Tools";
+    repo = "HIPIFY";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-EaHtI1ywjEHioWptuHvCllJ3dENtSClVoE6NpWTOa9I=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libxml2 ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "\''${LLVM_TOOLS_BINARY_DIR}/clang" "${stdenv.cc}/bin/clang"
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  # Fixup weird install paths
+  postInstall = ''
+    mkdir -p $out/bin
+    mv $out/{*.sh,hipify-*} $out/bin
+    cp -afs $out/bin $out/hip
+  '';
+
+  meta = with lib; {
+    description = "Convert CUDA to Portable C++ Code";
+    homepage = "https://github.com/ROCm-Developer-Tools/HIPIFY";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    platforms = platforms.linux;
+    broken = finalAttrs.version != stdenv.cc.version;
+  };
+})

--- a/pkgs/development/compilers/hipify/default.nix
+++ b/pkgs/development/compilers/hipify/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
     platforms = platforms.linux;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/compilers/hipify/default.nix
+++ b/pkgs/development/compilers/hipify/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipify";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";

--- a/pkgs/development/compilers/llvm/rocm/llvm.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm.nix
@@ -48,7 +48,7 @@ let
     else throw "Unsupported ROCm LLVM platform";
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-llvm-${targetName}";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"
@@ -65,7 +65,7 @@ in stdenv.mkDerivation (finalAttrs: {
     owner = "RadeonOpenCompute";
     repo = "llvm-project";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-rlVo77h344PLGj/mIzsw+/ndWywsBsiKDXsEDpWSUno=";
+    hash = "sha256-iyr3cstC8CB1YaACadNqBs/oI8lh4bJzK0WtEB0wZvg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/blaze/default.nix
+++ b/pkgs/development/libraries/blaze/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromBitbucket
+, cmake
+, blas
+, lapack-reference
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "blaze";
+  version = "3.8.1";
+
+  src = fetchFromBitbucket {
+    owner = "blaze-lib";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-fe6J0aquk4j+b11Sq+ihagWA/LMTYnAgIHbaDCZacP0=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    blas
+    lapack-reference
+  ];
+
+  meta = with lib; {
+    description = "high performance C++ math library";
+    homepage = "https://bitbucket.org/blaze-lib/blaze";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ Madouura ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/development/libraries/clang-ocl/default.nix
+++ b/pkgs/development/libraries/clang-ocl/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clang-ocl";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/development/libraries/clang-ocl/default.nix
+++ b/pkgs/development/libraries/clang-ocl/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/RadeonOpenCompute/clang-ocl";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != stdenv.cc.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/clang-ocl/default.nix
+++ b/pkgs/development/libraries/clang-ocl/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/RadeonOpenCompute/clang-ocl";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/composable_kernel/default.nix
+++ b/pkgs/development/libraries/composable_kernel/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "composable_kernel";
-  version = "unstable-2022-12-15";
+  version = "unstable-2023-01-16";
 
   outputs = [
     "out"
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "composable_kernel";
-    rev = "0345963eef4f92e9c5eab608bb8557b5463a1dcb";
-    hash = "sha256-IJbUZ3/UIPbYO9H+BUPP6T2HyUnC+FVbVPXQE5bEjRg=";
+    rev = "80e05267417f948e4f7e63c0fe807106d9a0c0ef";
+    hash = "sha256-+c0E2UtlG/abweLwCWWjNHDO5ZvSIVKwwwettT9mqR4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/composable_kernel/default.nix
+++ b/pkgs/development/libraries/composable_kernel/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , unstableGitUpdater
+, runCommand
 , cmake
 , rocm-cmake
 , hip
@@ -13,71 +14,98 @@
 , gpuTargets ? [ ] # gpuTargets = [ "gfx803" "gfx900" "gfx1030" ... ]
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "composable_kernel";
-  version = "unstable-2023-01-16";
+let
+  # This is now over 3GB, to allow hydra caching we separate it
+  ck = stdenv.mkDerivation (finalAttrs: {
+    pname = "composable_kernel";
+    version = "unstable-2023-01-16";
 
-  outputs = [
-    "out"
-  ] ++ lib.optionals buildTests [
-    "test"
-  ] ++ lib.optionals buildExamples [
-    "example"
-  ];
+    outputs = [
+      "out"
+    ] ++ lib.optionals buildTests [
+      "test"
+    ] ++ lib.optionals buildExamples [
+      "example"
+    ];
 
-  # There is now a release, but it's cpu-only it seems to be for a very specific purpose
-  # Thus, we're sticking with the develop branch for now...
-  src = fetchFromGitHub {
-    owner = "ROCmSoftwarePlatform";
-    repo = "composable_kernel";
-    rev = "80e05267417f948e4f7e63c0fe807106d9a0c0ef";
-    hash = "sha256-+c0E2UtlG/abweLwCWWjNHDO5ZvSIVKwwwettT9mqR4=";
-  };
+    # There is now a release, but it's cpu-only it seems to be for a very specific purpose
+    # Thus, we're sticking with the develop branch for now...
+    src = fetchFromGitHub {
+      owner = "ROCmSoftwarePlatform";
+      repo = "composable_kernel";
+      rev = "80e05267417f948e4f7e63c0fe807106d9a0c0ef";
+      hash = "sha256-+c0E2UtlG/abweLwCWWjNHDO5ZvSIVKwwwettT9mqR4=";
+    };
 
-  nativeBuildInputs = [
-    cmake
-    rocm-cmake
-    hip
-    clang-tools-extra
-  ];
+    nativeBuildInputs = [
+      cmake
+      rocm-cmake
+      hip
+      clang-tools-extra
+    ];
 
-  buildInputs = [
-    openmp
-  ];
+    buildInputs = [
+      openmp
+    ];
 
-  cmakeFlags = [
-    "-DCMAKE_C_COMPILER=hipcc"
-    "-DCMAKE_CXX_COMPILER=hipcc"
-  ] ++ lib.optionals (gpuTargets != [ ]) [
-    "-DGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
-  ] ++ lib.optionals buildTests [
-    "-DGOOGLETEST_DIR=${gtest.src}" # Custom linker names
-  ];
+    cmakeFlags = [
+      "-DCMAKE_C_COMPILER=hipcc"
+      "-DCMAKE_CXX_COMPILER=hipcc"
+    ] ++ lib.optionals (gpuTargets != [ ]) [
+      "-DGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
+    ] ++ lib.optionals buildTests [
+      "-DGOOGLETEST_DIR=${gtest.src}" # Custom linker names
+    ];
 
-  # No flags to build selectively it seems...
-  postPatch = lib.optionalString (!buildTests) ''
-    substituteInPlace CMakeLists.txt \
-      --replace "add_subdirectory(test)" ""
-  '' + lib.optionalString (!buildExamples) ''
-    substituteInPlace CMakeLists.txt \
-      --replace "add_subdirectory(example)" ""
+    # No flags to build selectively it seems...
+    postPatch = lib.optionalString (!buildTests) ''
+      substituteInPlace CMakeLists.txt \
+        --replace "add_subdirectory(test)" ""
+    '' + lib.optionalString (!buildExamples) ''
+      substituteInPlace CMakeLists.txt \
+        --replace "add_subdirectory(example)" ""
+    '';
+
+    postInstall = lib.optionalString buildTests ''
+      mkdir -p $test/bin
+      mv $out/bin/test_* $test/bin
+    '' + lib.optionalString buildExamples ''
+      mkdir -p $example/bin
+      mv $out/bin/example_* $example/bin
+    '';
+
+    passthru.updateScript = unstableGitUpdater { };
+
+    meta = with lib; {
+      description = "Performance portable programming model for machine learning tensor operators";
+      homepage = "https://github.com/ROCmSoftwarePlatform/composable_kernel";
+      license = with licenses; [ mit ];
+      maintainers = teams.rocm.members;
+      broken = buildExamples; # bin/example_grouped_gemm_xdl_bfp16] Error 139
+    };
+  });
+
+  ckProfiler = runCommand "ckProfiler" { preferLocalBuild = true; } ''
+    cp -a ${ck}/bin/ckProfiler $out
   '';
+in stdenv.mkDerivation {
+  inherit (ck) pname version outputs src passthru meta;
 
-  postInstall = lib.optionalString buildTests ''
-    mkdir -p $test/bin
-    mv $out/bin/test_* $test/bin
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -as ${ckProfiler} $out/bin/ckProfiler
+    cp -an ${ck}/* $out
+  '' + lib.optionalString buildTests ''
+    cp -a ${ck.test} $test
   '' + lib.optionalString buildExamples ''
-    mkdir -p $example/bin
-    mv $out/bin/example_* $example/bin
+    cp -a ${ck.example} $example
+  '' + ''
+    runHook postInstall
   '';
-
-  passthru.updateScript = unstableGitUpdater { };
-
-  meta = with lib; {
-    description = "Performance portable programming model for machine learning tensor operators";
-    homepage = "https://github.com/ROCmSoftwarePlatform/composable_kernel";
-    license = with licenses; [ mit ];
-    maintainers = teams.rocm.members;
-    broken = buildExamples; # bin/example_grouped_gemm_xdl_bfp16] Error 139
-  };
-})
+}

--- a/pkgs/development/libraries/composable_kernel/default.nix
+++ b/pkgs/development/libraries/composable_kernel/default.nix
@@ -81,6 +81,7 @@ let
       homepage = "https://github.com/ROCmSoftwarePlatform/composable_kernel";
       license = with licenses; [ mit ];
       maintainers = teams.rocm.members;
+      platforms = platforms.linux;
       broken = buildExamples; # bin/example_grouped_gemm_xdl_bfp16] Error 139
     };
   });

--- a/pkgs/development/libraries/hipblas/default.nix
+++ b/pkgs/development/libraries/hipblas/default.nix
@@ -18,7 +18,7 @@
 # Can also use cuBLAS
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipblas";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/hipblas/default.nix
+++ b/pkgs/development/libraries/hipblas/default.nix
@@ -1,0 +1,99 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, cmake
+, rocm-cmake
+, hip
+, gfortran
+, rocblas
+, rocsolver
+, gtest
+, lapack-reference
+, buildTests ? false
+, buildBenchmarks ? false
+, buildSamples ? false
+}:
+
+# Can also use cuBLAS
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hipblas";
+  version = "5.4.1";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ] ++ lib.optionals buildSamples [
+    "sample"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "hipBLAS";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-mSZCq8UaiffMzWVflW1nAX6CQZ1DqwWJaSIzKslZSEk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+    gfortran
+  ];
+
+  buildInputs = [
+    rocblas
+    rocsolver
+  ] ++ lib.optionals buildTests [
+    gtest
+  ] ++ lib.optionals (buildTests || buildBenchmarks) [
+    lapack-reference
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_C_COMPILER=hipcc"
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_CLIENTS_TESTS=ON"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DBUILD_CLIENTS_BENCHMARKS=ON"
+  ] ++ lib.optionals buildSamples [
+    "-DBUILD_CLIENTS_SAMPLES=ON"
+  ];
+
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv $out/bin/hipblas-test $test/bin
+  '' + lib.optionalString buildBenchmarks ''
+    mkdir -p $benchmark/bin
+    mv $out/bin/hipblas-bench $benchmark/bin
+  '' + lib.optionalString buildSamples ''
+    mkdir -p $sample/bin
+    mv $out/bin/example-* $sample/bin
+  '' + lib.optionalString (buildTests || buildBenchmarks || buildSamples) ''
+    rmdir $out/bin
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "ROCm BLAS marshalling library";
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipBLAS";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    # Fixed in develop branch by using C++17 and related refactor
+    broken = finalAttrs.version != hip.version || buildTests || buildBenchmarks || buildSamples;
+  };
+})

--- a/pkgs/development/libraries/hipblas/default.nix
+++ b/pkgs/development/libraries/hipblas/default.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
     # Fixed in develop branch by using C++17 and related refactor
-    broken = finalAttrs.version != hip.version || buildTests || buildBenchmarks || buildSamples;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version || buildTests || buildBenchmarks || buildSamples;
   };
 })

--- a/pkgs/development/libraries/hipblas/default.nix
+++ b/pkgs/development/libraries/hipblas/default.nix
@@ -93,6 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipBLAS";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     # Fixed in develop branch by using C++17 and related refactor
     broken = versions.minor finalAttrs.version != versions.minor hip.version || buildTests || buildBenchmarks || buildSamples;
   };

--- a/pkgs/development/libraries/hipcub/default.nix
+++ b/pkgs/development/libraries/hipcub/default.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipCUB";
     license = with licenses; [ bsd3 ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/hipcub/default.nix
+++ b/pkgs/development/libraries/hipcub/default.nix
@@ -15,7 +15,7 @@
 # CUB can also be used as a backend instead of rocPRIM.
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipcub";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/hipcub/default.nix
+++ b/pkgs/development/libraries/hipcub/default.nix
@@ -81,6 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipCUB";
     license = with licenses; [ bsd3 ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/hipfft/default.nix
+++ b/pkgs/development/libraries/hipfft/default.nix
@@ -20,7 +20,7 @@
 # Can also use cuFFT
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipfft";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/hipfft/default.nix
+++ b/pkgs/development/libraries/hipfft/default.nix
@@ -1,0 +1,106 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, cmake
+, rocm-cmake
+, hip
+, git
+, rocfft
+, gtest
+, boost
+, fftw
+, fftwFloat
+, openmp
+, buildTests ? false
+, buildBenchmarks ? false
+, buildSamples ? false
+}:
+
+# Can also use cuFFT
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hipfft";
+  version = "5.4.1";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ] ++ lib.optionals buildSamples [
+    "sample"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "hipFFT";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-yDtm9J0wqH6zo4HcgQbqhvwbzbOiJPQ48gJ2gC8PvjA=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    hip
+    git
+    cmake
+    rocm-cmake
+  ];
+
+  buildInputs = [
+    rocfft
+  ] ++ lib.optionals (buildTests || buildBenchmarks || buildSamples) [
+    gtest
+    boost
+    fftw
+    fftwFloat
+    openmp
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_C_COMPILER=hipcc"
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    "-DCMAKE_MODULE_PATH=${hip}/lib/cmake/hip"
+    "-DHIP_ROOT_DIR=${hip}"
+    "-DHIP_PATH=${hip}"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_CLIENTS_TESTS=ON"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DBUILD_CLIENTS_RIDER=ON"
+  ] ++ lib.optionals buildSamples [
+    "-DBUILD_CLIENTS_SAMPLES=ON"
+  ];
+
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv $out/bin/hipfft-test $test/bin
+  '' + lib.optionalString buildBenchmarks ''
+    mkdir -p $benchmark/bin
+    mv $out/bin/hipfft-rider $benchmark/bin
+  '' + lib.optionalString buildSamples ''
+    mkdir -p $sample/bin
+    mv clients/staging/hipfft_* $sample/bin
+    patchelf $sample/bin/hipfft_* --shrink-rpath --allowed-rpath-prefixes /nix/store
+  '' + lib.optionalString (buildTests || buildBenchmarks) ''
+    rmdir $out/bin
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "FFT marshalling library";
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipFFT";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    broken = finalAttrs.version != hip.version;
+  };
+})

--- a/pkgs/development/libraries/hipfft/default.nix
+++ b/pkgs/development/libraries/hipfft/default.nix
@@ -101,6 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipFFT";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/hipfft/default.nix
+++ b/pkgs/development/libraries/hipfft/default.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipFFT";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/hipfort/default.nix
+++ b/pkgs/development/libraries/hipfort/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, cmake
+, rocm-cmake
+, gfortran
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hipfort";
+  version = "5.4.1";
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "hipfort";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-cXzNOvWIU388AU5hzLwmIGaX5DvzIJJCvgkP2BA4jao=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    gfortran
+  ];
+
+  cmakeFlags = [
+    "-DHIPFORT_COMPILER=${gfortran}/bin/gfortran"
+    "-DHIPFORT_AR=${gfortran.cc}/bin/gcc-ar"
+    "-DHIPFORT_RANLIB=${gfortran.cc}/bin/gcc-ranlib"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  postPatch = ''
+    patchShebangs bin
+
+    substituteInPlace bin/hipfc bin/mymcpu \
+      --replace "/bin/cat" "cat"
+
+    substituteInPlace bin/CMakeLists.txt \
+      --replace "/bin/mkdir" "mkdir" \
+      --replace "/bin/cp" "cp" \
+      --replace "/bin/sed" "sed" \
+      --replace "/bin/chmod" "chmod" \
+      --replace "/bin/ln" "ln"
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "Fortran interfaces for ROCm libraries";
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipfort";
+    license = with licenses; [ mit ]; # mitx11
+    maintainers = teams.rocm.members;
+    broken = finalAttrs.version != stdenv.cc.version;
+  };
+})

--- a/pkgs/development/libraries/hipfort/default.nix
+++ b/pkgs/development/libraries/hipfort/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipfort";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";

--- a/pkgs/development/libraries/hipfort/default.nix
+++ b/pkgs/development/libraries/hipfort/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipfort";
     license = with licenses; [ mit ]; # mitx11
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/hipfort/default.nix
+++ b/pkgs/development/libraries/hipfort/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipfort";
     license = with licenses; [ mit ]; # mitx11
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/hipsolver/default.nix
+++ b/pkgs/development/libraries/hipsolver/default.nix
@@ -94,6 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipSOLVER";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/hipsolver/default.nix
+++ b/pkgs/development/libraries/hipsolver/default.nix
@@ -18,7 +18,7 @@
 # Can also use cuSOLVER
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipsolver";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/hipsolver/default.nix
+++ b/pkgs/development/libraries/hipsolver/default.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipSOLVER";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/hipsolver/default.nix
+++ b/pkgs/development/libraries/hipsolver/default.nix
@@ -1,0 +1,99 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, cmake
+, rocm-cmake
+, hip
+, gfortran
+, rocblas
+, rocsolver
+, gtest
+, lapack-reference
+, buildTests ? false
+, buildBenchmarks ? false
+, buildSamples ? false
+}:
+
+# Can also use cuSOLVER
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hipsolver";
+  version = "5.4.1";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ] ++ lib.optionals buildSamples [
+    "sample"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "hipSOLVER";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-p9hgKqRALLItv/HTpVlTsu+m9wlwCBYPYnJcm8StIao=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    hip
+    gfortran
+  ];
+
+  buildInputs = [
+    rocblas
+    rocsolver
+  ] ++ lib.optionals buildTests [
+    gtest
+  ] ++ lib.optionals (buildTests || buildBenchmarks) [
+    lapack-reference
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_C_COMPILER=hipcc"
+    "-DCMAKE_CXX_COMPILER=hipcc"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_CLIENTS_TESTS=ON"
+  ] ++ lib.optionals buildBenchmarks [
+    "-DBUILD_CLIENTS_BENCHMARKS=ON"
+  ] ++ lib.optionals buildSamples [
+    "-DBUILD_CLIENTS_SAMPLES=ON"
+  ];
+
+  postInstall = lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv $out/bin/hipsolver-test $test/bin
+  '' + lib.optionalString buildBenchmarks ''
+    mkdir -p $benchmark/bin
+    mv $out/bin/hipsolver-bench $benchmark/bin
+  '' + lib.optionalString buildSamples ''
+    mkdir -p $sample/bin
+    mv clients/staging/example-* $sample/bin
+    patchelf $sample/bin/example-* --shrink-rpath --allowed-rpath-prefixes /nix/store
+  '' + lib.optionalString (buildTests || buildBenchmarks) ''
+    rmdir $out/bin
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "ROCm SOLVER marshalling library";
+    homepage = "https://github.com/ROCmSoftwarePlatform/hipSOLVER";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    broken = finalAttrs.version != hip.version;
+  };
+})

--- a/pkgs/development/libraries/hipsparse/default.nix
+++ b/pkgs/development/libraries/hipsparse/default.nix
@@ -17,7 +17,7 @@
 # This can also use cuSPARSE as a backend instead of rocSPARSE
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipsparse";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/hipsparse/default.nix
+++ b/pkgs/development/libraries/hipsparse/default.nix
@@ -130,6 +130,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipSPARSE";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/hipsparse/default.nix
+++ b/pkgs/development/libraries/hipsparse/default.nix
@@ -130,6 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/hipSPARSE";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/migraphx/default.nix
+++ b/pkgs/development/libraries/migraphx/default.nix
@@ -156,6 +156,6 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/AMDMIGraphX";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/migraphx/default.nix
+++ b/pkgs/development/libraries/migraphx/default.nix
@@ -1,0 +1,161 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, pkg-config
+, cmake
+, rocm-cmake
+, hip
+, clang-tools-extra
+, cppcheck
+, openmp
+, rocblas
+, rocmlir
+, miopengemm
+, miopen
+, protobuf
+, half
+, nlohmann_json
+, msgpack
+, sqlite
+, oneDNN
+, blaze
+, texlive
+, doxygen
+, sphinx
+, docutils
+, ghostscript
+, python3Packages
+, buildDocs ? false
+, buildTests ? false
+}:
+
+let
+  latex = lib.optionalAttrs buildDocs texlive.combine {
+    inherit (texlive) scheme-small
+    latexmk
+    tex-gyre
+    fncychap
+    wrapfig
+    capt-of
+    framed
+    needspace
+    tabulary
+    varwidth
+    titlesec
+    epstopdf;
+  };
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "migraphx";
+  version = "5.4.1";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildDocs [
+    "doc"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "AMDMIGraphX";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-afJ4UpZq/NVDeHnCZJyXL4TMFG1KTu/+RHIloptzGGk=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    rocm-cmake
+    hip
+    clang-tools-extra
+    cppcheck
+    python3Packages.python
+  ] ++ lib.optionals buildDocs [
+    latex
+    doxygen
+    sphinx
+    docutils
+    ghostscript
+    python3Packages.sphinx-rtd-theme
+    python3Packages.breathe
+  ];
+
+  buildInputs = [
+    openmp
+    rocblas
+    rocmlir
+    miopengemm
+    miopen
+    protobuf
+    half
+    nlohmann_json
+    msgpack
+    sqlite
+    oneDNN
+    blaze
+    python3Packages.pybind11
+    python3Packages.onnx
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_POLICY_DEFAULT_CMP0079=NEW"
+    # "-DCMAKE_C_COMPILER=hipcc"
+    # "-DCMAKE_CXX_COMPILER=hipcc"
+    "-DMIGRAPHX_ENABLE_GPU=OFF" # GPU compilation is broken, don't know why
+    "-DMIGRAPHX_ENABLE_CPU=ON"
+    "-DMIGRAPHX_ENABLE_FPGA=ON"
+    "-DMIGRAPHX_ENABLE_MLIR=ON"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  postPatch = ''
+    patchShebangs tools
+
+    substituteInPlace src/targets/gpu/CMakeLists.txt \
+      --replace "CMAKE_CXX_COMPILER MATCHES \".*clang\\\+\\\+\$\"" "TRUE"
+  '' + lib.optionalString (!buildDocs) ''
+    substituteInPlace CMakeLists.txt \
+      --replace "add_subdirectory(doc)" ""
+  '' + lib.optionalString (!buildTests) ''
+    substituteInPlace CMakeLists.txt \
+      --replace "add_subdirectory(test)" ""
+  '';
+
+  # Unfortunately, it seems like we have to call make on this manually
+  preInstall = lib.optionalString buildDocs ''
+    export HOME=$(mktemp -d)
+    make -j$NIX_BUILD_CORES doc
+    cd ../doc/pdf
+    make -j$NIX_BUILD_CORES
+    cd -
+  '';
+
+  postInstall = lib.optionalString buildDocs ''
+    mv ../doc/html $out/share/doc/migraphx
+    mv ../doc/pdf/MIGraphX.pdf $out/share/doc/migraphx
+  '' + lib.optionalString buildTests ''
+    mkdir -p $test/bin
+    mv bin/test_* $test/bin
+    patchelf $test/bin/test_* --shrink-rpath --allowed-rpath-prefixes /nix/store
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "AMD's graph optimization engine";
+    homepage = "https://github.com/ROCmSoftwarePlatform/AMDMIGraphX";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    broken = finalAttrs.version != hip.version;
+  };
+})

--- a/pkgs/development/libraries/migraphx/default.nix
+++ b/pkgs/development/libraries/migraphx/default.nix
@@ -156,6 +156,7 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/AMDMIGraphX";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/migraphx/default.nix
+++ b/pkgs/development/libraries/migraphx/default.nix
@@ -47,7 +47,7 @@ let
   };
 in stdenv.mkDerivation (finalAttrs: {
   pname = "migraphx";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"
@@ -61,7 +61,7 @@ in stdenv.mkDerivation (finalAttrs: {
     owner = "ROCmSoftwarePlatform";
     repo = "AMDMIGraphX";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-afJ4UpZq/NVDeHnCZJyXL4TMFG1KTu/+RHIloptzGGk=";
+    hash = "sha256-UDhm+j9qs4Rk81C1PE4kkacytfY2StYbfsCOtFL+p6s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/miopen/default.nix
+++ b/pkgs/development/libraries/miopen/default.nix
@@ -182,6 +182,7 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/MIOpen";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/miopen/default.nix
+++ b/pkgs/development/libraries/miopen/default.nix
@@ -182,6 +182,6 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/MIOpen";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/miopen/default.nix
+++ b/pkgs/development/libraries/miopen/default.nix
@@ -53,7 +53,7 @@ let
   };
 in stdenv.mkDerivation (finalAttrs: {
   pname = "miopen";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/miopengemm/default.nix
+++ b/pkgs/development/libraries/miopengemm/default.nix
@@ -117,6 +117,7 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/MIOpenGEMM";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/miopengemm/default.nix
+++ b/pkgs/development/libraries/miopengemm/default.nix
@@ -31,7 +31,7 @@ let
   };
 in stdenv.mkDerivation (finalAttrs: {
   pname = "miopengemm";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/miopengemm/default.nix
+++ b/pkgs/development/libraries/miopengemm/default.nix
@@ -117,6 +117,6 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/MIOpenGEMM";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/oneDNN/default.nix
+++ b/pkgs/development/libraries/oneDNN/default.nix
@@ -21,6 +21,15 @@ stdenv.mkDerivation rec {
   # Tests fail on some Hydra builders, because they do not support SSE4.2.
   doCheck = false;
 
+  # Fixup bad cmake paths
+  postInstall = ''
+    substituteInPlace $out/lib/cmake/dnnl/dnnl-config.cmake \
+      --replace "\''${PACKAGE_PREFIX_DIR}/" ""
+
+    substituteInPlace $out/lib/cmake/dnnl/dnnl-targets.cmake \
+      --replace "\''${_IMPORT_PREFIX}/" ""
+  '';
+
   meta = with lib; {
     description = "oneAPI Deep Neural Network Library (oneDNN)";
     homepage = "https://01.org/oneDNN";

--- a/pkgs/development/libraries/rccl/default.nix
+++ b/pkgs/development/libraries/rccl/default.nix
@@ -77,6 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rccl";
     license = with licenses; [ bsd2 bsd3 ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rccl/default.nix
+++ b/pkgs/development/libraries/rccl/default.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rccl";
     license = with licenses; [ bsd2 bsd3 ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rccl/default.nix
+++ b/pkgs/development/libraries/rccl/default.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rccl";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ROCmSoftwarePlatform";
     repo = "rccl";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-y9gTGk8LyX7owb2xdtb6VlnIXu/CYHOjnNa/wrNl02g=";
+    hash = "sha256-hQTzaiPMo5FAVScmxV0iNhy80uJ1xvx/kzlbfwROOs4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/rocalution/default.nix
+++ b/pkgs/development/libraries/rocalution/default.nix
@@ -109,6 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocALUTION";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocalution/default.nix
+++ b/pkgs/development/libraries/rocalution/default.nix
@@ -109,6 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocALUTION";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocalution/default.nix
+++ b/pkgs/development/libraries/rocalution/default.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocalution";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocblas/default.nix
+++ b/pkgs/development/libraries/rocblas/default.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocblas";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocblas/default.nix
+++ b/pkgs/development/libraries/rocblas/default.nix
@@ -131,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocBLAS";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocblas/default.nix
+++ b/pkgs/development/libraries/rocblas/default.nix
@@ -131,6 +131,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocBLAS";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocclr/default.nix
+++ b/pkgs/development/libraries/rocclr/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocclr";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";

--- a/pkgs/development/libraries/rocclr/default.nix
+++ b/pkgs/development/libraries/rocclr/default.nix
@@ -59,6 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     # to be supported yet by the build infrastructure. Recheck in
     # the future.
     platforms = [ "x86_64-linux" ];
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocdbgapi/default.nix
+++ b/pkgs/development/libraries/rocdbgapi/default.nix
@@ -1,0 +1,100 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, cmake
+, rocm-cmake
+, git
+, rocm-comgr
+, rocm-runtime
+, texlive
+, doxygen
+, graphviz
+, buildDocs ? true
+}:
+
+let
+  latex = lib.optionalAttrs buildDocs texlive.combine {
+    inherit (texlive) scheme-small
+    latexmk
+    varwidth
+    multirow
+    hanging
+    adjustbox
+    collectbox
+    stackengine
+    enumitem
+    alphalph
+    wasysym
+    sectsty
+    tocloft
+    newunicodechar
+    etoc
+    helvetic
+    wasy
+    courier;
+  };
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "rocdbgapi";
+  version = "5.4.1";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildDocs [
+    "doc"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCm-Developer-Tools";
+    repo = "ROCdbgapi";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-KoFa6JzoEPT5/ns9X/hMfu8bOh29HD9n2qGJ3gzhiBA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    rocm-cmake
+    git
+  ] ++ lib.optionals buildDocs [
+    latex
+    doxygen
+    graphviz
+  ];
+
+  buildInputs = [
+    rocm-comgr
+    rocm-runtime
+  ];
+
+  # Unfortunately, it seems like we have to call make on this manually
+  postBuild = lib.optionalString buildDocs ''
+    export HOME=$(mktemp -d)
+    make -j$NIX_BUILD_CORES doc
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/lib/cmake/amd-dbgapi/amd-dbgapi-config.cmake \
+      --replace "/build/source/build/" ""
+
+    substituteInPlace $out/lib/cmake/amd-dbgapi/amd-dbgapi-targets.cmake \
+      --replace "/build/source/build" "$out"
+  '' + lib.optionalString buildDocs ''
+    mv $out/share/html/amd-dbgapi $doc/share/doc/amd-dbgapi/html
+    rmdir $out/share/html
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "Debugger support for control of execution and inspection state";
+    homepage = "https://github.com/ROCm-Developer-Tools/ROCdbgapi";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    platforms = platforms.linux;
+    broken = finalAttrs.version != stdenv.cc.version;
+  };
+})

--- a/pkgs/development/libraries/rocdbgapi/default.nix
+++ b/pkgs/development/libraries/rocdbgapi/default.nix
@@ -95,6 +95,6 @@ in stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
     platforms = platforms.linux;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocdbgapi/default.nix
+++ b/pkgs/development/libraries/rocdbgapi/default.nix
@@ -36,7 +36,7 @@ let
   };
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocdbgapi";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocfft";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -5,6 +5,7 @@
 , runCommand
 , cmake
 , rocm-cmake
+, rocrand
 , hip
 , openmp
 , sqlite
@@ -49,6 +50,7 @@ let
     ] ++ lib.optionals buildTests [
       gtest
     ] ++ lib.optionals (buildTests || buildBenchmarks) [
+      rocrand
       boost
       fftw
       fftwFloat

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -107,6 +107,7 @@ let
       homepage = "https://github.com/ROCmSoftwarePlatform/rocFFT";
       license = with licenses; [ mit ];
       maintainers = teams.rocm.members;
+      platforms = platforms.linux;
       broken = versions.minor finalAttrs.version != versions.minor hip.version;
     };
   });

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocFFT";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
     hydraPlatforms = [ ]; # rocFFT produces an extremely large output
   };
 })

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , rocmUpdateScript
+, runCommand
 , cmake
 , rocm-cmake
 , hip
@@ -16,94 +17,139 @@
 , buildBenchmarks ? false
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "rocfft";
-  version = "5.4.2";
+let
+  rocfft = stdenv.mkDerivation (finalAttrs: {
+    pname = "rocfft";
+    version = "5.4.2";
 
-  outputs = [
-    "out"
-  ] ++ lib.optionals buildTests [
-    "test"
-  ] ++ lib.optionals buildBenchmarks [
-    "benchmark"
-  ];
+    outputs = [
+      "out"
+    ] ++ lib.optionals buildTests [
+      "test"
+    ] ++ lib.optionals buildBenchmarks [
+      "benchmark"
+    ];
 
-  src = fetchFromGitHub {
-    owner = "ROCmSoftwarePlatform";
-    repo = "rocFFT";
-    rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-NsYeEoBQ/0z31ZQ32l7N+qavWEVkH37snkTHntot7nE=";
-  };
+    src = fetchFromGitHub {
+      owner = "ROCmSoftwarePlatform";
+      repo = "rocFFT";
+      rev = "rocm-${finalAttrs.version}";
+      hash = "sha256-NsYeEoBQ/0z31ZQ32l7N+qavWEVkH37snkTHntot7nE=";
+    };
 
-  nativeBuildInputs = [
-    cmake
-    rocm-cmake
-    hip
-  ];
+    nativeBuildInputs = [
+      cmake
+      rocm-cmake
+      hip
+    ];
 
-  buildInputs = [
-    sqlite
-    python3
-  ] ++ lib.optionals buildTests [
-    gtest
-  ] ++ lib.optionals (buildTests || buildBenchmarks) [
-    boost
-    fftw
-    fftwFloat
-    openmp
-  ];
+    buildInputs = [
+      sqlite
+      python3
+    ] ++ lib.optionals buildTests [
+      gtest
+    ] ++ lib.optionals (buildTests || buildBenchmarks) [
+      boost
+      fftw
+      fftwFloat
+      openmp
+    ];
 
-  propogatedBuildInputs = lib.optionals buildTests [
-    fftw
-    fftwFloat
-  ];
+    propogatedBuildInputs = lib.optionals buildTests [
+      fftw
+      fftwFloat
+    ];
 
-  cmakeFlags = [
-    "-DCMAKE_C_COMPILER=hipcc"
-    "-DCMAKE_CXX_COMPILER=hipcc"
-    "-DUSE_HIP_CLANG=ON"
-    "-DSQLITE_USE_SYSTEM_PACKAGE=ON"
-    # Manually define CMAKE_INSTALL_<DIR>
-    # See: https://github.com/NixOS/nixpkgs/pull/197838
-    "-DCMAKE_INSTALL_BINDIR=bin"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-  ] ++ lib.optionals buildTests [
-    "-DBUILD_CLIENTS_TESTS=ON"
-  ] ++ lib.optionals buildBenchmarks [
-    "-DBUILD_CLIENTS_RIDER=ON"
-    "-DBUILD_CLIENTS_SAMPLES=ON"
-  ];
+    cmakeFlags = [
+      "-DCMAKE_C_COMPILER=hipcc"
+      "-DCMAKE_CXX_COMPILER=hipcc"
+      "-DUSE_HIP_CLANG=ON"
+      "-DSQLITE_USE_SYSTEM_PACKAGE=ON"
+      # Manually define CMAKE_INSTALL_<DIR>
+      # See: https://github.com/NixOS/nixpkgs/pull/197838
+      "-DCMAKE_INSTALL_BINDIR=bin"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
+      "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    ] ++ lib.optionals buildTests [
+      "-DBUILD_CLIENTS_TESTS=ON"
+    ] ++ lib.optionals buildBenchmarks [
+      "-DBUILD_CLIENTS_RIDER=ON"
+      "-DBUILD_CLIENTS_SAMPLES=ON"
+    ];
 
-  postInstall = lib.optionalString buildTests ''
-    mkdir -p $test/{bin,lib/fftw}
-    cp -a $out/bin/* $test/bin
-    ln -s ${fftw}/lib/libfftw*.so $test/lib/fftw
-    ln -s ${fftwFloat}/lib/libfftw*.so $test/lib/fftw
-    rm -r $out/lib/fftw
-    rm $test/bin/{rocfft_rtc_helper,*-rider} || true
-  '' + lib.optionalString buildBenchmarks ''
-    mkdir -p $benchmark/bin
-    cp -a $out/bin/* $benchmark/bin
-    rm $benchmark/bin/{rocfft_rtc_helper,*-test} || true
-  '' + lib.optionalString (buildTests || buildBenchmarks ) ''
-    mv $out/bin/rocfft_rtc_helper $out
-    rm -r $out/bin/*
-    mv $out/rocfft_rtc_helper $out/bin
+    postInstall = lib.optionalString buildTests ''
+      mkdir -p $test/{bin,lib/fftw}
+      cp -a $out/bin/* $test/bin
+      ln -s ${fftw}/lib/libfftw*.so $test/lib/fftw
+      ln -s ${fftwFloat}/lib/libfftw*.so $test/lib/fftw
+      rm -r $out/lib/fftw
+      rm $test/bin/{rocfft_rtc_helper,*-rider} || true
+    '' + lib.optionalString buildBenchmarks ''
+      mkdir -p $benchmark/bin
+      cp -a $out/bin/* $benchmark/bin
+      rm $benchmark/bin/{rocfft_rtc_helper,*-test} || true
+    '' + lib.optionalString (buildTests || buildBenchmarks ) ''
+      mv $out/bin/rocfft_rtc_helper $out
+      rm -r $out/bin/*
+      mv $out/rocfft_rtc_helper $out/bin
+    '';
+
+    passthru.updateScript = rocmUpdateScript {
+      name = finalAttrs.pname;
+      owner = finalAttrs.src.owner;
+      repo = finalAttrs.src.repo;
+    };
+
+    meta = with lib; {
+      description = "FFT implementation for ROCm ";
+      homepage = "https://github.com/ROCmSoftwarePlatform/rocFFT";
+      license = with licenses; [ mit ];
+      maintainers = teams.rocm.members;
+      broken = versions.minor finalAttrs.version != versions.minor hip.version;
+    };
+  });
+
+  rocfft-zero = runCommand "rocfft-zero" { preferLocalBuild = true; } ''
+    mkdir -p $out
+    cp -a ${rocfft}/lib/librocfft-device-0* $out
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    owner = finalAttrs.src.owner;
-    repo = finalAttrs.src.repo;
-  };
+  rocfft-one = runCommand "rocfft-one" { preferLocalBuild = true; } ''
+    mkdir -p $out
+    cp -a ${rocfft}/lib/librocfft-device-1* $out
+  '';
 
-  meta = with lib; {
-    description = "FFT implementation for ROCm ";
-    homepage = "https://github.com/ROCmSoftwarePlatform/rocFFT";
-    license = with licenses; [ mit ];
-    maintainers = teams.rocm.members;
-    broken = versions.minor finalAttrs.version != versions.minor hip.version;
-    hydraPlatforms = [ ]; # rocFFT produces an extremely large output
-  };
-})
+  rocfft-two = runCommand "rocfft-two" { preferLocalBuild = true; } ''
+    mkdir -p $out
+    cp -a ${rocfft}/lib/librocfft-device-2* $out
+  '';
+
+  rocfft-three = runCommand "rocfft-three" { preferLocalBuild = true; } ''
+    mkdir -p $out
+    cp -a ${rocfft}/lib/librocfft-device-3* $out
+  '';
+in stdenv.mkDerivation {
+  inherit (rocfft) pname version outputs src passthru meta;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+
+    for path in ${rocfft-zero} ${rocfft-one} ${rocfft-two} ${rocfft-three}; do
+      cp -as $path/* $out/lib
+    done
+
+    cp -an ${rocfft}/* $out
+  '' + lib.optionalString buildTests ''
+    cp -a ${rocfft.test} $test
+  '' + lib.optionalString buildBenchmarks ''
+    cp -a ${rocfft.benchmark} $benchmark
+  '' + ''
+    runHook postInstall
+  '';
+}

--- a/pkgs/development/libraries/rocm-comgr/default.nix
+++ b/pkgs/development/libraries/rocm-comgr/default.nix
@@ -51,6 +51,6 @@ in stdenv.mkDerivation (finalAttrs: {
     license = licenses.ncsa;
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocm-comgr/default.nix
+++ b/pkgs/development/libraries/rocm-comgr/default.nix
@@ -15,7 +15,7 @@ let
     else throw "Unsupported ROCm LLVM platform";
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-comgr";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/development/libraries/rocm-core/default.nix
+++ b/pkgs/development/libraries/rocm-core/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, runCommand
+, substituteAll
+, cmake
+}:
+
+let
+  rocm_version = with lib; concatStrings (intersperse "0" (splitString "." stdenv.cc.version));
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "rocm-core";
+  version = stdenv.cc.version;
+
+  # Based on https://github.com/rocm-arch/rocm-arch/tree/ad0b15690d403e5822db062ffff4db3912de6669/rocm-core
+  src = let
+    rocm_major = lib.versions.major finalAttrs.version;
+    rocm_minor = lib.versions.minor finalAttrs.version;
+    rocm_patch = lib.versions.patch finalAttrs.version;
+
+    cmake_lists = substituteAll {
+      inherit rocm_version;
+      src = ./src/CMakeLists.txt;
+    };
+
+    version_c = substituteAll {
+      inherit rocm_major rocm_minor rocm_patch;
+      src = ./src/rocm_version.c;
+    };
+
+    version_h = substituteAll {
+      inherit rocm_major rocm_minor rocm_patch;
+      src = ./src/rocm_version.h;
+    };
+  in runCommand "rocm-core-${finalAttrs.version}-source" { preferLocalBuild = true; } ''
+    mkdir -p $out/rocm-core
+    ln -s ${cmake_lists} $out/CMakeLists.txt
+    ln -s ${version_c} $out/rocm_version.c
+    ln -s ${version_h} $out/rocm-core/rocm_version.h
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  postInstall = ''
+    mkdir -p $out/include
+    cp -a ../rocm-core $out/include
+    ln -s $out/include/rocm-core/rocm_version.h $out/include
+    ln -s $out/lib/librocm-core.so.1.0.${rocm_version} $out/lib/librocm-core.so.1
+  '';
+
+  meta = with lib; {
+    description = "ROCm core";
+    homepage = "https://docs.amd.com";
+    license = with licenses; [ ncsa ]; # See src/rocm_version.h
+    maintainers = teams.rocm.members;
+  };
+})

--- a/pkgs/development/libraries/rocm-core/default.nix
+++ b/pkgs/development/libraries/rocm-core/default.nix
@@ -53,5 +53,6 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://docs.amd.com";
     license = with licenses; [ ncsa ]; # See src/rocm_version.h
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
   };
 })

--- a/pkgs/development/libraries/rocm-core/src/CMakeLists.txt
+++ b/pkgs/development/libraries/rocm-core/src/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.23)
+project(rocm-core)
+add_library(rocm-core SHARED rocm_version.c)
+set_target_properties(rocm-core PROPERTIES VERSION "1.0.@rocm_version@")
+install(TARGETS rocm-core LIBRARY DESTINATION lib)

--- a/pkgs/development/libraries/rocm-core/src/rocm_version.c
+++ b/pkgs/development/libraries/rocm-core/src/rocm_version.c
@@ -1,0 +1,10 @@
+#include "rocm-core/rocm_version.h"
+
+VerErrors getROCmVersion(unsigned int *Major, unsigned int *Minor,
+                         unsigned int *Patch) {
+  *Major = @rocm_major@;
+  *Minor = @rocm_minor@;
+  *Patch = @rocm_patch@;
+
+  return 0;
+}

--- a/pkgs/development/libraries/rocm-core/src/rocm_version.h
+++ b/pkgs/development/libraries/rocm-core/src/rocm_version.h
@@ -1,0 +1,82 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2014-2021, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef _ROCM_VERSION_H_
+#define _ROCM_VERSION_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+
+#define ROCM_VERSION_MAJOR   @rocm_major@
+#define ROCM_VERSION_MINOR   @rocm_minor@
+#define ROCM_VERSION_PATCH   @rocm_patch@
+
+
+typedef enum {
+	VerSuccess=0,
+	VerIncorrecPararmeters,
+	VerValuesNotDefined,
+	VerErrorMAX		//This should always be last value in the enumerations
+} VerErrors;
+
+
+//  API for getting the verion
+//  Return val :  VerErros : API execution status.  The parameters are valid only when the exetution status is SUCCESS==0
+VerErrors getROCmVersion(unsigned int* Major, unsigned int* Minor, unsigned int* Patch) __attribute__((nonnull)) ;
+//  Usage :
+//  int mj=0,mn=0,p=0,ret=0;
+//  ret=getROCMVersion(&mj,&mn,&p);
+//  if(ret !=VerSuccess )  // error occured
+//
+//  check for the values and
+//
+
+
+#ifdef __cplusplus
+}  // end extern "C" block
+#endif
+
+#endif  //_ROCM_VERSION_H_  header guard

--- a/pkgs/development/libraries/rocm-device-libs/default.nix
+++ b/pkgs/development/libraries/rocm-device-libs/default.nix
@@ -45,6 +45,6 @@ in stdenv.mkDerivation (finalAttrs: {
     license = licenses.ncsa;
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocm-device-libs/default.nix
+++ b/pkgs/development/libraries/rocm-device-libs/default.nix
@@ -14,7 +14,7 @@ let
     else throw "Unsupported ROCm LLVM platform";
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-device-libs";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/development/libraries/rocm-opencl-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime/default.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-opencl-runtime";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/development/libraries/rocm-opencl-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime/default.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ asl20 mit ];
     maintainers = with maintainers; [ acowley lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocm-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-runtime/default.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/RadeonOpenCompute/ROCR-Runtime";
     license = with licenses; [ ncsa ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocm-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-runtime/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/RadeonOpenCompute/ROCR-Runtime";
     license = with licenses; [ ncsa ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocm-thunk/default.nix
+++ b/pkgs/development/libraries/rocm-thunk/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface";
     license = with licenses; [ bsd2 mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocm-thunk/default.nix
+++ b/pkgs/development/libraries/rocm-thunk/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-thunk";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/development/libraries/rocm-thunk/default.nix
+++ b/pkgs/development/libraries/rocm-thunk/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface";
     license = with licenses; [ bsd2 mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocmlir/default.nix
+++ b/pkgs/development/libraries/rocmlir/default.nix
@@ -100,6 +100,7 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocMLIR";
     license = with licenses; [ asl20 ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocmlir/default.nix
+++ b/pkgs/development/libraries/rocmlir/default.nix
@@ -100,7 +100,6 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocMLIR";
     license = with licenses; [ asl20 ];
     maintainers = teams.rocm.members;
-    # Once again, they haven't updated the tags...
-    broken = lib.versions.minor finalAttrs.version != lib.versions.minor stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocmlir/default.nix
+++ b/pkgs/development/libraries/rocmlir/default.nix
@@ -25,7 +25,7 @@ let
     else throw "Unsupported ROCm LLVM platform";
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocmlir";
-  version = "5.4.0";
+  version = "5.4.1";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocprim/default.nix
+++ b/pkgs/development/libraries/rocprim/default.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprim";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocprim/default.nix
+++ b/pkgs/development/libraries/rocprim/default.nix
@@ -76,6 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocPRIM";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocprim/default.nix
+++ b/pkgs/development/libraries/rocprim/default.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocPRIM";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocprofiler/default.nix
+++ b/pkgs/development/libraries/rocprofiler/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCm-Developer-Tools/rocprofiler";
     license = with licenses; [ mit ]; # mitx11
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocprofiler/default.nix
+++ b/pkgs/development/libraries/rocprofiler/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCm-Developer-Tools/rocprofiler";
     license = with licenses; [ mit ]; # mitx11
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/libraries/rocprofiler/default.nix
+++ b/pkgs/development/libraries/rocprofiler/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprofiler";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";

--- a/pkgs/development/libraries/rocr-debug-agent/default.nix
+++ b/pkgs/development/libraries/rocr-debug-agent/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocr-debug-agent";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";

--- a/pkgs/development/libraries/rocr-debug-agent/default.nix
+++ b/pkgs/development/libraries/rocr-debug-agent/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, cmake
+, hip
+, git
+, rocdbgapi
+, rocm-runtime
+, elfutils
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rocr-debug-agent";
+  version = "5.4.1";
+
+  src = fetchFromGitHub {
+    owner = "ROCm-Developer-Tools";
+    repo = "rocr_debug_agent";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-5l6svWSWCxVoyr1zJabxbt5rXQMtdZtHrf9gS2PcRKc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    hip
+    git
+  ];
+
+  buildInputs = [
+    rocdbgapi
+    rocm-runtime
+    elfutils
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_MODULE_PATH=${hip}/lib/cmake/hip"
+    "-DHIP_ROOT_DIR=${hip}"
+    "-DHIP_PATH=${hip}"
+  ];
+
+  # Weird install target
+  postInstall = ''
+    rm -rf $out/src
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "Library that provides some debugging functionality for ROCr";
+    homepage = "https://github.com/ROCm-Developer-Tools/rocr_debug_agent";
+    license = with licenses; [ ncsa ];
+    maintainers = teams.rocm.members;
+    platforms = platforms.linux;
+    broken = finalAttrs.version != hip.version;
+  };
+})

--- a/pkgs/development/libraries/rocr-debug-agent/default.nix
+++ b/pkgs/development/libraries/rocr-debug-agent/default.nix
@@ -56,6 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ ncsa ];
     maintainers = teams.rocm.members;
     platforms = platforms.linux;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocrand/default.nix
+++ b/pkgs/development/libraries/rocrand/default.nix
@@ -79,6 +79,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocRAND";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocrand/default.nix
+++ b/pkgs/development/libraries/rocrand/default.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocrand";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocrand/default.nix
+++ b/pkgs/development/libraries/rocrand/default.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocRAND";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocsolver/default.nix
+++ b/pkgs/development/libraries/rocsolver/default.nix
@@ -87,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocSOLVER";
     license = with licenses; [ bsd2 ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocsolver/default.nix
+++ b/pkgs/development/libraries/rocsolver/default.nix
@@ -87,6 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocSOLVER";
     license = with licenses; [ bsd2 ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocsolver/default.nix
+++ b/pkgs/development/libraries/rocsolver/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocsolver";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocsparse/default.nix
+++ b/pkgs/development/libraries/rocsparse/default.nix
@@ -140,6 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocSPARSE";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocsparse/default.nix
+++ b/pkgs/development/libraries/rocsparse/default.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocsparse";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocsparse/default.nix
+++ b/pkgs/development/libraries/rocsparse/default.nix
@@ -140,6 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocSPARSE";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocthrust/default.nix
+++ b/pkgs/development/libraries/rocthrust/default.nix
@@ -78,6 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocThrust";
     license = with licenses; [ asl20 ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocthrust/default.nix
+++ b/pkgs/development/libraries/rocthrust/default.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocthrust";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/rocthrust/default.nix
+++ b/pkgs/development/libraries/rocthrust/default.nix
@@ -78,6 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocThrust";
     license = with licenses; [ asl20 ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/roctracer/default.nix
+++ b/pkgs/development/libraries/roctracer/default.nix
@@ -95,6 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCm-Developer-Tools/roctracer";
     license = with licenses; [ mit ]; # mitx11
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/roctracer/default.nix
+++ b/pkgs/development/libraries/roctracer/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "roctracer";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/roctracer/default.nix
+++ b/pkgs/development/libraries/roctracer/default.nix
@@ -95,6 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCm-Developer-Tools/roctracer";
     license = with licenses; [ mit ]; # mitx11
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocwmma/default.nix
+++ b/pkgs/development/libraries/rocwmma/default.nix
@@ -140,6 +140,6 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocWMMA";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != hip.version;
+    broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocwmma/default.nix
+++ b/pkgs/development/libraries/rocwmma/default.nix
@@ -140,6 +140,7 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCmSoftwarePlatform/rocWMMA";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor hip.version;
   };
 })

--- a/pkgs/development/libraries/rocwmma/default.nix
+++ b/pkgs/development/libraries/rocwmma/default.nix
@@ -36,7 +36,7 @@ let
   };
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocwmma";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -1,40 +1,75 @@
-{ lib, stdenv, fetchurl, cmake, gfortran, ninja, cudaPackages, libpthreadstubs, lapack, blas }:
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, ninja
+, gfortran
+, libpthreadstubs
+, lapack
+, blas
+, cudaPackages
+, hip
+, hipblas
+, hipsparse
+, openmp
+, useCUDA ? true
+, useROCM ? false
+, gpuTargets ? [ ]
+}:
 
 let
   inherit (cudaPackages) cudatoolkit cudaFlags;
-in
-
-assert let majorIs = lib.versions.major cudatoolkit.version;
-       in majorIs == "9" || majorIs == "10" || majorIs == "11";
-
-let
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "magma";
   version = "2.6.2";
 
-in stdenv.mkDerivation {
-  pname = "magma";
-  inherit version;
   src = fetchurl {
-    url = "https://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-${version}.tar.gz";
+    name = "magma-${finalAttrs.version}.tar.gz";
+    url = "https://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-${finalAttrs.version}.tar.gz";
     hash = "sha256-dbVU2rAJA+LRC5cskT5Q5/iMvGLzrkMrWghsfk7aCnE=";
-    name = "magma-${version}.tar.gz";
   };
 
-  nativeBuildInputs = [ gfortran cmake ninja ];
+  nativeBuildInputs = [
+    cmake
+    ninja
+    gfortran
+  ];
 
-  buildInputs = [ cudatoolkit libpthreadstubs lapack blas ];
+  buildInputs = [
+    libpthreadstubs
+    lapack
+    blas
+  ] ++ lib.optionals useCUDA [
+    cudatoolkit
+  ] ++ lib.optionals useROCM [
+    hip
+    hipblas
+    hipsparse
+    openmp
+  ];
 
-  cmakeFlags = [
+  cmakeFlags = lib.optionals useCUDA [
+    "-DCMAKE_C_COMPILER=${cudatoolkit.cc}/bin/gcc"
+    "-DCMAKE_CXX_COMPILER=${cudatoolkit.cc}/bin/g++"
+    "-DMAGMA_ENABLE_CUDA=ON"
     "-DGPU_TARGET=${builtins.concatStringsSep "," cudaFlags.cudaRealArchs}"
+  ] ++ lib.optionals useROCM [
+    "-DCMAKE_C_COMPILER=${hip}/bin/hipcc"
+    "-DCMAKE_CXX_COMPILER=${hip}/bin/hipcc"
+    "-DMAGMA_ENABLE_HIP=ON"
+    "-DGPU_TARGET=${builtins.concatStringsSep "," (if gpuTargets == [ ] then hip.gpuTargets else gpuTargets)}"
+  ];
+
+  buildFlags = [
+    "magma"
+    "magma_sparse"
   ];
 
   doCheck = false;
 
-  preConfigure = ''
-    export CC=${cudatoolkit.cc}/bin/gcc CXX=${cudatoolkit.cc}/bin/g++
-  '';
-
-  enableParallelBuilding=true;
-  buildFlags = [ "magma" "magma_sparse" ];
+  passthru = {
+    inherit cudatoolkit;
+  };
 
   meta = with lib; {
     description = "Matrix Algebra on GPU and Multicore Architectures";
@@ -42,7 +77,7 @@ in stdenv.mkDerivation {
     homepage = "http://icl.cs.utk.edu/magma/index.html";
     platforms = platforms.unix;
     maintainers = with maintainers; [ tbenst ];
+    # CUDA and ROCm are mutually exclusive
+    broken = useCUDA && useROCM || useCUDA && versionOlder cudatoolkit.version "9";
   };
-
-  passthru.cudatoolkit = cudatoolkit;
-}
+})

--- a/pkgs/development/libraries/tensile/default.nix
+++ b/pkgs/development/libraries/tensile/default.nix
@@ -36,6 +36,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/ROCmSoftwarePlatform/Tensile";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor version != versions.minor stdenv.cc.version;
   };
 }

--- a/pkgs/development/libraries/tensile/default.nix
+++ b/pkgs/development/libraries/tensile/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ROCmSoftwarePlatform/Tensile";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = version != stdenv.cc.version;
+    broken = versions.minor version != versions.minor stdenv.cc.version;
   };
 }

--- a/pkgs/development/libraries/tensile/default.nix
+++ b/pkgs/development/libraries/tensile/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "tensile";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -29,7 +29,16 @@
   # dependencies for torch.utils.tensorboard
   pillow, six, future, tensorboard, protobuf,
 
-  isPy3k, pythonOlder }:
+  isPy3k, pythonOlder,
+
+  # ROCm dependencies
+  rocmSupport ? false,
+  gpuTargets ? [ ],
+  openmp, rocm-core, hip, rccl, miopen, miopengemm, rocrand, rocblas,
+  rocfft, rocsparse, hipsparse, rocthrust, rocprim, hipcub, roctracer,
+  rocsolver, hipfft, hipsolver, hipblas, rocminfo, rocm-thunk, rocm-comgr,
+  rocm-device-libs, rocm-runtime, rocm-opencl-runtime, hipify
+}:
 
 let
   inherit (cudaPackages) cudatoolkit cudaFlags cudnn nccl;
@@ -62,6 +71,17 @@ let
   cudaStubEnv = lib.optionalString cudaSupport
     "LD_LIBRARY_PATH=${cudaStub}\${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH ";
 
+  rocmtoolkit_joined = symlinkJoin {
+    name = "rocm-merged";
+
+    paths = [
+      rocm-core hip rccl miopen miopengemm rocrand rocblas
+      rocfft rocsparse hipsparse rocthrust rocprim hipcub
+      roctracer rocfft rocsolver hipfft hipsolver hipblas
+      rocminfo rocm-thunk rocm-comgr rocm-device-libs
+      rocm-runtime rocm-opencl-runtime hipify
+    ];
+  };
 in buildPythonPackage rec {
   pname = "torch";
   # Don't forget to update torch-bin to the same version.
@@ -93,11 +113,40 @@ in buildPythonPackage rec {
     ./pthreadpool-disable-gcd.diff
   ];
 
+  postPatch = lib.optionalString rocmSupport ''
+    # https://github.com/facebookincubator/gloo/pull/297
+    substituteInPlace third_party/gloo/cmake/Hipify.cmake \
+      --replace "\''${HIPIFY_COMMAND}" "python \''${HIPIFY_COMMAND}"
+
+    # Replace hard-coded rocm paths
+    substituteInPlace caffe2/CMakeLists.txt \
+      --replace "/opt/rocm" "${rocmtoolkit_joined}" \
+      --replace "hcc/include" "hip/include" \
+      --replace "rocblas/include" "include/rocblas" \
+      --replace "hipsparse/include" "include/hipsparse"
+
+    # Doesn't pick up the environment variable?
+    substituteInPlace third_party/kineto/libkineto/CMakeLists.txt \
+      --replace "\''$ENV{ROCM_SOURCE_DIR}" "${rocmtoolkit_joined}" \
+      --replace "/opt/rocm" "${rocmtoolkit_joined}"
+
+    # Strangely, this is never set in cmake
+    substituteInPlace cmake/public/LoadHIP.cmake \
+      --replace "set(ROCM_PATH \$ENV{ROCM_PATH})" \
+        "set(ROCM_PATH \$ENV{ROCM_PATH})''\nset(ROCM_VERSION ${lib.concatStrings (lib.intersperse "0" (lib.splitString "." hip.version))})"
+  '';
+
   preConfigure = lib.optionalString cudaSupport ''
     export TORCH_CUDA_ARCH_LIST="${cudaFlags.cudaCapabilitiesSemiColonString}"
     export CC=${cudatoolkit.cc}/bin/gcc CXX=${cudatoolkit.cc}/bin/g++
   '' + lib.optionalString (cudaSupport && cudnn != null) ''
     export CUDNN_INCLUDE_DIR=${cudnn}/include
+  '' + lib.optionalString rocmSupport ''
+    export ROCM_PATH=${rocmtoolkit_joined}
+    export ROCM_SOURCE_DIR=${rocmtoolkit_joined}
+    export PYTORCH_ROCM_ARCH="${lib.strings.concatStringsSep ";" (if gpuTargets == [ ] then hip.gpuTargets else gpuTargets)}"
+    export CMAKE_CXX_FLAGS="-I${rocmtoolkit_joined}/include -I${rocmtoolkit_joined}/include/rocblas"
+    python tools/amd_build/build_amd.py
   '';
 
   # Use pytorch's custom configurations
@@ -164,11 +213,14 @@ in buildPythonPackage rec {
     ninja
     pybind11
     removeReferencesTo
-  ] ++ lib.optionals cudaSupport [ cudatoolkit_joined ];
+  ] ++ lib.optionals cudaSupport [ cudatoolkit_joined ]
+    ++ lib.optionals rocmSupport [ rocmtoolkit_joined ];
 
   buildInputs = [ blas blas.provider pybind11 ]
     ++ lib.optionals stdenv.isLinux [ linuxHeaders_5_19 ] # TMP: avoid "flexible array member" errors for now
-    ++ lib.optionals cudaSupport [ cudnn magma nccl ]
+    ++ lib.optionals cudaSupport [ cudnn nccl ]
+    ++ lib.optionals rocmSupport [ openmp ]
+    ++ lib.optionals (cudaSupport || rocmSupport) [ magma ]
     ++ lib.optionals stdenv.isLinux [ numactl ]
     ++ lib.optionals stdenv.isDarwin [ CoreServices libobjc ];
 
@@ -180,7 +232,8 @@ in buildPythonPackage rec {
     typing-extensions
     # the following are required for tensorboard support
     pillow six future tensorboard protobuf
-  ] ++ lib.optionals MPISupport [ mpi ];
+  ] ++ lib.optionals MPISupport [ mpi ]
+    ++ lib.optionals rocmSupport [ rocmtoolkit_joined ];
 
   # Tests take a long time and may be flaky, so just sanity-check imports
   doCheck = false;
@@ -227,6 +280,12 @@ in buildPythonPackage rec {
     mkdir $lib
     mv $out/${python.sitePackages}/torch/lib $lib/lib
     ln -s $lib/lib $out/${python.sitePackages}/torch/lib
+  '' + lib.optionalString rocmSupport ''
+    substituteInPlace $dev/share/cmake/Tensorpipe/TensorpipeTargets-release.cmake \
+      --replace "\''${_IMPORT_PREFIX}/lib64" "$lib/lib"
+
+    substituteInPlace $dev/share/cmake/ATen/ATenConfig.cmake \
+      --replace "/build/source/torch/include" "$dev/include"
   '';
 
   postFixup = lib.optionalString stdenv.isDarwin ''
@@ -260,6 +319,7 @@ in buildPythonPackage rec {
     homepage = "https://pytorch.org/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ teh thoughtpolice tscholak ]; # tscholak esp. for darwin-related builds
-    platforms = with platforms; linux ++ lib.optionals (!cudaSupport) darwin;
+    platforms = with platforms; linux ++ lib.optionals (!cudaSupport || !rocmSupport) darwin;
+    broken = rocmSupport && cudaSupport; # CUDA and ROCm are mutually exclusive
   };
 }

--- a/pkgs/development/tools/build-managers/rocm-cmake/default.nix
+++ b/pkgs/development/tools/build-managers/rocm-cmake/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-cmake";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/development/tools/build-managers/rocm-cmake/default.nix
+++ b/pkgs/development/tools/build-managers/rocm-cmake/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     maintainers = teams.rocm.members;
     platforms = platforms.unix;
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/development/tools/misc/rdc/default.nix
+++ b/pkgs/development/tools/misc/rdc/default.nix
@@ -40,7 +40,7 @@ let
   };
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rdc";
-  version = "5.4.1";
+  version = "5.4.2";
 
   outputs = [
     "out"

--- a/pkgs/development/tools/misc/rdc/default.nix
+++ b/pkgs/development/tools/misc/rdc/default.nix
@@ -1,0 +1,123 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, cmake
+, rocm-smi
+, rocm-runtime
+, libcap
+, grpc
+, protobuf
+, openssl
+, doxygen
+, graphviz
+, texlive
+, gtest
+, buildDocs ? true
+, buildTests ? false
+}:
+
+let
+  latex = lib.optionalAttrs buildDocs texlive.combine {
+    inherit (texlive) scheme-small
+    latexmk
+    varwidth
+    multirow
+    hanging
+    adjustbox
+    collectbox
+    stackengine
+    enumitem
+    alphalph
+    wasysym
+    sectsty
+    tocloft
+    newunicodechar
+    etoc
+    helvetic
+    wasy
+    courier;
+  };
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "rdc";
+  version = "5.4.1";
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildDocs [
+    "doc"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "rdc";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-dYacqkRp+zVejo/4dME1K6EN8t/1EBtIynEQ+AQ4JZo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    protobuf
+  ] ++ lib.optionals buildDocs [
+    doxygen
+    graphviz
+    latex
+  ];
+
+  buildInputs = [
+    rocm-smi
+    rocm-runtime
+    libcap
+    grpc
+    openssl
+  ] ++ lib.optionals buildTests [
+    gtest
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_VERBOSE_MAKEFILE=OFF"
+    "-DRDC_INSTALL_PREFIX=${placeholder "out"}"
+    "-DBUILD_ROCRTEST=ON"
+    "-DRSMI_INC_DIR=${rocm-smi}/include"
+    "-DRSMI_LIB_DIR=${rocm-smi}/lib"
+    "-DGRPC_ROOT=${grpc}"
+    # Manually define CMAKE_INSTALL_<DIR>
+    # See: https://github.com/NixOS/nixpkgs/pull/197838
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBEXECDIR=libexec"
+    "-DCMAKE_INSTALL_DOCDIR=doc"
+  ] ++ lib.optionals buildTests [
+    "-DBUILD_TESTS=ON"
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "file(STRINGS /etc/os-release LINUX_DISTRO LIMIT_COUNT 1 REGEX \"NAME=\")" "set(LINUX_DISTRO \"NixOS\")"
+  '';
+
+  postInstall = ''
+    find $out/bin -executable -type f -exec \
+      patchelf {} --shrink-rpath --allowed-rpath-prefixes /nix/store \;
+  '' + lib.optionalString buildTests ''
+    mkdir -p $test
+    mv $out/bin/rdctst_tests $test/bin
+  '';
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "Simplifies administration and addresses infrastructure challenges in cluster and datacenter environments";
+    homepage = "https://github.com/RadeonOpenCompute/rdc";
+    license = with licenses; [ mit ];
+    maintainers = teams.rocm.members;
+    broken = finalAttrs.version != rocm-smi.version;
+  };
+})

--- a/pkgs/development/tools/misc/rdc/default.nix
+++ b/pkgs/development/tools/misc/rdc/default.nix
@@ -118,6 +118,7 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/RadeonOpenCompute/rdc";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
     broken = versions.minor finalAttrs.version != versions.minor rocm-smi.version;
   };
 })

--- a/pkgs/development/tools/misc/rdc/default.nix
+++ b/pkgs/development/tools/misc/rdc/default.nix
@@ -118,6 +118,6 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/RadeonOpenCompute/rdc";
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
-    broken = finalAttrs.version != rocm-smi.version;
+    broken = versions.minor finalAttrs.version != versions.minor rocm-smi.version;
   };
 })

--- a/pkgs/development/tools/misc/rocgdb/default.nix
+++ b/pkgs/development/tools/misc/rocgdb/default.nix
@@ -53,5 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ROCm-Developer-Tools/ROCgdb";
     license = with licenses; [ gpl2 gpl3 bsd3 ];
     maintainers = teams.rocm.members;
+    platforms = platforms.linux;
   };
 })

--- a/pkgs/development/tools/misc/rocgdb/default.nix
+++ b/pkgs/development/tools/misc/rocgdb/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rocmUpdateScript
+, pkg-config
+, texinfo
+, bison
+, flex
+, zlib
+, elfutils
+, gmp
+, ncurses
+, expat
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rocgdb";
+  version = "5.4.1";
+
+  src = fetchFromGitHub {
+    owner = "ROCm-Developer-Tools";
+    repo = "ROCgdb";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-DORPvfon32+rIk+YcO9LlUefNvvC7trmiTswg9MMuIs=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    texinfo # For makeinfo
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    zlib
+    elfutils
+    gmp
+    ncurses
+    expat
+  ];
+
+  # `-Wno-format-nonliteral` doesn't work
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
+
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    owner = finalAttrs.src.owner;
+    repo = finalAttrs.src.repo;
+  };
+
+  meta = with lib; {
+    description = "ROCm source-level debugger for Linux, based on GDB";
+    homepage = "https://github.com/ROCm-Developer-Tools/ROCgdb";
+    license = with licenses; [ gpl2 gpl3 bsd3 ];
+    maintainers = teams.rocm.members;
+  };
+})

--- a/pkgs/development/tools/misc/rocgdb/default.nix
+++ b/pkgs/development/tools/misc/rocgdb/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocgdb";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";

--- a/pkgs/development/tools/rocminfo/default.nix
+++ b/pkgs/development/tools/rocminfo/default.nix
@@ -18,7 +18,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "5.4.1";
+  version = "5.4.2";
   pname = "rocminfo";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/rocminfo/default.nix
+++ b/pkgs/development/tools/rocminfo/default.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.ncsa;
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken = stdenv.isAarch64 || finalAttrs.version != stdenv.cc.version;
+    broken = stdenv.isAarch64 || versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/tools/system/rocm-smi/default.nix
+++ b/pkgs/tools/system/rocm-smi/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = [ "x86_64-linux" ];
-    broken = finalAttrs.version != stdenv.cc.version;
+    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version;
   };
 })

--- a/pkgs/tools/system/rocm-smi/default.nix
+++ b/pkgs/tools/system/rocm-smi/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-smi";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15310,6 +15310,10 @@ with pkgs;
     useNVIDIA = true;
   };
 
+  hipify = callPackage ../development/compilers/hipify {
+    stdenv = rocmClangStdenv;
+  };
+
   hipcub = callPackage ../development/libraries/hipcub {
     stdenv = rocmClangStdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15376,6 +15376,11 @@ with pkgs;
     stdenv = rocmClangStdenv;
   };
 
+  # Best just use GCC here
+  rocgdb = callPackage ../development/tools/misc/rocgdb {
+    elfutils = elfutils.override { enableDebuginfod = true; };
+  };
+
   rocdbgapi = callPackage ../development/libraries/rocdbgapi {
     stdenv = rocmClangStdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15332,6 +15332,10 @@ with pkgs;
     stdenv = rocmClangStdenv;
   };
 
+  hipsolver = callPackage ../development/libraries/hipsolver {
+    stdenv = rocmClangStdenv;
+  };
+
   rccl = callPackage ../development/libraries/rccl {
     stdenv = rocmClangStdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15376,6 +15376,10 @@ with pkgs;
     stdenv = rocmClangStdenv;
   };
 
+  rocdbgapi = callPackage ../development/libraries/rocdbgapi {
+    stdenv = rocmClangStdenv;
+  };
+
   rocmlir-rock = rocmlir.override {
     buildRockCompiler = true;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15377,6 +15377,9 @@ with pkgs;
   };
 
   # Best just use GCC here
+  rdc = callPackage ../development/tools/misc/rdc { };
+
+  # Best just use GCC here
   rocgdb = callPackage ../development/tools/misc/rocgdb {
     elfutils = elfutils.override { enableDebuginfod = true; };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15421,6 +15421,10 @@ with pkgs;
     buildRockCompiler = true;
   };
 
+  rocm-core = callPackage ../development/libraries/rocm-core {
+    stdenv = rocmClangStdenv;
+  };
+
   rocprim = callPackage ../development/libraries/rocprim {
     stdenv = rocmClangStdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15342,6 +15342,12 @@ with pkgs;
     stdenv = rocmClangStdenv;
   };
 
+  migraphx = callPackage ../development/libraries/migraphx {
+    inherit (llvmPackages_rocm) clang-tools-extra openmp;
+    stdenv = rocmClangStdenv;
+    rocmlir = rocmlir-rock;
+  };
+
   rccl = callPackage ../development/libraries/rccl {
     stdenv = rocmClangStdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15327,6 +15327,11 @@ with pkgs;
     stdenv = rocmClangStdenv;
   };
 
+  hipfft = callPackage ../development/libraries/hipfft {
+    inherit (llvmPackages_rocm) openmp;
+    stdenv = rocmClangStdenv;
+  };
+
   rccl = callPackage ../development/libraries/rccl {
     stdenv = rocmClangStdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15385,6 +15385,10 @@ with pkgs;
     stdenv = rocmClangStdenv;
   };
 
+  rocr-debug-agent = callPackage ../development/libraries/rocr-debug-agent {
+    stdenv = rocmClangStdenv;
+  };
+
   rocmlir-rock = rocmlir.override {
     buildRockCompiler = true;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36119,7 +36119,20 @@ with pkgs;
 
   lie = callPackage ../applications/science/math/LiE { };
 
-  magma = callPackage ../development/libraries/science/math/magma { };
+  magma = callPackage ../development/libraries/science/math/magma {
+    inherit (llvmPackages_rocm) openmp;
+  };
+
+  magma-cuda = magma.override {
+    useCUDA = true;
+    useROCM = false;
+  };
+
+  magma-hip = magma.override {
+    useCUDA = false;
+    useROCM = true;
+  };
+
   clmagma = callPackage ../development/libraries/science/math/clmagma { };
 
   mathematica = callPackage ../applications/science/math/mathematica { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15253,6 +15253,8 @@ with pkgs;
     stdenv = llvmPackages_9.stdenv;
   };
 
+  blaze = callPackage ../development/libraries/blaze { };
+
   pony-corral = callPackage ../development/compilers/ponyc/pony-corral.nix { };
 
   qbe = callPackage ../development/compilers/qbe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15323,6 +15323,10 @@ with pkgs;
     stdenv = rocmClangStdenv;
   };
 
+  hipfort = callPackage ../development/libraries/hipfort {
+    stdenv = rocmClangStdenv;
+  };
+
   rccl = callPackage ../development/libraries/rccl {
     stdenv = rocmClangStdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15336,6 +15336,10 @@ with pkgs;
     stdenv = rocmClangStdenv;
   };
 
+  hipblas = callPackage ../development/libraries/hipblas {
+    stdenv = rocmClangStdenv;
+  };
+
   rccl = callPackage ../development/libraries/rccl {
     stdenv = rocmClangStdenv;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11419,16 +11419,27 @@ self: super: with self; {
     cudaSupport = pkgs.config.cudaSupport or false;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
     inherit (pkgs.darwin) libobjc;
+    inherit (pkgs.llvmPackages_rocm) openmp;
   };
 
   torch-bin = callPackage ../development/python-modules/torch/bin.nix { };
 
   torchWithCuda = self.torch.override {
+    magma = pkgs.magma-cuda;
     cudaSupport = true;
   };
 
   torchWithoutCuda = self.torch.override {
     cudaSupport = false;
+  };
+
+  torchWithRocm = self.torch.override {
+    magma = pkgs.magma-hip;
+    rocmSupport = true;
+  };
+
+  torchWithoutRocm = self.torch.override {
+    rocmSupport = false;
   };
 
   torch-tb-profiler = callPackage ../development/python-modules/torch-tb-profiler/default.nix { };


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
Last of the rocm packages with the exception of MIVisionX, atmi, and aomp.
~~Ignore the commits up to ``hipify: init at 5.4.1``, they're just there to prevent a conflict until the next staging-next is merged into master. Then I'll rebase.~~ staging-next has been merged.
closes #200479
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
