### PR TITLE
splice.nix: add convenience functions 

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -1,31 +1,17 @@
 { config
 , lib
 , pkgs
-, splicePackages
-, newScope
-, pkgsBuildBuild
-, pkgsBuildHost
-, pkgsBuildTarget
-, pkgsHostHost
-, pkgsTargetTarget
+, generateSplicesForMkScope
+, makeScopeWithSplicing
 }:
 
 let
-  otherSplices = {
-    selfBuildBuild = pkgsBuildBuild.xfce;
-    selfBuildHost = pkgsBuildHost.xfce;
-    selfBuildTarget = pkgsBuildTarget.xfce;
-    selfHostHost = pkgsHostHost.xfce;
-    selfTargetTarget = pkgsTargetTarget.xfce or { };
-  };
   keep = _self: { };
   extra = _spliced0: { };
 
 in
-lib.makeScopeWithSplicing
-  splicePackages
-  newScope
-  otherSplices
+makeScopeWithSplicing
+  (generateSplicesForMkScope "xfce")
   keep
   extra
   (self:

--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -24,7 +24,7 @@ let
         # - imports lua-packages.nix
         # - adds spliced package sets to the package set
         # - applies overrides from `packageOverrides`
-        ({ lua, overrides, callPackage, splicePackages, newScope }: let
+        ({ lua, overrides, callPackage, makeScopeWithSplicing }: let
           luaPackagesFun = callPackage ../../../top-level/lua-packages.nix {
             lua = self;
           };
@@ -47,9 +47,7 @@ let
             overriddenPackages
             overrides
           ];
-        in lib.makeScopeWithSplicing
-          splicePackages
-          newScope
+        in makeScopeWithSplicing
           otherSplices
           keep
           extra

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -5,9 +5,8 @@
 , db
 , lib
 , libffiBoot
-, newScope
+, makeScopeWithSplicing
 , pythonPackagesExtensions
-, splicePackages
 , stdenv
 }:
 
@@ -71,9 +70,7 @@
             overrides
           ]);
           aliases = self: super: lib.optionalAttrs config.allowAliases (import ../../../top-level/python-aliases.nix lib self super);
-        in lib.makeScopeWithSplicing
-          splicePackages
-          newScope
+        in makeScopeWithSplicing
           otherSplices
           keep
           extra

--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -1,5 +1,4 @@
-{ lib, newScope, splicePackages, steamPackagesAttr ? "steamPackages"
-, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, pkgsHostHost, pkgsTargetTarget
+{ makeScopeWithSplicing, generateSplicesForMkScope
 , stdenv, buildFHSUserEnv, pkgsi686Linux
 }:
 
@@ -18,19 +17,12 @@ let
       glxinfo-i686 = pkgsi686Linux.glxinfo;
       steam-runtime-wrapped-i686 =
         if self.steamArch == "amd64"
-        then pkgsi686Linux.${steamPackagesAttr}.steam-runtime-wrapped
+        then pkgsi686Linux.steamPackages.steam-runtime-wrapped
         else null;
       inherit buildFHSUserEnv;
     };
     steamcmd = callPackage ./steamcmd.nix { };
   };
-  otherSplices = {
-    selfBuildBuild = pkgsBuildBuild.${steamPackagesAttr};
-    selfBuildHost = pkgsBuildHost.${steamPackagesAttr};
-    selfBuildTarget = pkgsBuildTarget.${steamPackagesAttr};
-    selfHostHost = pkgsHostHost.${steamPackagesAttr};
-    selfTargetTarget = pkgsTargetTarget.${steamPackagesAttr} or {}; # might be missing;
-  };
   keep = self: { };
   extra = spliced0: { };
-in lib.makeScopeWithSplicing splicePackages newScope otherSplices keep extra steamPackagesFun
+in makeScopeWithSplicing (generateSplicesForMkScope "steamPackages") keep extra steamPackagesFun

--- a/pkgs/os-specific/bsd/freebsd/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, stdenvNoCC
-, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, pkgsHostHost, pkgsTargetTarget
-, buildPackages, splicePackages, newScope
+, makeScopeWithSplicing, generateSplicesForMkScope
+, buildPackages
 , bsdSetupHook, makeSetupHook
 , fetchgit, fetchurl, coreutils, groff, mandoc, byacc, flex, which, m4, gawk, substituteAll, runtimeShell
 , zlib, expat, libmd
