### PR TITLE
ulogd: init at 2.0.8

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -842,6 +842,12 @@ in mkLicense lset) ({
     fullName = "SGI Free Software License B v2.0";
   };
 
+  # Gentoo seems to treat it as a license:
+  # https://gitweb.gentoo.org/repo/gentoo.git/tree/licenses/SGMLUG?id=7d999af4a47bf55e53e54713d98d145f935935c1
+  sgmlug = {
+    fullName = "SGML UG SGML Parser Materials license";
+  };
+
   sleepycat = {
     spdxId = "Sleepycat";
     fullName = "Sleepycat License";

--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -67,6 +67,14 @@
           <link xlink:href="options.html#opt-services.v2raya.enable">services.v2raya</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://www.netfilter.org/projects/ulogd/index.html">ulogd</link>,
+          a userspace logging daemon for netfilter/iptables related
+          logging. Available as
+          <link xlink:href="options.html#opt-services.ulogd.enable">services.ulogd</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-23.05-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -26,6 +26,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [v2rayA](https://v2raya.org), a Linux web GUI client of Project V which supports V2Ray, Xray, SS, SSR, Trojan and Pingtunnel. Available as [services.v2raya](options.html#opt-services.v2raya.enable).
 
+- [ulogd](https://www.netfilter.org/projects/ulogd/index.html), a userspace logging daemon for netfilter/iptables related logging. Available as [services.ulogd](options.html#opt-services.ulogd.enable).
+
 ## Backward Incompatibilities {#sec-release-23.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -520,6 +520,7 @@
   ./services/logging/syslog-ng.nix
   ./services/logging/syslogd.nix
   ./services/logging/vector.nix
+  ./services/logging/ulogd.nix
   ./services/mail/clamsmtp.nix
   ./services/mail/davmail.nix
   ./services/mail/dkimproxy-out.nix

--- a/nixos/modules/services/logging/ulogd.nix
+++ b/nixos/modules/services/logging/ulogd.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.ulogd;
+  settingsFormat = pkgs.formats.ini { };
+  settingsFile = settingsFormat.generate "ulogd.conf" cfg.settings;
+in {
+  options = {
+    services.ulogd = {
+      enable = mkEnableOption (lib.mdDoc "ulogd");
+
+      settings = mkOption {
+        example = {
+          global.stack = "stack=log1:NFLOG,base1:BASE,pcap1:PCAP";
+          log1.group = 2;
+          pcap1 = {
+            file = "/var/log/ulogd.pcap";
+            sync = 1;
+          };
+        };
+        type = settingsFormat.type;
+        default = { };
+        description = lib.mdDoc "Configuration for ulogd. See {file}`/share/doc/ulogd/` in `pkgs.ulogd.doc`.";
+      };
+
+      logLevel = mkOption {
+        type = types.enum [ 1 3 5 7 8 ];
+        default = 5;
+        description = lib.mdDoc "Log level (1 = debug, 3 = info, 5 = notice, 7 = error, 8 = fatal)";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.ulogd = {
+      description = "Ulogd Daemon";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-pre.target" ];
+      before = [ "network-pre.target" ];
+
+      serviceConfig = {
+        ExecStart = "${pkgs.ulogd}/bin/ulogd -c ${settingsFile} --verbose --loglevel ${toString cfg.logLevel}";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -681,6 +681,7 @@ in {
   tuxguitar = handleTest ./tuxguitar.nix {};
   ucarp = handleTest ./ucarp.nix {};
   udisks2 = handleTest ./udisks2.nix {};
+  ulogd = handleTest ./ulogd.nix {};
   unbound = handleTest ./unbound.nix {};
   unifi = handleTest ./unifi.nix {};
   unit-php = handleTest ./web-servers/unit-php.nix {};

--- a/nixos/tests/ulogd.nix
+++ b/nixos/tests/ulogd.nix
@@ -1,0 +1,84 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "ulogd";
+
+  meta = with lib; {
+    maintainers = with maintainers; [ p-h ];
+  };
+
+  nodes.machine = { ... }: {
+    networking.firewall.enable = false;
+    networking.nftables.enable = true;
+    networking.nftables.ruleset = ''
+      table inet filter {
+        chain input {
+          type filter hook input priority 0;
+          log group 2 accept
+        }
+
+        chain output {
+          type filter hook output priority 0; policy accept;
+          log group 2 accept
+        }
+
+        chain forward {
+          type filter hook forward priority 0; policy drop;
+          log group 2 accept
+        }
+
+      }
+    '';
+    services.ulogd = {
+      enable = true;
+      settings = {
+        global = {
+          logfile = "/var/log/ulogd.log";
+          stack = "log1:NFLOG,base1:BASE,pcap1:PCAP";
+        };
+
+        log1.group = 2;
+
+        pcap1 = {
+          file = "/var/log/ulogd.pcap";
+          sync = 1;
+        };
+      };
+    };
+
+    environment.systemPackages = with pkgs; [
+      tcpdump
+    ];
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("ulogd.service")
+    machine.wait_for_unit("network-online.target")
+
+    with subtest("Ulogd is running"):
+        machine.succeed("pgrep ulogd >&2")
+
+    # All packets show up twice in the logs
+    with subtest("Logs are collected"):
+        machine.succeed("ping -f 127.0.0.1 -c 5 >&2")
+        machine.succeed("sleep 2")
+        machine.wait_until_succeeds("du /var/log/ulogd.pcap >&2")
+        _, echo_request_packets = machine.execute("tcpdump -r /var/log/ulogd.pcap icmp[0] == 8 and host 127.0.0.1")
+        expected, actual = 5*2, len(echo_request_packets.splitlines())
+        assert expected == actual, f"Expected {expected} packets, got: {actual}"
+        _, echo_reply_packets = machine.execute("tcpdump -r /var/log/ulogd.pcap icmp[0] == 0 and host 127.0.0.1")
+        expected, actual = 5*2, len(echo_reply_packets.splitlines())
+        assert expected == actual, f"Expected {expected} packets, got: {actual}"
+
+    with subtest("Reloading service reopens log file"):
+        machine.succeed("mv /var/log/ulogd.pcap /var/log/old_ulogd.pcap")
+        machine.succeed("systemctl reload ulogd.service")
+        machine.succeed("ping -f 127.0.0.1 -c 5 >&2")
+        machine.succeed("sleep 2")
+        _, echo_request_packets = machine.execute("tcpdump -r /var/log/ulogd.pcap icmp[0] == 8 and host 127.0.0.1")
+        expected, actual = 5*2, len(echo_request_packets.splitlines())
+        assert expected == actual, f"Expected {expected} packets, got: {actual}"
+        _, echo_reply_packets = machine.execute("tcpdump -r /var/log/ulogd.pcap icmp[0] == 0 and host 127.0.0.1")
+        expected, actual = 5*2, len(echo_reply_packets.splitlines())
+        assert expected == actual, f"Expected {expected} packets, got: {actual}"
+  '';
+})

--- a/pkgs/os-specific/linux/ulogd/default.nix
+++ b/pkgs/os-specific/linux/ulogd/default.nix
@@ -1,0 +1,72 @@
+{ stdenv, lib, fetchurl, gnumake, libnetfilter_acct, libnetfilter_conntrack
+, libnetfilter_log, libmnl, libnfnetlink, automake, autoconf, autogen, libtool
+, pkg-config, libpcap, linuxdoc-tools, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  version = "2.0.8";
+  pname = "ulogd";
+
+  src = fetchurl {
+    url = "https://netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
+    hash = "sha256-Tq1sOXDD9X+h6J/i18xIO6b+K9GwhwFSHgs6/WZ98pE=";
+  };
+
+  outputs = [ "out" "doc" "man" ];
+
+  postPatch = ''
+    substituteInPlace ulogd.8 --replace "/usr/share/doc" "$doc/share/doc"
+  '';
+
+  postBuild = ''
+    pushd doc/
+    linuxdoc --backend=txt --filter ulogd.sgml
+    linuxdoc --backend=html --split=0 ulogd.sgml
+    popd
+  '';
+
+  postInstall = ''
+    install -Dm444 -t $out/share/doc/${pname} ulogd.conf doc/ulogd.txt doc/ulogd.html README doc/*table
+    install -Dm444 -t $out/share/doc/${pname}-mysql doc/mysql*.sql
+    install -Dm444 -t $out/share/doc/${pname}-pgsql doc/pgsql*.sql
+  '';
+
+  buildInputs = [
+    libnetfilter_acct
+    libnetfilter_conntrack
+    libnetfilter_log
+    libmnl
+    libnfnetlink
+    libpcap
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    automake
+    autoconf
+    autogen
+    libtool
+    linuxdoc-tools
+  ];
+
+  meta = with lib; {
+    description = "Userspace logging daemon for netfilter/iptables";
+
+    longDescription = ''
+      Logging daemon that reads event messages coming from the Netfilter
+      connection tracking, the Netfilter packet logging subsystem and from the
+      Netfilter accounting subsystem. You have to enable support for connection
+      tracking event delivery; ctnetlink and the NFLOG target in your Linux
+      kernel 2.6.x or load their respective modules. The deprecated ULOG target
+      (which has been superseded by NFLOG) is also supported.
+
+      The received messages can be logged into files or into a MySQL, SQLite3
+      or PostgreSQL database. IPFIX and Graphite output are also supported.
+    '';
+
+    homepage = "https://www.netfilter.org/projects/ulogd/index.html";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ p-h ];
+  };
+}

--- a/pkgs/os-specific/linux/ulogd/default.nix
+++ b/pkgs/os-specific/linux/ulogd/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, gnumake, libnetfilter_acct, libnetfilter_conntrack
 , libnetfilter_log, libmnl, libnfnetlink, automake, autoconf, autogen, libtool
-, pkg-config, libpcap, linuxdoc-tools, autoreconfHook }:
+, pkg-config, libpcap, linuxdoc-tools, autoreconfHook, nixosTests }:
 
 stdenv.mkDerivation rec {
   version = "2.0.8";
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
     libtool
     linuxdoc-tools
   ];
+
+  passthru.tests = { inherit (nixosTests) ulogd; };
 
   meta = with lib; {
     description = "Userspace logging daemon for netfilter/iptables";

--- a/pkgs/tools/text/sgml/linuxdoc-tools/default.nix
+++ b/pkgs/tools/text/sgml/linuxdoc-tools/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, lib, makeWrapper, fetchFromGitLab, openjade, gnumake, perl, flex
+, gnused, coreutils, which, opensp, groff, texlive, texinfo, withLatex ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "linuxdoc-tools";
+  version = "0.9.82";
+
+  src = fetchFromGitLab {
+    owner = "agmartin";
+    repo = "linuxdoc-tools";
+    rev = version;
+    sha256 = "17v9ilh79av4n94vk4m52aq57ykb9myffxd2qr8kb8b3xnq5d36z";
+  };
+
+  outputs = [ "out" "man" "doc" ];
+
+  configureFlags = [
+    ("--enable-docs=txt info lyx html rtf"
+      + lib.optionalString withLatex " pdf")
+  ];
+
+  LEX = "flex";
+
+  postInstall = ''
+    wrapProgram $out/bin/linuxdoc \
+      --prefix PATH : "${lib.makeBinPath [ groff opensp ]}:$out/bin" \
+      --prefix PERL5LIB : "$out/share/linuxdoc-tools/"
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    pushd doc/example
+    substituteInPlace Makefile \
+      --replace "COMMAND=linuxdoc" "COMMAND=$out/bin/linuxdoc" \
+      ${lib.optionalString (!withLatex) "--replace '.tex .dvi .ps .pdf' ''"}
+    make
+    popd
+  '';
+
+  nativeBuildInputs = [ flex which makeWrapper ];
+
+  buildInputs = [ opensp groff texinfo perl gnused coreutils ]
+    ++ lib.optionals withLatex [ texlive.combined.scheme-medium ];
+
+  meta = with lib; {
+    description = "Toolset for processing LinuxDoc DTD SGML files";
+    longDescription = ''
+      A collection of text formatters which understands a LinuxDoc DTD SGML
+      source file. Each formatter (or "back-end") renders the source file into
+      a variety of output formats, including HTML, TeX, DVI, PostScript, plain
+      text, and groff source in manual-page format. The linuxdoc suite is
+      provided for backward compatibility, because there are still many useful
+      documents written in LinuxDoc DTD sgml source.
+    '';
+    homepage = "https://gitlab.com/agmartin/linuxdoc-tools";
+    license = with licenses; [ gpl3Plus mit sgmlug ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ p-h ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4928,6 +4928,8 @@ with pkgs;
 
   linuxptp = callPackage ../os-specific/linux/linuxptp { };
 
+  linuxdoc-tools = callPackage ../tools/text/sgml/linuxdoc-tools { };
+
   lisgd = callPackage ../tools/inputmethods/lisgd { };
 
   lite = callPackage ../applications/editors/lite { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13093,6 +13093,8 @@ with pkgs;
     inherit (chickenPackages_4) eggDerivation fetchegg;
   };
 
+  ulogd = callPackage ../os-specific/linux/ulogd { };
+
   unar = callPackage ../tools/archivers/unar {
     inherit (darwin.apple_sdk.frameworks) Foundation AppKit;
     stdenv = clangStdenv;


### PR DESCRIPTION
###### Description of changes
- ulogd: init at 2.0.8
- linuxdoc-tools: init at 0.9.82
- ulogd service
- ulogd tests

###### Things done

This is almost entirely based on @xvuko's [PR](https://github.com/NixOS/nixpkgs/pull/103804), which sadly never got merged.
I rebased his branch on master and fixed the tests and updated and fixed the packages.

I'm unsure if I should squash anything or include him as a maintainer as he doesn't seem to have contributed anything since.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
