### PR TITLE
libsForQt5.maplibre-gl-native: unstable-2022-04-07 -> 2.0.1

### DIFF
--- a/pkgs/development/libraries/mapbox-gl-qml/default.nix
+++ b/pkgs/development/libraries/mapbox-gl-qml/default.nix
@@ -11,13 +11,13 @@
 
 mkDerivation rec {
   pname = "mapbox-gl-qml";
-  version = "2.0.1";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "rinigus";
     repo = "mapbox-gl-qml";
     rev = version;
-    hash = "sha256-EVZbQXV8pI0QTqFDTTynVglsqX1O5oK0Pl5Y/wp+/q0=";
+    hash = "sha256-zZcD85nOZZ067FRvSuzE8lr2gyuVxpcZGp44D4ayc3Q=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/libraries/maplibre-gl-native/default.nix
+++ b/pkgs/development/libraries/maplibre-gl-native/default.nix
@@ -13,14 +13,14 @@
 
 mkDerivation rec {
   pname = "maplibre-gl-native";
-  version = "unstable-2022-04-07";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "maplibre";
     repo = "maplibre-gl-native";
-    rev = "225f8a4bfe7ad30fd59d693c1fb3ca0ba70d2806";
+    rev = "qt-v${version}";
     fetchSubmodules = true;
-    hash = "sha256-NLtpi+bDLTHlnzMZ4YFQyF5B1xt9lzHyZPvEQLlBAnY=";
+    hash = "sha256-g5J873U/6mrl27iquPl3BdEGhMxkOdfP15dHr27wa48=";
   };
 
   patches = [
@@ -61,6 +61,5 @@ mkDerivation rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ dotlambda ];
     platforms = platforms.linux;
-    broken = lib.versionOlder qtbase.version "5.15";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
