### PR TITLE
ratslap: init at 0.4.1

### DIFF
--- a/pkgs/by-name/ra/ratslap/package.nix
+++ b/pkgs/by-name/ra/ratslap/package.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, libusb1
+, pkg-config
+, installShellFiles
+, git
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ratslap";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "krayon";
+    repo = "ratslap";
+    rev = version;
+    sha256 = "sha256-PO/79tTiO4TBtojrEtkSf5W6zuG+Ml2iJGAtYHDwHEY=";
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    git
+  ];
+
+  buildInputs = [
+    libusb1
+  ];
+
+  preBuild = ''
+    makeFlagsArray+=(
+      "-W gitup"
+      "VDIRTY="
+      "MAJVER=${version}"
+      "APPBRANCH=main"
+      "BINNAME=${pname}"
+      "MARKDOWN_GEN="
+      "BUILD_DATE=$(git show -s --date=format:'%Y-%m-%d %H:%M:%S%z' --format=%cd)"
+      "BUILD_MONTH=$(git show -s --date=format:'%B' --format=%cd)"
+      "BUILD_YEAR=$(git show -s --date=format:'%Y' --format=%cd)"
+    )
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ratslap $out/bin
+
+    mv manpage.1 ${pname}.1
+    installManPage ${pname}.1
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Configure G300 and G300s Logitech mice";
+    longDescription = ''
+      A tool to configure Logitech mice on Linux. Supports remapping
+      all buttons and configuring modes, DPI settings and the LED.
+    '';
+    homepage = "https://github.com/krayon/ratslap";
+    changelog = "https://github.com/krayon/ratslap/releases/tag/${version}";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ zebreus ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

[ratslap](https://github.com/krayon/ratslap) is not yet packaged for nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
