### PR TITLE
warpd: 1.3.4 -> 1.3.5

### DIFF
--- a/pkgs/applications/misc/warpd/default.nix
+++ b/pkgs/applications/misc/warpd/default.nix
@@ -2,35 +2,29 @@
 , stdenv
 , fetchFromGitHub
 , git
-, libXi
-, libXinerama
-, libXft
-, libXfixes
-, libXtst
-, libX11
-, libXext
-, waylandSupport ? false, cairo, libxkbcommon, wayland
+, withWayland ? true, cairo, libxkbcommon, wayland
+, withX ? true, libXi, libXinerama, libXft, libXfixes, libXtst, libX11, libXext
 }:
 
 stdenv.mkDerivation rec {
   pname = "warpd";
-  version = "1.3.4";
+  version = "1.3.5";
 
   src = fetchFromGitHub {
     owner = "rvaiya";
     repo = "warpd";
     rev = "v${version}";
-    sha256 = "sha256-aNv2/+tREvKlpTAsbvmFxkXzONNt73/061i4E3fPFBM=";
+    hash = "sha256-5B3Ec+R1vF2iI0ennYcsRlnFXJkSns0jVbyAWJA4lTU=";
     leaveDotGit = true;
   };
 
   nativeBuildInputs = [ git ];
 
-  buildInputs =  if waylandSupport then [
+  buildInputs = lib.optionals withWayland [
     cairo
     libxkbcommon
     wayland
-  ] else [
+  ] ++ lib.optionals withX [
     libXi
     libXinerama
     libXft
@@ -40,10 +34,12 @@ stdenv.mkDerivation rec {
     libXext
   ];
 
-  makeFlags = [ "PREFIX=$(out)" ] ++ lib.optionals waylandSupport [ "PLATFORM=wayland" ];
+  makeFlags = [ "PREFIX=$(out)" ]
+    ++ lib.optional (!withWayland) "DISABLE_WAYLAND=y"
+    ++ lib.optional (!withX) "DISABLE_X=y";
 
   postPatch = ''
-    substituteInPlace Makefile \
+    substituteInPlace mk/linux.mk \
       --replace '-m644' '-Dm644' \
       --replace '-m755' '-Dm755' \
       --replace 'warpd.1.gz $(DESTDIR)' 'warpd.1.gz -t $(DESTDIR)' \


### PR DESCRIPTION
###### Description of changes

Rewrites part of warpd's declaration as the make/install process between 1.3.4 and 1.3.5 has changed somewhat. Prior to this release, warpd released as two binaries (one for Xorg, one for Wayland); these changes make warpd into a single executable with flags allowing for the Wayland and/or Xorg bits to be left out. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 207065` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>warpd</li>
  </ul>
</details>