### PR TITLE
nixos/tests: Add test for VS Code - Remote SSH

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -812,6 +812,7 @@ in {
   victoriametrics = handleTest ./victoriametrics.nix {};
   vikunja = handleTest ./vikunja.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
+  vscode-remote-ssh = handleTestOn ["x86_64-linux"] ./vscode-remote-ssh.nix {};
   vscodium = discoverTests (import ./vscodium.nix);
   vsftpd = handleTest ./vsftpd.nix {};
   warzone2100 = handleTest ./warzone2100.nix {};

--- a/nixos/tests/vscode-remote-ssh.nix
+++ b/nixos/tests/vscode-remote-ssh.nix
@@ -1,9 +1,13 @@
-import ./make-test-python.nix ({ lib, ... }: let
-  pkgs = (import ../..) {
-    config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
-      "vscode" "vscode-with-extensions" "vscode-extension-ms-vscode-remote-remote-ssh"
-    ];
-  };
+import ./make-test-python.nix ({ lib, ... }@args: let
+  pkgs = args.pkgs.extend (self: super: {
+    stdenv = super.stdenv.override {
+      config = super.config // {
+        allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+          "vscode" "vscode-with-extensions" "vscode-extension-ms-vscode-remote-remote-ssh"
+        ];
+      };
+    };
+  });
 
   inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
 

