### PR TITLE
darwin.apple_sdk_11_0.libpm: init

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -50,6 +50,7 @@ let
     libcharset = callPackage ./libcharset.nix {};
     libunwind = callPackage ./libunwind.nix {};
     libnetwork = callPackage ./libnetwork.nix {};
+    libpm = callPackage ./libpm.nix {};
     # Avoid introducing a new objc4 if stdenv already has one, to prevent
     # conflicting LLVM modules.
     objc4 = if stdenv ? objc4 then stdenv.objc4 else callPackage ./libobjc.nix {};

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/libpm.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/libpm.nix
@@ -1,0 +1,23 @@
+{ stdenvNoCC, MacOSX-SDK, checkReexportsHook }:
+
+stdenvNoCC.mkDerivation {
+  pname = "libpm";
+  version = MacOSX-SDK.version;
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ checkReexportsHook ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp ${MacOSX-SDK}/usr/lib/libpm* $out/lib
+  '';
+
+  passthru = {
+    tbdRewrites = {
+      const."/usr/lib/libpmenergy.dylib" = "${placeholder "out"}/lib/libpmenergy.dylib";
+      const."/usr/lib/libpmsample.dylib" = "${placeholder "out"}/lib/libpmsample.dylib";
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

The **p**rocess **m**etrics **lib**raries are required by [Chromium](https://chromium.googlesource.com/chromium/src/base/+/refs/heads/main/process/process_metrics_mac.cc#44), therefore Qt WebEngine 5.15+ (#208090, #203310).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
