### PR TITLE
rcodesign: init at 0.22.0

### DIFF
--- a/pkgs/development/tools/rcodesign/default.nix
+++ b/pkgs/development/tools/rcodesign/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rcodesign";
+  version = "0.22.0";
+
+  src = fetchFromGitHub {
+    owner = "indygreg";
+    repo = "apple-platform-rs";
+    rev = "apple-codesign/${version}";
+    hash = "sha256-ndbDBGtTOfHHUquKrETe4a+hB5Za9samlnXwVGVvWy4=";
+  };
+
+  cargoHash = "sha256-cpQBdxTw/ge4VtzjdL2a2xgSeCT22fMIjuKu5UEedhI=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk_11_0.frameworks.Security
+  ];
+
+  cargoBuildFlags = [
+    # Only build the binary we want
+    "--bin"
+    "rcodesign"
+  ];
+
+  checkFlags = [
+    # Does network IO
+    "--skip=ticket_lookup::test::lookup_ticket"
+  ];
+
+  meta = with lib; {
+    description = "A cross-platform CLI interface to interact with Apple code signing.";
+    longDescription = ''
+      rcodesign provides various commands to interact with Apple signing,
+      including signing and notarizing binaries, generating signing
+      certificates, and verifying existing signed binaries.
+
+      For more information, refer to the [documentation](https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_rcodesign.html).
+    '';
+    homepage = "https://github.com/indygreg/apple-platform-rs";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ euank ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17943,6 +17943,8 @@ with pkgs;
 
   hammer = callPackage ../development/tools/parsing/hammer { };
 
+  rcodesign = darwin.apple_sdk_11_0.callPackage ../development/tools/rcodesign {};
+
   rdocker = callPackage ../development/tools/rdocker { };
 
   redis-dump = callPackage ../development/tools/redis-dump { };


### PR DESCRIPTION
###### Description of changes

This adds a new package, rcodesign, which allows signing macOS binaries from linux, windows, etc. 

Some links to learn more:

* [Github Repo](https://github.com/indygreg/apple-platform-rs)
* [Blogpost about it](https://gregoryszorc.com/blog/2022/08/08/achieving-a-completely-open-source-implementation-of-apple-code-signing-and-notarization/) (specifically about it being able to notarize, by the owner of the project)
* [Some nice docs](https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_rcodesign.html)

Note that I have verified that the `rcodesign verify` subcommand works, but I have not yet used this built package to sign something. I will soon, but I have pretty high confidence this can be merged with only the minimal testing I've done so far.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).