### PR TITLE
lilypond, lilypond-unstable: bump version, add passthru.updateScript

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -50,6 +50,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru.updateScript = {
+    command = [ ./update.sh ];
+    supportedFeatures = [ "commit" ];
+  };
+
   meta = with lib; {
     description = "Music typesetting system";
     homepage = "http://lilypond.org/";

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -1,19 +1,19 @@
 { stdenv, lib, fetchurl, ghostscript, gyre-fonts, texinfo, imagemagick, texi2html, guile
 , python3, gettext, flex, perl, bison, pkg-config, autoreconfHook, dblatex
 , fontconfig, freetype, pango, fontforge, help2man, zip, netpbm, groff
-, makeWrapper, t1utils
+, makeWrapper, t1utils, boehmgc, rsync
 , texlive, tex ? texlive.combine {
-    inherit (texlive) scheme-small lh metafont epsf;
+    inherit (texlive) scheme-small lh metafont epsf fontinst;
   }
 }:
 
 stdenv.mkDerivation rec {
   pname = "lilypond";
-  version = "2.22.2";
+  version = "2.24.0";
 
   src = fetchurl {
     url = "http://lilypond.org/download/sources/v${lib.versions.majorMinor version}/lilypond-${version}.tar.gz";
-    sha256 = "sha256-3ekIVPp94QEvThMEpoYXrqmrMiky7AznaYT2DSaqI74=";
+    sha256 = "sha256-PO2+O5KwJWnjpvLwZ0hYlns9onjXCqPpiu9b3Nf3i2k=";
   };
 
   postInstall = ''
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ ghostscript texinfo imagemagick texi2html guile dblatex tex zip netpbm
       python3 gettext perl fontconfig freetype pango
-      fontforge help2man groff t1utils
+      fontforge help2man groff t1utils boehmgc rsync
     ];
 
   autoreconfPhase = "NOCONFIGURE=1 sh autogen.sh";

--- a/pkgs/misc/lilypond/unstable.nix
+++ b/pkgs/misc/lilypond/unstable.nix
@@ -8,4 +8,9 @@
     url = "https://lilypond.org/download/sources/v${lib.versions.majorMinor version}/lilypond-${version}.tar.gz";
     sha256 = "sha256-SLZ9/Jybltd8+1HANk8pTGHRb7MuZSJJDDY/S4Kwz/k=";
   };
+
+  passthru.updateScript = {
+    command = [ ./update.sh "unstable" ];
+    supportedFeatures = [ "commit" ];
+  };
 })

--- a/pkgs/misc/lilypond/unstable.nix
+++ b/pkgs/misc/lilypond/unstable.nix
@@ -1,12 +1,10 @@
-{ lib, fetchurl, guile, lilypond }:
+{ lib, fetchurl, lilypond }:
 
-(lilypond.override {
-  inherit guile;
-}).overrideAttrs (oldAttrs: rec {
-  version = "2.23.12";
+lilypond.overrideAttrs (oldAttrs: rec {
+  version = "2.25.1";
   src = fetchurl {
     url = "https://lilypond.org/download/sources/v${lib.versions.majorMinor version}/lilypond-${version}.tar.gz";
-    sha256 = "sha256-SLZ9/Jybltd8+1HANk8pTGHRb7MuZSJJDDY/S4Kwz/k=";
+    sha256 = "sha256-DchY+4+bWIvTZb4v9q/fAqStkbsxHhvty3eur0ZFYVs=";
   };
 
   passthru.updateScript = {

--- a/pkgs/misc/lilypond/update.sh
+++ b/pkgs/misc/lilypond/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl gnused nix
+
+set -euo pipefail
+
+if [ $# -gt 0 ] && [ "$1" = "unstable" ]; then
+    ATTR="lilypond-unstable"
+    FILE="$(dirname "${BASH_SOURCE[@]}")/unstable.nix"
+    QUERY="VERSION_DEVEL="
+else
+    ATTR="lilypond"
+    FILE="$(dirname "${BASH_SOURCE[@]}")/default.nix"
+    QUERY="VERSION_STABLE="
+fi
+
+# update version
+PREV=$(nix eval --raw -f default.nix $ATTR.version)
+NEXT=$(curl -s 'https://gitlab.com/lilypond/lilypond/-/raw/master/VERSION' | grep "$QUERY" | cut -d= -f2)
+sed -i "s|$PREV|$NEXT|" "$FILE"
+echo "[{\"commitMessage\":\"$ATTR: $PREV -> $NEXT\"}]"
+
+# update hash
+PREV=$(nix eval --raw -f default.nix $ATTR.src.outputHash)
+NEXT=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 $(nix eval --raw -f default.nix $ATTR.src.url)))
+sed -i "s|$PREV|$NEXT|" "$FILE"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36985,7 +36985,7 @@ with pkgs;
     inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation Security;
   };
 
-  lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };
+  lilypond = callPackage ../misc/lilypond { };
 
   lilypond-unstable = callPackage ../misc/lilypond/unstable.nix { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

##### passthru.updateScript
The update script can be run by
```
nix-shell ./maintainers/scripts/update.nix --argstr package lilypond --argstr commit true
nix-shell ./maintainers/scripts/update.nix --argstr package lilypond-unstable --argstr commit true
```
to auto update and commit the two packages.

##### lilypond
Changelog: https://gitlab.com/lilypond/lilypond/-/releases/v2.24.0
Diff: https://gitlab.com/lilypond/lilypond/-/compare/v2.22.2...v2.24.0

Currently `lilypond` won't build without `bdw-gc`:
```
configure: error: Package requirements (bdw-gc) were not met:
No package 'bdw-gc' found
```

It also won't build with `guile = guile_1_8`:
```
ERROR: Please install required programs:  guile-devel >= 2.2
```

I also added `texlive.fontinst` and `rsync` to `buildInputs`:
```
WARNING: Please consider installing optional programs or files:
extractpdfmark (Using GhostScript >= 9.20 together with extractpdfmark can significantly reduce the size of the final PDF files.)
fontinst CTAN package (texlive-fontinst or texlive-font-utils)
rsync
```
It might worth considering to init `extractpdfmark` in a separate PR, but it will take some effort.

##### lilypond-unstable
Changelog: https://gitlab.com/lilypond/lilypond/-/releases/v2.25.0
Diff: https://gitlab.com/lilypond/lilypond/-/compare/v2.23.12...v2.25.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
