### PR TITLE
bottles: 2022.12.14 -> 2022.12.14.1, fix GStreamer

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -28,13 +28,13 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "bottles-unwrapped";
-  version = "2022.12.14";
+  version = "2022.12.14.1";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = "bottles";
     rev = version;
-    sha256 = "sha256-G2FQy+mea/+2RjK/WjLeX+7TP+HU6fCUFYuprFGKEyw=";
+    sha256 = "sha256-hoWyXCP7/0m8akUGBJyuF2yQcRKR8C7MDBLUdPdtBgE=";
   };
 
   patches = [ ./vulkan_icd.patch ];

--- a/pkgs/applications/misc/bottles/fhsenv.nix
+++ b/pkgs/applications/misc/bottles/fhsenv.nix
@@ -2,6 +2,7 @@
 , buildFHSUserEnvBubblewrap
 , symlinkJoin
 , bottles-unwrapped
+, gst_all_1
 , extraPkgs ? pkgs: [ ]
 , extraLibraries ? pkgs: [ ]
 }:
@@ -9,6 +10,8 @@
 let fhsEnv = {
   targetPkgs = pkgs: with pkgs; [
     bottles-unwrapped
+    # This only allows to enable the toggle, vkBasalt won't work if not installed with environment.systemPackages (or nix-env)
+    # See https://github.com/bottlesdevs/Bottles/issues/2401
     vkbasalt
   ] ++ extraPkgs pkgs;
 
@@ -46,6 +49,9 @@ let fhsEnv = {
       gsm
       gst_all_1.gstreamer
       gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-ugly
+      gst_all_1.gst-plugins-bad
       libgphoto2
       libjpeg_turbo
       libkrb5
@@ -83,6 +89,13 @@ let fhsEnv = {
       zlib # Freetype
     ] ++ xorgDeps pkgs
     ++ extraLibraries pkgs;
+
+  profile = ''
+    # Remove if merged https://github.com/bottlesdevs/Bottles/pull/2415
+    export BOTTLES_USE_SYSTEM_GSTREAMER=1
+    # Dirty hack, may be related with https://github.com/NixOS/nixpkgs/issues/148007
+    export GST_PLUGIN_PATH=${ lib.makeSearchPath "lib/gstreamer-1.0" (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad ]) }
+  '';
 };
 in
 symlinkJoin {


### PR DESCRIPTION
###### Description of changes
https://github.com/bottlesdevs/Bottles/releases/tag/2022.12.14.1

Added some stuff that allows GStreamer to work (Bottles' Wine doesn't bundle GStreamer). See comments for details.
Tested GStreamer with "Star Wars Jedi: Fallen Order" (EA App) intro video.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