--- a/nixos/tests/vscode-remote-ssh.nix
+++ b/nixos/tests/vscode-remote-ssh.nix
@@ -1,0 +1,145 @@
+import ./make-test-python.nix ({ lib, ... }: let
+  pkgs = (import ../..) {
+    config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+      "vscode" "vscode-with-extensions" "vscode-extension-ms-vscode-remote-remote-ssh"
+    ];
+  };
+
+  inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
+
+  # Every VS Code server build corresponds to a specific commit of VS Code, so we
+  # want this to match the commit of VS Code in Nixpkgs.
+  # e.g. git rev-parse 1.77.0
+  rev = "7f329fe6c66b0f86ae1574c2911b681ad5a45d63";
+  shortRev = builtins.substring 0 8 rev;
+
+  # Our tests run without networking so the remote-ssh extension will always fail to
+  # download the VSCode server so we can copy it onto the server ourselves.
+  vscode-server = pkgs.srcOnly {
+    name = "vscode-server-${shortRev}";
+    src = pkgs.fetchurl {
+      name = "vscode-server-${shortRev}.tar.gz";
+      url = "https://update.code.visualstudio.com/commit:${rev}/server-linux-x64/stable";
+      sha256 = "11g234lwl3jn5q3637n9sxz5ghhzqvq137lk42vl2nbb57hgyqgq";
+    };
+  };
+in {
+  name = "vscode-remote-ssh";
+  meta.maintainers = with lib.maintainers; [ Enzime ];
+
+  nodes = let
+    serverAddress = "192.168.0.2";
+    clientAddress = "192.168.0.1";
+  in {
+    server = { ... }: {
+      networking.interfaces.eth1.ipv4.addresses = [ { address = serverAddress; prefixLength = 24; } ];
+      services.openssh.enable = true;
+      users.users.root.openssh.authorizedKeys.keys = [ snakeOilPublicKey ];
+      virtualisation.additionalPaths = [ pkgs.nodejs-14_x pkgs.nodejs-16_x ];
+    };
+    client = { ... }: {
+      imports = [ ./common/x11.nix ./common/user-account.nix ];
+      networking.interfaces.eth1.ipv4.addresses = [ { address = clientAddress; prefixLength = 24; } ];
+      networking.hosts.${serverAddress} = [ "server" ];
+      test-support.displayManager.auto.user = "alice";
+      environment.systemPackages = [
+        (pkgs.vscode-with-extensions.override {
+          vscodeExtensions = [
+            pkgs.vscode-extensions.ms-vscode-remote.remote-ssh
+          ];
+        })
+      ];
+    };
+  };
+
+  enableOCR = true;
+
+  testScript = let
+    jq = "${pkgs.jq}/bin/jq";
+
+    ssh-config = builtins.toFile "ssh.conf" ''
+      UserKnownHostsFile=/dev/null
+      StrictHostKeyChecking=no
+    '';
+
+    vscode-config = builtins.toFile "settings.json" ''
+      {
+        "window.zoomLevel": 1,
+        "security.workspace.trust.startupPrompt": "always"
+      }
+    '';
+  in ''
+    def connect_with_remote_ssh(screenshot, should_succeed):
+      print(f"connect_with_remote_ssh({screenshot=}, {should_succeed=})")
+
+      if server.execute("test -d ~/.vscode-server")[0] == 0:
+        server.succeed("rm -r ~/.vscode-server")
+
+      server.succeed("mkdir -p ~/.vscode-server/bin")
+      server.succeed("cp -r ${vscode-server} ~/.vscode-server/bin/${rev}")
+
+      client.succeed("sudo -u alice code --remote=ssh-remote+root@server /root")
+      client.wait_for_window("Visual Studio Code")
+
+      client.wait_for_text("Do you trust the authors" if should_succeed else "Disconnected from SSH")
+      client.screenshot(screenshot)
+
+      if should_succeed:
+        # Press the Don't Trust button
+        client.send_key("tab")
+        client.send_key("tab")
+        client.send_key("tab")
+        client.send_key("\n")
+      else:
+        # Close the error dialog
+        client.send_key("esc")
+
+      client.send_key("ctrl-q")
+      client.wait_until_fails("pidof code")
+
+
+    start_all()
+    server.wait_for_open_port(22)
+
+    VSCODE_COMMIT = server.execute("${jq} -r .commit ${pkgs.vscode}/lib/vscode/resources/app/product.json")[1].rstrip()
+    SERVER_COMMIT = server.execute("${jq} -r .commit ${vscode-server}/product.json")[1].rstrip()
+
+    print(f"{VSCODE_COMMIT=} {SERVER_COMMIT=}")
+    assert VSCODE_COMMIT == SERVER_COMMIT, "VSCODE_COMMIT and SERVER_COMMIT do not match"
+
+    client.wait_until_succeeds("ping -c1 server")
+    client.succeed("sudo -u alice mkdir ~alice/.ssh")
+    client.succeed("sudo -u alice install -Dm 600 ${snakeOilPrivateKey} ~alice/.ssh/id_ecdsa")
+    client.succeed("sudo -u alice install ${ssh-config} ~alice/.ssh/config")
+    client.succeed("sudo -u alice install -Dm 644 ${vscode-config} ~alice/.config/Code/User/settings.json")
+
+    client.wait_for_x()
+    client.wait_for_file("~alice/.Xauthority")
+    client.succeed("xauth merge ~alice/.Xauthority")
+    # Move the mouse out of the way
+    client.succeed("${pkgs.xdotool}/bin/xdotool mousemove 0 0")
+
+    with subtest("fails to connect when Node is broken"):
+      server.fail("node -v")
+      connect_with_remote_ssh(screenshot="no_node_installed", should_succeed=False)
+      server.succeed("test -e ~/.vscode-server/bin/*/node")
+      server.fail("~/.vscode-server/bin/*/node -v")
+
+    with subtest("fails to connect when server has the wrong Node installed"):
+      server.succeed("nix-env -i ${pkgs.nodejs-14_x}")
+      connect_with_remote_ssh(screenshot="wrong_node_installed", should_succeed=False)
+      server.fail("~/.vscode-server/bin/*/node -v")
+
+    with subtest("connects when server has the correct Node installed"):
+      server.succeed("nix-env -i ${pkgs.nodejs-16_x}")
+      connect_with_remote_ssh(screenshot="correct_node_installed", should_succeed=True)
+      server.succeed("~/.vscode-server/bin/*/node -v")
+      server.succeed("kill $(pgrep -f [v]scode-server)")
+      server.succeed("nix-env -e nodejs")
+
+    with subtest("connects when server can build Node from Nixpkgs"):
+      server.succeed("mkdir -p /nix/var/nix/profiles/per-user/root/channels")
+      server.succeed("ln -s ${pkgs.path} /nix/var/nix/profiles/per-user/root/channels/nixos")
+      connect_with_remote_ssh(screenshot="build_node_with_nix", should_succeed=True)
+  '';
+})

--- a/pkgs/applications/editors/vscode/extensions/ms-vscode-remote.remote-ssh/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode-remote.remote-ssh/default.nix
@@ -10,8 +10,6 @@
 let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
 
