### PR TITLE
nixos/installation-cd-minimal: disable `noXlibs`

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix
@@ -9,6 +9,9 @@
     ./installation-cd-base.nix
   ];
 
+  # Causes a lot of uncached builds for a negligible decrease in size.
+  environment.noXlibs = lib.mkOverride 500 false;
+
   documentation.man.enable = lib.mkOverride 500 true;
 
   fonts.fontconfig.enable = lib.mkForce false;


### PR DESCRIPTION
Causes a lot of uncached builds for a negligible decrease in size (822 → 821 MiB currently).

See https://github.com/NixOS/nixpkgs/pull/205318, I don't know if `noXlibs` makes sense in general for the minimal profile, but at least this seems uncontroversial.

(In fact, I think a general "minimal" profile does not make sense, precisely because of this kind of questions.)