### PR TITLE
magic-wormhole-rs: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/tools/networking/magic-wormhole-rs/default.nix
+++ b/pkgs/tools/networking/magic-wormhole-rs/default.nix
@@ -3,27 +3,37 @@
 , fetchFromGitHub
 , rustPlatform
 , libxcb
+, installShellFiles
 , Security
 , AppKit
 }:
 rustPlatform.buildRustPackage rec {
   pname = "magic-wormhole-rs";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "magic-wormhole";
     repo = "magic-wormhole.rs";
     rev = version;
-    sha256 = "sha256-+H/IzMxiGz7UVVkEWpmyBepGET9doQFNDvOCZEMF0p4=";
+    sha256 = "sha256-gNHtlbYWQvgboIG++N1680a4ql66PTF45DJGz521zzk=";
   };
 
-  cargoSha256 = "sha256-pRdb5NSqueHmK5vbZfmbDGOz7NQvmUI/pj9KgShiIn0=";
+  cargoSha256 = "sha256-powJrbVVBWtIg0CV7ZdhaVIQA+VhEPtPCts7f8Sl1VY=";
 
   buildInputs = [ libxcb ]
     ++ lib.optionals stdenv.isDarwin [ Security AppKit ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   # all tests involve networking and are bound fail
   doCheck = false;
+
+  postInstall = ''
+    installShellCompletion --cmd wormhole-rs \
+      --bash <($out/bin/wormhole-rs completion bash) \
+      --fish <($out/bin/wormhole-rs completion fish) \
+      --zsh <($out/bin/wormhole-rs completion zsh)
+  '';
 
   meta = with lib; {
     description = "Rust implementation of Magic Wormhole, with new features and enhancements";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
