### PR TITLE
validator-nu: init at 22.9.29

### DIFF
--- a/pkgs/tools/text/validator-nu/default.nix
+++ b/pkgs/tools/text/validator-nu/default.nix
@@ -1,0 +1,68 @@
+{ fetchFromGitHub
+, git
+, jdk_headless
+, jre_headless
+, makeWrapper
+, python3
+, stdenvNoCC
+, lib
+}:
+
+let
+  pname = "validator-nu";
+  version = "22.9.29";
+
+  src = fetchFromGitHub {
+    owner = "validator";
+    repo = "validator";
+    rev = version;
+    fetchSubmodules = true;
+    hash = "sha256-NH/OyaKGITAL2yttB1kmuKVuZuYzhVuS0Oohj1N4icI=";
+  };
+
+  deps = stdenvNoCC.mkDerivation {
+    pname = "${pname}-deps";
+    inherit version src;
+
+    nativeBuildInputs = [ git jdk_headless python3 python3.pkgs.certifi ];
+
+    buildPhase = ''
+      python checker.py dldeps
+    '';
+
+    installPhase = ''
+      mkdir "$out"
+      mv dependencies extras "$out"
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = "sha256-LPtxpUd7LAYZHJL7elgcZOTaTgHqeqquiB9hiuajA6c=";
+  };
+
+in
+stdenvNoCC.mkDerivation rec {
+  inherit pname version src;
+
+  nativeBuildInputs = [ git jdk_headless makeWrapper python3 ];
+
+  buildPhase = ''
+    ln -s '${deps}/dependencies' '${deps}/extras' .
+    JAVA_HOME='${jdk_headless}' python checker.py build
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/bin" "$out/share/java"
+    mv build/dist/vnu.jar "$out/share/java/"
+    makeWrapper "${jre_headless}/bin/java" "$out/bin/vnu" \
+      --add-flags "-jar '$out/share/java/vnu.jar'"
+  '';
+
+  meta = with lib; {
+    description = "Helps you catch problems in your HTML/CSS/SVG";
+    homepage = "https://validator.github.io/validator/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ andersk ];
+    mainProgram = "vnu";
+    sourceProvenance = with sourceTypes; [ binaryBytecode fromSource ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12643,6 +12643,8 @@ with pkgs;
 
   vacuum = callPackage ../applications/networking/instant-messengers/vacuum {};
 
+  validator-nu = callPackage ../tools/text/validator-nu { };
+
   vampire = callPackage ../applications/science/logic/vampire {};
 
   variety = callPackage ../applications/misc/variety {};


### PR DESCRIPTION
###### Description of changes

Package the [Nu Html Checker](https://validator.github.io/validator/) (validator.nu). Fixes #185842.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
