### PR TITLE
itk: unstable -> 5.3.0

### DIFF
--- a/pkgs/applications/graphics/c3d/default.nix
+++ b/pkgs/applications/graphics/c3d/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, itk, Cocoa }:
+{ lib, stdenv, fetchFromGitHub, cmake, itk_5_2, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname   = "c3d";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ itk ]
+  buildInputs = [ itk_5_2 ]
     ++ lib.optional stdenv.isDarwin Cocoa;
 
   cmakeFlags = [ "-DCONVERT3D_USE_ITK_REMOTE_MODULES=OFF" ];

--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, makeWrapper, itk-unstable, vtk_8, Cocoa }:
+{ lib, stdenv, fetchFromGitHub, cmake, makeWrapper, itk, vtk_8, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname    = "ANTs";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];
-  buildInputs = [ itk-unstable vtk_8 ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+  buildInputs = [ itk vtk_8 ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 
   cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE" ];
 

--- a/pkgs/development/libraries/itk/5.2.x.nix
+++ b/pkgs/development/libraries/itk/5.2.x.nix
@@ -1,0 +1,5 @@
+import ./generic.nix rec {
+  version = "5.2.1";
+  rev = "v${version}";
+  sourceSha256 = "sha256-KaVe9FMGm4ZVMpwAT12fA67T0qZS3ZueiI8z85+xSwE=";
+}

--- a/pkgs/development/libraries/itk/5.x.nix
+++ b/pkgs/development/libraries/itk/5.x.nix
@@ -1,5 +1,5 @@
 import ./generic.nix rec {
-  version = "5.2.1";
+  version = "5.3.0";
   rev = "v${version}";
-  sourceSha256 = "sha256-KaVe9FMGm4ZVMpwAT12fA67T0qZS3ZueiI8z85+xSwE=";
+  sourceSha256 = "sha256-+qCd8Jzpl5fEPTUpLyjjFBkfgCn3+Lf4pi8QnjCwofs=";
 }

--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     substituteInPlace CMake/ITKSetStandardCompilerFlags.cmake  \
       --replace "-march=corei7" ""  \
       --replace "-mtune=native" ""
+    substituteInPlace Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/src/lib/openjp2/libopenjp2.pc.cmake.in  \
+      --replace "@OPENJPEG_INSTALL_LIB_DIR@" "@OPENJPEG_INSTALL_FULL_LIB_DIR@"
     ln -sr ${itkGenericLabelInterpolatorSrc} Modules/External/ITKGenericLabelInterpolator
     ln -sr ${itkAdaptiveDenoisingSrc} Modules/External/ITKAdaptiveDenoising
   '';

--- a/pkgs/development/libraries/itk/unstable.nix
+++ b/pkgs/development/libraries/itk/unstable.nix
@@ -1,5 +1,0 @@
-import ./generic.nix {
-  version = "unstable-2022-07-02";
-  rev = "5e7aea957c82b67d4364b2b88999805616e3b01d";
-  sourceSha256 = "sha256-tjkoaHCuVdvgE6X+7Kb8mt9oxINWs4R0xD9cxdEeYKk=";
-}

--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, itk, python3, Cocoa }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, itk_5_2, python3, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname    = "elastix";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake python3 ];
-  buildInputs = [ itk ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+  buildInputs = [ itk_5_2 ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 
   doCheck = !stdenv.isDarwin;  # usual dynamic linker issues
 

--- a/pkgs/development/libraries/simpleitk/default.nix
+++ b/pkgs/development/libraries/simpleitk/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, swig4, lua, itk }:
+{ lib, stdenv, fetchFromGitHub, cmake, swig4, lua, itk_5_2 }:
 
 stdenv.mkDerivation rec {
   pname = "simpleitk";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake swig4 ];
-  buildInputs = [ lua itk ];
+  buildInputs = [ lua itk_5_2 ];
 
   # 2.0.0: linker error building examples
   cmakeFlags = [ "-DBUILD_EXAMPLES=OFF" "-DBUILD_SHARED_LIBS=ON" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20000,11 +20000,11 @@ with pkgs;
     nodejs = nodejs-14_x;
   };
 
-  itk_5 = callPackage ../development/libraries/itk/5.x.nix {
+  itk_5_2 = callPackage ../development/libraries/itk/5.2.x.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
-  itk-unstable = callPackage ../development/libraries/itk/unstable.nix {
+  itk_5 = callPackage ../development/libraries/itk/5.x.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 


### PR DESCRIPTION
###### Description of changes

Previously we had itk 5.2.1 and itk-unstable tracking the 5.3 branch (used only by the `ANTs` package).  Due to the ITK 5.3.0 release, this PR replaces itk-unstable with 5.3.0 and makes it the default and renames 5.2.1 to itk_5_2.  Even though only one package has so far switched to it out of the 5 or so packages depending on ITK directly, it seems to make 5.3.x the default in the interest of forward compatibility (VTK in Nixpkgs made the opposite decision and it's been annoying to get things updated, although perhaps not for technical reasons).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
