### PR TITLE
electron-fiddle: init 0.31.0

### DIFF
--- a/pkgs/development/tools/electron-fiddle/default.nix
+++ b/pkgs/development/tools/electron-fiddle/default.nix
@@ -1,0 +1,163 @@
+{ buildFHSUserEnv
+, electron_20
+, fetchFromGitHub
+, fetchYarnDeps
+, fixup_yarn_lock
+, git
+, lib
+, makeDesktopItem
+, nodejs-16_x
+, stdenvNoCC
+, util-linux
+, zip
+}:
+
+let
+  pname = "electron-fiddle";
+  version = "0.31.0";
+  electron = electron_20;
+  nodejs = nodejs-16_x;
+
+  src = fetchFromGitHub {
+    owner = "electron";
+    repo = "fiddle";
+    rev = "v${version}";
+    hash = "sha256-GueLG+RYFHi3PVVxBTtpTHhfjygcQ6ZCbrp5n5I1gBM=";
+  };
+
+  inherit (nodejs.pkgs) yarn;
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-WVH1A0wtQl5nR1hvaL6mzm/7XBvo311FPKmsxB82e4U=";
+  };
+
+  electronDummyMirror = "https://electron.invalid/";
+  electronDummyDir = "nix";
+  electronDummyFilename =
+    builtins.baseNameOf (builtins.head (electron.src.urls));
+  electronDummyHash =
+    builtins.hashString "sha256" "${electronDummyMirror}${electronDummyDir}";
+
+  unwrapped = stdenvNoCC.mkDerivation {
+    pname = "${pname}-unwrapped";
+    inherit version src;
+
+    nativeBuildInputs = [ fixup_yarn_lock git nodejs util-linux yarn zip ];
+
+    configurePhase = ''
+      export HOME=$TMPDIR
+      fixup_yarn_lock yarn.lock
+      yarn config --offline set yarn-offline-mirror ${offlineCache}
+      yarn install --offline --frozen-lockfile --ignore-scripts --no-progress --non-interactive
+      patchShebangs node_modules
+
+      mkdir -p ~/.cache/electron/${electronDummyHash}
+      cp -ra '${electron}/lib/electron' "$TMPDIR/electron"
+      chmod -R u+w "$TMPDIR/electron"
+      (cd "$TMPDIR/electron" && zip -0Xr ~/.cache/electron/${electronDummyHash}/${electronDummyFilename} .)
+    '';
+
+    buildPhase = ''
+      ELECTRON_CUSTOM_VERSION='${electron.version}' \
+        ELECTRON_MIRROR='${electronDummyMirror}' \
+        ELECTRON_CUSTOM_DIR='${electronDummyDir}' \
+        ELECTRON_CUSTOM_FILENAME='${electronDummyFilename}' \
+        yarn --offline run package
+    '';
+
+    installPhase = ''
+      mkdir -p "$out/lib/electron-fiddle/resources"
+      cp "out/Electron Fiddle-"*/resources/app.asar "$out/lib/electron-fiddle/resources/"
+      mkdir -p "$out/share/icons/hicolor/scalable/apps"
+      cp assets/icons/fiddle.svg "$out/share/icons/hicolor/scalable/apps/electron-fiddle.svg"
+    '';
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "electron-fiddle";
+    desktopName = "Electron Fiddle";
+    comment = "The easiest way to get started with Electron";
+    genericName = "Electron Fiddle";
+    exec = "electron-fiddle %U";
+    icon = "electron-fiddle";
+    startupNotify = true;
+    categories = [ "GNOME" "GTK" "Utility" ];
+    mimeTypes = [ "x-scheme-handler/electron-fiddle" ];
+  };
+
+in
+buildFHSUserEnv {
+  name = "electron-fiddle";
+  runScript = "${electron}/bin/electron ${unwrapped}/lib/electron-fiddle/resources/app.asar";
+  extraInstallCommands = ''
+    mkdir -p "$out/share/icons/hicolor/scalable/apps"
+    ln -s "${unwrapped}/share/icons/hicolor/scalable/apps/electron-fiddle.svg" "$out/share/icons/hicolor/scalable/apps/"
+    mkdir -p "$out/share/applications"
+    cp "${desktopItem}/share/applications"/*.desktop "$out/share/applications/"
+  '';
+  targetPkgs = pkgs:
+    with pkgs;
+    map lib.getLib [
+      # for electron-fiddle itself
+      udev
+
+      # for running Electron 22.0.0 inside
+      alsa-lib
+      atk
+      cairo
+      cups
+      dbus
+      expat
+      glib
+      gtk3
+      libdrm
+      libnotify
+      libxkbcommon
+      mesa
+      nspr
+      nss
+      pango
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrandr
+      xorg.libxcb
+
+      # for running Electron before 18.3.5/19.0.5/20.0.0 inside
+      gdk-pixbuf
+
+      # for running Electron before 16.0.0 inside
+      xorg.libxshmfence
+
+      # for running Electron before 11.0.0 inside
+      xorg.libXcursor
+      xorg.libXi
+      xorg.libXrender
+      xorg.libXtst
+
+      # for running Electron before 10.0.0 inside
+      xorg.libXScrnSaver
+
+      # for running Electron before 8.0.0 inside
+      libuuid
+
+      # for running Electron before 4.0.0 inside
+      fontconfig
+
+      # for running Electron before 3.0.0 inside
+      gnome2.GConf
+
+      # Electron 2.0.8 is the earliest working version, due to
+      # https://github.com/electron/electron/issues/13972
+    ];
+
+  meta = with lib; {
+    description = "The easiest way to get started with Electron";
+    homepage = "https://www.electronjs.org/fiddle";
+    license = licenses.mit;
+    maintainers = with maintainers; [ andersk ];
+    platforms = electron.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17228,6 +17228,8 @@ with pkgs;
 
   egypt = callPackage ../development/tools/analysis/egypt { };
 
+  electron-fiddle = callPackage ../development/tools/electron-fiddle { };
+
   elf2uf2-rs = callPackage ../development/embedded/elf2uf2-rs { };
 
   elfinfo = callPackage ../development/tools/misc/elfinfo { };


### PR DESCRIPTION
###### Description of changes

Package [Electron Fiddle](https://www.electronjs.org/fiddle), a tool that lets you easily develop, test, and share small applications for any version of Electron. (I use it during development of Zulip Desktop for writing minimal test cases and bisecting Electron bugs.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).