-  nodeVersion = "16";
-
   # As VS Code executes this code on the remote machine
   # we test to see if we can build Node from Nixpkgs
   # otherwise we check if the globally installed Node
@@ -24,38 +22,44 @@ let
     serverNode="$serverDir/node"
     echo "VS Code Node: $serverNode"
 
-    # Check if VS Code Server has a non-working Node or the wrong version of Node
-    if ! nodeVersion=$($serverNode -v) || [ "\''${nodeVersion:1:2}" != "${nodeVersion}" ]; then
+    # Check if Node included with VS Code Server runs
+    if ! nodeVersion=$($serverNode -v); then
       echo "VS Code Node Version: $nodeVersion"
 
-      if nix-build "<nixpkgs>" -A nodejs-${nodeVersion}_x --out-link "$serverDir/nix" && [ -e "$serverDir/nix/bin/node" ]; then
-        nodePath="$serverDir/nix/bin/node"
+      if ! nix-build "<nixpkgs>" -A patchelf --out-link "$serverDir/patchelf" || ! "$serverDir/patchelf/bin/patchelf" --version; then
+        echo "Failed to get patchelf from nixpkgs"
       fi
 
-      echo "Node from Nix: $nodePath"
-
-      nodeVersion=$($nodePath -v)
-      echo "Node from Nix Version: $nodeVersion"
-
-      if [ "\''${nodeVersion:1:2}" != "${nodeVersion}" ]; then
-        echo "Getting Node from Nix failed, use Local Node instead"
-        nodePath=$(which node)
-        echo "Local Node: $nodePath"
-        nodeVersion=$($nodePath -v)
-        echo "Local Node Version: $nodeVersion"
+      if [ -e $serverNode.orig ]; then
+        cp $serverNode.orig $serverNode
+      else
+        cp $serverNode $serverNode.orig
       fi
 
-      if [ "\''${nodeVersion:1:2}" == "${nodeVersion}" ]; then
-        echo PATCH: replacing $serverNode with $nodePath
-        ln -sf $nodePath $serverNode
+      if ! nix-build "<nixpkgs>" -A bintools --out-link $serverDir/bintools; then
+        echo "Failed to build bintools from nixpkgs"
       fi
+
+      INTERPRETER=$(cat $serverDir/bintools/nix-support/dynamic-linker)
+
+      echo "Interpreter from bintools: $INTERPRETER"
+
+      if ! nix-build "<nixpkgs>" -A stdenv.cc.cc.lib --out-link $serverDir/cc; then
+        echo "Failed to build stdenv.cc.cc.lib from nixpkgs"
+      fi
+
+      if ! $serverDir/patchelf/bin/patchelf --set-interpreter $INTERPRETER --set-rpath $serverDir/cc-lib/lib $serverNode; then
+        echo "Failed to patch Node binary"
+      fi
+
+      rm "$serverDir/patchelf"
     fi
 
     nodeVersion=$($serverNode -v)
     echo "VS Code Node Version: $nodeVersion"
 
-    if [ "\''${nodeVersion:1:2}" != "${nodeVersion}" ]; then
-      echo "Unsupported VS Code Node version: $nodeVersion", quitting
+    if ! nodeVersion=$($serverNode -v); then
+      echo "Unable to fix Node binary, quitting"
       fail_with_exitcode ''${o.InstallExitCode.ServerTransferFailed}
     fi
 

--- a/pkgs/applications/editors/vscode/extensions/ms-vscode-remote.remote-ssh/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode-remote.remote-ssh/default.nix
@@ -1,4 +1,5 @@
 { lib
+, nixosTests
 , vscode-utils
 , useLocalExtensions ? false
 }:
