### PR TITLE
nixos: Add new_kernel_no_zfs image variants

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-minimal-new-kernel-no-zfs.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-minimal-new-kernel-no-zfs.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+{
+  imports = [ ./installation-cd-minimal-new-kernel.nix ];
+
+  # Makes `availableOn` fail for zfs, see <nixos/modules/profiles/base.nix>.
+  # This is a workaround since we cannot remove the `"zfs"` string from `supportedFilesystems`.
+  # The proper fix would be to make `supportedFilesystems` an attrset with true/false which we
+  # could then `lib.mkForce false`
+  nixpkgs.overlays = [(final: super: {
+    zfs = super.zfs.overrideAttrs(_: {
+      meta.platforms = [];
+    });
+  })];
+}

--- a/nixos/modules/installer/sd-card/sd-image-aarch64-new-kernel-no-zfs-installer.nix
+++ b/nixos/modules/installer/sd-card/sd-image-aarch64-new-kernel-no-zfs-installer.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+{
+  imports = [ ./sd-image-aarch64-new-kernel-installer.nix ];
+
+  # Makes `availableOn` fail for zfs, see <nixos/modules/profiles/base.nix>.
+  # This is a workaround since we cannot remove the `"zfs"` string from `supportedFilesystems`.
+  # The proper fix would be to make `supportedFilesystems` an attrset with true/false which we
+  # could then `lib.mkForce false`
+  nixpkgs.overlays = [(final: super: {
+    zfs = super.zfs.overrideAttrs(_: {
+      meta.platforms = [];
+    });
+  })];
+}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -181,11 +181,19 @@ in rec {
     inherit system;
   });
 
-  # A variant with a more recent (but possibly less stable) kernel
-  # that might support more hardware.
+  # A variant with a more recent (but possibly less stable) kernel that might support more hardware.
+  # This variant keeps zfs support enabled, hoping it will build and work.
   iso_minimal_new_kernel = forMatchingSystems [ "x86_64-linux" "aarch64-linux" ] (system: makeIso {
     module = ./modules/installer/cd-dvd/installation-cd-minimal-new-kernel.nix;
     type = "minimal-new-kernel";
+    inherit system;
+  });
+
+  # A variant with a more recent (but possibly less stable) kernel that might support more hardware.
+  # ZFS support disabled since it is unlikely to support the latest kernel.
+  iso_minimal_new_kernel_no_zfs = forMatchingSystems [ "x86_64-linux" "aarch64-linux" ] (system: makeIso {
+    module = ./modules/installer/cd-dvd/installation-cd-minimal-new-kernel-no-zfs.nix;
+    type = "minimal-new-kernel-no-zfs";
     inherit system;
   });
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -214,6 +214,14 @@ in rec {
     inherit system;
   });
 
+  sd_image_new_kernel_no_zfs = forMatchingSystems [ "aarch64-linux" ] (system: makeSdImage {
+    module = {
+        aarch64-linux = ./modules/installer/sd-card/sd-image-aarch64-new-kernel-no-zfs-installer.nix;
+      }.${system};
+    type = "minimal-new-kernel-no-zfs";
+    inherit system;
+  });
+
   # A bootable VirtualBox virtual appliance as an OVA file (i.e. packaged OVF).
   ova = forMatchingSystems [ "x86_64-linux" ] (system:
 


### PR DESCRIPTION
###### Description of changes

With these changes, we should have ~~the~~ a `new_kernel` iso and SD image pair building on the dot at each kernel upgrade. In turn, this will allow us to *publish* and *publicize* the images. This would help with new hardware, be it x86_64 or aarch64.

The implementation I think is not that objectionable. The only way to properly fix this would be to rewrite how `supportedFilesystems` works, and use an attrset with `true/false` values to allow overriding values. Once we pour values in a list, in the NixOS modules system, it is impossible to take them back out. If you have an alternative workable solution, feel free to submit it.

The overlay here shouldn't cause any issues for evaluation time, as this is an extremely leafy eval; it affects strictly only the two newly added outputs.

Workaround for:

 - #189184
 - #161296

Obsoletes:

 - #59863
 - #204773

I'm probably missing some.

###### Alternative approach

I still believe the approach in this comment is the best for the future:

 - https://github.com/NixOS/nixpkgs/pull/59863#issuecomment-932789533

We're gaining too many discrete disk images. It would be best if we could describe *features* for the disk image and join by the logical feature names, rather than making a new file to eval.



###### Future related work

 - Adding the jobs to `tested`
 - Publishing the images

###### Things done

I only instantiated the `aarch64-linux` image. Instantiation here is sufficient since the problem is we can't even attempt to build images with the newer kernels. Compare the following:

```
 $ nix-instantiate ./nixos/release.nix -A sd_image_new_kernel.aarch64-linux
trace: warning: system.stateVersion is not set, defaulting to 23.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
error: Package ‘zfs-kernel-2.1.7-6.1’ in /Users/samuel/tmp/nixpkgs/feature-new_kernel-no-zfs/pkgs/os-specific/linux/zfs/default.nix:196 is marked as broken, refusing to evaluate.
...
(use '--show-trace' to show detailed location information)

 $ nix-instantiate ./nixos/release.nix -A sd_image_new_kernel_no_zfs.aarch64-linux
trace: warning: system.stateVersion is not set, defaulting to 23.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
/nix/store/bkzij6b8l8prspr90awmdxfmp0nr2k34-nixos-sd-image-23.05pre130979.gfedcba-aarch64-linux.img.drv
```

I did build the x86_64 iso image, but it's not really needed to build it. What was needed was to verify zfs support is not present.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (kinda)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
