### PR TITLE
fortls: init at 2.13.0

### DIFF
--- a/pkgs/development/tools/fortls/default.nix
+++ b/pkgs/development/tools/fortls/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonApplication
+, lib
+, fetchFromGitHub
+, setuptools-scm
+, json5
+, packaging
+}:
+
+buildPythonApplication rec {
+  pname = "fortls";
+  version = "2.13.0";
+
+  src = fetchFromGitHub {
+    owner = "fortran-lang";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-kFk2Dlnb0FXM3Ysvsy+g2AAMgpWmwzxuyJPovDm/FJU=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [ json5 packaging ];
+
+  preBuild = "export SETUPTOOLS_SCM_PRETEND_VERSION=${version}";
+
+  doCheck = true;
+  checkPhase = "$out/bin/fortls --help 1>/dev/null";
+
+  meta = with lib; {
+    description = "Fortran Language Server ";
+    homepage = "https://github.com/fortran-lang/fortls";
+    license = [ licenses.mit ];
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17307,6 +17307,8 @@ with pkgs;
 
   fprettify = callPackage ../development/tools/fprettify { };
 
+  fortls = python3.pkgs.callPackage ../development/tools/fortls { };
+
   fortran-language-server = python3.pkgs.callPackage ../development/tools/fortran-language-server { };
 
   framac = callPackage ../development/tools/analysis/frama-c { };


### PR DESCRIPTION
###### Description of changes

Adds the Fortran language server, which is the continued and concurrent developemt of the fortran-language-server.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

