### PR TITLE
nixos: reusable assertions

### DIFF
--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -404,7 +404,7 @@ in
           inherit fileSystems definitionsDirectory mkfsEnv;
         };
       in
-      lib.asserts.checkAssertWarn cfg.assertions cfg.warnings val;
+      cfg.assertAndWarn val;
   };
 
   meta.maintainers = with lib.maintainers; [

--- a/nixos/modules/misc/assertions.nix
+++ b/nixos/modules/misc/assertions.nix
@@ -1,4 +1,10 @@
-{ lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
+
 {
 
   options = {
@@ -31,8 +37,19 @@
       '';
     };
 
+    assertAndWarn = lib.mkOption {
+      description = ''
+        A function that prints the ${options.warnings} and returns its argument if the ${options.assertions} all pass.
+        Otherwise, it throws an error with the assertion messages.
+      '';
+    };
+
   };
-  # impl of assertions is in
-  # - <nixpkgs/nixos/modules/system/activation/top-level.nix>
-  # - <nixpkgs/nixos/modules/system/service/portable/lib.nix>
+
+  config = {
+
+    assertAndWarn = val: lib.asserts.checkAssertWarn config.assertions config.warnings val;
+
+  };
+
 }

--- a/nixos/modules/misc/assertions.nix
+++ b/nixos/modules/misc/assertions.nix
@@ -44,11 +44,20 @@
       '';
     };
 
+    assertionsAndWarnings = lib.mkOption {
+      description = ''
+        A value that when evaluated, performs the assertions and warnings checks.
+        This option always has value `null`, but its evaluation triggers the side effects.
+      '';
+    };
+
   };
 
   config = {
 
-    assertAndWarn = val: lib.asserts.checkAssertWarn config.assertions config.warnings val;
+    assertAndWarn = val: builtins.seq config.assertionsAndWarnings val;
+
+    assertionsAndWarnings = lib.asserts.checkAssertWarn config.assertions config.warnings null;
 
   };
 

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -80,7 +80,7 @@ let
   );
 
   # Handle assertions and warnings
-  baseSystemAssertWarn = lib.asserts.checkAssertWarn config.assertions config.warnings baseSystem;
+  baseSystemAssertWarn = config.assertAndWarn baseSystem;
 
   # Replace runtime dependencies
   system =


### PR DESCRIPTION
###### Description of changes

Cleaning up some tech debt that we bumped into in https://github.com/NixOS/nixpkgs/pull/207095#discussion_r1054944968

Manually tested by editing `simple.nix`

```
nix-repl> nixosTests.simple
trace: warning: The option `machine' defined in `makeTest parameters' has been renamed to `nodes.machine'.
«derivation /nix/store/x43w4wab5n15q8jb0ivk1q3raycdk8n9-vm-test-run-simple.drv»

```

And of course, the classic:

```
nix-repl> (nixos {}).toplevel
error:
       Failed assertions:
       - The ‘fileSystems’ option does not specify your root file system.
       - You must set the option ‘boot.loader.grub.devices’ or 'boot.loader.grub.mirroredBoots' to make the system bootable.

```

cc @infinisil for a humble improvement in an area where we had more ambitious ideas.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
