### PR TITLE
pwndbg: 2022.08.30 -> 2022.12.19

### DIFF
--- a/pkgs/development/tools/misc/pwndbg/default.nix
+++ b/pkgs/development/tools/misc/pwndbg/default.nix
@@ -22,7 +22,7 @@ let
     python3.pkgs.pwntools   # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/wrappers/checksec.py#L8
   ] ++ lib.optionals stdenv.isLinux [
     python3.pkgs.ropper     # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/commands/ropper.py#L30
-    python3.pkgs.ROPGadget  # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/commands/rop.py#L32
+    python3.pkgs.ropgadget  # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/commands/rop.py#L32
   ]);
 
 in stdenv.mkDerivation rec {

--- a/pkgs/development/tools/misc/pwndbg/default.nix
+++ b/pkgs/development/tools/misc/pwndbg/default.nix
@@ -8,38 +8,45 @@
 
 let
   pythonPath = with python3.pkgs; makePythonPath [
+    capstone
     future
-    isort
     psutil
+    pwntools
     pycparser
     pyelftools
-    python-ptrace
-    ropgadget
-    six
-    unicorn
     pygments
+    unicorn
+    rpyc
   ];
+  binPath = lib.makeBinPath ([
+    python3.pkgs.pwntools   # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/wrappers/checksec.py#L8
+  ] ++ lib.optionals stdenv.isLinux [
+    python3.pkgs.ropper     # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/commands/ropper.py#L30
+    python3.pkgs.ROPGadget  # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/commands/rop.py#L32
+  ]);
 
 in stdenv.mkDerivation rec {
   pname = "pwndbg";
-  version = "2022.08.30";
+  version = "2022.12.19";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pwndbg";
     repo = "pwndbg";
     rev = version;
-    sha256 = "sha256-rMdpNJonzbHyTXbnr6MtlVUmfAfLiCHaVSzuQRhtVpE=";
+    sha256 = "sha256-pyY2bMasd6GaJZZjLF48SvkKUBw3XfVa0g3Q0LiEi4k=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/share/pwndbg
-    cp -r *.py pwndbg $out/share/pwndbg
+    cp -r *.py pwndbg gdb-pt-dump $out/share/pwndbg
     chmod +x $out/share/pwndbg/gdbinit.py
     makeWrapper ${gdb}/bin/gdb $out/bin/pwndbg \
       --add-flags "-q -x $out/share/pwndbg/gdbinit.py" \
+      --prefix PATH : ${binPath} \
       --set NIX_PYTHONPATH ${pythonPath}
   '';
 
@@ -48,8 +55,8 @@ in stdenv.mkDerivation rec {
     homepage = "https://github.com/pwndbg/pwndbg";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ mic92 ];
-    # never built on aarch64-darwin since first introduction in nixpkgs
+    maintainers = with maintainers; [ mic92 patryk4815 ];
+    # not supported on aarch64-darwin see: https://inbox.sourceware.org/gdb/3185c3b8-8a91-4beb-a5d5-9db6afb93713@Spark/
     broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
###### Description of changes

There was big release in pwndbg yesterday. So we need update our build :)
aarch64-darwin - gdb still broken, doesn't exist on this platform yet
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] ~~aarch64-darwin~~
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
