### PR TITLE
fix nix-env -f . -qaP --attr pkgsCross.aarch64-multiplatform --out-path

### DIFF
--- a/pkgs/applications/version-management/gitflow/default.nix
+++ b/pkgs/applications/version-management/gitflow/default.nix
@@ -1,6 +1,4 @@
-{ pkgs, lib, stdenv, fetchFromGitHub }:
-
-with pkgs.lib;
+{ lib, stdenv, fetchFromGitHub, makeWrapper, getopt, git, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "gitflow";
@@ -13,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-kHirHG/bfsU6tKyQ0khNSTyChhzHfzib+HyA3LOtBI8=";
   };
 
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   preBuild = ''
     makeFlagsArray+=(prefix="$out")
@@ -21,9 +19,9 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/git-flow \
-      --set FLAGS_GETOPT_CMD ${pkgs.getopt}/bin/getopt \
-      --suffix PATH : ${pkgs.git}/bin \
-      --prefix PATH : ${pkgs.coreutils}/bin
+      --set FLAGS_GETOPT_CMD ${getopt}/bin/getopt \
+      --suffix PATH : ${git}/bin \
+      --prefix PATH : ${coreutils}/bin
   '';
 
   meta = with lib; {

--- a/pkgs/build-support/node/build-npm-package/hooks/default.nix
+++ b/pkgs/build-support/node/build-npm-package/hooks/default.nix
@@ -26,7 +26,7 @@
   npmInstallHook = makeSetupHook
     {
       name = "npm-install-hook";
-      deps = [ makeWrapper ];
+      deps = [ buildPackages.makeWrapper ];
       substitutions = {
         hostNode = "${nodejs}/bin/node";
         jq = "${buildPackages.jq}/bin/jq";

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -1,6 +1,7 @@
-{ lib, pkgs, erlang }:
+{ lib, __splicedPackages, erlang }:
 
 let
+  pkgs = __splicedPackages;
   inherit (lib) makeExtensible;
 
   lib' = pkgs.callPackage ./lib.nix { };

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -1,5 +1,8 @@
-{ pkgs, lib }:
+{ __splicedPackages, lib }:
 
+let
+  pkgs = __splicedPackages;
+in
 rec {
 
   /* Similar to callPackageWith/callPackage, but without makeOverridable

--- a/pkgs/development/libraries/icu/63.nix
+++ b/pkgs/development/libraries/icu/63.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, fixDarwinDylibNames, nativeBuildRoot }:
+{ stdenv, lib, fetchurl, fetchpatch, fixDarwinDylibNames, nativeBuildRoot, buildRootOnly ? false }:
 
 import ./base.nix {
   version = "63.1";
@@ -11,4 +11,4 @@ import ./base.nix {
     })
   ];
   patchFlags = [ "-p3" ];
-} { inherit stdenv lib fetchurl fixDarwinDylibNames nativeBuildRoot; }
+} { inherit stdenv lib fetchurl fixDarwinDylibNames nativeBuildRoot buildRootOnly; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -971,7 +971,8 @@ with pkgs;
   makeShellWrapper = makeSetupHook
     { deps = [ dieHook ];
       substitutions = {
-        shell = targetPackages.runtimeShell;
+        # targetPackages.runtimeShell only exists when pkgs == targetPackages (when targetPackages is not  __raw)
+        shell = if targetPackages ? runtimeShell then targetPackages.runtimeShell else throw "makeWrapper/makeShellWrapper must be in nativeBuildInputs";
       };
       passthru = {
         tests = tests.makeWrapper;


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/116207

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