@@ -23,14 +23,6 @@ let
   freebsdSetupHook = makeSetupHook {
     name = "freebsd-setup-hook";
   } ./setup-hook.sh;
-
-  otherSplices = {
-    selfBuildBuild = pkgsBuildBuild.freebsd;
-    selfBuildHost = pkgsBuildHost.freebsd;
-    selfBuildTarget = pkgsBuildTarget.freebsd;
-    selfHostHost = pkgsHostHost.freebsd;
-    selfTargetTarget = pkgsTargetTarget.freebsd or {}; # might be missing
-  };
 
   mkBsdArch = stdenv':  {
     x86_64 = "amd64";
@@ -74,10 +66,8 @@ let
     done
   '';
 
-in lib.makeScopeWithSplicing
-  splicePackages
-  newScope
-  otherSplices
+in makeScopeWithSplicing
+  (generateSplicesForMkScope "freebsd")
   (_: {})
   (_: {})
   (self: let

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, stdenvNoCC
-, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, pkgsHostHost, pkgsTargetTarget
-, buildPackages, splicePackages, newScope
+, makeScopeWithSplicing, generateSplicesForMkScope
+, buildPackages
 , bsdSetupHook, makeSetupHook, fetchcvs, groff, mandoc, byacc, flex
 , zlib
 , writeShellScript, writeText, runtimeShell, symlinkJoin
@@ -20,24 +20,14 @@ let
     name = "netbsd-setup-hook";
   } ./setup-hook.sh;
 
-  otherSplices = {
-    selfBuildBuild = pkgsBuildBuild.netbsd;
-    selfBuildHost = pkgsBuildHost.netbsd;
-    selfBuildTarget = pkgsBuildTarget.netbsd;
-    selfHostHost = pkgsHostHost.netbsd;
-    selfTargetTarget = pkgsTargetTarget.netbsd or {}; # might be missing
-  };
-
   defaultMakeFlags = [
     "MKSOFTFLOAT=${if stdenv.hostPlatform.gcc.float or (stdenv.hostPlatform.parsed.abi.float or "hard") == "soft"
       then "yes"
       else "no"}"
   ];
 
-in lib.makeScopeWithSplicing
-  splicePackages
-  newScope
-  otherSplices
+in makeScopeWithSplicing
+  (generateSplicesForMkScope "netbsd")
   (_: {})
   (_: {})
   (self: let
@@ -46,7 +36,7 @@ in lib.makeScopeWithSplicing
 
   # Why do we have splicing and yet do `nativeBuildInputs = with self; ...`?
   #
-  # We use `lib.makeScopeWithSplicing` because this should be used for all
+  # We use `makeScopeWithSplicing` because this should be used for all
   # nested package sets which support cross, so the inner `callPackage` works
   # correctly. But for the inline packages we don't bother to use
   # `callPackage`.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24955,13 +24955,6 @@ with pkgs;
   };
 
   xorg = let
-    otherSplices = {
-      selfBuildBuild = pkgsBuildBuild.xorg;
-      selfBuildHost = pkgsBuildHost.xorg;
-      selfBuildTarget = pkgsBuildTarget.xorg;
-      selfHostHost = pkgsHostHost.xorg;
-      selfTargetTarget = pkgsTargetTarget.xorg or { };
-    };
     keep = _self: { };
     extra = _spliced0: { };
 
@@ -24980,10 +24973,8 @@ with pkgs;
 
     generatedPackages = lib.callPackageWith __splicedPackages ../servers/x11/xorg/default.nix {};
 
-    xorgPackages = lib.makeScopeWithSplicing
-      splicePackages
-      newScope
-      otherSplices
+    xorgPackages = makeScopeWithSplicing
+      (generateSplicesForMkScope "xorg")
       keep
       extra
       (lib.extends overrides generatedPackages);

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -1,19 +1,11 @@
 { lib
 , buildPackages, pkgs, targetPackages
-, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, pkgsHostHost, pkgsTargetTarget
-, stdenv, splicePackages, newScope
+, generateSplicesForMkScope, makeScopeWithSplicing
+, stdenv
 , preLibcCrossHeaders
 }:
 
 let
