### PR TITLE
Mathematica: Allow overriding src directly.

### DIFF
--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -5,6 +5,24 @@
 , cudaSupport ? config.cudaSupport or false
 , lang ? "en"
 , version ? null
+/*
+If you wish to completely override the src, use:
+my_mathematica = mathematica.override {
+  source = pkgs.requireFile {
+    name = "Mathematica_XX.X.X_BNDL_LINUX.sh";
+    # Get this hash via a command similar to this:
+    # nix-store --query --hash \
+    # $(nix store add-path Mathematica_XX.X.X_BNDL_LINUX.sh --name 'Mathematica_XX.X.X_BNDL_LINUX.sh')
+    sha256 = "0000000000000000000000000000000000000000000000000000";
+    message = ''
+      Your override for Mathematica includes a different src for the installer,
+      and it is missing.
+    '';
+    hashMode = "recursive";
+  };
+}
+*/
+, source ? null
 }:
 
 let versions = callPackage ./versions.nix { };
@@ -38,7 +56,8 @@ in
 
 callPackage real-drv {
   inherit cudaSupport cudaPackages;
-  inherit (found-version) version lang src;
+  inherit (found-version) version lang;
+  src = if source == null then found-version.src else source;
   name = ("mathematica"
           + lib.optionalString cudaSupport "-cuda"
           + "-${found-version.version}"


### PR DESCRIPTION
###### Description of changes

Today I got the installer for Mathematica 13.1.0 that my university provides. The hash that `versions.nix` has for 13.1.0 is different then the hash I got with this command:

```
nix-store --add-fixed sha256 Mathematica_13.1.0_LINUX.sh
```

Also the file name was different then what `versions.nix` expects - my filename missed the `BNDL` word - indicating that it is indeed a different file. Still I'd like to get Mathematica working with the installer I downloaded, so I figured that the solution proposed here is the best we can get.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
