### PR TITLE
nixos/public-inbox: fix incorrectly restrictive option type

### DIFF
--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -275,7 +275,11 @@ in
           default = {};
           description = lib.mdDoc "public inboxes";
           type = types.submodule {
-            freeformType = with types; /*inbox name*/attrsOf (/*inbox option name*/attrsOf /*inbox option value*/iniAtom);
+            # Keeping in line with the tradition of unnecessarily specific types, allow users to set
+            # freeform settings either globally under the `publicinbox` section, or for specific
+            # inboxes through additional nesting.
+            freeformType = with types; attrsOf (oneOf [ iniAtom (attrsOf iniAtom) ]);
+
             options.css = mkOption {
               type = with types; listOf str;
               default = [];


### PR DESCRIPTION
The `freeformType` of `settings.publicinbox` in this module prevented users from setting settings on the `publicinbox` section itself (which is necessary for making e.g. IMAP work correctly), and only allowed configuration of nested per-inbox sections.

In general I believe that these overly specific types which are traditional in NixOS, and this kind of config generation, are a huge footgun. This commit is the least invasive change that makes the module work correctly.
