### PR TITLE
nixos/nginx: fix config validation with hostnames in proxy_pass

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -427,11 +427,11 @@ let
   validatedConfigFile = pkgs.runCommand "validated-nginx.conf" { nativeBuildInputs = [ cfg.package pkgs.bubblewrap pkgs.fakedns pkgs.getent ]; } ''
     # nginx absolutely wants to read the certificates even when told to only validate config, so let's provide fake certs
     sed ${configFile} \
-    -e "s|ssl_certificate .*;|ssl_certificate ${snakeOilCert}/server.crt;|g" \
-    -e "s|ssl_trusted_certificate .*;|ssl_trusted_certificate ${snakeOilCert}/server.crt;|g" \
-    -e "s|ssl_certificate_key .*;|ssl_certificate_key ${snakeOilCert}/server.key;|g" \
-    -e "s|ssl_password_file .*;||g" \
-    -e "s|ssl_dhparam .*;|ssl_dhparam ${snakeOilCert}/dhparam.pem;|g" \
+    -e "s|ssl_certificate [^;]*;|ssl_certificate ${snakeOilCert}/server.crt;|g" \
+    -e "s|ssl_trusted_certificate [^;]*;|ssl_trusted_certificate ${snakeOilCert}/server.crt;|g" \
+    -e "s|ssl_certificate_key [^;]*;|ssl_certificate_key ${snakeOilCert}/server.key;|g" \
+    -e "s|ssl_password_file [^;]*;||g" \
+    -e "s|ssl_dhparam [^;]*;|ssl_dhparam ${snakeOilCert}/dhparam.pem;|g" \
     > conf
 
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -401,6 +401,7 @@ let
     openssl req -new -key $out/server.key -out server.csr \
     -subj "/C=UK/ST=Warwickshire/L=Leamington/O=OrgName/OU=IT Department/CN=example.com"
     openssl x509 -req -days 1 -in server.csr -signkey $out/server.key -out $out/server.crt
+    openssl dhparam -out $out/dhparam.pem 1024
   '';
   fakednsConfig = builtins.toFile "fakednsConfig" ''
     [Settings]
@@ -429,7 +430,10 @@ let
     -e "s|ssl_certificate .*;|ssl_certificate ${snakeOilCert}/server.crt;|g" \
     -e "s|ssl_trusted_certificate .*;|ssl_trusted_certificate ${snakeOilCert}/server.crt;|g" \
     -e "s|ssl_certificate_key .*;|ssl_certificate_key ${snakeOilCert}/server.key;|g" \
+    -e "s|ssl_password_file .*;||g" \
+    -e "s|ssl_dhparam .*;|ssl_dhparam ${snakeOilCert}/dhparam.pem;|g" \
     > conf
+
 
     # nginx absolutely wants to resolve hostnames of upstream servers during parsing.
     # we run a fake dns server inside a network namespace to fake that.

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -59,6 +59,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         services.nginx.package = pkgs.nginxMainline;
       };
 
+      # configuration validation must not fail when configuration references
+      # unreachable hostnames, https://github.com/NixOS/nixpkgs/issues/207409
+      specialisation.configValidationRegression.configuration = {
+        services.nginx.virtualHosts."1.my.test".locations."/".proxyPass = "http://some.other.domain";
+        services.nginx.upstreams."yay".servers."1.2.3.4:3000" = {};
+      };
+
       specialisation.reloadWithErrorsSystem.configuration = {
         services.nginx.package = pkgs.nginxMainline;
         services.nginx.virtualHosts."hello".extraConfig = "access_log /does/not/exist.log;";

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -62,8 +62,19 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       # configuration validation must not fail when configuration references
       # unreachable hostnames, https://github.com/NixOS/nixpkgs/issues/207409
       specialisation.configValidationRegression.configuration = {
-        services.nginx.virtualHosts."1.my.test".locations."/".proxyPass = "http://some.other.domain";
+        services.nginx.virtualHosts."1.my.test" = {
+          addSSL = true;
+          sslTrustedCertificate = "/dev/nonexistent/ca";
+          sslCertificateKey = "/dev/nonexistent/key";
+          sslCertificate = "/dev/nonexistent/cert";
+          locations."/".proxyPass = "http://some.other.domain";
+        };
         services.nginx.upstreams."yay".servers."1.2.3.4:3000" = {};
+        services.nginx.sslDhparam = "/var/lib/dhparams/nginx.pem";
+        security.dhparams = {
+          stateful = true;
+          params = { nginx.bits = 2048; };
+        };
       };
 
       specialisation.reloadWithErrorsSystem.configuration = {

--- a/pkgs/development/python-modules/cli-formatter/default.nix
+++ b/pkgs/development/python-modules/cli-formatter/default.nix
@@ -1,0 +1,17 @@
+{ buildPythonPackage, fetchPypi, lib }:
+buildPythonPackage rec {
+  pname = "cli-formatter";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Vpi2R0DHL9ouxsEtcyJx+reMjItlvtihfbMxJbECfak=";
+  };
+
+  meta = {
+    description = "Utility for formatting console output for cli scripts";
+    homepage = "https://github.com/wahlflo/cli-formatter";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.symphorien ];
+  };
+}

