### PR TITLE
rapid-photo-downloader: 0.9.18 -> 0.9.34

### DIFF
--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -1,24 +1,24 @@
-{ lib, mkDerivationWith, fetchurl, python3Packages
+{ lib, mkDerivationWith, fetchFromGitHub, python3Packages
 , file, intltool, gobject-introspection, libgudev
-, udisks, gexiv2, gst_all_1, libnotify
+, udisks, gexiv2, gst_all_1, libnotify, ifuse, libimobiledevice
 , exiftool, gdk-pixbuf, libmediainfo, vmtouch
 }:
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "rapid-photo-downloader";
-  version = "0.9.18";
+  version = "0.9.34";
 
-  src = fetchurl {
-    url = "https://launchpad.net/rapid/pyqt/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "15p7sssg6vmqbm5xnc4j5dr89d7gl7y5qyq44a240yl5aqkjnybw";
+  src = fetchFromGitHub {
+    owner = "damonlynch";
+    repo = "rapid-photo-downloader";
+    rev = "v${version}";
+    hash = "sha256-4VC1fwQh9L3c5tgLUaC36p9QHL4dR2vkWc2XlNl0Xzw=";
   };
 
-  # Disable version check and fix install tests
+  # Disable version check
   postPatch = ''
     substituteInPlace raphodo/constants.py \
       --replace "disable_version_check = False" "disable_version_check = True"
-    substituteInPlace raphodo/rescan.py \
-      --replace "from preferences" "from raphodo.preferences"
   '';
 
   nativeBuildInputs = [
@@ -28,9 +28,15 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
 
   # Package has no generally usable unit tests.
   # The included doctests expect specific, hardcoded hardware to be present.
-  doCheck = false;
+  # Instead, we just make sure the program runs enough to report its version.
+  checkPhase = ''
+    export XDG_DATA_HOME=$(mktemp -d)
+    export QT_QPA_PLATFORM=offscreen
+    $out/bin/rapid-photo-downloader --detailed-version
+  '';
 
-  # NOTE: Without gobject-introspection in buildInputs, launching fails with
+  # NOTE: Without gobject-introspection in buildInputs and strictDeps = false,
+  #       launching fails with:
   #       "Namespace [Notify / GExiv2 / GUdev] not available"
   buildInputs = [
     gdk-pixbuf
@@ -46,7 +52,11 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     udisks
   ];
 
+  strictDeps = false;
+
   propagatedBuildInputs = with python3Packages; [
+    ifuse
+    libimobiledevice
     pyqt5
     pygobject3
     gphoto2
@@ -57,15 +67,19 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     arrow
     python-dateutil
     easygui
+    babel
     colour
+    pillow
+    pyheif
     pymediainfo
     sortedcontainers
-    rawkit
     requests
     colorlog
     pyprind
+    setuptools
+    show-in-file-manager
     tenacity
-  ];
+  ] ++ lib.optional (pythonOlder "3.8") importlib-metadata;
 
   preFixup = ''
     makeWrapperArgs+=(

--- a/pkgs/development/python-modules/pyheif/default.nix
+++ b/pkgs/development/python-modules/pyheif/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cffi
+, libheif
+}:
+
+buildPythonPackage rec {
+  pname = "pyheif";
+  version = "0.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-hqXFF0N51xRrXtGmiJL69yaKE1+39QOaARv7em6QMgA=";
+  };
+
+  propagatedBuildInputs = [ cffi libheif ];
+
+  meta = with lib; {
+    homepage = "https://github.com/carsales/pyheif";
+    description = "Python interface to libheif library";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/show-in-file-manager/default.nix
+++ b/pkgs/development/python-modules/show-in-file-manager/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, importlib-metadata
+, packaging
+, pyxdg
+}:
+
+buildPythonPackage rec {
+  pname = "show-in-file-manager";
+  version = "1.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-FdFuSodbniF7A40C8CnDgAxKatZF4/c8nhB+omurOts=";
+  };
+
+  propagatedBuildInputs = [
+    packaging
+  ]
+  ++ lib.optional (stdenv.isLinux) pyxdg
+  ++ lib.optional (pythonOlder "3.8") importlib-metadata;
+
+  meta = with lib; {
+    homepage = "https://github.com/damonlynch/showinfilemanager";
+    description = "Open the system file manager and select files in it";
+    longDescription = ''
+      Show in File Manager is a Python package to open the system file
+      manager and optionally select files in it. The point is not to
+      open the files, but to select them in the file manager, thereby
+      highlighting the files and allowing the user to quickly do
+      something with them.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7995,6 +7995,8 @@ self: super: with self; {
 
   pyhs100 = callPackage ../development/python-modules/pyhs100 { };
 
+  pyheif = callPackage ../development/python-modules/pyheif { };
+
   pyi2cflash = callPackage ../development/python-modules/pyi2cflash { };
 
   pyialarm = callPackage ../development/python-modules/pyialarm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10286,6 +10286,8 @@ self: super: with self; {
 
   should-dsl = callPackage ../development/python-modules/should-dsl { };
 
+  show-in-file-manager = callPackage ../development/python-modules/show-in-file-manager { };
+
   showit = callPackage ../development/python-modules/showit { };
 
   shtab = callPackage ../development/python-modules/shtab { };


### PR DESCRIPTION
###### Description of changes

- Updates rapid-photo-downloader from 0.9.18 to 0.9.34. ([changelog](https://github.com/damonlynch/rapid-photo-downloader/blob/v0.9.34/CHANGES.md))
    - Major changes: support for iOS devices, better support for high DPI displays, drops dependency on rawkit which is unmaintained.
- Packages new dependency python3Packages.pyheif (https://github.com/carsales/pyheif)
- Packages new dependency python3Packages.show-in-file-manager (https://github.com/damonlynch/showinfilemanager)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).