### PR TITLE
maintainers/scripts/haskell: fix regenerate-transitive-broken

### DIFF
--- a/maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p coreutils nix gnused -I nixpkgs=.
+#! nix-shell -i bash -p coreutils jq nix -I nixpkgs=.
 
 config_file=pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
 
@@ -12,4 +12,4 @@ dont-distribute-packages:
 EOF
 
 echo "Regenerating list of transitive broken packages ..."
-echo -e $(nix-instantiate --eval --strict maintainers/scripts/haskell/transitive-broken-packages.nix) | sed 's/\"//' | LC_ALL=C.UTF-8 sort -i >> $config_file
+nix-instantiate --eval --option restrict-eval true -I . --strict --json maintainers/scripts/haskell/transitive-broken-packages.nix | jq -r . | LC_ALL=C.UTF-8 sort -i >> $config_file

--- a/maintainers/scripts/haskell/transitive-broken-packages.nix
+++ b/maintainers/scripts/haskell/transitive-broken-packages.nix
@@ -12,5 +12,5 @@ let
     (getEvaluating (nixpkgs { config.allowBroken = true; }).haskellPackages);
 in
 ''
-  ${lib.concatMapStringsSep "\n" (x: "  - ${x}") brokenDeps}
+  ${lib.concatMapStringsSep "\n" (x: " - ${x}") brokenDeps}
 ''


### PR DESCRIPTION
Not related to the current haskell updates, just something I ran into. EDIT: forgot to change the branch name lol

- use `restrict-eval` so that we're not affected by the user's environment
- use jq instead of the horrible echo+sed hack

The second point also fixes the indentation before each line to be two spaces instead of one, so I set it back to one space to avoid a diff.

Alternatively we could use `nix --experimental-features nix-command eval --raw` without jq.
