### PR TITLE
xteve: init at 2.2.0.200

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10282,6 +10282,12 @@
     githubId = 34083928;
     name = "Tim DeHerrera";
   };
+  nrhelmi = {
+    email = "helmiinour@gmail.com";
+    github = "nrhelmi";
+    githubId = 15707703;
+    name = "Helmi Nour";
+  };
   nshalman = {
     email = "nahamu@gmail.com";
     github = "nshalman";

--- a/pkgs/servers/xteve/default.nix
+++ b/pkgs/servers/xteve/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "xteve";
+  version = "2.2.0.200";
+
+  src = fetchFromGitHub {
+    owner = "xteve-project";
+    repo = "xTeVe";
+    rev = version;
+    hash = "sha256-hD4GudSkGZO41nR/CgcMg/SqKjpAO1yJDkfwa8AUges=";
+  };
+
+  vendorSha256 = "sha256-oPkSWpqNozfSFLIFsJ+e2pOL6CcR91YHbqibEVF2aSk=";
+
+  meta = with lib; {
+    description = "M3U Proxy for Plex DVR and Emby Live TV";
+    homepage = "https://github.com/xteve-project/xTeVe";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nrhelmi AndersonTorres ];
+  };
+}

--- a/pkgs/servers/xteve/default.nix
+++ b/pkgs/servers/xteve/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "xteve";
+  version = "2.2.0.200";
+
+  src = fetchFromGitHub {
+    owner = "xteve-project";
+    repo = "xTeVe";
+    rev = version;
+    hash = "sha256-hD4GudSkGZO41nR/CgcMg/SqKjpAO1yJDkfwa8AUges=";
+  };
+
+  vendorSha256 = "sha256-oPkSWpqNozfSFLIFsJ+e2pOL6CcR91YHbqibEVF2aSk=";
+
+  meta = with lib; {
+    description = "M3U Proxy for Plex DVR and Emby Live TV";
+    homepage = "https://github.com/xteve-project/xTeVe";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nrhelmi ];
+  };
+}

--- a/pkgs/servers/xteve/default.nix
+++ b/pkgs/servers/xteve/default.nix
@@ -17,6 +17,6 @@ buildGoModule rec {
     description = "M3U Proxy for Plex DVR and Emby Live TV";
     homepage = "https://github.com/xteve-project/xTeVe";
     license = licenses.mit;
-    maintainers = with maintainers; [ nrhelmi AndersonTorres ];
+    maintainers = with maintainers; [ nrhelmi ];
   };
 }

--- a/pkgs/servers/xteve/default.nix
+++ b/pkgs/servers/xteve/default.nix
@@ -1,28 +1,22 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
-let
-  owner = "xteve-project";
-  repo  = "xTeVe";
+buildGoModule rec {
+  pname = "xteve";
   version = "2.2.0.200";
 
-in buildGoModule rec {
-  pname = "xteve";
-  inherit version;
-
   src = fetchFromGitHub {
-    inherit owner repo;
+    owner = "xteve-project";
+    repo = "xTeVe";
     rev = version;
-    sha256 = "sha256-hD4GudSkGZO41nR/CgcMg/SqKjpAO1yJDkfwa8AUges=";
+    hash = "sha256-hD4GudSkGZO41nR/CgcMg/SqKjpAO1yJDkfwa8AUges=";
   };
 
   vendorSha256 = "sha256-oPkSWpqNozfSFLIFsJ+e2pOL6CcR91YHbqibEVF2aSk=";
 
   meta = with lib; {
-    description = ''
-      M3U Proxy for Plex DVR and Emby Live TV.
-    '';
+    description = "M3U Proxy for Plex DVR and Emby Live TV";
     homepage = "https://github.com/xteve-project/xTeVe";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ nrhelmi AndersonTorres ];
   };
 }

--- a/pkgs/servers/xteve/default.nix
+++ b/pkgs/servers/xteve/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+let
+  owner = "xteve-project";
+  repo  = "xTeVe";
+  version = "2.2.0.200";
+
+in buildGoModule rec {
+  pname = "xteve";
+  inherit version;
+
+  src = fetchFromGitHub {
+    inherit owner repo;
+    rev = version;
+    sha256 = "sha256-hD4GudSkGZO41nR/CgcMg/SqKjpAO1yJDkfwa8AUges=";
+  };
+
+  vendorSha256 = "sha256-oPkSWpqNozfSFLIFsJ+e2pOL6CcR91YHbqibEVF2aSk=";
+
+  meta = with lib; {
+    description = ''
+      M3U Proxy for Plex DVR and Emby Live TV.
+    '';
+    homepage = "https://github.com/xteve-project/xTeVe";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12896,6 +12896,8 @@ with pkgs;
 
   xray = callPackage ../tools/networking/xray { };
 
+  xteve = callPackage ../servers/xteve { };
+
   testdisk = libsForQt5.callPackage ../tools/system/testdisk { };
 
   testdisk-qt = testdisk.override { enableQt = true; };


### PR DESCRIPTION
###### Description of changes
I nix packaged `xTeVe` and added it to my plex setup, I thought that this might be useful to add it to `nixpkgs`.
`xTeVe` is an M3U proxy server for Plex DVR and Emby Live TV
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
