### PR TITLE
pantheon.gala: Backport various upstream fixes

### DIFF
--- a/pkgs/desktops/pantheon/desktop/gala/default.nix
+++ b/pkgs/desktops/pantheon/desktop/gala/default.nix
@@ -60,6 +60,49 @@ stdenv.mkDerivation rec {
       url = "https://github.com/elementary/gala/commit/23c7edeb0ee9b0ff0aa48c1d19fbd1739df7af78.patch";
       sha256 = "sha256-OfIDBfVEZoY8vMu9F8gtfRg4TYA1MUAG94BSOBKVGcI=";
     })
+
+    # Work around crash when receiving notifications
+    # https://github.com/elementary/gala/pull/1497
+    (fetchpatch {
+      url = "https://github.com/elementary/gala/commit/8842e576e3e8643a018d506605f80d152e3f5cec.patch";
+      sha256 = "sha256-xu9Rh7TH0ccRU1TInTNTm+dDaCXj5aaEwDw3rBW02q8=";
+    })
+
+    # ShadowEffect: let Clutter know the shadow's size
+    # https://github.com/elementary/gala/pull/1500
+    (fetchpatch {
+      url = "https://github.com/elementary/gala/commit/34a208e26d2ee0bf4a1689c8ad6ddfc06c540ff8.patch";
+      sha256 = "sha256-KPIXNWTlKGc3JImt82t5lmcMu0bqrPx1JNv+TbsxhOg=";
+    })
+
+    # Fix awkward two-finger scroll in multitasking view
+    # https://github.com/elementary/gala/pull/1499
+    (fetchpatch {
+      url = "https://github.com/elementary/gala/commit/c175d2662dd05e940a5b3311cc9dc285242b7fc5.patch";
+      sha256 = "sha256-xsxYDagPmaNSZO/Cj7NjPqBHCc1hrqvpboAvPIg9P58=";
+    })
+
+    # Fix crash when monitor is turned off
+    # https://github.com/elementary/gala/pull/1491
+    (fetchpatch {
+      url = "https://github.com/elementary/gala/commit/1487660812a343e6a6178881e6e7b25c2405cece.patch";
+      sha256 = "sha256-YsRaWmDSg0h0RFTUOoMxlNcKoA4MNa8AhW1GGmk8qLA=";
+    })
+
+    # Fix quick zooming (next 3 patches)
+    # https://github.com/elementary/gala/pull/1501
+    (fetchpatch {
+      url = "https://github.com/elementary/gala/commit/b9c5c9c79a045c3eef7695f74f82d851438ba7e2.patch";
+      sha256 = "sha256-PGjf/B/7UQxpW0Pby7ZXuMoDlamZwEaDvaN9PaRulHU=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/gala/commit/49d3ddae5b631027466ff528c2935e05a8f5dc3f.patch";
+      sha256 = "sha256-hvm2GcqiMYYxOLpQFXdyz325jZme7W+VYipu5goKoiU=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/gala/commit/45126e4c2d3736e872c05941a2047a54788cd011.patch";
+      sha256 = "sha256-LdhFFFNwvF1p1LqJXer8+DOgAptiHZHlfnQBwVEIZjo=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Still holding the version update, we will do that in https://github.com/NixOS/nixpkgs/pull/196511

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
