### PR TITLE
gawk: 5.1.1 -> 5.2.1

### DIFF
--- a/pkgs/tools/text/gawk/darwin-no-pma.patch
+++ b/pkgs/tools/text/gawk/darwin-no-pma.patch
@@ -1,0 +1,31 @@
+https://git.savannah.gnu.org/cgit/gawk.git/patch/?id=e0b7737930f8a677d3c509f8ce72b9130965ec0a
+--- a/m4/pma.m4
++++ b/m4/pma.m4
+@@ -23,15 +23,18 @@ then
+ 				[LDFLAGS="${LDFLAGS} -no-pie"
+ 				export LDFLAGS])
+ 			;;
+-		*darwin*)
+-			# 23 October 2022: See README_d/README.macosx for
+-			# the details on what's happening here. See also
+-			# the manual.
+-
+-			# Compile as Intel binary all the time, even on M1.
+-			CFLAGS="${CFLAGS} -arch x86_64"
+-			LDFLAGS="${LDFLAGS} -Xlinker -no_pie"
+-			export CFLAGS LDFLAGS
++ 		*darwin*)
++			# 27 November 2022: PMA only works on Intel.
++			case $host in
++			x86_64-*)
++				LDFLAGS="${LDFLAGS} -Xlinker -no_pie"
++				export LDFLAGS
++				;;
++			*)
++				# disable on all other macOS systems
++				use_persistent_malloc=no
++				;;
++			esac
+ 			;;
+ 		*cygwin* | *CYGWIN* | *solaris2.11* | freebsd13.* | openbsd7.* )
+ 			true	# nothing do, exes on these systems are not PIE

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -2,6 +2,7 @@
 # TODO: links -lsigsegv but loses the reference for some reason
 , withSigsegv ? (false && stdenv.hostPlatform.system != "x86_64-cygwin"), libsigsegv
 , interactive ? false, readline
+, autoreconfHook # no-pma fix
 
 /* Test suite broke on:
        stdenv.isCygwin # XXX: `test-dup2' segfaults on Cygwin 6.1
@@ -17,18 +18,26 @@ assert (doCheck && stdenv.isLinux) -> glibcLocales != null;
 
 stdenv.mkDerivation rec {
   pname = "gawk" + lib.optionalString interactive "-interactive";
-  version = "5.1.1";
+  version = "5.2.1";
 
   src = fetchurl {
     url = "mirror://gnu/gawk/gawk-${version}.tar.xz";
-    sha256 = "18kybw47fb1sdagav7aj95r9pp09r5gm202y3ahvwjw9dqw2jxnq";
+    hash = "sha256-ZzVTuR+eGMxXku1RB1341RDJBA9VCm904Jya3SQ6fk8=";
   };
+
+  patches = [
+    # Pull upstream fix for aarch64-darwin where pma does not work.
+    # Can be removed after next gawk release.
+    ./darwin-no-pma.patch
+  ];
 
   # When we do build separate interactive version, it makes sense to always include man.
   outputs = [ "out" "info" ]
     ++ lib.optional (!interactive) "man";
 
-  nativeBuildInputs = lib.optional (doCheck && stdenv.isLinux) glibcLocales;
+  nativeBuildInputs = lib.optional (doCheck && stdenv.isLinux) glibcLocales
+    # no-pma fix
+    ++ [ autoreconfHook ];
 
   buildInputs = lib.optional withSigsegv libsigsegv
     ++ lib.optional interactive readline


### PR DESCRIPTION
changelogs:
- 5.2.1: https://lists.gnu.org/archive/html/info-gnu/2022-11/msg00008.html
- 5.2.0: https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00003.html

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
