### PR TITLE
classicube: add .desktop file

### DIFF
--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -3,6 +3,8 @@
 , fetchFromGitHub
 , dos2unix
 , makeWrapper
+, makeDesktopItem
+, copyDesktopItems
 , SDL2
 , libGL
 , curl
@@ -21,7 +23,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-m7pg9OL2RuCVKgFD3hMtIeY0XdJ1YviXBFVJH8/T5gI=";
   };
 
-  nativeBuildInputs = [ dos2unix makeWrapper ];
+  nativeBuildInputs = [ dos2unix makeWrapper copyDesktopItems ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = pname;
+      genericName = "Sandbox Block Game";
+      exec = "ClassiCube";
+      icon = "CCicon";
+      comment = "Minecraft Classic inspired sandbox game";
+      categories = [ "Game" ];
+    })
+  ];
 
   prePatch = ''
     # The ClassiCube sources have DOS-style newlines
@@ -77,20 +91,9 @@ stdenv.mkDerivation rec {
       --run 'mkdir -p "$HOME/.local/share/ClassiCube"' \
       --run 'cd       "$HOME/.local/share/ClassiCube"'
     runHook postInstall
-  '';
 
-  postInstall = ''
-    mkdir -p "$out/share/applications" "$out/share/resources"
-    cp 'misc/CCicon.png' "$out/share/resources"
-    cat >"$out/share/applications/ClassiCube.desktop" <<EOF
-    [Desktop Entry]
-    Type = Application
-    Exec = "$out/bin/ClassiCube"
-    Icon = "$out/share/resources/CCicon.png"
-    Name = ClassiCube
-    GenericName = Sandbox Block Game
-    Categories = ["Game"]
-    EOF
+    mkdir -p "$out/share/icons/hicolor/256x256/apps"
+    cp misc/CCicon.png "$out/share/icons/hicolor/256x256/apps"
   '';
 
   meta = with lib; {

--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation rec {
   postBuild = "cd -";
 
   installPhase = ''
+    runHook preInstall
     mkdir -p "$out/bin"
     cp 'src/ClassiCube' "$out/bin"
     # ClassiCube puts downloaded resources
@@ -75,6 +76,21 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/bin/ClassiCube" \
       --run 'mkdir -p "$HOME/.local/share/ClassiCube"' \
       --run 'cd       "$HOME/.local/share/ClassiCube"'
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/share/applications" "$out/share/resources"
+    cp 'misc/CCicon.png' "$out/share/resources"
+    cat >"$out/share/applications/ClassiCube.desktop" <<EOF
+    [Desktop Entry]
+    Type = Application
+    Exec = "$out/bin/ClassiCube"
+    Icon = "$out/share/resources/CCicon.png"
+    Name = ClassiCube
+    GenericName = Sandbox Block Game
+    Categories = ["Game"]
+    EOF
   '';
 
   meta = with lib; {

--- a/pkgs/games/classicube/default.nix
+++ b/pkgs/games/classicube/default.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p "$out/bin"
     cp 'src/ClassiCube' "$out/bin"
     # ClassiCube puts downloaded resources
@@ -90,10 +91,11 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/bin/ClassiCube" \
       --run 'mkdir -p "$HOME/.local/share/ClassiCube"' \
       --run 'cd       "$HOME/.local/share/ClassiCube"'
-    runHook postInstall
 
     mkdir -p "$out/share/icons/hicolor/256x256/apps"
     cp misc/CCicon.png "$out/share/icons/hicolor/256x256/apps"
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Adds a .desktop file for ClassiCube

Closes #207036

###### Things done

**I use Sway which doesn't support .desktop files. I have not tested that the .desktop file actually works.**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
