### PR TITLE
catppuccin-cursors: unstable-2022-08-23 -> 0.2.0

### DIFF
--- a/pkgs/data/icons/catppuccin-cursors/default.nix
+++ b/pkgs/data/icons/catppuccin-cursors/default.nix
@@ -1,9 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
-, inkscape
-, xcursorgen
-, makeFontsConf
+, unzip
 }:
 
 let
@@ -15,37 +13,24 @@ let
   variantName = { palette, color }: (lib.strings.toLower palette) + color;
   variants = map variantName product;
 in
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation rec {
   pname = "catppuccin-cursors";
-  version = "unstable-2022-08-23";
+  version = "0.2.0";
+  dontBuild = true;
 
   src = fetchFromGitHub {
     owner = "catppuccin";
     repo = "cursors";
-    rev = "3d3023606939471c45cff7b643bffc5d5d4ff29c";
-    sha256 = "1z9cjxxsj3vrmhsw1k05b31zmncz1ksaswc4r1k3vd2mmpigq1nk";
+    rev = "v${version}";
+    sha256 = "sha256-TgV5f8+YWR+h61m6WiBMg3aBFnhqShocZBdzZHSyU2c=";
+    sparseCheckout = [ "cursors" ];
   };
+
+  nativeBuildInputs = [ unzip ];
 
   outputs = variants ++ [ "out" ]; # dummy "out" output to prevent breakage
 
   outputsToInstall = [];
-
-  nativeBuildInputs = [
-    inkscape
-    xcursorgen
-  ];
-
-  postPatch = ''
-    patchShebangs ./build.sh
-  '';
-
-  # Make fontconfig stop warning about being unable to load config
-  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
-
-  # Make inkscape stop warning about being unable to create profile directory
-  preBuild = ''
-    export HOME="$NIX_BUILD_ROOT"
-  '';
 
   installPhase = ''
     runHook preInstall
@@ -61,7 +46,7 @@ stdenvNoCC.mkDerivation {
         local variant=$(sed 's/\([A-Z]\)/-\1/g' <<< "$output")
         local variant=''${variant^}
 
-        cp -r dist/Catppuccin-"$variant"-Cursors "$iconsDir"
+        unzip "cursors/Catppuccin-$variant-Cursors.zip" -d "$iconsDir"
       fi
     done
 


### PR DESCRIPTION
###### Description of changes
Places the cursor files from `cursors/` into the correct directory instead of building.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).