### PR TITLE
ax25-tools: init at 0.0.10-rc5

### DIFF
--- a/pkgs/applications/radio/ax25-tools/default.nix
+++ b/pkgs/applications/radio/ax25-tools/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchurl
+, libax25
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ax25-tools";
+  version = "0.0.10-rc5";
+
+  buildInputs = [ libax25 ];
+
+  # Due to recent unsolvable administrative domain problems with linux-ax25.org,
+  # the new domain is linux-ax25.in-berlin.de
+  src = fetchurl {
+    url = "https://linux-ax25.in-berlin.de/pub/ax25-tools/ax25-tools-${version}.tar.gz";
+    sha256 = "sha256-kqnLi1iobcufVWMPxUyaRsWKIPyTvtUkuMERGQs2qgY=";
+  };
+
+  configureFlags = [ "--sysconfdir=/etc" ];
+
+  meta = with lib; {
+    description = "Non-GUI tools used to configure an AX.25 enabled computer";
+    homepage = "https://linux-ax25.in-berlin.de/wiki/Main_Page";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ sarcasticadmin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27735,6 +27735,8 @@ with pkgs;
 
   avocode = callPackage ../applications/graphics/avocode {};
 
+  ax25-tools = callPackage ../applications/radio/ax25-tools {};
+
   azpainter = callPackage ../applications/graphics/azpainter { };
 
   bambootracker = libsForQt5.callPackage ../applications/audio/bambootracker { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Non-GUI tools used to configure an AX.25 enabled computer. With the recent additional of ax25lib to nixpkgs (#205376) we can now add more ham radio tools that depend on that library. `ax25-tools` allows you to configure things like tncs (modems) via provided binaries like `kissparms` or make connections to packet radio packet nodes via `ax25call` (another provided binary).

It includes several binaries that are key to using ax.25 from the commandline. Ill include the list here for context:

```
~$ result/bin/
ax25_call
ax25d
axctl
axgetput
axparms
axspawn
axwrapper
beacon
bget
bpqparms
bput
dmascc_cfg
kissattach
kissnetd
kissparms
m6pack
mcs2h
mheard
mheardd
mkiss
net2kiss
netrom_call
netromd
nodesave
nrattach
nrparms
nrsdrv
rip98d
rose_call
rsattach
rsdwnlnk
rsmemsiz
rsparms
rsuplnk
rsusers.sh
rxecho
sethdlc
smmixer
spattach
tcp_call
ttylinkd
yamcfg
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
