### PR TITLE
nix-monitored: init + nixos module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -25,6 +25,14 @@
     <itemizedlist>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/ners/nix-monitored">nix-monitored</link>,
+          a transparent wrapper around Nix that pipes its output through
+          Nix Output Monitor. Available as
+          <link xlink:href="options.html#opt-nix.monitored.enable">nix.monitored.enable</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://akkoma.social">Akkoma</link>, an
           ActivityPub microblogging server. Available as
           <link xlink:href="options.html#opt-services.akkoma.enable">services.akkoma</link>.

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -14,6 +14,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [nix-monitored](https://github.com/ners/nix-monitored), a transparent wrapper around Nix that pipes its output through Nix Output Monitor. Available as [nix.monitored.enable](options.html#opt-nix.monitored.enable).
+
 - [Akkoma](https://akkoma.social), an ActivityPub microblogging server. Available as [services.akkoma](options.html#opt-services.akkoma.enable).
 
 - [blesh](https://github.com/akinomyoga/ble.sh), a line editor written in pure bash. Available as [programs.bash.blesh](#opt-programs.bash.blesh.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -203,6 +203,7 @@
   ./programs/nethoscope.nix
   ./programs/nix-index.nix
   ./programs/nix-ld.nix
+  ./programs/nix-monitored.nix
   ./programs/nm-applet.nix
   ./programs/nncp.nix
   ./programs/noisetorch.nix

--- a/nixos/modules/programs/nix-monitored.nix
+++ b/nixos/modules/programs/nix-monitored.nix
@@ -10,12 +10,22 @@ in
     enable = mkEnableOption (mdDoc "nix-monitored, an improved output formatter for Nix");
     notify = mkEnableOption (mdDoc "notifications using libnotify");
     package = mkPackageOption pkgs "nix-monitored" { };
+    fallbackPackage = mkOption {
+      type = types.package;
+      description = mdDoc ''
+        The nix package to additionally install as a fallback to nix-monitored.
+        This package can be selected with `which -a nix`.
+      '';
+      default = pkgs.nix;
+      defaultText = literalExpression "pkgs.nix";
+    };
   };
 
   config =
     let package = cfg.package.override { withNotify = cfg.notify; }; in
     lib.mkIf cfg.enable {
       nix.package = package;
+      environment.systemPackages = [ cfg.fallbackPackage ];
       nixpkgs.overlays = [
         (self: super: {
           nixos-rebuild = super.nixos-rebuild.override {

--- a/nixos/modules/programs/nix-monitored.nix
+++ b/nixos/modules/programs/nix-monitored.nix
@@ -1,0 +1,30 @@
+{ pkgs, lib, config, ... }:
+
+let
+  cfg = config.nix.monitored;
+in
+{
+  meta.maintainers = [ lib.maintainers.ners ];
+
+  options.nix.monitored = with lib; {
+    enable = mkEnableOption (mdDoc "nix-monitored, an improved output formatter for Nix");
+    notify = mkEnableOption (mdDoc "notifications using libnotify");
+    package = mkPackageOption pkgs "nix-monitored" { };
+  };
+
+  config =
+    let package = cfg.package.override { withNotify = cfg.notify; }; in
+    lib.mkIf cfg.enable {
+      nix.package = package;
+      nixpkgs.overlays = [
+        (self: super: {
+          nixos-rebuild = super.nixos-rebuild.override {
+            nix = package;
+          };
+          nix-direnv = super.nix-direnv.override {
+            nix = package;
+          };
+        })
+      ];
+    };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -457,6 +457,7 @@ in {
   nifi = handleTestOn ["x86_64-linux"] ./web-apps/nifi.nix {};
   nitter = handleTest ./nitter.nix {};
   nix-ld = handleTest ./nix-ld.nix {};
+  nix-monitored = handleTest ./nix-monitored.nix {};
   nix-serve = handleTest ./nix-serve.nix {};
   nix-serve-ssh = handleTest ./nix-serve-ssh.nix {};
   nixops = handleTest ./nixops/default.nix {};

--- a/nixos/tests/nix-monitored.nix
+++ b/nixos/tests/nix-monitored.nix
@@ -1,0 +1,30 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+  let nix-monitored = attrs: pkgs.nix-monitored.override attrs; in
+  {
+    name = "nix-monitored";
+    nodes.withNotify = { pkgs, ... }: {
+      environment.systemPackages = with pkgs; [ expect ];
+      nix.monitored.enable = true;
+      nix.monitored.notify = true;
+    };
+    nodes.withoutNotify = { pkgs, ... }: {
+      environment.systemPackages = with pkgs; [ expect ];
+      nix.monitored.enable = true;
+    };
+    testScript = ''
+      start_all()
+
+      machines = [withNotify, withoutNotify]
+      packages = ["${nix-monitored { withNotify = true; }}", "${nix-monitored { withNotify = false; }}"]
+
+      for (machine, package) in zip(machines, packages):
+        for binary in ["nix", "nix-build", "nix-shell"]:
+          actual = machine.succeed(f"readlink $(which {binary})")
+          expected = f"{package}/bin/{binary}"
+          assert expected == actual.strip(), f"{binary} binary is {actual}, expected {expected}"
+
+        actual = machine.succeed("unbuffer nix --version")
+        expected = "nix-output-monitor ${pkgs.nix-output-monitor.version}\nnix (Nix) ${pkgs.nix.version}"
+        assert expected == actual.strip(), f"version string is {actual}, expected {expected}"
+    '';
+  })

--- a/nixos/tests/nix-monitored.nix
+++ b/nixos/tests/nix-monitored.nix
@@ -26,5 +26,9 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
         actual = machine.succeed("unbuffer nix --version")
         expected = "nix-output-monitor ${pkgs.nix-output-monitor.version}\nnix (Nix) ${pkgs.nix.version}"
         assert expected == actual.strip(), f"version string is {actual}, expected {expected}"
+
+        actual = machine.succeed("which -a nix")
+        expected = "/run/current-system/sw/bin/nix\n${pkgs.nix}/bin/nix"
+        assert expected == actual.strip(), f"nix paths are {actual}, expected {expected}"
     '';
   })

--- a/pkgs/tools/nix/nix-monitored/default.nix
+++ b/pkgs/tools/nix/nix-monitored/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, nix
+, nix-output-monitor
+, withNotify ? stdenv.isLinux
+, libnotify
+, nixos-icons
+}: stdenv.mkDerivation rec {
+  pname = "nix-monitored";
+  version = "${nix.version}-${builtins.substring 0 7 src.rev}";
+
+  src = fetchFromGitHub {
+    owner = "ners";
+    repo = "nix-monitored";
+    rev = "c76769ebf25b657fb42ddc9f2e866a6a2e76d85e";
+    hash = "sha256-w+MKdEiPp5BMKxmWKp30W0XSwH5+Ztw8IvRGvZgM7Pg=";
+  };
+
+  inherit (nix) outputs;
+
+  CXXFLAGS = [
+    "-O2"
+    "-DNDEBUG"
+  ] ++ lib.optionals withNotify [
+    "-DNOTIFY"
+  ];
+  makeFlags = [
+    "BIN=nix"
+    "BINDIR=$(out)/bin"
+    "NIXPATH=${lib.makeBinPath ([ nix nix-output-monitor ] ++ lib.optional withNotify libnotify) }"
+  ] ++ lib.optionals withNotify [
+    "NOTIFY_ICON=${nixos-icons}/share/icons/hicolor/32x32/apps/nix-snowflake.png"
+  ];
+
+  postInstall = ''
+    ln -s $out/bin/nix $out/bin/nix-build
+    ln -s $out/bin/nix $out/bin/nix-shell
+    ls ${nix} | while read d; do
+      [ -e "$out/$d" ] || ln -s ${nix}/$d $out/$d
+    done
+    ls ${nix}/bin | while read b; do
+      [ -e $out/bin/$b ] || ln -s ${nix}/bin/$b $out/bin/$b
+    done
+  '' + lib.pipe nix.outputs [
+    (builtins.map (o: ''
+      [ -e "''$${o}" ] || ln -s ${nix.${o}} ''$${o}
+    ''))
+    (builtins.concatStringsSep "\n")
+  ];
+
+  # Nix will try to fixup the propagated outputs (e.g. nix-dev), to which it has
+  # no write permission when building this derivation.
+  # We don't actually need any fixup, as the derivation we are building is a native Nix build,
+  # and all the propagated outputs have already been fixed up for the Nix derivation.
+  dontFixup = true;
+
+  meta = with lib; {
+    description = "A transparent wrapper around Nix that pipes its output through Nix Output Monitor";
+    homepage = "https://github.com/ners/nix-monitored";
+    license = licenses.mit;
+    mainProgram = "nix";
+    maintainers = with maintainers; [ ners ];
+    platforms = platforms.unix;
+    inherit (nix.meta) outputsToInstall;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37262,6 +37262,8 @@ with pkgs;
 
   nixos-option = callPackage ../tools/nix/nixos-option { nix = nixVersions.nix_2_3; };
 
+  nix-monitored = callPackage ../tools/nix/nix-monitored { };
+
   nix-pin = callPackage ../tools/package-management/nix-pin { };
 
   nix-prefetch = callPackage ../tools/package-management/nix-prefetch { };


### PR DESCRIPTION
###### Description of changes

# Democratising pretty Nix output

![](https://github.com/maralorn/nix-output-monitor/raw/main/example-screenshot.png)

## Dramatis personae

*Nix*
A beloved package manager and build system used by many. But beneath its veneer of elegance hides a dated user interface . . .

*Nix Output Monitor*
A companion to Nix, hailing from https://github.com/maralorn/nix-output-monitor. Not many people know of it, but those who do are happier for it. Its reclusive nature makes it difficult to call upon.

*nix-monitored*
Our hero, saviour of UX. A transparent wrapper around Nix, it reunites it with its great friend, Nix Output Monitor.

*NixOS*
An operating system *extraordinaire*. Only with its power we are able to conduct this play.

*Darwin*
A neighbouring operating system where Nix is also at home. There too may Nix Output Monitor be found; and like in NixOS, nix-darwin allows a modular approach, so long as the package nix-monitored is upstreamed.

## Description

This PR introduces a new Nix package, `nix-monitored`, which executes Nix together with Nix Output Monitor.

It is a wrapper around Nix, designed as a drop-in replacement that can be used in NixOS' `nix.package`.

This is so that users can enjoy better UX with the same commands they're already used to and without having to invoke any new programs.

## Motivation

Everyone I know wants to have nom's pretty output, but no one I know remembers to put `|& nom` after every command. Further, this PR integrates nom with direnv and nixos-rebuild, which is difficult to do without overriding the Nix package.

## Shouldn't this be a shell script / `wrapProgram` / etc.?

The reasons it is C++ rather than a shell wrapper are:
 - It runs on every Nix invocation, so overhead should be minimal.
 - Building C++ is trivial with `stdenv`.
 - Nix itself is C++, so it should be easier to maintain.
 - Bash is notoriously terrible with string / parameter manipulation. The first version of this wrapper was Bash, and I kept running into weird string splitting errors, despite using `"$@"`.

## Does it work?

I've been using this implementation in my configs for some months now with no issues. In particular I use it with:
 - nix commands on the CLI
 - nix-direnv
 - nixos-rebuild

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