-  otherSplices = {
-    selfBuildBuild = pkgsBuildBuild.darwin;
-    selfBuildHost = pkgsBuildHost.darwin;
-    selfBuildTarget = pkgsBuildTarget.darwin;
-    selfHostHost = pkgsHostHost.darwin;
-    selfTargetTarget = pkgsTargetTarget.darwin or {}; # might be missing
-  };
-
   # Prefix for binaries. Customarily ends with a dash separator.
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
@@ -22,7 +14,7 @@ let
                                         (stdenv.targetPlatform.config + "-");
 in
 
-lib.makeScopeWithSplicing splicePackages newScope otherSplices (_: {}) (spliced: spliced.apple_sdk.frameworks) (self: let
+makeScopeWithSplicing (generateSplicesForMkScope "darwin") (_: {}) (spliced: spliced.apple_sdk.frameworks) (self: let
   inherit (self) mkDerivation callPackage;
 
   # Must use pkgs.callPackage to avoid infinite recursion.

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -146,6 +146,24 @@ in
 
   newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extra);
 
+  # prefill 2 fields of the function for convenience
+  makeScopeWithSplicing = lib.makeScopeWithSplicing splicePackages pkgs.newScope;
+
+  # generate 'otherSplices' for 'makeScopeWithSplicing'
+  generateSplicesForMkScope = attr:
+    let
+      split = X: lib.splitString "." "${X}.${attr}";
+    in
+    {
+      # nulls should never be reached
+      selfBuildBuild = lib.attrByPath (split "pkgsBuildBuild") null pkgs;
+      selfBuildHost = lib.attrByPath (split "pkgsBuildHost") null pkgs;
+      selfBuildTarget = lib.attrByPath (split "pkgsBuildTarget") null pkgs;
+      selfHostHost = lib.attrByPath (split "pkgsHostHost") null pkgs;
+      selfHostTarget = lib.attrByPath (split "pkgsHostTarget") null pkgs;
+      selfTargetTarget = lib.attrByPath (split "pkgsTargetTarget") { } pkgs;
+    };
+
   # Haskell package sets need this because they reimplement their own
   # `newScope`.
   __splicedPackages = splicedPackages // { recurseForDerivations = false; };

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -18,86 +18,103 @@ lib: pkgs: actuallySplice:
 
 let
 
-  spliceReal = { pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
-               , pkgsHostHost, pkgsHostTarget
-               , pkgsTargetTarget
-               }: let
-    mash =
-      # Other pkgs sets
-      pkgsBuildBuild // pkgsBuildTarget // pkgsHostHost // pkgsTargetTarget
-      # The same pkgs sets one probably intends
-      // pkgsBuildHost // pkgsHostTarget;
-    merge = name: {
-      inherit name;
-      value = let
-        defaultValue = mash.${name};
-        # `or {}` is for the non-derivation attsert splicing case, where `{}` is the identity.
-        valueBuildBuild = pkgsBuildBuild.${name} or {};
-        valueBuildHost = pkgsBuildHost.${name} or {};
-        valueBuildTarget = pkgsBuildTarget.${name} or {};
-        valueHostHost = pkgsHostHost.${name} or {};
-        valueHostTarget = pkgsHostTarget.${name} or {};
-        valueTargetTarget = pkgsTargetTarget.${name} or {};
-        augmentedValue = defaultValue
-          # TODO(@Artturin): remove before release 23.05 and only have __spliced.
-          // (lib.optionalAttrs (pkgsBuildHost ? ${name}) { nativeDrv = lib.warn "use ${name}.__spliced.buildHost instead of ${name}.nativeDrv" valueBuildHost; })
-          // (lib.optionalAttrs (pkgsHostTarget ? ${name}) { crossDrv = lib.warn "use ${name}.__spliced.hostTarget instead of ${name}.crossDrv" valueHostTarget; })
-          // {
-            __spliced =
-                 (lib.optionalAttrs (pkgsBuildBuild ? ${name}) { buildBuild = valueBuildBuild; })
-              // (lib.optionalAttrs (pkgsBuildHost ? ${name}) { buildHost = valueBuildHost; })
-              // (lib.optionalAttrs (pkgsBuildTarget ? ${name}) { buildTarget = valueBuildTarget; })
-              // (lib.optionalAttrs (pkgsHostHost ? ${name}) { hostHost = valueHostHost; })
-              // (lib.optionalAttrs (pkgsHostTarget ? ${name}) { hostTarget = valueHostTarget; })
-              // (lib.optionalAttrs (pkgsTargetTarget ? ${name}) { targetTarget = valueTargetTarget;
-          });
-        };
-        # Get the set of outputs of a derivation. If one derivation fails to
-        # evaluate we don't want to diverge the entire splice, so we fall back
-        # on {}
-        tryGetOutputs = value0: let
-          inherit (builtins.tryEval value0) success value;
-        in getOutputs (lib.optionalAttrs success value);
-        getOutputs = value: lib.genAttrs
-          (value.outputs or (lib.optional (value ? out) "out"))
-          (output: value.${output});
-      in
-        # The derivation along with its outputs, which we recur
-        # on to splice them together.
-        if lib.isDerivation defaultValue then augmentedValue // spliceReal {
-          pkgsBuildBuild = tryGetOutputs valueBuildBuild;
-          pkgsBuildHost = tryGetOutputs valueBuildHost;
-          pkgsBuildTarget = tryGetOutputs valueBuildTarget;
-          pkgsHostHost = tryGetOutputs valueHostHost;
-          pkgsHostTarget = getOutputs valueHostTarget;
-          pkgsTargetTarget = tryGetOutputs valueTargetTarget;
-        # Just recur on plain attrsets
-        } else if lib.isAttrs defaultValue then spliceReal {
-          pkgsBuildBuild = valueBuildBuild;
-          pkgsBuildHost = valueBuildHost;
-          pkgsBuildTarget = valueBuildTarget;
-          pkgsHostHost = valueHostHost;
-          pkgsHostTarget = valueHostTarget;
-          pkgsTargetTarget = valueTargetTarget;
-        # Don't be fancy about non-derivations. But we could have used used
-        # `__functor__` for functions instead.
-        } else defaultValue;
-    };
-  in lib.listToAttrs (map merge (lib.attrNames mash));
+  spliceReal =
+    { pkgsBuildBuild
+    , pkgsBuildHost
+    , pkgsBuildTarget
+    , pkgsHostHost
+    , pkgsHostTarget
+    , pkgsTargetTarget
+    }:
+    let
+      mash =
+        # Other pkgs sets
+        pkgsBuildBuild // pkgsBuildTarget // pkgsHostHost // pkgsTargetTarget
+        # The same pkgs sets one probably intends
+        // pkgsBuildHost // pkgsHostTarget;
+      merge = name: {
+        inherit name;
+        value =
+          let
+            defaultValue = mash.${name};
+            # `or {}` is for the non-derivation attsert splicing case, where `{}` is the identity.
+            valueBuildBuild = pkgsBuildBuild.${name} or { };
+            valueBuildHost = pkgsBuildHost.${name} or { };
+            valueBuildTarget = pkgsBuildTarget.${name} or { };
+            valueHostHost = pkgsHostHost.${name} or { };
+            valueHostTarget = pkgsHostTarget.${name} or { };
+            valueTargetTarget = pkgsTargetTarget.${name} or { };
+            augmentedValue = defaultValue
+              # TODO(@Artturin): remove before release 23.05 and only have __spliced.
+              // (lib.optionalAttrs (pkgsBuildHost ? ${name}) { nativeDrv = lib.warn "use ${name}.__spliced.buildHost instead of ${name}.nativeDrv" valueBuildHost; })
+              // (lib.optionalAttrs (pkgsHostTarget ? ${name}) { crossDrv = lib.warn "use ${name}.__spliced.hostTarget instead of ${name}.crossDrv" valueHostTarget; })
+              // {
+              __spliced =
+                (lib.optionalAttrs (pkgsBuildBuild ? ${name}) { buildBuild = valueBuildBuild; })
+                  // (lib.optionalAttrs (pkgsBuildHost ? ${name}) { buildHost = valueBuildHost; })
+                  // (lib.optionalAttrs (pkgsBuildTarget ? ${name}) { buildTarget = valueBuildTarget; })
+                  // (lib.optionalAttrs (pkgsHostHost ? ${name}) { hostHost = valueHostHost; })
+                  // (lib.optionalAttrs (pkgsHostTarget ? ${name}) { hostTarget = valueHostTarget; })
+                  // (lib.optionalAttrs (pkgsTargetTarget ? ${name}) {
+                  targetTarget = valueTargetTarget;
+                });
+            };
+            # Get the set of outputs of a derivation. If one derivation fails to
+            # evaluate we don't want to diverge the entire splice, so we fall back
+            # on {}
+            tryGetOutputs = value0:
+              let
+                inherit (builtins.tryEval value0) success value;
+              in
+              getOutputs (lib.optionalAttrs success value);
+            getOutputs = value: lib.genAttrs
+              (value.outputs or (lib.optional (value ? out) "out"))
+              (output: value.${output});
+          in
+          # The derivation along with its outputs, which we recur
+            # on to splice them together.
+          if lib.isDerivation defaultValue then augmentedValue // spliceReal {
+            pkgsBuildBuild = tryGetOutputs valueBuildBuild;
+            pkgsBuildHost = tryGetOutputs valueBuildHost;
+            pkgsBuildTarget = tryGetOutputs valueBuildTarget;
+            pkgsHostHost = tryGetOutputs valueHostHost;
+            pkgsHostTarget = getOutputs valueHostTarget;
+            pkgsTargetTarget = tryGetOutputs valueTargetTarget;
+            # Just recur on plain attrsets
+          } else if lib.isAttrs defaultValue then
+            spliceReal
+              {
+                pkgsBuildBuild = valueBuildBuild;
+                pkgsBuildHost = valueBuildHost;
+                pkgsBuildTarget = valueBuildTarget;
+                pkgsHostHost = valueHostHost;
+                pkgsHostTarget = valueHostTarget;
+                pkgsTargetTarget = valueTargetTarget;
+                # Don't be fancy about non-derivations. But we could have used used
+                # `__functor__` for functions instead.
+              } else defaultValue;
+      };
+    in
+    lib.listToAttrs (map merge (lib.attrNames mash));
 
