### PR TITLE
gitstats: migrate to python3

### DIFF
--- a/pkgs/applications/version-management/gitstats/default.nix
+++ b/pkgs/applications/version-management/gitstats/default.nix
@@ -1,4 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, perl, python2, gnuplot, coreutils, gnugrep }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, installShellFiles
+, perl
+, python3
+, gnuplot
+, coreutils
+, gnugrep
+}:
 
 stdenv.mkDerivation rec {
   pname = "gitstats";
@@ -12,9 +22,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-qUQB3aCRbPkbMoMf39kPQ0vil8RjXL8RqjdTryfkzK0=";
   };
 
-  nativeBuildInputs = [ perl ];
+  patches = [
+    # make gitstats compatible with python3
+    # https://github.com/hoxu/gitstats/pull/105
+    (fetchpatch {
+      name = "convert-gitstats-to-use-python3.patch";
+      url = "https://github.com/hoxu/gitstats/commit/ca415668ce6b739ca9fefba6acd29c63b89f4211.patch";
+      hash = "sha256-sgjoj8eQ5CxQBffmhqymsmXb8peuaSbfFoWciLK3LOo=";
+    })
+  ];
 
-  buildInputs = [ python2 ];
+  nativeBuildInputs = [ installShellFiles perl ];
+
+  buildInputs = [ python3 ];
 
   strictDeps = true;
 
@@ -25,13 +45,15 @@ stdenv.mkDerivation rec {
         -i gitstats
   '';
 
-  buildPhase = ''
-    make man VERSION="${version}"
-  '';
+  makeFlags = [
+    "PREFIX=$(out)"
+    "VERSION=${version}"
+  ];
 
-  installPhase = ''
-    make install PREFIX="$out" VERSION="${version}"
-    install -Dm644 doc/gitstats.1 "$out"/share/man/man1/gitstats.1
+  buildFlags = [ "man" ];
+
+  postInstall = ''
+    installManPage doc/gitstats.1
   '';
 
   meta = with lib; {
@@ -39,6 +61,6 @@ stdenv.mkDerivation rec {
     description = "Git history statistics generator";
     license = licenses.gpl2Plus;
     platforms = platforms.all;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor ];
   };
 }


### PR DESCRIPTION
###### Description of changes

#201859

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
