### PR TITLE
libquotient: 0.6.11 -> 0.7.0

### DIFF
--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -15,11 +15,6 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [
-    # we need libqtolm for this
-    "-DQuotient_ENABLE_E2EE=OFF"
-  ];
-
   # https://github.com/quotient-im/libQuotient/issues/551
   postPatch = ''
     substituteInPlace Quotient.pc.in \

--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -1,17 +1,17 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, qtmultimedia }:
+{ mkDerivation, lib, fetchFromGitHub, cmake, qtmultimedia, qtkeychain }:
 
 mkDerivation rec {
   pname = "libquotient";
-  version = "0.6.11";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "quotient-im";
     repo = "libQuotient";
     rev = version;
-    sha256 = "sha256-FPtxeZOfChIPi4e/h/eZkByH1QL3Fn0OJxe0dnMcTRw=";
+    sha256 = "sha256-9NAWphpAI7/qWDMjsx26s+hOaQh0hbzjePfESC7PtXc=";
   };
 
-  buildInputs = [ qtmultimedia ];
+  buildInputs = [ qtmultimedia qtkeychain ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
I want to use neochat, but it does not have E2EE yet.
With libquotient 0.7.0, it gets E2EE support, so we need to update libquotient... 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

