### PR TITLE
borgbackup: 1.2.2 -> 1.2.3

### DIFF
--- a/pkgs/development/libraries/libb2/default.nix
+++ b/pkgs/development/libraries/libb2/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, pkg-config }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, libtool
+, pkg-config
+}:
 
 stdenv.mkDerivation rec {
   pname = "libb2";
@@ -7,18 +13,19 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "BLAKE2";
     repo = "libb2";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     sha256 = "0qj8aaqvfcavj1vj5asm4pqm03ap7q8x4c2fy83cqggvky0frgya";
   };
 
-  preConfigure = ''
-    patchShebangs autogen.sh
-    ./autogen.sh
-  '';
+  nativeBuildInputs = [
+    autoreconfHook
+    libtool
+    pkg-config
+  ];
 
   configureFlags = lib.optional stdenv.hostPlatform.isx86 "--enable-fat=yes";
 
-  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+  enableParallelBuilding = true;
 
   doCheck = true;
 

--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -10,17 +10,27 @@
 , zstd
 , installShellFiles
 , nixosTests
+, fetchpatch
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "borgbackup";
-  version = "1.2.2";
+  version = "1.2.3";
   format = "pyproject";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-1zBodEPxvrYCsdcrrjYxj2+WVIGPzcUEWFQOxXnlcmA=";
+    hash = "sha256-4yQY+GM8lvqWgTUqVutjuY4pQgNHLBFKUkJwnTaWZ4U=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Fix HashIndexSizeTestCase.test_size_on_disk_accurate problems on ZFS,
+      # see https://github.com/borgbackup/borg/issues/7250
+      url = "https://github.com/borgbackup/borg/pull/7252/commits/537a814e53e20013a041faa7192da005f137cf5b.patch";
+      hash = "sha256-dnF/FW8pS4Ub9aAL4b7zf6ZNjMZaiMqdtl5R+DlAZTM=";
+    })
+  ];
 
   postPatch = ''
     # sandbox does not support setuid/setgid/sticky bits

--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -7,6 +7,7 @@
 , openssh
 , openssl
 , python3
+, xxHash
 , zstd
 , installShellFiles
 , nixosTests
@@ -41,6 +42,7 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = with python3.pkgs; [
     cython
     setuptools-scm
+    pkgconfig
 
     # docs
     sphinxHook
@@ -55,6 +57,7 @@ python3.pkgs.buildPythonApplication rec {
   buildInputs = [
     libb2
     lz4
+    xxHash
     zstd
     openssl
   ] ++ lib.optionals stdenv.isLinux [
@@ -66,13 +69,6 @@ python3.pkgs.buildPythonApplication rec {
     packaging
     (if stdenv.isLinux then pyfuse3 else llfuse)
   ];
-
-  preConfigure = ''
-    export BORG_OPENSSL_PREFIX="${openssl.dev}"
-    export BORG_LZ4_PREFIX="${lz4.dev}"
-    export BORG_LIBB2_PREFIX="${libb2}"
-    export BORG_LIBZSTD_PREFIX="${zstd.dev}"
-  '';
 
   makeWrapperArgs = [
     ''--prefix PATH ':' "${openssh}/bin"''


### PR DESCRIPTION
https://github.com/borgbackup/borg/blob/1.2.3/docs/changes.rst#version-123-2022-12-24

Currently reverting two commits that make a test fail, still have to talk to the upstream about that.

```
_______________ HashIndexSizeTestCase.test_size_on_disk_accurate _______________

self = <borg.testsuite.hashindex.HashIndexSizeTestCase testMethod=test_size_on_disk_accurate>

    def test_size_on_disk_accurate(self):
        idx = ChunkIndex()
        for i in range(1234):
            idx[H(i)] = i, i**2, i**3
        with tempfile.NamedTemporaryFile() as file:
            idx.write(file)
            size = os.path.getsize(file.fileno())
>       assert idx.size() == size
E       assert 90350 == 0
E        +  where 90350 = <built-in method size of borg.hashindex.ChunkIndex object at 0x7ffff351da10>()
E        +    where <built-in method size of borg.hashindex.ChunkIndex object at 0x7ffff351da10> = <borg.hashindex.ChunkIndex object at 0x7ffff351da10>.size
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
