### PR TITLE
highlight-assertions: init at unstable-2022-11-24

### DIFF
--- a/pkgs/development/tools/misc/highlight-assertions/default.nix
+++ b/pkgs/development/tools/misc/highlight-assertions/default.nix
@@ -1,0 +1,25 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "highlight-assertions";
+  version = "unstable-2022-11-24";
+
+  src = fetchFromGitHub {
+    owner = "thehamsta";
+    repo = pname;
+    rev = "c738a51513285ded4fc16d68afcdb77761543f92";
+    sha256 = "sha256-vYXr0xFwRUwSEP++834A/4M1QB14Wx+qWwB9PUtn3uA=";
+  };
+
+  cargoSha256 = "sha256-sezjd7tmVVDoRsrsTK2zKjHmrBcAQDHyHd/dR1q1za0=";
+
+  # requires nightly features
+  RUSTC_BOOTSTRAP = 1;
+
+  meta = with lib; {
+    description = "A tool for unit testing tree sitter highlights for nvim-treesitter";
+    homepage = "https://github.com/thehamsta/highlight-assertions";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17475,6 +17475,8 @@ with pkgs;
 
   heroku = callPackage ../development/tools/heroku { };
 
+  highlight-assertions = callPackage ../development/tools/misc/highlight-assertions { };
+
   ccloud-cli = callPackage ../development/tools/ccloud-cli { };
 
   confluent-cli = callPackage ../development/tools/confluent-cli { };


### PR DESCRIPTION
###### Description of changes

`highlight-assertions` is a tool for unit testing tree sitter highlights for nvim-treesitter

using the unstable version since the latest stable version 0.1.5 has an outdated Cargo.lock and the version is 0.1.4 on master (and on the 0.1.5 tag)

https://github.com/thehamsta/highlight-assertions

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
