### PR TITLE
python3Packages.emborg: init at 1.34

### DIFF
--- a/pkgs/development/python-modules/emborg/default.nix
+++ b/pkgs/development/python-modules/emborg/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pytestCheckHook
+, borgbackup
+, appdirs
+, arrow
+, docopt
+, inform
+, nestedtext
+, parametrize-from-file
+, quantiphy
+, requests
+, shlib
+, voluptuous
+}:
+
+buildPythonPackage rec {
+  pname = "emborg";
+  version = "1.34";
+
+  src = fetchFromGitHub {
+    owner = "KenKundert";
+    repo = "emborg";
+    rev = "v${version}";
+    sha256 = "sha256-bnlELPZzTU9KyVsz5Q0aW9xWvVrgwpowQrjkQvX844g=";
+  };
+
+  format = "flit";
+  checkInputs = [
+    nestedtext
+    parametrize-from-file
+    pytestCheckHook
+    shlib
+    voluptuous
+    borgbackup
+  ];
+  propagatedBuildInputs = [
+    appdirs
+    arrow
+    docopt
+    inform
+    quantiphy
+    requests
+  ];
+
+  # this disables testing fuse mounts
+  MISSING_DEPENDENCIES = "fuse";
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  # this patch fixes a whitespace issue in the message that a test is expecting, https://github.com/KenKundert/emborg/pull/67
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/KenKundert/emborg/commit/afac6d1ddcecdb4bddbec87b6c8eed4cfbf4ebf9.diff";
+      sha256 = "3xg2z03FLKH4ckmiBZqE1FDjpgjgdO8OZL1ewrJlQ4o=";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Interactive command line interface to Borg Backup";
+    homepage = "https://github.com/KenKundert/emborg";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/emborg/default.nix
+++ b/pkgs/development/python-modules/emborg/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , fetchpatch
 , pytestCheckHook
+, pythonOlder
 , borgbackup
 , appdirs
 , arrow
@@ -19,23 +20,17 @@
 buildPythonPackage rec {
   pname = "emborg";
   version = "1.34";
+  format = "flit";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "KenKundert";
     repo = "emborg";
     rev = "v${version}";
-    sha256 = "sha256-bnlELPZzTU9KyVsz5Q0aW9xWvVrgwpowQrjkQvX844g=";
+    hash = "sha256-bnlELPZzTU9KyVsz5Q0aW9xWvVrgwpowQrjkQvX844g=";
   };
 
-  format = "flit";
-  checkInputs = [
-    nestedtext
-    parametrize-from-file
-    pytestCheckHook
-    shlib
-    voluptuous
-    borgbackup
-  ];
   propagatedBuildInputs = [
     appdirs
     arrow
@@ -45,8 +40,18 @@ buildPythonPackage rec {
     requests
   ];
 
+  checkInputs = [
+    nestedtext
+    parametrize-from-file
+    pytestCheckHook
+    shlib
+    voluptuous
+    borgbackup
+  ];
+
   # this disables testing fuse mounts
   MISSING_DEPENDENCIES = "fuse";
+
   postPatch = ''
     patchShebangs .
   '';
@@ -59,9 +64,14 @@ buildPythonPackage rec {
     })
   ];
 
+  pythonImportsCheck = [
+    "emborg"
+  ];
+
   meta = with lib; {
     description = "Interactive command line interface to Borg Backup";
     homepage = "https://github.com/KenKundert/emborg";
+    changelog = "https://github.com/KenKundert/emborg/releases/tag/v${version}";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jpetrucciani ];
   };

