### PR TITLE
xfce.xfce4-screenshooter: 1.9.11 -> 1.10.1

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
@@ -1,30 +1,30 @@
 { lib
 , mkXfceDerivation
 , exo
-, glib-networking
-, gtk3
-, libsoup
+, libxml2
+, libsoup_3
 , libxfce4ui
 , libxfce4util
 , xfce4-panel
+, xfconf
 }:
 
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-screenshooter";
-  version = "1.9.11";
+  version = "1.10.1";
   odd-unstable = false;
 
-  sha256 = "sha256-sW0SEXypCcly7MlO9lnxHTkYwIiRt+gOME5UQ++Y3JQ=";
+  sha256 = "sha256-TKtEKjRmrdhi1nFRo1OovmPndT2RTYV9kt7auBDESmE=";
 
   buildInputs = [
     exo
-    glib-networking
-    gtk3
-    libsoup
+    libxml2
+    libsoup_3
     libxfce4ui
     libxfce4util
     xfce4-panel
+    xfconf
   ];
 
   meta = with lib; {

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -109,9 +109,7 @@ lib.makeScopeWithSplicing
 
       xfce4-screensaver = callPackage ./applications/xfce4-screensaver { };
 
-      xfce4-screenshooter = callPackage ./applications/xfce4-screenshooter {
-        inherit (pkgs.gnome) libsoup;
-      };
+      xfce4-screenshooter = callPackage ./applications/xfce4-screenshooter { };
 
       xfdashboard = callPackage ./applications/xfdashboard { };
 


### PR DESCRIPTION
###### Description of changes

Update to version [1.10.1](https://gitlab.xfce.org/apps/xfce4-screenshooter/-/tags)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
