### PR TITLE
mod_python: 3.5.0 -> unstable-2022-10-18, mod_wsgi2: remove, mod_wsgi: refactor derivation

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_python/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_python/default.nix
@@ -1,36 +1,32 @@
-{ lib, stdenv, fetchurl, apacheHttpd, python2, libintl }:
+{ lib, stdenv, fetchFromGitHub, apacheHttpd, python3, libintl }:
 
 stdenv.mkDerivation rec {
   pname = "mod_python";
-  version = "3.5.0";
+  version = "unstable-2022-10-18";
 
-  src = fetchurl {
-    url = "http://dist.modpython.org/dist/${pname}-${version}.tgz";
-    sha256 = "146apll3yfqk05s8fkf4acmxzqncl08bgn4rv0c1rd4qxmc91w0f";
+  src = fetchFromGitHub {
+    owner = "grisha";
+    repo = pname;
+    rev = "d066b07564d2194839eceb535485eb1ba0c292d8";
+    hash = "sha256-EH8wrXqUAOFWyPKfysGeiIezgrVc789RYO4AHeSA6t4=";
   };
 
   patches = [ ./install.patch ];
 
-  postPatch = ''
-    substituteInPlace dist/version.sh \
-        --replace 'GIT=`git describe --always`' "" \
-        --replace '-$GIT' ""
-  '';
-
-  installFlags = [ "LIBEXECDIR=${placeholder "out"}/modules" ];
-
-  preInstall = ''
-    mkdir -p $out/modules $out/bin
-  '';
+  installFlags = [
+    "LIBEXECDIR=$(out)/modules"
+    "BINDIR=$(out)/bin"
+  ];
 
   passthru = { inherit apacheHttpd; };
 
-  buildInputs = [ apacheHttpd python2 ]
+  buildInputs = [ apacheHttpd python3 ]
     ++ lib.optional stdenv.isDarwin libintl;
 
-  meta = {
+  meta = with lib; {
     homepage = "http://modpython.org/";
     description = "An Apache module that embeds the Python interpreter within the server";
-    platforms = lib.platforms.unix;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_wsgi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, apacheHttpd, python, ncurses }:
+{ lib, stdenv, fetchFromGitHub, apacheHttpd, python3, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "mod_wsgi";
@@ -11,13 +11,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-6rRHdgdTb94kqIpWJOJOwoIsaXb/c4XY3q331GwQyf0=";
   };
 
-  buildInputs = [ apacheHttpd python ncurses ];
+  buildInputs = [ apacheHttpd python3 ncurses ];
 
-  patchPhase = ''
-    sed -r -i -e "s|^LIBEXECDIR=.*$|LIBEXECDIR=$out/modules|" \
-      ${if stdenv.isDarwin then "-e 's|/usr/bin/lipo|lipo|'" else ""} \
-      configure
+  postPatch = ''
+    substituteInPlace configure --replace '/usr/bin/lipo' 'lipo'
   '';
+
+  makeFlags = [
+    "LIBEXECDIR=$(out)/modules"
+  ];
 
   meta = {
     homepage = "https://github.com/GrahamDumpleton/mod_wsgi";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -951,7 +951,7 @@ mapAliases ({
   moby = throw "moby has been removed, merged into linuxkit in 2018.  Use linuxkit instead";
   module_init_tools = throw "'module_init_tools' has been renamed to/replaced by 'kmod'"; # Converted to throw 2022-02-22
   monero = monero-cli; # Added 2021-11-28
-  monodevelop = throw "monodevelop has been removed from nixpgks"; # Added 2022-01-15
+  monodevelop = throw "monodevelop has been removed from nixpkgs"; # Added 2022-01-15
   mopidy-gmusic = throw "mopidy-gmusic has been removed because Google Play Music was discontinued"; # Added 2021-03-07
   mopidy-local-images = throw "mopidy-local-images has been removed as it's unmaintained. Its functionality has been merged into the mopidy-local extension"; # Added 2020-10-18
   mopidy-local-sqlite = throw "mopidy-local-sqlite has been removed as it's unmaintained. Its functionality has been merged into the mopidy-local extension"; # Added 2020-10-18

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23710,7 +23710,7 @@ with pkgs;
     mod_tile = callPackage ../servers/http/apache-modules/mod_tile { };
 
     mod_wsgi  = self.mod_wsgi2;
-    mod_wsgi2 = callPackage ../servers/http/apache-modules/mod_wsgi { python = python2; ncurses = null; };
+    mod_wsgi2 = throw "mod_wsgi2 has been removed since Python 2 is EOL. Use mod_wsgi3 instead";
     mod_wsgi3 = callPackage ../servers/http/apache-modules/mod_wsgi { python = python3; };
 
     mod_itk = callPackage ../servers/http/apache-modules/mod_itk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23711,7 +23711,7 @@ with pkgs;
 
     mod_wsgi  = self.mod_wsgi2;
     mod_wsgi2 = throw "mod_wsgi2 has been removed since Python 2 is EOL. Use mod_wsgi3 instead";
-    mod_wsgi3 = callPackage ../servers/http/apache-modules/mod_wsgi { python = python3; };
+    mod_wsgi3 = callPackage ../servers/http/apache-modules/mod_wsgi { };
 
     mod_itk = callPackage ../servers/http/apache-modules/mod_itk { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See motivation: https://github.com/NixOS/nixpkgs/pull/201859

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
