### PR TITLE
vector: fix build against rust 1.66

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -45,6 +45,11 @@ rustPlatform.buildRustPackage {
     sha256 = pinData.sha256;
   };
 
+  patches = [
+    # replace with https://github.com/vectordotdev/vector/pull/15093 when ready
+    ./fix-for-rust-1.66.diff
+  ];
+
   cargoSha256 = pinData.cargoSha256;
   nativeBuildInputs = [ pkg-config cmake perl ];
   buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]

--- a/pkgs/tools/misc/vector/fix-for-rust-1.66.diff
+++ b/pkgs/tools/misc/vector/fix-for-rust-1.66.diff
@@ -1,0 +1,13 @@
+diff --git a/src/sources/aws_kinesis_firehose/filters.rs b/src/sources/aws_kinesis_firehose/filters.rs
+index ac33682..fe65ed4 100644
+--- a/src/sources/aws_kinesis_firehose/filters.rs
++++ b/src/sources/aws_kinesis_firehose/filters.rs
+@@ -28,7 +28,7 @@ pub fn firehose(
+     acknowledgements: bool,
+     out: SourceSender,
+     log_namespace: LogNamespace,
+-) -> impl Filter<Extract = impl warp::Reply, Error = Infallible> + Clone {
++) -> impl Filter<Extract = (impl warp::Reply,), Error = Infallible> + Clone {
+     let bytes_received = register!(BytesReceived::from(Protocol::HTTP));
+     let context = handlers::Context {
+         compression: record_compression,


### PR DESCRIPTION
###### Description of changes

Originally reported upstream in https://github.com/vectordotdev/vector/issues/15627 and needed for https://github.com/NixOS/nixpkgs/pull/206270. When it's ready, the patch introduced here can be replaced by https://github.com/vectordotdev/vector/pull/15093.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
