### PR TITLE
plasma5Packages.okular: add option to build without qtspeech

### DIFF
--- a/pkgs/applications/kde/okular.nix
+++ b/pkgs/applications/kde/okular.nix
@@ -1,23 +1,25 @@
-{
-  stdenv, mkDerivation, lib,
-  extra-cmake-modules, kdoctools,
-  breeze-icons, chmlib, discount, djvulibre, ebook_tools, kactivities,
-  karchive, kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
-  kdbusaddons, kdegraphics-mobipocket, kiconthemes, kjs, khtml, kio, kparts,
-  kpty, kpurpose, kwallet, kwindowsystem, libkexiv2, libspectre, libzip, phonon, poppler,
-  qca-qt5, qtdeclarative, qtsvg, threadweaver, kcrash, qtspeech
+{ stdenv, mkDerivation, lib
+, extra-cmake-modules, kdoctools
+, breeze-icons, chmlib, discount, djvulibre, ebook_tools, kactivities
+, karchive, kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons
+, kdbusaddons, kdegraphics-mobipocket, kiconthemes, kjs, khtml, kio, kparts
+, kpty, kpurpose, kwallet, kwindowsystem, libkexiv2, libspectre, libzip, phonon, poppler
+, qca-qt5, qtdeclarative, qtsvg, threadweaver, kcrash
+, withSpeech ? true, qtspeech
 }:
 
 mkDerivation {
   pname = "okular";
+
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+
   buildInputs = [
     breeze-icons discount djvulibre ebook_tools kactivities karchive kbookmarks
     kcompletion kconfig kconfigwidgets kcoreaddons kdbusaddons
     kdegraphics-mobipocket kiconthemes kjs khtml kio kparts kpty kpurpose kwallet
     kwindowsystem libkexiv2 libspectre libzip phonon poppler qca-qt5
-    qtdeclarative qtsvg threadweaver kcrash qtspeech chmlib
-  ];
+    qtdeclarative qtsvg threadweaver kcrash chmlib
+  ] ++ lib.optional withSpeech qtspeech;
 
   # InitialPreference values are too high and end up making okular
   # default for anything considered text/plain. Resetting to 1, which
@@ -26,6 +28,8 @@ mkDerivation {
     substituteInPlace generators/txt/okularApplication_txt.desktop \
       --replace InitialPreference=3 InitialPreference=1
   '';
+
+  cmakeFlags = lib.optional (!withSpeech) "-DFORCE_NOT_REQUIRED_DEPENDENCIES=Qt5TextToSpeech";
 
   meta = with lib; {
     homepage = "http://www.kde.org";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
