### PR TITLE
haskell.packages.*.haskell-language-server: fix eval

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -118,15 +118,18 @@ self: super: {
     ]) (super.hls-brittany-plugin.overrideScope (lself: lsuper: {
     brittany = doJailbreak lself.brittany_0_13_1_2;
     aeson = lself.aeson_1_5_6_0;
-    multistate = dontCheck lsuper.multistate;
+    multistate = doDistribute (markUnbroken (dontCheck lsuper.multistate));
     lsp-types = doJailbreak lsuper.lsp-types; # Checks require aeson >= 2.0
   }))));
 
   # This package is marked as unbuildable on GHC 9.2, so hackage2nix doesn't include any dependencies.
   # See https://github.com/NixOS/nixpkgs/pull/205902 for why we use `self.<package>.scope`
-  hls-haddock-comments-plugin = addBuildDepends (with self.hls-haddock-comments-plugin.scope; [
+  hls-haddock-comments-plugin = doDistribute (markUnbroken (addBuildDepends (with self.hls-haddock-comments-plugin.scope; [
     ghc-exactprint ghcide hls-plugin-api hls-refactor-plugin lsp-types unordered-containers
-  ]) super.hls-haddock-comments-plugin;
+  ]) super.hls-haddock-comments-plugin));
+
+  hls-splice-plugin = doDistribute (markUnbroken super.hls-splice-plugin);
+  hls-tactics-plugin = doDistribute (markUnbroken super.hls-tactics-plugin);
 
   mime-string = disableOptimization super.mime-string;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -113,14 +113,14 @@ self: super: {
     lsp-types = doJailbreak lsuper.lsp-types; # Checks require aeson >= 2.0
   }));
 
-  hls-brittany-plugin = addBuildDepends (with self.hls-brittany-plugin.scope; [
+  hls-brittany-plugin = doDistribute (markUnbroken (addBuildDepends (with self.hls-brittany-plugin.scope; [
     brittany czipwith extra ghc-exactprint ghcide hls-plugin-api hls-test-utils lens lsp-types
     ]) (super.hls-brittany-plugin.overrideScope (lself: lsuper: {
     brittany = doJailbreak lself.brittany_0_13_1_2;
     aeson = lself.aeson_1_5_6_0;
     multistate = dontCheck lsuper.multistate;
     lsp-types = doJailbreak lsuper.lsp-types; # Checks require aeson >= 2.0
-  }));
+  }))));
 
   # This package is marked as unbuildable on GHC 9.2, so hackage2nix doesn't include any dependencies.
   # See https://github.com/NixOS/nixpkgs/pull/205902 for why we use `self.<package>.scope`

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -67,7 +67,7 @@ self: super: {
   base-compat-batteries = addBuildDepend self.OneTuple super.base-compat-batteries;
 
   # Pick right versions for GHC-specific packages
-  ghc-api-compat = doDistribute self.ghc-api-compat_8_10_7;
+  ghc-api-compat = doDistribute (markUnbroken self.ghc-api-compat_8_10_7);
 
   # ghc versions which don‘t match the ghc-lib-parser-ex version need the
   # additional dependency to compile successfully.

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -133,7 +133,7 @@ self: super: {
   # vector 0.12.2 indroduced doctest checks that don‘t work on older compilers
   vector = dontCheck super.vector;
 
-  ghc-api-compat = doDistribute super.ghc-api-compat_8_6;
+  ghc-api-compat = doDistribute (markUnbroken super.ghc-api-compat_8_6);
 
   mime-string = disableOptimization super.mime-string;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -159,13 +159,13 @@ self: super: {
   # additional dependency to compile successfully.
   ghc-lib-parser-ex = addBuildDepend self.ghc-lib-parser self.ghc-lib-parser-ex_8_10_0_24;
 
-  hls-brittany-plugin = addBuildDepends (with self.hls-brittany-plugin.scope; [
+  hls-brittany-plugin = doDistribute (markUnbroken (addBuildDepends (with self.hls-brittany-plugin.scope; [
     brittany czipwith extra ghc-exactprint ghcide hls-plugin-api hls-test-utils lens lsp-types
     ]) (super.hls-brittany-plugin.overrideScope (lself: lsuper: {
     brittany = doJailbreak lself.brittany_0_13_1_2;
     multistate = dontCheck lsuper.multistate;
     lsp-types = doJailbreak lsuper.lsp-types; # Checks require aeson >= 2.0
-  }));
+  }))));
 
   # This package is marked as unbuildable on GHC 9.2, so hackage2nix doesn't include any dependencies.
   # See https://github.com/NixOS/nixpkgs/pull/205902 for why we use `self.<package>.scope`

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -163,15 +163,18 @@ self: super: {
     brittany czipwith extra ghc-exactprint ghcide hls-plugin-api hls-test-utils lens lsp-types
     ]) (super.hls-brittany-plugin.overrideScope (lself: lsuper: {
     brittany = doJailbreak lself.brittany_0_13_1_2;
-    multistate = dontCheck lsuper.multistate;
+    multistate = doDistribute (markUnbroken (dontCheck lsuper.multistate));
     lsp-types = doJailbreak lsuper.lsp-types; # Checks require aeson >= 2.0
   }))));
 
   # This package is marked as unbuildable on GHC 9.2, so hackage2nix doesn't include any dependencies.
   # See https://github.com/NixOS/nixpkgs/pull/205902 for why we use `self.<package>.scope`