@@ -86,6 +87,8 @@ buildVscodeMarketplaceExtension {
     substituteInPlace "out/extension.js" \
       --replace '# Start the server\n' '${patch}'
   '';
+
+  passthru.tests = { inherit (nixosTests) vscode-remote-ssh; };
 
   meta = {
     description = "Use any remote machine with a SSH server as your development environment.";

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -13,6 +13,8 @@
 , version, src, meta, sourceRoot, commandLineArgs
 , executableName, longName, shortName, pname, updateScript
 , dontFixup ? false
+, rev ? null, vscodeServer ? null
+
 # sourceExecutableName is the name of the binary in the source archive, over
 # which we have no control
 , sourceExecutableName ? executableName
@@ -30,6 +32,8 @@ let
       inherit executableName longName tests updateScript;
       fhs = fhs {};
       fhsWithPackages = f: fhs { additionalPkgs = f; };
+    } // lib.optionalAttrs (vscodeServer != null) {
+      inherit rev vscodeServer;
     };
 
     desktopItem = makeDesktopItem {

--- a/pkgs/applications/editors/vscode/update-vscode.sh
+++ b/pkgs/applications/editors/vscode/update-vscode.sh
@@ -14,14 +14,34 @@ if [ ! -f "$ROOT/vscode.nix" ]; then
   exit 1
 fi
 
+NIXPKGS_ROOT="$(git rev-parse --show-toplevel)"
+
+if [ ! -f "$NIXPKGS_ROOT/nixos/tests/vscode-remote-ssh.nix" ]; then
+  echo "ERROR: cannot find nixos/tests/vscode-remote-ssh.nix"
+  exit 1
+fi
+
 # VSCode
 
 VSCODE_VER=$(curl --fail --silent https://api.github.com/repos/Microsoft/vscode/releases/latest | jq --raw-output .tag_name)
 sed -i "s/version = \".*\"/version = \"${VSCODE_VER}\"/" "$ROOT/vscode.nix"
 
+TEMP_FOLDER=$(mktemp -d)
+
 VSCODE_X64_LINUX_URL="https://update.code.visualstudio.com/${VSCODE_VER}/linux-x64/stable"
-VSCODE_X64_LINUX_SHA256=$(nix-prefetch-url ${VSCODE_X64_LINUX_URL})
-sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_X64_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
+
+# Split output by newlines into Bash array
+readarray -t VSCODE_X64_LINUX <<< $(nix-prefetch-url --print-path ${VSCODE_X64_LINUX_URL})
+
+sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_X64_LINUX[0]}\"/" "$ROOT/vscode.nix"
+
+tar xf $VSCODE_X64_LINUX[1] -C $TEMP_FOLDER
+VSCODE_COMMIT=$(jq --raw-output .commit $TEMP_FOLDER/VSCode-linux-x64/resources/app/product.json)
+sed -i "s/rev = \".\{40\}\"/rev = \"${VSCODE_COMMIT}\"/" "$NIXPKGS_ROOT/nixos/tests/vscode-remote-ssh.nix"
+
+SERVER_X64_LINUX_URL="https://update.code.visualstudio.com/commit:${VSCODE_COMMIT}/server-linux-x64/stable"
+SERVER_X64_LINUX_SHA256=$(nix-prefetch-url ${SERVER_X64_LINUX_URL})
+sed -i "s/sha256 = \".\{51,52\}\"/sha256 = \"${SERVER_X64_LINUX_SHA256}\"/" "$NIXPKGS_ROOT/nixos/tests/vscode-remote-ssh.nix"
 
 VSCODE_X64_DARWIN_URL="https://update.code.visualstudio.com/${VSCODE_VER}/darwin/stable"
 VSCODE_X64_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_X64_DARWIN_URL})

--- a/pkgs/applications/editors/vscode/update-vscode.sh
+++ b/pkgs/applications/editors/vscode/update-vscode.sh
@@ -14,13 +14,6 @@ if [ ! -f "$ROOT/vscode.nix" ]; then
   exit 1
 fi
 
