### PR TITLE
radare2: 5.7.8 -> 5.8.0

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -30,7 +30,7 @@
 
 let
   # FIXME: Compare revision with
-  # https://github.com/radareorg/radare2/blob/master/libr/asm/arch/arm/v35arm64/Makefile#L26-L27
+  # https://github.com/radareorg/radare2/blob/master/libr/arch/p/arm/v35arm64/Makefile#L26-L27
   arm64 = fetchFromGitHub {
     owner = "radareorg";
     repo = "vector35-arch-arm64";
@@ -47,21 +47,23 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "radare2";
-  version = "5.7.8";
+  version = "5.8.0";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     rev = version;
-    hash = "sha256-+/9SeILuDCUaYwPhhN6z3vQFicd1Bh8N/yicZTybR5o=";
+    hash = "sha256-9bDwtMNru7tG0L735y+Vrcg7Htk/TV9SVZn7WP4Ap4c=";
   };
 
   preBuild = ''
-    cp -r ${arm64} ../libr/asm/arch/arm/v35arm64/arch-arm64
-    chmod -R +w ../libr/asm/arch/arm/v35arm64/arch-arm64
+    pushd ../libr/arch/p/arm/v35arm64
+    cp -r ${arm64} arch-arm64
+    chmod -R +w arch-arm64
 
-    cp -r ${armv7} ../libr/asm/arch/arm/v35arm64/arch-armv7
-    chmod -R +w ../libr/asm/arch/arm/v35arm64/arch-armv7
+    cp -r ${armv7} arch-armv7
+    chmod -R +w arch-armv7
+    popd
   '';
 
   postFixup = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/tools/security/iaito/default.nix
+++ b/pkgs/tools/security/iaito/default.nix
@@ -13,21 +13,21 @@
 
 stdenv.mkDerivation rec {
   pname = "iaito";
-  version = "5.7.8";
+  version = "5.8.0";
 
   srcs = [
     (fetchFromGitHub rec {
       owner = "radareorg";
       repo = "iaito";
       rev = version;
-      hash = "sha256-c36WLpVUnffeY6cXSEHvguo8BHyxaLAluN9hBKsQc0s=";
+      hash = "sha256-LqJu30Bp+JgB+y3MDyPVuFmEoXTpfA7K2pxv1ZCABx0=";
       name = repo;
     })
     (fetchFromGitHub rec {
       owner = "radareorg";
       repo = "iaito-translations";
-      rev = "ab923335409fa298c39f0014588d78d926c6f3a2";
-      hash = "sha256-qkIC67a6YRwOa2Sr16Vg6If1TmAiSKUV7hw13Wxwl/w=";
+      rev = "e66b3a962a7fc7dfd730764180011ecffbb206bf";
+      hash = "sha256-6NRTZ/ydypsB5TwbivvwOH9TEMAff/LH69hCXTvMPp8=";
       name = repo;
     })
   ];
@@ -55,6 +55,9 @@ stdenv.mkDerivation rec {
     qtbase
     radare2
   ];
+
+  # the radare2 binary package seems to not install all necessary headers.
+  NIX_CFLAGS_COMPILE = [ "-I" "${radare2.src}/shlr/sdb/include/sdb" ];
 
   postBuild = ''
     pushd ../../../iaito-translations


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->