### PR TITLE
nixos/zfs: fix `boot.zfs.requestEncryptionCredentials = [ ]`

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -100,6 +100,7 @@ let
   getKeyLocations = pool:
     if isBool cfgZfs.requestEncryptionCredentials
     then "${cfgZfs.package}/sbin/zfs list -rHo name,keylocation,keystatus ${pool}"
+    else if (filter (x: datasetToPool x == pool) cfgZfs.requestEncryptionCredentials) == [ ] then ":"
     else "${cfgZfs.package}/sbin/zfs list -Ho name,keylocation,keystatus ${toString (filter (x: datasetToPool x == pool) cfgZfs.requestEncryptionCredentials)}";
 
   createImportService = { pool, systemd, force, prefix ? "" }:


### PR DESCRIPTION
When requesting no keys for a given pool, return no keys, not those of all imported pools.

`boot.zfs.requestEncryptionCredentials` is a list of datasets, and `zfs-import-${pool}.service` wants to list all datasets in a given `pool`.
If the list contains only entries that are not in `pool`, then evaluating the previous `getKeyLocations`, the filtered list would be empty, causing `zfs list` to return *all* datasets, not none.
This PR fixes that. `:` outputs nothing, resulting in zero iterations of the `load-key` loop.

Alternatively, the `optionalString` check in line 145 could have the `(filter (x: datasetToPool x == pool) cfgZfs.requestEncryptionCredentials) != [ ]`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested:
  - [ ] As clearly this bug was not revealed by any test in nixpkgs, I don't think there is one that tests this.
  - [x] I have host configurations that have just one pool that is imported in the initrd and thus doesn't generate a `zfs-import-${pool}.service`, and ones with auxiliary pools imported later (via `zfs-import-${pool}.service`) but where only keys on other polls should be imported.
  - [ ] I have not tested actually loading keys via `zfs-import-${pool}.service`.

---

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) (I think).


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
