### PR TITLE
matrix-synapse: Use improved user search

### DIFF
--- a/pkgs/applications/misc/gramps/default.nix
+++ b/pkgs/applications/misc/gramps/default.nix
@@ -29,7 +29,7 @@ in buildPythonApplication rec {
     sha256 = "00358nzyw686ypqv45imc5k9frcqnhla0hpx9ynna3iy6iz5006x";
   };
 
-  pythonPath = with pythonPackages; [ bsddb3 PyICU pygobject3 pycairo ];
+  pythonPath = with pythonPackages; [ bsddb3 pyicu pygobject3 pycairo ];
 
   # Same installPhase as in buildPythonApplication but without --old-and-unmanageble
   # install flag.

--- a/pkgs/development/python-modules/agate/default.nix
+++ b/pkgs/development/python-modules/agate/default.nix
@@ -9,7 +9,7 @@
 , lxml
 , nose
 , parsedatetime
-, PyICU
+, pyicu
 , python-slugify
 , pytimeparse
 , pythonOlder
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     glibcLocales
     lxml
     nose
-    PyICU
+    pyicu
     pytz
   ];
 

--- a/pkgs/development/python-modules/natsort/default.nix
+++ b/pkgs/development/python-modules/natsort/default.nix
@@ -4,7 +4,7 @@
 , fetchPypi
 , glibcLocales
 , hypothesis
-, PyICU
+, pyicu
 , pytest-mock
 , pytestCheckHook
 , pythonOlder
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     fastnumbers
-    PyICU
+    pyicu
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/normality/default.nix
+++ b/pkgs/development/python-modules/normality/default.nix
@@ -4,7 +4,7 @@
 , text-unidecode
 , chardet
 , banal
-, PyICU
+, pyicu
 , pytestCheckHook
 }:
 buildPythonPackage rec {
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     text-unidecode
     chardet
     banal
-    PyICU
+    pyicu
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pyicu/default.nix
+++ b/pkgs/development/python-modules/pyicu/default.nix
@@ -7,12 +7,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "PyICU";
+  pname = "pyicu";
   version = "2.10.2";
+  format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-DDMJ7qf6toV1B6zmJANRW2D+CWy/tPkNFPVf91xUQcE=";
+    pname = "PyICU";
+    inherit version;
+    hash = "sha256-DDMJ7qf6toV1B6zmJANRW2D+CWy/tPkNFPVf91xUQcE=";
   };
 
   nativeBuildInputs = [ icu ]; # for icu-config, but should be replaced with pkg-config

--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , isPy3k
-, PyICU
+, pyicu
 , python
 }:
 
@@ -18,7 +18,7 @@ buildPythonPackage {
     sha256 = "01195hphjnlcvgykw143rf06s6y955sjc1r825a58vhjx7hj54zh";
   };
 
-  propagatedBuildInputs = [ PyICU ];
+  propagatedBuildInputs = [ pyicu ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest slob

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -65,7 +65,7 @@ buildPythonApplication rec {
     psycopg2
     pyasn1
     pydantic
-    PyICU
+    pyicu
     pyjwt
     pymacaroons
     pynacl

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -65,6 +65,7 @@ buildPythonApplication rec {
     psycopg2
     pyasn1
     pydantic
+    PyICU
     pyjwt
     pymacaroons
     pynacl

--- a/pkgs/servers/nominatim/default.nix
+++ b/pkgs/servers/nominatim/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     psycopg2
     psutil
     jinja2
-    PyICU
+    pyicu
     datrie
   ];
 

--- a/pkgs/tools/misc/xdxf2slob/default.nix
+++ b/pkgs/tools/misc/xdxf2slob/default.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication {
     sha256 = "0m3dnc3816ja3kmik1wabb706dkqdf5sxvabwgf2rcrq891xcddd";
   };
 
-  propagatedBuildInputs = [ python3Packages.PyICU python3Packages.slob ];
+  propagatedBuildInputs = [ python3Packages.pyicu python3Packages.slob ];
 
   meta = with lib; {
     description = "Tool to convert XDXF dictionary files to slob format";

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -148,6 +148,7 @@ mapAliases ({
   pycryptodome-test-vectors = throw "pycryptodome-test-vectors has been removed because it is an internal package to pycryptodome"; # added 2022-05-28
   pyialarmxr = pyialarmxr-homeassistant; # added 2022-06-07
   pyialarmxr-homeassistant = throw "The package was removed together with the component support in home-assistant 2022.7.0"; # added 2022-07-07
+  PyICU = pyicu; # Added 2022-12-22
   pyjson5 = json5; # added 2022-08-28
   pylibgen = throw "pylibgen is unmaintained upstreamed, and removed from nixpkgs"; # added 2020-06-20
   PyLD = pyld; # added 2022-06-22

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8013,7 +8013,7 @@ self: super: with self; {
 
   pyicloud = callPackage ../development/python-modules/pyicloud { };
 
-  PyICU = callPackage ../development/python-modules/pyicu { };
+  pyicu = callPackage ../development/python-modules/pyicu { };
 
   pyimpfuzzy = callPackage ../development/python-modules/pyimpfuzzy {
     inherit (pkgs) ssdeep;


### PR DESCRIPTION
by propagating pyicu, bindings to libicu, that help to deal with international display names.

Availabl since 1.74.0.

https://github.com/matrix-org/synapse/pull/14464
https://github.com/matrix-org/synapse/pull/14464

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