-  splicePackages = { pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
-                   , pkgsHostHost, pkgsHostTarget
-                   , pkgsTargetTarget
-                   } @ args:
+  splicePackages =
+    { pkgsBuildBuild
+    , pkgsBuildHost
+    , pkgsBuildTarget
+    , pkgsHostHost
+    , pkgsHostTarget
+    , pkgsTargetTarget
+    } @ args:
     if actuallySplice then spliceReal args else pkgsHostTarget;
 
-  splicedPackages = splicePackages {
-    inherit (pkgs)
-      pkgsBuildBuild pkgsBuildHost pkgsBuildTarget
-      pkgsHostHost pkgsHostTarget
-      pkgsTargetTarget
-      ;
-  } // {
+  splicedPackages = splicePackages
+    {
+      inherit (pkgs)
+        pkgsBuildBuild pkgsBuildHost pkgsBuildTarget
+        pkgsHostHost pkgsHostTarget
+        pkgsTargetTarget
+        ;
+    } // {
     # These should never be spliced under any circumstances
     inherit (pkgs)
       pkgsBuildBuild pkgsBuildHost pkgsBuildTarget
@@ -109,7 +126,10 @@ let
   };
 
   splicedPackagesWithXorg = splicedPackages // builtins.removeAttrs splicedPackages.xorg [
-    "callPackage" "newScope" "overrideScope" "packages"
+    "callPackage"
+    "newScope"
+    "overrideScope"
+    "packages"
   ];
 
 in
@@ -120,7 +140,7 @@ in
   # We use `callPackage' to be able to omit function arguments that can be
   # obtained `pkgs` or `buildPackages` and their `xorg` package sets. Use
   # `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
-  callPackage = pkgs.newScope {};
+  callPackage = pkgs.newScope { };
 
   callPackages = lib.callPackagesWith splicedPackagesWithXorg;
 


### PR DESCRIPTION
Replaces https://github.com/NixOS/nixpkgs/pull/105374

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
