### PR TITLE
Speed up application startup by using `ld.so.cache`

### DIFF
--- a/pkgs/build-support/setup-hooks/generate-ld-cache.sh
+++ b/pkgs/build-support/setup-hooks/generate-ld-cache.sh
@@ -1,0 +1,42 @@
+# shellcheck shell=bash
+
+fixupOutputHooks+=('if [ -z "${dontGenerateLDCache-}" ]; then generateLDCache "$prefix"; fi')
+
+generateLDCache() {
+    local dir="$1"
+    [ -e "$dir" ] || return 0
+
+    echo "generating LD cache for ELF executables in $dir"
+
+    declare -a libDirs
+
+    local i
+    while IFS= read -r -d $'\0' i; do
+        if [[ "$i" =~ .build-id ]]; then continue; fi
+        if ! isELF "$i"; then continue; fi
+
+        local lib
+        while IFS= read -r lib; do
+            lib="$(echo -n "$lib" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | cut -d ' ' -f 3)"
+            if [ -n "$lib" ]; then
+                echo "found lib: $lib"
+
+                local dir="$(dirname "$lib")"
+
+                if [[ ! " ${libDirs[*]} " =~ " $dir " ]]; then
+                    libDirs+=("$dir")
+                fi
+            fi
+        done < <(ldd "$i")
+    done < <(find "$dir" -mindepth 2 -maxdepth 2 -type f -print0) # we only want $dir/x/y, not $dir/x/y/z or $dir/x
+
+    (( ${#libDirs[@]} != 0 )) || return 0
+
+    echo "found lib dirs: ${libDirs[*]}"
+
+    mkdir -p "$out/etc"
+
+    echo "$(IFS=$'\n'; echo "${libDirs[*]}")" > "$TMPDIR/ld.so.conf"
+
+    ldconfig -f "$TMPDIR/ld.so.conf" -C "$out/etc/ld.so.cache" || echo "failed to generate LD cache"
+}

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -30,6 +30,7 @@
 , libidn2
 , bison
 , python3Minimal
+, substitute
 }:
 
 { pname
@@ -92,6 +93,11 @@ stdenv.mkDerivation ({
       ./nix-nss-open-files.patch
 
       ./0001-Revert-Remove-all-usage-of-BASH-or-BASH-in-installed.patch
+
+      (substitute {
+        src = ./dl-cache.patch;
+        replacements = [ "--replace" "@STORE_DIRECTORY@" "\"${builtins.storeDir}\"" ];
+      })
     ]
     ++ lib.optional stdenv.hostPlatform.isMusl ./fix-rpc-types-musl-conflicts.patch
     ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch;

--- a/pkgs/development/libraries/glibc/dl-cache.patch
+++ b/pkgs/development/libraries/glibc/dl-cache.patch
@@ -1,0 +1,140 @@
+Read the shared library cache relative to $ORIGIN instead of reading
+from /etc/ld.so.cache.  Also arrange so that this cache takes
+precedence over RUNPATH.
+
+diff --git a/elf/dl-cache.c b/elf/dl-cache.c
+index 93d185e788..e0760a1f40 100644
+--- a/elf/dl-cache.c
++++ b/elf/dl-cache.c
+@@ -171,6 +171,51 @@ _dl_cache_libcmp (const char *p1, const char *p2)
+   return *p1 - *p2;
+ }
+ 
++/* Special value representing the lack of an ld.so cache.  */
++static const char ld_so_cache_lacking[] = "/ld.so cache is lacking";
++
++/* Return the per-application ld.so cache, relative to $ORIGIN, or NULL if
++   that fails for some reason.  Do not return the system-wide LD_SO_CACHE
++   since on a foreign distro it would contain invalid information.  */
++static const char *
++ld_so_cache (void)
++{
++  static const char *loader_cache;
++
++  if (loader_cache == NULL)
++    {
++      static const char store[] = @STORE_DIRECTORY@;
++      const char *origin = _dl_get_origin ();
++
++      /* Check whether ORIGIN is something like "/gnu/store/…-foo/bin".  */
++      if (strncmp (store, origin, strlen (store)) == 0
++	  && origin[sizeof store - 1] == '/')
++	{
++	  char *store_item_end = strchr (origin + sizeof store, '/');
++
++	  if (store_item_end != NULL)
++	    {
++	      static const char suffix[] = "/etc/ld.so.cache";
++	      size_t store_item_len = store_item_end - origin;
++
++	      /* Note: We can't use 'malloc' because it can be interposed.
++		 Likewise, 'strncpy' is not available.  */
++	      char *cache = alloca (strlen (origin) + sizeof suffix);
++
++	      strcpy (cache, origin);
++	      strcpy (cache + store_item_len, suffix);
++
++	      loader_cache = __strdup (cache) ?: ld_so_cache_lacking;
++	    }
++	  else
++	    loader_cache = ld_so_cache_lacking;
++	}
++      else
++	loader_cache = ld_so_cache_lacking;
++    }
++
++  return loader_cache;
++}
+ 
+ /* Look up NAME in ld.so.cache and return the file name stored there, or null
+    if none is found.  The cache is loaded if it was not already.  If loading
+@@ -190,12 +235,15 @@ _dl_load_cache_lookup (const char *name)
+ 
+   /* Print a message if the loading of libs is traced.  */
+   if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
+-    _dl_debug_printf (" search cache=%s\n", LD_SO_CACHE);
++    _dl_debug_printf (" search cache=%s\n", ld_so_cache ());
++
++  if (__glibc_unlikely (ld_so_cache () == ld_so_cache_lacking))
++    return NULL;
+ 
+   if (cache == NULL)
+     {
+       /* Read the contents of the file.  */
+-      void *file = _dl_sysdep_read_whole_file (LD_SO_CACHE, &cachesize,
++      void *file = _dl_sysdep_read_whole_file (ld_so_cache (), &cachesize,
+ 					       PROT_READ);
+ 
+       /* We can handle three different cache file formats here:
+diff --git a/elf/dl-load.c b/elf/dl-load.c
+index f3201e7c14..a69aec3428 100644
+--- a/elf/dl-load.c
++++ b/elf/dl-load.c
+@@ -2152,28 +2152,6 @@ _dl_map_object (struct link_map *loader, const char *name,
+ 			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
+ 			LA_SER_LIBPATH, &found_other_class);
+ 
+-      /* Look at the RUNPATH information for this binary.  */
+-      if (fd == -1 && loader != NULL
+-	  && cache_rpath (loader, &loader->l_runpath_dirs,
+-			  DT_RUNPATH, "RUNPATH"))
+-	fd = open_path (name, namelen, mode,
+-			&loader->l_runpath_dirs, &realname, &fb, loader,
+-			LA_SER_RUNPATH, &found_other_class);
+-
+-      if (fd == -1)
+-        {
+-          realname = _dl_sysdep_open_object (name, namelen, &fd);
+-          if (realname != NULL)
+-            {
+-              fd = open_verify (realname, fd,
+-                                &fb, loader ?: GL(dl_ns)[nsid]._ns_loaded,
+-                                LA_SER_CONFIG, mode, &found_other_class,
+-                                false);
+-              if (fd == -1)
+-                free (realname);
+-            }
+-        }
+-
+ #ifdef USE_LDCONFIG
+       if (fd == -1
+ 	  && (__glibc_likely ((mode & __RTLD_SECURE) == 0)
+@@ -2232,6 +2210,28 @@ _dl_map_object (struct link_map *loader, const char *name,
+ 	}
+ #endif
+ 
++      /* Look at the RUNPATH information for this binary.  */
++      if (fd == -1 && loader != NULL
++	  && cache_rpath (loader, &loader->l_runpath_dirs,
++			  DT_RUNPATH, "RUNPATH"))
++	fd = open_path (name, namelen, mode,
++			&loader->l_runpath_dirs, &realname, &fb, loader,
++			LA_SER_RUNPATH, &found_other_class);
++
++      if (fd == -1)
++        {
++          realname = _dl_sysdep_open_object (name, namelen, &fd);
++          if (realname != NULL)
++            {
++              fd = open_verify (realname, fd,
++                                &fb, loader ?: GL(dl_ns)[nsid]._ns_loaded,
++                                LA_SER_CONFIG, mode, &found_other_class,
++                                false);
++              if (fd == -1)
++                free (realname);
++            }
++        }
++
+       /* Finally, try the default path.  */
+       if (fd == -1
+ 	  && ((l = loader ?: GL(dl_ns)[nsid]._ns_loaded) == NULL

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -71,7 +71,8 @@ let
       ../../build-support/setup-hooks/reproducible-builds.sh
       ../../build-support/setup-hooks/set-source-date-epoch-to-latest.sh
       ../../build-support/setup-hooks/strip.sh
-    ] ++ lib.optionals hasCC [ cc ];
+    ] ++ lib.optionals hostPlatform.isLinux [ ../../build-support/setup-hooks/generate-ld-cache.sh ]
+      ++ lib.optionals hasCC [ cc ];
 
   defaultBuildInputs = extraBuildInputs;
 


### PR DESCRIPTION
###### Description of changes

This PR does two things:
1. Patch glibc's dynamic loader to load the ld.so cache from `$ORIGIN/../etc/ld.so.cache` instead of `/etc/ld.so.cache`, and to prefer the cache over `RPATH` entries
2. Introduce a new setup hook, `generate-ld-cache`, to facilitate the generation of these caches

This was originally implemented by Guix's Ludovic Courtès in August of 2021 (after Ricardo came up with the idea) -- see [their blog post](https://guix.gnu.org/en/blog/2021/taming-the-stat-storm-with-a-loader-cache/) and [their discussion](https://issues.guix.gnu.org/44899) on the change for more information + some benchmarks. The glibc patch is copied verbatim from the Guix codebase.

As noted in the linked Guix issue, there are a few things to consider here:
- The hard-coded `$ORIGIN/../etc/ld.so.cache` path means that it can only be used with first-level sub-directories like `bin` and `sbin`
- There is a possibility that users could be tricked into loading a malicious `ld.so.cache`
- If you read the discussion, you'll note that I omitted one of their points here: that transient dependencies aren't added to the cache. Our implementation actually *does include* transient dependencies, because we use `ldd` to get the required dependencies, as opposed to just using the data from the ELF.

When discussing this with pennae, they brought up the idea of embedding an absolute path to the cache in an ELF section, and adjusting the patch to do that. We may want to do this instead; I'd appreciate thoughts on the matter.

I'd like to thank the Guix folks mentioned above for originally coming up with and implementing this idea, as well as pennae for nerd sniping me into looking at perf stuff, and their thoughts on the matter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
