### PR TITLE
golden-cheetah: add AppImage derivation

### DIFF
--- a/pkgs/applications/misc/golden-cheetah-bin/default.nix
+++ b/pkgs/applications/misc/golden-cheetah-bin/default.nix
@@ -1,0 +1,35 @@
+{ appimageTools, lib, fetchurl, stdenv }:
+let
+
+  pname = "golden-cheetah";
+  version = "3.6-RC3";
+
+  src = fetchurl {
+    url = "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/v${version}/GoldenCheetah_v3.6-DEV_x64.AppImage";
+    hash = "sha256-Bp1IFql96tHc5ssg9nhTrFQqNtaM+5iYJguPGkguvns=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname src version; };
+in
+appimageTools.wrapType2 {
+  inherit pname src version;
+
+  extraPkgs = pkgs: with pkgs; [ R zlib libusb-compat-0_1 ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/GoldenCheetah
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/pixmaps
+    cp ${appimageContents}/GoldenCheetah.desktop $out/share/applications/
+    cp ${appimageContents}/gc.png $out/share/pixmaps/
+  '';
+
+  meta = with lib; {
+    description = "Performance software for cyclists, runners and triathletes. This version includes the API Tokens for e.g. Strava";
+    platforms = platforms.linux;
+    broken = !stdenv.isx86_64;
+    maintainers = with maintainers; [ gador ];
+    license = licenses.gpl2Plus;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -74,7 +74,7 @@ in mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Performance software for cyclists, runners and triathletes";
+    description = "Performance software for cyclists, runners and triathletes. Built from source and without API tokens";
     platforms = platforms.linux;
     maintainers = [ ];
     license = licenses.gpl2Plus;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37919,6 +37919,8 @@ with pkgs;
 
   golden-cheetah = libsForQt5.callPackage ../applications/misc/golden-cheetah {};
 
+  golden-cheetah-bin = callPackage ../applications/misc/golden-cheetah-bin {};
+
   linkchecker = callPackage ../tools/networking/linkchecker { };
 
   tomb = callPackage ../os-specific/linux/tomb {};


### PR DESCRIPTION
###### Description of changes

Upstream bakes their API tokens for external services (like Strava) in its source. When users want to connect golden-cheetah to the external services, they fail and there is no option to add own API keys during runtime.

So either the user modifies the derivation to add their own API keys during build, or we add the pre-build AppImage to NixOS. This has the developers API keys built-in, so the connection to external services work as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
