### PR TITLE
kivy: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -11,22 +11,14 @@
 
 buildPythonPackage rec {
   pname = "Kivy";
-  version = "2.0.0";
+  version = "2.1.0";
 
-  # use github since pypi line endings are CRLF and patches do not apply
   src = fetchFromGitHub {
     owner = "kivy";
     repo = "kivy";
     rev = version;
-    sha256 = "sha256-/7GSVQUkYSBEnLVBizMnZAZZxvXVN4r4lskyOgLEcew=";
+    sha256 = "sha256-k9LIiLtlHY6H1xfVylI/Xbm7R6pCpC5UHe8GWnCwEGA=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/kivy/kivy/commit/1c0656c4472817677cf3b08be504de9ca6b1713f.patch";
-      sha256 = "sha256-phAjMaC3LQuvufwiD0qXzie5B+kezCf8FpKeQMhy/ms=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
###### Description of changes

https://github.com/kivy/kivy/blob/ce0bf8c7dcc7cdf93a32c5fb9965cc973e373357/doc/sources/changelog.rst#core-providers
("Use NSString instead of..." patch seems to have been upstreamed)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - tested by using an external dependent (smoopi) build on this, it works... (and its now requires this version)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