-NIXPKGS_ROOT="$(git rev-parse --show-toplevel)"
-
-if [ ! -f "$NIXPKGS_ROOT/nixos/tests/vscode-remote-ssh.nix" ]; then
-  echo "ERROR: cannot find nixos/tests/vscode-remote-ssh.nix"
-  exit 1
-fi
-
 # VSCode
 
 VSCODE_VER=$(curl --fail --silent https://api.github.com/repos/Microsoft/vscode/releases/latest | jq --raw-output .tag_name)
@@ -35,13 +28,13 @@ readarray -t VSCODE_X64_LINUX <<< $(nix-prefetch-url --print-path ${VSCODE_X64_L
 
 sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_X64_LINUX[0]}\"/" "$ROOT/vscode.nix"
 
-tar xf $VSCODE_X64_LINUX[1] -C $TEMP_FOLDER
+tar xf ${VSCODE_X64_LINUX[1]} -C $TEMP_FOLDER
 VSCODE_COMMIT=$(jq --raw-output .commit $TEMP_FOLDER/VSCode-linux-x64/resources/app/product.json)
-sed -i "s/rev = \".\{40\}\"/rev = \"${VSCODE_COMMIT}\"/" "$NIXPKGS_ROOT/nixos/tests/vscode-remote-ssh.nix"
+sed -i "s/rev = \".\{40\}\"/rev = \"${VSCODE_COMMIT}\"/" "$ROOT/vscode.nix"
 
 SERVER_X64_LINUX_URL="https://update.code.visualstudio.com/commit:${VSCODE_COMMIT}/server-linux-x64/stable"
 SERVER_X64_LINUX_SHA256=$(nix-prefetch-url ${SERVER_X64_LINUX_URL})
-sed -i "s/sha256 = \".\{51,52\}\"/sha256 = \"${SERVER_X64_LINUX_SHA256}\"/" "$NIXPKGS_ROOT/nixos/tests/vscode-remote-ssh.nix"
+sed -i "s/sha256 = \".\{51,52\}\"/sha256 = \"${SERVER_X64_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
 
 VSCODE_X64_DARWIN_URL="https://update.code.visualstudio.com/${VSCODE_VER}/darwin/stable"
 VSCODE_X64_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_X64_DARWIN_URL})

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -1,4 +1,8 @@
-{ stdenv, lib, callPackage, fetchurl
+{ stdenv
+, lib
+, callPackage
+, fetchurl
+, nixosTests
 , isInsiders ? false
 , commandLineArgs ? ""
 , useVSCodeRipgrep ? stdenv.isDarwin
@@ -47,6 +51,8 @@ in
     tests = {};
 
     sourceRoot = "";
+
+    tests = { inherit (nixosTests) vscode-remote-ssh; };
 
     updateScript = ./update-vscode.sh;
 

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -77,7 +77,7 @@ in
       homepage = "https://code.visualstudio.com/";
       downloadPage = "https://code.visualstudio.com/Updates";
       license = licenses.unfree;
-      maintainers = with maintainers; [ eadwu synthetica maxeaubrey bobby285271 ];
+      maintainers = with maintainers; [ eadwu synthetica maxeaubrey bobby285271 Enzime ];
       platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" "armv7l-linux" ];
     };
   }

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -3,6 +3,7 @@
 , callPackage
 , fetchurl
 , nixosTests
+, srcOnly
 , isInsiders ? false
 , commandLineArgs ? ""
 , useVSCodeRipgrep ? stdenv.isDarwin
@@ -36,6 +37,9 @@ in
     version = "1.79.0";
     pname = "vscode";
 
+    # This is used for VS Code - Remote SSH test
+    rev = "b380da4ef1ee00e224a15c1d4d9793e27c2b6302";
+
     executableName = "code" + lib.optionalString isInsiders "-insiders";
     longName = "Visual Studio Code" + lib.optionalString isInsiders " - Insiders";
     shortName = "Code" + lib.optionalString isInsiders " - Insiders";
@@ -51,6 +55,16 @@ in
     tests = {};
 
     sourceRoot = "";
+
+    # As tests run without networking, we need to download this for the Remote SSH server
+    vscodeServer = srcOnly {
+      name = "vscode-server-${rev}.tar.gz";
+      src = fetchurl {
+        name = "vscode-server-${rev}.tar.gz";
+        url = "https://update.code.visualstudio.com/commit:${rev}/server-linux-x64/stable";
+        sha256 = "0732wpl4fjknhn423k23zrcqz9psjj1iy8lqa0fc8970n1m7i58b";
+      };
+    };
 
     tests = { inherit (nixosTests) vscode-remote-ssh; };
 

--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -1,7 +1,6 @@
 { stdenv }:
 # srcOnly is a utility builder that only fetches and unpacks the given `src`,
-# maybe pathings it in the process with the optional `patches` and
-# `buildInputs` attributes.
+# and optionally patching with `patches` or adding build inputs.
 #
 # It can be invoked directly, or be used to wrap an existing derivation. Eg:
 #


### PR DESCRIPTION
###### Description of changes

Due to the Node version bundled with the VS Code Server occasionally changing, the patch to allow Remote SSH to work with NixOS hosts sometimes gets out of date. This new test ensures the Remote SSH patch is still working :smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).