### PR TITLE
ocamlPackages.jwto: 0.3.0 → 0.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/jwto/default.nix
+++ b/pkgs/development/ocaml-modules/jwto/default.nix
@@ -1,26 +1,26 @@
-{ lib, buildDunePackage, fetchFromGitHub, alcotest, cryptokit, fmt, yojson
+{ lib, buildDunePackage, fetchFromGitHub, alcotest, digestif, fmt, yojson
 , ppxlib
 , base64, re, ppx_deriving }:
 
 buildDunePackage rec {
   pname = "jwto";
-  version = "0.3.0";
+  version = "0.4.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.05";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "sporto";
     repo = "jwto";
     rev = version;
-    sha256 = "1p799zk8j9c0002xzi2x7ndj1bzqf14744ampcqndrjnsi7mq71s";
+    hash = "sha256-TOWwNyrOqboCm8Y4mM6GgtmxGO3NmyDdAX7m8CifA7Y=";
   };
 
   buildInputs = [ ppxlib ];
 
   propagatedBuildInputs =
-    [ cryptokit fmt yojson base64 re ppx_deriving ];
+    [ digestif fmt yojson base64 re ppx_deriving ];
 
   checkInputs = [ alcotest ];
 


### PR DESCRIPTION
###### Description of changes

https://github.com/sporto/jwto/blob/0.4.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainers @Zimmi48 @jtcoolen 