### PR TITLE
gnustep.base: use multiple outputs and support multiple outputs in hook

### DIFF
--- a/pkgs/desktops/gnustep/base/default.nix
+++ b/pkgs/desktops/gnustep/base/default.nix
@@ -19,6 +19,7 @@ gsmakeDerivation rec {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/${pname}-${version}.tar.gz";
     sha256 = "05vjz19v1w7yb7hm8qrc41bqh6xd8in7sgg2p0h1vldyyaa5sh90";
   };
+  outputs = [ "out" "dev" "lib" ];
   nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [
     aspell audiofile

--- a/pkgs/desktops/gnustep/make/setup-hook.sh
+++ b/pkgs/desktops/gnustep/make/setup-hook.sh
@@ -1,20 +1,24 @@
 # this path is used by some packages to install additional makefiles
 export DESTDIR_GNUSTEP_MAKEFILES=$out/share/GNUstep/Makefiles
 
-installFlagsArray=( \
-  "GNUSTEP_INSTALLATION_DOMAIN=SYSTEM" \
-  "GNUSTEP_SYSTEM_APPS=$out/lib/GNUstep/Applications" \
-  "GNUSTEP_SYSTEM_ADMIN_APPS=$out/lib/GNUstep/Applications" \
-  "GNUSTEP_SYSTEM_WEB_APPS=$out/lib/GNUstep/WebApplications" \
-  "GNUSTEP_SYSTEM_TOOLS=$out/bin" \
-  "GNUSTEP_SYSTEM_ADMIN_TOOLS=$out/sbin" \
-  "GNUSTEP_SYSTEM_LIBRARY=$out/lib/GNUstep" \
-  "GNUSTEP_SYSTEM_HEADERS=$out/include" \
-  "GNUSTEP_SYSTEM_LIBRARIES=$out/lib" \
-  "GNUSTEP_SYSTEM_DOC=$out/share/GNUstep/Documentation" \
-  "GNUSTEP_SYSTEM_DOC_MAN=$out/share/man" \
-  "GNUSTEP_SYSTEM_DOC_INFO=$out/share/info" \
-)
+addGnustepInstallFlags() {
+    installFlagsArray=( \
+      "GNUSTEP_INSTALLATION_DOMAIN=SYSTEM" \
+      "GNUSTEP_SYSTEM_APPS=${!outputLib}/lib/GNUstep/Applications" \
+      "GNUSTEP_SYSTEM_ADMIN_APPS=${!outputLib}/lib/GNUstep/Applications" \
+      "GNUSTEP_SYSTEM_WEB_APPS=${!outputLib}/lib/GNUstep/WebApplications" \
+      "GNUSTEP_SYSTEM_TOOLS=${!outputBin}/bin" \
+      "GNUSTEP_SYSTEM_ADMIN_TOOLS=${!outputBin}/sbin" \
+      "GNUSTEP_SYSTEM_LIBRARY=${!outputLib}/lib/GNUstep" \
+      "GNUSTEP_SYSTEM_HEADERS=${!outputInclude}/include" \
+      "GNUSTEP_SYSTEM_LIBRARIES=${!outputLib}/lib" \
+      "GNUSTEP_SYSTEM_DOC=${!outputDoc}/share/GNUstep/Documentation" \
+      "GNUSTEP_SYSTEM_DOC_MAN=${!outputMan}/share/man" \
+      "GNUSTEP_SYSTEM_DOC_INFO=${!outputInfo}/share/info" \
+    )
+}
+
+preInstallPhases+=" addGnustepInstallFlags"
 
 addEnvVars() {
     local filename

--- a/pkgs/servers/web-apps/sogo/default.nix
+++ b/pkgs/servers/web-apps/sogo/default.nix
@@ -51,7 +51,7 @@ gnustep.stdenv.mkDerivation rec {
     sed -i "s:${gnustep.make}:$out:g" $out/share/GNUstep/GNUstep.conf
 
     # Link in GNUstep base
-    ${lndir}/bin/lndir ${gnustep.base}/lib/GNUstep/ $out/lib/GNUstep/
+    ${lndir}/bin/lndir ${lib.getLib gnustep.base}/lib/GNUstep/ $out/lib/GNUstep/
 
     # Link in sope
     ${lndir}/bin/lndir ${sope}/ $out/


### PR DESCRIPTION
had to move the installFlagsArray in preInstallPhases so that ${!outputX} work because they're set by the multiple-output hook

unar before:
closure size 1.4G

unar after:
closure size 138.9M

Closes https://github.com/NixOS/nixpkgs/issues/117208

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
