### PR TITLE
lvm2: 2.03.17 -> 2.03.18

### DIFF
--- a/pkgs/os-specific/linux/lvm2/2_03.nix
+++ b/pkgs/os-specific/linux/lvm2/2_03.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "2.03.17";
-  hash = "sha256-cobPqWUYKMWJOJUJVGMzuNqWXfqEoaTIqz5oGkf6uuc=";
+  version = "2.03.18";
+  hash = "sha256-n2g+KYDZXA3Ou9JcfBdwMsVhXXJnv8iF6r/OWSgPR2k=";
 }


### PR DESCRIPTION
###### Description of changes
- Fix issues reported by coverity scan.
- Fix warning for thin pool overprovisioning on lvextend (2.03.17).
- Add support for writecache metadata_only and pause_writeback settings.
- Fix missing error messages in lvmdbusd.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).