--- a/pkgs/development/python-modules/dns-messages/default.nix
+++ b/pkgs/development/python-modules/dns-messages/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, fetchPypi, lib }:
+
+buildPythonPackage rec {
+  pname = "dns-messages";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-00gjYwEUeizid/kXxGV2WjBzO/PCpDjV2hMmYUdjPd4=";
+  };
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "dns_messages" ];
+
+  meta = {
+    description = "A Python3 library for parsing and generating DNS messages";
+    homepage = "https://github.com/wahlflo/dns-messages";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.symphorien ];
+  };
+}

--- a/pkgs/tools/networking/fakedns/default.nix
+++ b/pkgs/tools/networking/fakedns/default.nix
@@ -1,0 +1,27 @@
+{ python3, fetchFromGitHub, lib }:
+
+python3.pkgs.buildPythonApplication {
+  pname = "fakedns";
+  version = "2022-08-14";
+
+  src = fetchFromGitHub {
+    owner = "wahlflo";
+    repo = "fakedns";
+    rev = "11397c3e5180f30de184fba1dbfe9fc8ea85fadd";
+    sha256 = "sha256-ZGNZ8pa9loSTDqrx3ra7sRfsDKzJ1Z2UDlsg+qGq9xo=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    cli-formatter
+    dns-messages
+  ];
+
+  pythonImportsCheck = [ "fakedns" ];
+
+  meta = {
+    description = "A fake DNS server for malware analysis";
+    homepage = "https://github.com/wahlflo/fakedns";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.symphorien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4444,6 +4444,8 @@ with pkgs;
 
   facter = callPackage ../tools/system/facter { };
 
+  fakedns = callPackage ../tools/networking/fakedns { };
+
   faketty = callPackage ../tools/misc/faketty { };
 
   fasd = callPackage ../tools/misc/fasd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2696,6 +2696,8 @@ self: super: with self; {
 
   dnspython = callPackage ../development/python-modules/dnspython { };
 
+  dns-messages = callPackage ../development/python-modules/dns-messages { };
+
   doc8 = callPackage ../development/python-modules/doc8 { };
 
   docformatter = callPackage ../development/python-modules/docformatter { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1815,6 +1815,8 @@ self: super: with self; {
 
   clize = callPackage ../development/python-modules/clize { };
 
+  cli-formatter = callPackage ../development/python-modules/cli-formatter { };
+
   clldutils = callPackage ../development/python-modules/clldutils { };
 
   cloudflare = callPackage ../development/python-modules/cloudflare { };


### PR DESCRIPTION
###### Description of changes

There are actually many directives which trigger domain name resolution, so using regexes to "fix" them all does not seem like a good approach. Instead I run a fake dns server that answers all requests with a dummy IP.
Unfortunately libredirect tricks to point nginx to a fake /etc/resolv.conf don't work, because nginx uses getaddrinfo, so it is glibc which reads /etc/resolv.conf, and one cannot fake glibc calls to glibc it seems.
So I use bubblewrap instead, but that requires user namespaces, which are not always available. If this is not the case, and validation fails on dns failure, then we ignore the failure. The goal is that if it builds somewhere, it builds everywhere (use case: heterogenous remote builders). I have not yet tested building without user namespaces.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


cc @delroth 
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
