### PR TITLE
hydron: 3.3.5 -> 3.3.6

### DIFF
--- a/pkgs/servers/hydron/default.nix
+++ b/pkgs/servers/hydron/default.nix
@@ -1,25 +1,36 @@
-{ lib, buildGoModule, fetchFromGitHub, pkg-config, ffmpeg }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, gitUpdater
+, pkg-config
+, ffmpeg
+}:
 
 buildGoModule rec {
   pname = "hydron";
-  version = "3.3.5";
+  version = "3.3.6";
 
   src = fetchFromGitHub {
     owner = "bakape";
     repo = "hydron";
     rev = "v${version}";
-    sha256 = "0c958dsw5pq9z8n1b9q9j8y6vgiqf6mmlsf77ncb7yrlilhbrz6s";
+    hash = "sha256-Q1pZf5FPQw+pHItcZyOGx0N+iHmz9rW0+ANFsketh6E=";
   };
 
-  vendorSha256 = "0cc8ar8p7lgg6rj76vhfp6bzrxyn5yaqjwj8i1bn0zp6sj6zcfam";
+  vendorHash = "sha256-fyGC6k9/xER5GwVelBhy5C5tiq6NMhwSmYjSpvenrfA=";
   proxyVendor = true;
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ ffmpeg ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/bakape/hydron";
     description = "High performance media tagger and organizer";
-    license = licenses.lgpl3Plus;
+    license = with licenses; [ lgpl3Plus ];
     maintainers = with maintainers; [ Madouura ];
   };
 }


### PR DESCRIPTION
###### Description of changes
Version bump.
Final update, hydron is now archived.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
