### PR TITLE
looking-glass-client/kvmfr: B5.0.1 -> B6

### DIFF
--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://looking-glass.io/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ alexbakker babbaj ];
+    maintainers = with maintainers; [ alexbakker babbaj j-brn ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -1,7 +1,39 @@
-{ stdenv, lib, fetchFromGitHub, makeDesktopItem, cmake, pkg-config
-, freefont_ttf, spice-protocol, nettle, libbfd, fontconfig, libffi, expat
-, libxkbcommon, libGL, libXext, libXrandr, libXi, libXScrnSaver, libXinerama
-, libXcursor, libXpresent, wayland, wayland-protocols
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeDesktopItem
+, pkg-config
+, cmake
+, freefont_ttf
+, spice-protocol
+, nettle
+, libbfd
+, fontconfig
+, libffi
+, expat
+, libGL
+
+, libX11
+, libxkbcommon
+, libXext
+, libXrandr
+, libXi
+, libXScrnSaver
+, libXinerama
+, libXcursor
+, libXpresent
+
+, wayland
+, wayland-protocols
+
+, pipewire
+, pulseaudio
+, libsamplerate
+
+, xorgSupport ? true
+, waylandSupport ? true
+, pipewireSupport ? true
+, pulseSupport ? true
 }:
 
 let
@@ -16,40 +48,30 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "looking-glass-client";
-  version = "B5.0.1";
+  version = "B6";
 
   src = fetchFromGitHub {
     owner = "gnif";
     repo = "LookingGlass";
     rev = version;
-    sha256 = "sha256-UzZQU5SzJ2mo9QBweQB0VJSnKfzgTG5QaKpIQN/6LCE=";
+    sha256 = "sha256-6vYbNmNJBCoU23nVculac24tHqH7F4AZVftIjL93WJU=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [
-    libGL
-    freefont_ttf
-    spice-protocol
-    expat
-    libbfd
-    nettle
-    fontconfig
-    libffi
-    libxkbcommon
-    libXi
-    libXScrnSaver
-    libXinerama
-    libXcursor
-    libXpresent
-    libXext
-    libXrandr
-    wayland
-    wayland-protocols
-  ];
+  buildInputs = [ libGL libX11 freefont_ttf spice-protocol expat libbfd nettle fontconfig libffi ]
+    ++ lib.optionals xorgSupport [ libxkbcommon libXi libXScrnSaver libXinerama libXcursor libXpresent libXext libXrandr ]
+    ++ lib.optionals waylandSupport [ libxkbcommon wayland wayland-protocols ]
+    ++ lib.optionals pipewireSupport [ pipewire libsamplerate ]
+    ++ lib.optionals pulseSupport [ pulseaudio libsamplerate ];
 
-  cmakeFlags = [ "-DOPTIMIZE_FOR_NATIVE=OFF" ];
+  cmakeFlags = [ "-DOPTIMIZE_FOR_NATIVE=OFF" ]
+    ++ lib.optional (!xorgSupport) "-DENABLE_X11=no"
+    ++ lib.optional (!waylandSupport) "-DENABLE_WAYLAND=no"
+    ++ lib.optional (!pulseSupport) "-DENABLE_PULSEAUDIO=no"
+    ++ lib.optional (!pipewireSupport) "-DENABLE_PIPEWIRE=no";
+
 
   postUnpack = ''
     echo ${src.rev} > source/VERSION

--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel, kmod, looking-glass-client }:
+{ lib, stdenv, fetchFromGitHub, kernel, kmod, looking-glass-client }:
 
 stdenv.mkDerivation rec {
   pname = "kvmfr";
@@ -8,19 +8,6 @@ stdenv.mkDerivation rec {
   sourceRoot = "source/module";
   hardeningDisable = [ "pic" "format" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
-
-  patches = lib.optional (kernel.kernelAtLeast "5.16") (fetchpatch {
-    name = "kvmfr-5.16.patch";
-    url = "https://github.com/gnif/LookingGlass/commit/a9b5302a517e19d7a2da114acf71ef1e69cfb497.patch";
-    sha256 = "017nxlk2f7kyjp6llwa74dbczdb1jk8v791qld81dxhzkm9dyqqx";
-    stripLen = 1;
-  })
-  ++ lib.optional (kernel.kernelAtLeast "5.18") (fetchpatch {
-    name = "kvmfr-5.18.patch";
-    url = "https://github.com/gnif/LookingGlass/commit/c7029f95042fe902843cb6acbfc75889e93dc210.patch";
-    sha256 = "sha256-6DpL17XWj8BKpiBdKdCPC51MWKLIo6PixQ9UaygT2Zg=";
-    stripLen = 1;
-  });
 
   makeFlags = [
     "KVER=${kernel.modDirVersion}"


### PR DESCRIPTION
###### Description of changes

- updated looking-glass-client and kvmfr to B6
- added parameters to optionally disable X11, Wayland, Pulseaudio or Pipewire support
- removed backported patches for kvmfr that are already included in the new release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