--- a/pkgs/development/python-modules/parametrize-from-file/default.nix
+++ b/pkgs/development/python-modules/parametrize-from-file/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, coveralls
+, numpy
+, contextlib2
+, decopatch
+, more-itertools
+, nestedtext
+, pyyaml
+, tidyexc
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "parametrize-from-file";
+  version = "0.17.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "parametrize_from_file";
+    sha256 = "1c91j869n2vplvhawxc1sv8km8l53bhlxhhms43fyjsqvy351v5j";
+  };
+
+  format = "flit";
+  pythonImportsCheck = [ "parametrize_from_file" ];
+
+  # patch out coveralls since it doesn't provide us value
+  preBuild = ''
+    sed -i '/coveralls/d' ./pyproject.toml
+  '';
+
+  checkInputs = [
+    numpy
+    pytestCheckHook
+  ];
+  propagatedBuildInputs = [
+    contextlib2
+    decopatch
+    more-itertools
+    nestedtext
+    pyyaml
+    tidyexc
+    toml
+  ];
+
+  meta = with lib; {
+    description = "Read unit test parameters from config files";
+    homepage = "https://github.com/kalekundert/parametrize_from_file";
+    changelog = "https://github.com/kalekundert/parametrize_from_file/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/quantiphy-eval/default.nix
+++ b/pkgs/development/python-modules/quantiphy-eval/default.nix
@@ -2,21 +2,24 @@
 , buildPythonPackage
 , fetchFromGitHub
 , inform
+, pythonOlder
 , sly
 }:
 
 buildPythonPackage rec {
   pname = "quantiphy-eval";
   version = "0.5";
+  format = "flit";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "KenKundert";
     repo = "quantiphy_eval";
     rev = "v${version}";
-    sha256 = "sha256-7VHcuINhe17lRNkHUnZkVOEtD6mVWk5gu0NbrLZwprg=";
+    hash = "sha256-7VHcuINhe17lRNkHUnZkVOEtD6mVWk5gu0NbrLZwprg=";
   };
 
