### PR TITLE
python310Packages.ssh-mitm: 2.1.0 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/ssh-mitm/default.nix
+++ b/pkgs/development/python-modules/ssh-mitm/default.nix
@@ -1,23 +1,21 @@
 { lib
+, argcomplete
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
 , colored
-, enhancements
 , packaging
 , paramiko
 , pytz
 , pyyaml
-, requests
 , rich
 , sshpubkeys
-, typeguard
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "ssh-mitm";
-  version = "2.1.0";
+  version = "3.0.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -26,20 +24,18 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-DMXzDgSt1p3ZNGrXnSr79KH33SJNN8U4/94Hoz7Rs+I=";
+    hash = "sha256-bFxpgzomtcFGf0LfLUR05y3+/8DNhND6EKAmCZcYb5E=";
   };
 
   propagatedBuildInputs = [
+    argcomplete
     colored
-    enhancements
     packaging
     paramiko
     pytz
     pyyaml
-    requests
     rich
     sshpubkeys
-    typeguard
   ];
 
   # Module has no tests

--- a/pkgs/development/python-modules/ssh-mitm/default.nix
+++ b/pkgs/development/python-modules/ssh-mitm/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     description = "Tool for SSH security audits";
     homepage = "https://github.com/ssh-mitm/ssh-mitm";
     changelog = "https://github.com/ssh-mitm/ssh-mitm/blob/${version}/CHANGELOG.md";
-    license = licenses.lgpl3Only;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/ssh-mitm/default.nix
+++ b/pkgs/development/python-modules/ssh-mitm/default.nix
@@ -52,6 +52,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Tool for SSH security audits";
     homepage = "https://github.com/ssh-mitm/ssh-mitm";
+    changelog = "https://github.com/ssh-mitm/ssh-mitm/blob/${version}/CHANGELOG.md";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
###### Description of changes

Successor of #207247

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
