### PR TITLE
libusb1 - enable build with examples

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11656,6 +11656,12 @@
     githubId = 1973389;
     name = "Reuben D'Netto";
   };
+  realsnick = {
+    name = "Ido Samuelson";
+    email = "ido.samuelson@gmail.com";
+    github = "realsnick";
+    githubId = 1440852;
+  };
   redbaron = {
     email = "ivanov.maxim@gmail.com";
     github = "redbaron";


### PR DESCRIPTION
I added `withExamples` to build all examples into `examples/bin`. 

since the `fxload` package is outdated and source code moved to  libusb's examples. I believe it is better to build `fxload` here and have it install to `/sbin` similarly to how `fxload` package does it. 

this version of `fxload` supports USB3 devices.

https://github.com/NixOS/nixpkgs/issues/207381