### PR TITLE
[staging-22.05] curl: backport 7.87.0 security fixes

### DIFF
--- a/pkgs/tools/networking/curl/CVE-2022-43551.patch
+++ b/pkgs/tools/networking/curl/CVE-2022-43551.patch
@@ -1,0 +1,32 @@
+From b0d4cffd80ff133ddf22848011ff697d481f8655 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 19 Dec 2022 08:36:55 +0100
+Subject: [PATCH] http: use the IDN decoded name in HSTS checks
+
+Otherwise it stores the info HSTS into the persistent cache for the IDN
+name which will not match when the HSTS status is later checked for
+using the decoded name.
+
+Reported-by: Hiroki Kurosawa
+
+Closes #10111
+---
+ lib/http.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/http.c b/lib/http.c
+index b215307dc..3adb57200 100644
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -3643,7 +3643,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
+   else if(data->hsts && checkprefix("Strict-Transport-Security:", headp) &&
+           (conn->handler->flags & PROTOPT_SSL)) {
+     CURLcode check =
+-      Curl_hsts_parse(data->hsts, data->state.up.hostname,
++      Curl_hsts_parse(data->hsts, conn->host.name,
+                       headp + strlen("Strict-Transport-Security:"));
+     if(check)
+       infof(data, "Illegal STS header skipped");
+-- 
+2.38.1
+

--- a/pkgs/tools/networking/curl/CVE-2022-43552.patch
+++ b/pkgs/tools/networking/curl/CVE-2022-43552.patch
@@ -1,0 +1,78 @@
+From 10542332532302f0c3d99f90696574adf24228a6 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 19 Dec 2022 08:38:37 +0100
+Subject: [PATCH] smb/telnet: do not free the protocol struct in *_done()
+
+It is managed by the generic layer.
+
+Reported-by: Trail of Bits
+
+Closes #10112
+---
+ lib/smb.c    | 14 ++------------
+ lib/telnet.c |  3 ---
+ 2 files changed, 2 insertions(+), 15 deletions(-)
+
+diff --git a/lib/smb.c b/lib/smb.c
+index 8f44704a2..a8b729872 100644
+--- a/lib/smb.c
++++ b/lib/smb.c
+@@ -60,8 +60,6 @@ static CURLcode smb_connect(struct Curl_easy *data, bool *done);
+ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done);
+ static CURLcode smb_do(struct Curl_easy *data, bool *done);
+ static CURLcode smb_request_state(struct Curl_easy *data, bool *done);
+-static CURLcode smb_done(struct Curl_easy *data, CURLcode status,
+-                         bool premature);
+ static CURLcode smb_disconnect(struct Curl_easy *data,
+                                struct connectdata *conn, bool dead);
+ static int smb_getsock(struct Curl_easy *data, struct connectdata *conn,
+@@ -76,7 +74,7 @@ const struct Curl_handler Curl_handler_smb = {
+   "SMB",                                /* scheme */
+   smb_setup_connection,                 /* setup_connection */
+   smb_do,                               /* do_it */
+-  smb_done,                             /* done */
++  ZERO_NULL,                            /* done */
+   ZERO_NULL,                            /* do_more */
+   smb_connect,                          /* connect_it */
+   smb_connection_state,                 /* connecting */
+@@ -103,7 +101,7 @@ const struct Curl_handler Curl_handler_smbs = {
+   "SMBS",                               /* scheme */
+   smb_setup_connection,                 /* setup_connection */
+   smb_do,                               /* do_it */
+-  smb_done,                             /* done */
++  ZERO_NULL,                            /* done */
+   ZERO_NULL,                            /* do_more */
+   smb_connect,                          /* connect_it */
+   smb_connection_state,                 /* connecting */
+@@ -939,14 +937,6 @@ static CURLcode smb_request_state(struct Curl_easy *data, bool *done)
+   return CURLE_OK;
+ }
+ 
+-static CURLcode smb_done(struct Curl_easy *data, CURLcode status,
+-                         bool premature)
+-{
+-  (void) premature;
+-  Curl_safefree(data->req.p.smb);
+-  return status;
+-}
+-
+ static CURLcode smb_disconnect(struct Curl_easy *data,
+                                struct connectdata *conn, bool dead)
+ {
+diff --git a/lib/telnet.c b/lib/telnet.c
+index 2abfcd952..8ec3ac2c1 100644
+--- a/lib/telnet.c
++++ b/lib/telnet.c
+@@ -1246,9 +1246,6 @@ static CURLcode telnet_done(struct Curl_easy *data,
+ 
+   curl_slist_free_all(tn->telnet_vars);
+   tn->telnet_vars = NULL;
+-
+-  Curl_safefree(data->req.p.telnet);
+-
+   return CURLE_OK;
+ }
+ 
+-- 
+2.38.1
+

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -87,6 +87,8 @@ stdenv.mkDerivation rec {
     ./CVE-2022-32221.patch
     ./CVE-2022-42915.patch
     ./CVE-2022-42916.patch
+    ./CVE-2022-43551.patch
+    ./CVE-2022-43552.patch
   ] ++ lib.optional patchNetrcRegression ./netrc-regression.patch;
 
   patchFlags = [ "-p1" "--binary" ];


### PR DESCRIPTION
https://curl.se/docs/CVE-2022-43551.html
https://curl.se/docs/CVE-2022-43552.html

Fixes: CVE-2022-43551, CVE-2022-43552

cc #207158 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
