### PR TITLE
Docs/fix attrsets

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -104,8 +104,6 @@ rec {
   /* Creates an Option attribute set for an option that specifies the
      package a module should use for some purpose.
 
-     Type: mkPackageOption :: pkgs -> string -> { default :: [string], example :: null | string | [string] } -> option
-
      The package is specified as a list of strings representing its attribute path in nixpkgs.
 
      Because of this, you need to pass nixpkgs itself as the first argument.
@@ -115,6 +113,8 @@ rec {
      You can also pass an example value, either a literal string or a package's attribute path.
 
      You can omit the default path if the name of the option is also attribute path in nixpkgs.
+
+     Type: mkPackageOption :: pkgs -> string -> { default :: [string], example :: null | string | [string] } -> option
 
      Example:
        mkPackageOption pkgs "hello" { }


### PR DESCRIPTION
#### Description of changes

[x] Add some more type annotations to lib/attrsets.nix
[x] Fix some errors in the existing ones.
[x] Minor enhancements for comprehensiveness.

### some background:

### [noogle.dev](https://noogle.dev)

Recently started __noogle.dev__ - A search engine for `functions` within nix. :star: 

-> Site [here](https://noogle.dev)
-> Github [here](https://github.com/hsjobeki/noogle)

Currently available on  [noogle.dev](https://noogle.dev)

- everything from `lib folder`
- All nix `builtins`

Its currently under development and i would like to Index all nixpkgs functions.

This involves typing all functions, starting with the most important ones. (like libs, trivial-builders, builtins, etc)
I will maintain those types inside my fork and sync them with the official nixpkgs on regular basis.

#### I am happy if you share and use this site. :heart: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

[x] Parsed with nixdoc
[x] Double checked every type

- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)