-  format = "flit";
   propagatedBuildInputs = [
     inform
     sly
@@ -30,9 +33,14 @@ buildPythonPackage rec {
   # tests require quantiphy import
   doCheck = false;
 
+  pythonImportsCheck = [
+    "quantiphy_eval"
+  ];
+
   meta = with lib; {
     description = "QuantiPhy support for evals in-line";
     homepage = "https://github.com/KenKundert/quantiphy_eval/";
+    changelog = "https://github.com/KenKundert/quantiphy_eval/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ jpetrucciani ];
   };

--- a/pkgs/development/python-modules/quantiphy-eval/default.nix
+++ b/pkgs/development/python-modules/quantiphy-eval/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   # tests require quantiphy import
   doCheck = false;
 
-  # Also affeted by the circular dependency on quantiphy
+  # Also affected by the circular dependency on quantiphy
   # pythonImportsCheck = [
   #   "quantiphy_eval"
   # ];

--- a/pkgs/development/python-modules/quantiphy-eval/default.nix
+++ b/pkgs/development/python-modules/quantiphy-eval/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, inform
+, sly
+}:
+
+buildPythonPackage rec {
+  pname = "quantiphy-eval";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "KenKundert";
+    repo = "quantiphy_eval";
+    rev = "v${version}";
+    sha256 = "sha256-7VHcuINhe17lRNkHUnZkVOEtD6mVWk5gu0NbrLZwprg=";
+  };
+
+  format = "flit";
+  propagatedBuildInputs = [
+    inform
+    sly
+  ];
+
+  # this has a circular dependency on quantiphy
+  preBuild = ''
+    sed -i '/quantiphy>/d' ./pyproject.toml
+  '';
+
+  # tests require quantiphy import
+  doCheck = false;
+
+  meta = with lib; {
+    description = "QuantiPhy support for evals in-line";
+    homepage = "https://github.com/KenKundert/quantiphy_eval/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/quantiphy-eval/default.nix
+++ b/pkgs/development/python-modules/quantiphy-eval/default.nix
@@ -33,9 +33,10 @@ buildPythonPackage rec {
   # tests require quantiphy import
   doCheck = false;
 
-  pythonImportsCheck = [
-    "quantiphy_eval"
-  ];
+  # Also affeted by the circular dependency on quantiphy
+  # pythonImportsCheck = [
+  #   "quantiphy_eval"
+  # ];
 
   meta = with lib; {
     description = "QuantiPhy support for evals in-line";

--- a/pkgs/development/python-modules/quantiphy/default.nix
+++ b/pkgs/development/python-modules/quantiphy/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flitBuildHook
+, pytestCheckHook
+, pythonOlder
+, inform
+, parametrize-from-file
+, setuptools
+, voluptuous
+, quantiphy-eval
+, rkm-codes
+}:
+
+buildPythonPackage rec {
+  pname = "quantiphy";
+  version = "2.18";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "KenKundert";
+    repo = "quantiphy";
+    rev = "v${version}";
+    sha256 = "sha256-KXZQTal5EQDrMNV9QKeuLeYYDaMfAJlEDEagq2XG9/Q=";
+  };
+
+  format = "pyproject";
+  nativeBuildInputs = [
+    flitBuildHook
+  ];
+  checkInputs = [
+    inform
+    parametrize-from-file
+    pytestCheckHook
+    setuptools
+    voluptuous
+  ];
+  propagatedBuildInputs = [
+    quantiphy-eval
+    rkm-codes
+  ];
+
+  meta = with lib; {
+    description = "Module for physical quantities (numbers with units)";
+    homepage = "https://quantiphy.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/quantiphy/default.nix
+++ b/pkgs/development/python-modules/quantiphy/default.nix
@@ -15,19 +15,26 @@
 buildPythonPackage rec {
   pname = "quantiphy";
   version = "2.18";
+  format = "pyproject";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "KenKundert";
     repo = "quantiphy";
     rev = "v${version}";
-    sha256 = "sha256-KXZQTal5EQDrMNV9QKeuLeYYDaMfAJlEDEagq2XG9/Q=";
+    hash = "sha256-KXZQTal5EQDrMNV9QKeuLeYYDaMfAJlEDEagq2XG9/Q=";
   };
 
-  format = "pyproject";
   nativeBuildInputs = [
     flitBuildHook
   ];
+
+  propagatedBuildInputs = [
+    quantiphy-eval
+    rkm-codes
+  ];
+
   checkInputs = [
     inform
     parametrize-from-file
@@ -35,14 +42,15 @@ buildPythonPackage rec {
     setuptools
     voluptuous
   ];
-  propagatedBuildInputs = [
-    quantiphy-eval
-    rkm-codes
+
+  pythonImportsCheck = [
+    "quantiphy"
   ];
 
   meta = with lib; {
     description = "Module for physical quantities (numbers with units)";
     homepage = "https://quantiphy.readthedocs.io";
+    changelog = "https://github.com/KenKundert/quantiphy/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ jpetrucciani ];
   };

--- a/pkgs/development/python-modules/rkm-codes/default.nix
+++ b/pkgs/development/python-modules/rkm-codes/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flitBuildHook
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "rkm-codes";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "KenKundert";
+    repo = "rkm_codes";
+    rev = "v${version}";
+    sha256 = "sha256-r4F72iHxH7BoPtgYm1RD6BeSZszKRrpeBQccmT4wzuw=";
+  };
+
+  format = "pyproject";
+  nativeBuildInputs = [
+    flitBuildHook
+  ];
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  # this has a circular dependency on quantiphy
+  preBuild = ''
+    sed -i '/quantiphy/d' ./setup.py
+    sed -i '/pytest-runner/d' ./setup.py
+  '';
+
+  # this import check will fail as quantiphy is imported by this package
+  # pythonImportsCheck = [ "rkm_codes" ];
+
+  # tests require quantiphy import
+  doCheck = false;
+
+  meta = with lib; {
+    description = "QuantiPhy support for RKM codes";
+    homepage = "https://github.com/kenkundert/rkm_codes/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/shlib/default.nix
+++ b/pkgs/development/python-modules/shlib/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, braceexpand
+, inform
+}:
+
+buildPythonPackage rec {
+  pname = "shlib";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "KenKundert";
+    repo = "shlib";
+    rev = "v${version}";
+    sha256 = "sha256-2fwRxa64QXKJuhYwt9Z4BxhTeq1iwbd/IznfxPUjeSM=";
+  };
+
+  pythonImportsCheck = [ "shlib" ];
+  postPatch = ''
+    patchShebangs .
+  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
+  propagatedBuildInputs = [
+    braceexpand
+    inform
+  ];
+
+  meta = with lib; {
+    description = "shell library";
+    homepage = "https://github.com/KenKundert/shlib";
+    changelog = "https://github.com/KenKundert/shlib/releases/tag/v${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/tidyexc/default.nix
+++ b/pkgs/development/python-modules/tidyexc/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "tidyexc";
+  version = "0.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gl1jmihafawg7hvnn4xb20vd2x5qpvca0m1wr2gk0m2jj42yiq6";
+  };
+
+  format = "flit";
+  pythonImportsCheck = [ "tidyexc" ];
+
+  meta = with lib; {
+    description = "Raise rich, helpful exceptions";
+    homepage = "https://github.com/kalekundert/tidyexc";
+    changelog = "https://github.com/kalekundert/tidyexc/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/tidyexc/default.nix
+++ b/pkgs/development/python-modules/tidyexc/default.nix
@@ -1,19 +1,24 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "tidyexc";
   version = "0.10.0";
+  format = "flit";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "1gl1jmihafawg7hvnn4xb20vd2x5qpvca0m1wr2gk0m2jj42yiq6";
   };
 
-  format = "flit";
-  pythonImportsCheck = [ "tidyexc" ];
+  pythonImportsCheck = [
+    "tidyexc"
+  ];
 
   meta = with lib; {
     description = "Raise rich, helpful exceptions";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6823,6 +6823,8 @@ with pkgs;
   embree = callPackage ../development/libraries/embree { };
   embree2 = callPackage ../development/libraries/embree/2.x.nix { };
 
+  emborg = python3Packages.callPackage ../development/python-modules/emborg { };
+
   emem = callPackage ../applications/misc/emem { };
 
   empty = callPackage ../tools/misc/empty { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9589,6 +9589,8 @@ self: super: with self; {
 
   quantities = callPackage ../development/python-modules/quantities { };
 
+  quantiphy = callPackage ../development/python-modules/quantiphy { };
+
   quantiphy-eval = callPackage ../development/python-modules/quantiphy-eval { };
 
   quantum-gateway = callPackage ../development/python-modules/quantum-gateway { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6709,6 +6709,8 @@ self: super: with self; {
 
   parameterized = callPackage ../development/python-modules/parameterized { };
 
+  parametrize-from-file = callPackage ../development/python-modules/parametrize-from-file { };
+
   paramiko = callPackage ../development/python-modules/paramiko { };
 
   paramz = callPackage ../development/python-modules/paramz { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2941,6 +2941,8 @@ self: super: with self; {
 
   embrace = callPackage ../development/python-modules/embrace { };
 
+  emborg = callPackage ../development/python-modules/emborg { };
+
   emcee = callPackage ../development/python-modules/emcee { };
 
   emv = callPackage ../development/python-modules/emv { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9589,6 +9589,8 @@ self: super: with self; {
 
   quantities = callPackage ../development/python-modules/quantities { };
 
+  quantiphy-eval = callPackage ../development/python-modules/quantiphy-eval { };
+
   quantum-gateway = callPackage ../development/python-modules/quantum-gateway { };
 
   querystring_parser = callPackage ../development/python-modules/querystring-parser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9863,6 +9863,8 @@ self: super: with self; {
 
   rki-covid-parser = callPackage ../development/python-modules/rki-covid-parser { };
 
+  rkm-codes = callPackage ../development/python-modules/rkm-codes { };
+
   rlax = callPackage ../development/python-modules/rlax { };
 
   rl-coach = callPackage ../development/python-modules/rl-coach { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10274,6 +10274,8 @@ self: super: with self; {
 
   sh = callPackage ../development/python-modules/sh { };
 
+  shlib = callPackage ../development/python-modules/shlib { };
+
   shellescape = callPackage ../development/python-modules/shellescape { };
 
   shellingham = callPackage ../development/python-modules/shellingham { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11185,6 +11185,8 @@ self: super: with self; {
     py = python.override { x11Support=true; };
   };
 
+  tidyexc = callPackage ../development/python-modules/tidyexc { };
+
   tidylib = callPackage ../development/python-modules/pytidylib { };
 
   tifffile = callPackage ../development/python-modules/tifffile { };


### PR DESCRIPTION
###### Description of changes

I would like to be able to use [emborg](https://github.com/KenKundert/emborg) to control [borgbackup](https://www.borgbackup.org/) (which is already in nixpkgs!) from within nixpkgs! This also adds a handful of packages that are dependencies for this to be possible

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