-  hls-haddock-comments-plugin = addBuildDepends (with self.hls-haddock-comments-plugin.scope; [
+  hls-haddock-comments-plugin = doDistribute (markUnbroken (addBuildDepends (with self.hls-haddock-comments-plugin.scope; [
     ghc-exactprint ghcide hls-plugin-api hls-refactor-plugin lsp-types unordered-containers
-  ]) super.hls-haddock-comments-plugin;
+  ]) super.hls-haddock-comments-plugin));
+
+  hls-splice-plugin = doDistribute (markUnbroken super.hls-splice-plugin);
+  hls-tactics-plugin = doDistribute (markUnbroken super.hls-tactics-plugin);
 
 
   # has a restrictive lower bound on Cabal

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -119,9 +119,12 @@ self: super: {
 
   # This package is marked as unbuildable on GHC 9.2, so hackage2nix doesn't include any dependencies.
   # See https://github.com/NixOS/nixpkgs/pull/205902 for why we use `self.<package>.scope`
-  hls-haddock-comments-plugin = addBuildDepends (with self.hls-haddock-comments-plugin.scope; [
+  hls-haddock-comments-plugin = doDistribute (markUnbroken (addBuildDepends (with self.hls-haddock-comments-plugin.scope; [
     ghc-exactprint ghcide hls-plugin-api hls-refactor-plugin lsp-types unordered-containers
-  ]) super.hls-haddock-comments-plugin;
+  ]) super.hls-haddock-comments-plugin));
+
+  hls-splice-plugin = doDistribute (markUnbroken super.hls-splice-plugin);
+  hls-tactics-plugin = doDistribute (markUnbroken super.hls-tactics-plugin);
 
   # The test suite depends on ChasingBottoms, which is broken with ghc-9.0.x.
   unordered-containers = dontCheck super.unordered-containers;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -172,4 +172,7 @@ self: super: {
   # Later versions only support GHC >= 9.2
   ghc-exactprint = self.ghc-exactprint_0_6_4;
   apply-refact = self.apply-refact_0_9_3_0;
+
+  # Only broken on GHC > 9.1
+  ghc-api-compat = doDistribute (markUnbroken super.ghc-api-compat);
 }


### PR DESCRIPTION
Mark some packages as unbroken on specific GHC versions to fix eval errors.