### PR TITLE
dovecot: 2.3.19.1 -> 2.3.20

### DIFF
--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dovecot";
-  version = "2.3.19.1";
+  version = "2.3.20";
 
   nativeBuildInputs = [ perl pkg-config ];
   buildInputs =
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dovecot.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.gz";
-    hash = "sha256-21q82H1zCWWeprRbLLbunF+XSGsrcZpd0Fp1nh9qXFE=";
+    hash = "sha256-yqgy65aBSKvfNe6dD1NLd5+nMsDOSpE9mrjDRpshhVI=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -3,11 +3,11 @@ let
   dovecotMajorMinor = lib.versions.majorMinor dovecot.version;
 in stdenv.mkDerivation rec {
   pname = "dovecot-pigeonhole";
-  version = "0.5.19";
+  version = "0.5.20";
 
   src = fetchurl {
     url = "https://pigeonhole.dovecot.org/releases/${dovecotMajorMinor}/dovecot-${dovecotMajorMinor}-pigeonhole-${version}.tar.gz";
-    hash = "sha256:033kkhby9k9yrmgvlfmyzp8fccsw5bhq1dyvxj94sg3grkpj7f8h";
+    hash = "sha256-rjK9SHDqLBMorgm6IG6ewSEoBG1q/KUvu8nvf3VhfJg=";
   };
 
   buildInputs = [ dovecot openssl ];


### PR DESCRIPTION
###### Description of changes
see commit messages

currently fails to build with:
```
long command ......................................................... : ok                                                                                                                                                                                                                                                                                                  
CLIENT[3]: Panic: file test-smtp-server-errors.c: line 978 (test_long_auth_line_client_deinit): assertion failed: (ctx->replied)                                                      
CLIENT[2]: Panic: file test-smtp-server-errors.c: line 978 (test_long_auth_line_client_deinit): assertion failed: (ctx->replied)                                                      
CLIENT[1]: Panic: file test-smtp-server-errors.c: line 978 (test_long_auth_line_client_deinit): assertion failed: (ctx->replied)
CLIENT[2]: Error: Raw backtrace: ./test-smtp-server-errors(backtrace_append+0x42) [0x487482] -> ./test-smtp-server-errors(backtrace_get+0x1e) [0x48759e] -> ./test-smtp-server-errors() [0x4621fb] -> ./test-smtp-server-errors() [0x462231] -> ./test-smtp-server-errors() [0x423c27] -> ./test-smtp-server-errors() [0x41e752] -> ./test-smtp-server-errors() [0x428b62] ->
 ./test-smtp-server-errors(connection_list_deinit+0x33) [0x45b1a3] -> ./test-smtp-server-errors() [0x4294db] -> ./test-smtp-server-errors(test_subprocess_fork+0x1b8) [0x455ea8] -> ./test-smtp-server-errors() [0x42b033] -> ./test-smtp-server-errors() [0x42d01b] -> ./test-smtp-server-errors() [0x454b5f] -> ./test-smtp-server-errors(test_run+0x4c) [0x45570c] -> ./te
st-smtp-server-errors(main+0x84) [0x428814] -> /nix/store/ayfr5l52xkqqjn3n4h9jfacgnchz1z7s-glibc-2.35-224/lib/libc.so.6(+0x2924e) [0x7ffff7dde24e] -> /nix/store/ayfr5l52xkqqjn3n4h9jfacgnchz1z7s-glibc-2.35-224/lib/libc.so.6(__libc_start_main+0x89) [0x7ffff7dde309] -> ./test-smtp-server-errors(_start+0x25) [0x428915]
CLIENT[1]: Error: Raw backtrace: ./test-smtp-server-errors(backtrace_append+0x42) [0x487482] -> ./test-smtp-server-errors(backtrace_get+0x1e) [0x48759e] -> ./test-smtp-server-errors() [0x4621fb] -> ./test-smtp-server-errors() [0x462231] -> ./test-smtp-server-errors() [0x423c27] -> ./test-smtp-server-errors() [0x41e752] -> ./test-smtp-server-errors() [0x428b62] ->
 ./test-smtp-server-errors(connection_list_deinit+0x33) [0x45b1a3] -> ./test-smtp-server-errors() [0x4294db] -> ./test-smtp-server-errors(test_subprocess_fork+0x1b8) [0x455ea8] -> ./test-smtp-server-errors() [0x42b033] -> ./test-smtp-server-errors() [0x42d01b] -> ./test-smtp-server-errors() [0x454b5f] -> ./test-smtp-server-errors(test_run+0x4c) [0x45570c] -> ./te
st-smtp-server-errors(main+0x84) [0x428814] -> /nix/store/ayfr5l52xkqqjn3n4h9jfacgnchz1z7s-glibc-2.35-224/lib/libc.so.6(+0x2924e) [0x7ffff7dde24e] -> /nix/store/ayfr5l52xkqqjn3n4h9jfacgnchz1z7s-glibc-2.35-224/lib/libc.so.6(__libc_start_main+0x89) [0x7ffff7dde309] -> ./test-smtp-server-errors(_start+0x25) [0x428915]
CLIENT[3]: Error: Raw backtrace: ./test-smtp-server-errors(backtrace_append+0x42) [0x487482] -> ./test-smtp-server-errors(backtrace_get+0x1e) [0x48759e] -> ./test-smtp-server-errors() [0x4621fb] -> ./test-smtp-server-errors() [0x462231] -> ./test-smtp-server-errors() [0x423c27] -> ./test-smtp-server-errors() [0x41e752] -> ./test-smtp-server-errors() [0x428b62] ->
 ./test-smtp-server-errors(connection_list_deinit+0x33) [0x45b1a3] -> ./test-smtp-server-errors() [0x4294db] -> ./test-smtp-server-errors(test_subprocess_fork+0x1b8) [0x455ea8] -> ./test-smtp-server-errors() [0x42b033] -> ./test-smtp-server-errors() [0x42d01b] -> ./test-smtp-server-errors() [0x454b5f] -> ./test-smtp-server-errors(test_run+0x4c) [0x45570c] -> ./te
st-smtp-server-errors(main+0x84) [0x428814] -> /nix/store/ayfr5l52xkqqjn3n4h9jfacgnchz1z7s-glibc-2.35-224/lib/libc.so.6(+0x2924e) [0x7ffff7dde24e] -> /nix/store/ayfr5l52xkqqjn3n4h9jfacgnchz1z7s-glibc-2.35-224/lib/libc.so.6(__libc_start_main+0x89) [0x7ffff7dde309] -> ./test-smtp-server-errors(_start+0x25) [0x428915]
long auth line: sub-process ended properly ........................... : FAILED
Warning: test: Sub-process forcibly terminated with signal 6                                                                                                                          
long auth line: sub-process ended properly ........................... : FAILED
Warning: test: Sub-process forcibly terminated with signal 6                                                                                                                          
long auth line: sub-process ended properly ........................... : FAILED
Warning: test: Sub-process forcibly terminated with signal 6                                                                                                                          
long auth line ....................................................... : FAILED                                                                                                       
long auth line (small i/o buffers) ................................... : ok                                                                                                           
```

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).