### PR TITLE
resholve: simplify python27 meta override using lib.addMetaAttrs

### DIFF
--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -1,21 +1,18 @@
 { lib
-, pkgs
-, pkgsBuildHost
+, python27
+, callPackage
 , ...
 }:
 
 let
-  python27' = (pkgsBuildHost.python27.overrideAttrs (old:
-    {
-      # Overriding `meta.knownVulnerabilities` here, see #201859 for why it exists
-      # In resholve case this should not be a security issue,
-      # since it will only be used during build, not runtime
-      meta = (old.meta or { }) // { knownVulnerabilities = [ ]; };
-    }
-  )).override {
-    self = python27';
-    pkgsBuildHost = pkgsBuildHost // { python27 = python27'; };
+  python27' = lib.addMetaAttrs {
+    # Overriding `meta.knownVulnerabilities` here, see #201859 for why it exists
+    # In resholve case this should not be a security issue,
+    # since it will only be used during build, not runtime
+    knownVulnerabilities = [ ];
+  } python27.override {
     # strip down that python version as much as possible
+    openssl = null;
     bzip2 = null;
     readline = null;
     ncurses = null;
@@ -83,9 +80,8 @@ let
     ];
     enableOptimizations = false;
   };
-  callPackage = lib.callPackageWith (pkgs // { python27 = python27'; });
-  source = callPackage ./source.nix { };
-  deps = callPackage ./deps.nix { };
+  source = callPackage ./source.nix { python27 = python27'; };
+  deps = callPackage ./deps.nix { python27 = python27'; };
 in
 rec {
   # resholve itself


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Using `lib.addMetaAttrs` simplify the meta override a lot and looks less messy.

Also re-added `openssl = null` removed in https://github.com/NixOS/nixpkgs/pull/206725 but looks safe to remove: https://github.com/NixOS/nixpkgs/pull/206725#discussion_r1052894845

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
