### PR TITLE
gtest: ensure C++17 support

### DIFF
--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -19,7 +19,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ninja ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+  ] ++ lib.optionals (stdenv.cc.isClang && (lib.versionOlder stdenv.cc.version "16.0")) [
+    # Enable C++17 support
+    # https://github.com/google/googletest/issues/3081
+    "-DCMAKE_CXX_STANDARD=17"
+  ];
 
   meta = with lib; {
     description = "Google's framework for writing C++ tests";


### PR DESCRIPTION
###### Description of changes

Fix to address an issue seen in #198805:
```
Undefined symbols for architecture x86_64:
  "__ZN7testing7MatcherIRKNSt3__117basic_string_viewIcNS1_11char_traitsIcEEEEEC1EPKc", referenced from:
      __ZN7testing8internal22ElementsAreMatcherImplIRKNSt3__16vectorINS2_17basic_string_viewIcNS2_11char_traitsIcEEEENS2_9allocatorIS7_EEEEEC2INS2_11__wrap_iterIPKPKcEEEET_SL_ in array_test.cc.o
      __ZN7testing8internal22ElementsAreMatcherImplIRKNSt3__16vectorINS2_17basic_string_viewIcNS2_11char_traitsIcEEEENS2_9allocatorIS7_EEEEEC2INS2_11__wrap_iterIPKPKcEEEET_SL_ in array_binary_test.cc.o
ld: symbol(s) not found for architecture x86_64
```
Turns out `GTEST_INTERNAL_HAS_STRING_VIEW` needs to be detected when gtest libraries are compiled, and then it should work. This enables -std=c++17 as it's the way intended by upstream https://github.com/google/googletest/issues/3081#issuecomment-716621383

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
