### PR TITLE
gradle: use gradle properties instead of wrapper

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -72,7 +72,7 @@ rec {
               let
                 javaHomeProperty = "org.gradle.java.home=" + java;
                 toolchainsProperty = "org.gradle.java.installations.paths=" + (concatStringsSep "," javaToolchains);
-                toolchainsPropertyWithCheck = 
+                toolchainsPropertyWithCheck =
                 if (hasToolchainSupport || (length javaToolchains) == 0) then toolchainsProperty
                 else lib.warn "This Gradle version (${version}) does not have toolchain support, yet the 'javaToolchains' list is not empty. The used toolchain will be ignored by Gradle." toolchainsProperty;
                 propDefs = concatStringsSep "\n" [ javaHomeProperty toolchainsPropertyWithCheck ];

--- a/pkgs/development/tools/build-managers/gradle/tests.nix
+++ b/pkgs/development/tools/build-managers/gradle/tests.nix
@@ -19,7 +19,15 @@
           mkdir $out
           cp -r * $out
           cd $out
-          ${gradleWithToolchains}/bin/gradle build
+          set -o pipefail
+          ${gradleWithToolchains}/bin/gradle :proj1:run :proj2:run | tee output.log
+          if [ $? != 0 ]; then
+            echo "Non-zero output from Gradle"
+            exit $?
+          fi;
+
+          echo "Correctly detected JDKs (should have 11 and 17):"
+          grep "JDK version: 11" output.log && grep "JDK version: 17" output.log
         '';
       };
     }

--- a/pkgs/development/tools/build-managers/gradle/tests.nix
+++ b/pkgs/development/tools/build-managers/gradle/tests.nix
@@ -1,0 +1,27 @@
+{ runCommand, testers, jdk11, jdk17, stdenv }:
+{ gradle, gradleWithToolchains ? null }:
+
+{
+  version = testers.testVersion {
+    package = gradle;
+  };
+} // (
+  if gradleWithToolchains != null then
+    let
+      src = ./tests/toolchain;
+    in
+    {
+      checkToolchain = stdenv.mkDerivation {
+        nativeBuildInputs = [ gradleWithToolchains ];
+        name = "gradle-toolchain";
+        src = ./tests/toolchain;
+        installPhase = ''
+          mkdir $out
+          cp -r * $out
+          cd $out
+          ${gradleWithToolchains}/bin/gradle build
+        '';
+      };
+    }
+  else { }
+)

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj1/build.gradle
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj1/build.gradle
@@ -1,9 +1,14 @@
 plugins {
 	id 'java'
+    id 'application'
 }
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(11)
     }
+}
+
+application {
+    mainClass = 'Hello'
 }

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj1/build.gradle
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj1/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+	id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj1/src/main/java/Hello.java
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj1/src/main/java/Hello.java
@@ -1,0 +1,5 @@
+class Hello {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
+}

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj1/src/main/java/Hello.java
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj1/src/main/java/Hello.java
@@ -1,5 +1,10 @@
 class Hello {
     public static void main(String[] args) {
-        System.out.println("Hello, world!");
+        var version = Runtime.version().feature();
+        System.out.println("JDK version: " + version);
+        if (version != 11) {
+            System.out.println("Wrong JDK version!");
+            System.exit(1);
+        }
     }
 }

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj2/build.gradle
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj2/build.gradle
@@ -1,9 +1,14 @@
 plugins {
 	id 'java'
+    id 'application'
 }
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+}
+
+application {
+    mainClass = 'Hello'
 }

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj2/build.gradle
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj2/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+	id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj2/src/main/java/Hello.java
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj2/src/main/java/Hello.java
@@ -1,0 +1,5 @@
+class Hello {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
+}

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj2/src/main/java/Hello.java
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/proj2/src/main/java/Hello.java
@@ -1,5 +1,10 @@
 class Hello {
     public static void main(String[] args) {
-        System.out.println("Hello, world!");
+        var version = Runtime.version().feature();
+        System.out.println("JDK version: " + version);
+        if (version != 17) {
+            System.out.println("Wrong JDK version!");
+            System.exit(1);
+        }
     }
 }

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchain/settings.gradle
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchain/settings.gradle
@@ -1,0 +1,1 @@
+include "proj1", "proj2"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18186,7 +18186,7 @@ with pkgs;
   gpuvis = callPackage ../development/tools/misc/gpuvis { };
 
   gradle-packages = import ../development/tools/build-managers/gradle {
-    inherit jdk8 jdk11 jdk17;
+    inherit jdk8 jdk11 jdk17 lib;
   };
   gradleGen = gradle-packages.gen;
   gradle_6 = callPackage gradle-packages.gradle_6 { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes #207153 by using `gradle.properties` instead of wrapper executable arguments. This is done in two cases currently:

- Java toolchain support
- Setting `JAVA_HOME`

As discussed in the issue, this generally leads to better support in tools that do *not* use the wrapper and directly use Gradle's installation directory (and therefore can only detect properties in `gradle.properties`).

This PR also adds tests to the Gradle packages:

- A simple version test
- An end-to-end test that checks that java toolchains work properly (only for Gradle 6+)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - **N/A** [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [x] and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - **N/A** or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - **N/A** made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - This would download 60GB of data and my computer would be obliterated into outer space sadly
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
