### PR TITLE
tvheadend: refactor and use python3

### DIFF
--- a/pkgs/data/misc/dtv-scan-tables/default.nix
+++ b/pkgs/data/misc/dtv-scan-tables/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, v4l-utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dtv-scan-tables";
+  version = "20221027";
+
+  src = fetchFromGitHub {
+    owner = "tvheadend";
+    repo = "dtv-scan-tables";
+    rev = "2a3dbfbab129c00d3f131c9c2f06b2be4c06fec6";
+    hash = "sha256-bJ+naUs3TDFul4PmpnWYld3j1Se+1X6U9jnECe3sno0=";
+  };
+
+  nativeBuildInputs = [
+    v4l-utils
+  ];
+
+  installFlags = [
+    "DATADIR=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "Digital TV scan tables";
+    homepage = "https://github.com/tvheadend/dtv-scan-tables";
+    license = with licenses; [ gpl2Only lgpl21Only ];
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, pkg-config
-, avahi, dbus, gettext, git, gnutar, gzip, bzip2, ffmpeg_4, libiconv, openssl, python2
+, avahi, dbus, gettext, git, gnutar, gzip, bzip2, ffmpeg_4, libiconv, openssl, python3
 , v4l-utils, which, zlib }:
 
 let
@@ -40,11 +40,11 @@ in stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    avahi dbus gettext git gnutar gzip bzip2 ffmpeg_4 libiconv openssl python2
+    avahi dbus gettext git gnutar gzip bzip2 ffmpeg_4 libiconv openssl
     which zlib
   ];
 
-  nativeBuildInputs = [ cmake makeWrapper pkg-config ];
+  nativeBuildInputs = [ cmake makeWrapper pkg-config python3 ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" "-Wno-error=stringop-truncation" ];
 

--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -13,6 +13,7 @@
 , avahi
 , bzip2
 , dbus
+, dtv-scan-tables
 , ffmpeg
 , gettext
 , gnutar
@@ -25,19 +26,6 @@
 
 let
   version = "4.2.8";
-
-  dtv-scan-tables = stdenv.mkDerivation {
-    pname = "dtv-scan-tables";
-    version = "2020-05-18";
-    src = fetchFromGitHub {
-      owner = "tvheadend";
-      repo = "dtv-scan-tables";
-      rev = "e3138a506a064f6dfd0639d69f383e8e576609da";
-      sha256 = "19ac9ds3rfc2xrqcywsbd1iwcpv7vmql7gp01iikxkzcgm2g2b6w";
-    };
-    nativeBuildInputs = [ v4l-utils ];
-    installFlags = [ "DATADIR=$(out)" ];
-  };
 in stdenv.mkDerivation {
   pname = "tvheadend";
   inherit version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -458,6 +458,8 @@ with pkgs;
 
   dsq = callPackage ../tools/misc/dsq { };
 
+  dtv-scan-tables = callPackage ../data/misc/dtv-scan-tables { };
+
   dufs = callPackage ../servers/http/dufs {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
Fix build after #201859 and refactor. More details in the commit messages.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
