### PR TITLE
openvswitch: 3.0.1 -> 3.0.3; openvswitch-lts: 2.17.3 -> 2.17.5

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "3.0.1";
-  hash = "sha256-5KEXFtCRn1syOSKLMrrcEJtWGl/maLlUfhQ7CxlbvWg=";
+  version = "3.0.3";
+  hash = "sha256-9QZlCnbx8s7737WD80NBIQLxcKvFXG/4dWd5Jrm9lGM=";
 }

--- a/pkgs/os-specific/linux/openvswitch/lts.nix
+++ b/pkgs/os-specific/linux/openvswitch/lts.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "2.17.3";
-  hash = "sha256-RGgR/JGuJFzDGQSmk3H7C/BEb3sk6yOaA320ADUwEcA=";
+  version = "2.17.5";
+  hash = "sha256-Woye+zUikjdGWIp8pRDBC7CsUrnInfJ23byGcxFtwQY=";
 }


### PR DESCRIPTION
https://www.openwall.com/lists/oss-security/2022/12/20/2

Fixes LLDP underflow issue while parsing malformed Auto Attach TLVs.

https://www.openvswitch.org/releases/NEWS-2.17.4.txt
https://www.openvswitch.org/releases/NEWS-2.17.5.txt

https://www.openvswitch.org/releases/NEWS-3.0.2.txt
https://www.openvswitch.org/releases/NEWS-3.0.3.txt

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
