### PR TITLE
edid-decode: unstable-2022-04-06 -> unstable-2022-12-14

### DIFF
--- a/pkgs/tools/misc/edid-decode/default.nix
+++ b/pkgs/tools/misc/edid-decode/default.nix
@@ -1,26 +1,37 @@
-{ lib, stdenv, fetchgit }:
+{ lib
+, stdenv
+, fetchgit
+, unstableGitUpdater
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "edid-decode";
-  version = "unstable-2022-04-06";
+  version = "unstable-2022-12-14";
+
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchgit {
     url = "git://linuxtv.org/edid-decode.git";
-    rev = "6def7bc83dfb0338632e06a8b14c93faa6af8879";
-    sha256 = "0v6d6jy309pb02l377l0fpmgfsvcpiqc5bvyrli34v413mhq6p15";
+    rev = "e052f5f9fdf74ca11aa1a8edfa62eff8d0aa3d0d";
+    hash = "sha256-qNtb/eM7VpS8nRbC/nNm6J9vEWVUSrg7OwNaW1774QY=";
   };
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp edid-decode $out/bin
+  preBuild = ''
+    export DESTDIR=$out
+    export bindir=/bin
+    export mandir=/share/man
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "EDID decoder and conformance tester";
     homepage = "https://git.linuxtv.org/edid-decode.git";
-    license = licenses.mit;
+    license = with licenses; [ mit ];
     maintainers = with maintainers; [ Madouura ];
-    platforms = lib.platforms.all;
+    platforms = platforms.all;
   };
-}
-
+})


### PR DESCRIPTION
###### Description of changes
Version bump.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
