### PR TITLE
xastir: add support for ax25 interfaces

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -395,6 +395,13 @@
           value of this setting.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://xastir.org/index.php/Main_Page">Xastir</link>
+          can now access AX.25 interfaces via the
+          <literal>libax25</literal> package.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -106,3 +106,5 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The `unifi-poller` package and corresponding NixOS module have been renamed to `unpoller` to match upstream.
 
 - The new option `services.tailscale.useRoutingFeatures` controls various settings for using Tailscale features like exit nodes and subnet routers. If you wish to use your machine as an exit node, you can set this setting to `server`, otherwise if you wish to use an exit node you can set this setting to `client`. The strict RPF warning has been removed as the RPF will be loosened automatically based on the value of this setting.
+
+- [Xastir](https://xastir.org/index.php/Main_Page) can now access AX.25 interfaces via the `libax25` package.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -244,6 +244,7 @@
   ./programs/waybar.nix
   ./programs/weylus.nix
   ./programs/wireshark.nix
+  ./programs/xastir.nix
   ./programs/wshowkeys.nix
   ./programs/xfconf.nix
   ./programs/xfs_quota.nix

--- a/nixos/modules/programs/xastir.nix
+++ b/nixos/modules/programs/xastir.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.xastir;
+in {
+  meta.maintainers = with maintainers; [ melling ];
+
+  options.programs.xastir = {
+    enable = mkEnableOption (mdDoc "Enable Xastir Graphical APRS client");
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ xastir ];
+    security.wrappers.xastir = {
+      source = "${pkgs.xastir}/bin/xastir";
+      capabilities = "cap_net_raw+p";
+      owner = "root";
+      group = "root";
+    };
+  };
+}

--- a/pkgs/applications/misc/xastir/default.nix
+++ b/pkgs/applications/misc/xastir/default.nix
@@ -2,6 +2,7 @@
 , curl, db, libgeotiff
 , xorg, motif, pcre
 , perl, proj, rastermagick, shapelib
+, libax25
 }:
 
 stdenv.mkDerivation rec {
@@ -24,6 +25,7 @@ stdenv.mkDerivation rec {
     curl db libgeotiff
     xorg.libXpm xorg.libXt motif pcre
     perl proj rastermagick shapelib
+    libax25
   ];
 
   configureFlags = [ "--with-motif-includes=${motif}/include" ];


### PR DESCRIPTION
###### Description of changes

#205376 adds `libax25` which is an optional dependency of Xastir. This PR adds `libax25` to Xastir to enable access to AX.25 interfaces.

- Added `libax25` to build inputs
- Added option `programs.xastir.enable` to install Xastir globally and create a setcap wrapper to grant the `CAP_NET_RAW` capability

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
