### PR TITLE
python311Packages.jedi: disable some tests

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -93,7 +93,7 @@ in {
     makePythonHook {
       name = "python-imports-check-hook.sh";
       substitutions = {
-        inherit pythonCheckInterpreter;
+        inherit pythonCheckInterpreter pythonSitePackages;
       };
     } ./python-imports-check-hook.sh) {};
 

--- a/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
@@ -6,6 +6,7 @@ pythonImportsCheckPhase () {
 
     if [ -n "$pythonImportsCheck" ]; then
         echo "Check whether the following modules can be imported: $pythonImportsCheck"
+        export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
         ( cd $out && eval "@pythonCheckInterpreter@ -c 'import os; import importlib; list(map(lambda mod: importlib.import_module(mod), os.environ[\"pythonImportsCheck\"].split()))'" )
     fi
 }

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -32,6 +32,24 @@ if isPyPy then null else buildPythonPackage rec {
     # deemed safe to trust in cffi.
     #
     ./darwin-use-libffi-closures.diff
+    (fetchpatch {
+      # Drop py.code usage from tests, no longer depend on the deprecated py package
+      url = "https://foss.heptapod.net/pypy/cffi/-/commit/9c7d865e17ec16a847090a3e0d1498b698b99756.patch";
+      excludes = [
+        "README.md"
+        "requirements.txt"
+      ];
+      hash = "sha256-HSuLLIYXXGGCPccMNLV7o1G3ppn2P0FGCrPjqDv2e7k=";
+    })
+    (fetchpatch {
+      #  Replace py.test usage with pytest
+      url = "https://foss.heptapod.net/pypy/cffi/-/commit/bd02e1b122612baa74a126e428bacebc7889e897.patch";
+      excludes = [
+        "README.md"
+        "requirements.txt"
+      ];
+      hash = "sha256-+2daRTvxtyrCPimOEAmVbiVm1Bso9hxGbaAbd03E+ws=";
+    })
   ] ++  lib.optionals (pythonAtLeast "3.11") [
     # Fix test that failed because python seems to have changed the exception format in the
     # final release. This patch should be included in the next version and can be removed when

--- a/pkgs/development/python-modules/exceptiongroup/default.nix
+++ b/pkgs/development/python-modules/exceptiongroup/default.nix
@@ -4,6 +4,7 @@
 , flit-scm
 , pytestCheckHook
 , pythonOlder
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
@@ -25,6 +26,8 @@ buildPythonPackage rec {
   ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  doCheck = pythonAtLeast "3.11"; # infinite recursion with pytest
 
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/execnet/default.nix
+++ b/pkgs/development/python-modules/execnet/default.nix
@@ -2,23 +2,30 @@
 , buildPythonPackage
 , isPyPy
 , fetchPypi
+, fetchpatch
 , pytestCheckHook
 , setuptools-scm
 , apipkg
+, py
 }:
 
 buildPythonPackage rec {
   pname = "execnet";
   version = "1.9.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5";
   };
 
-  checkInputs = [ pytestCheckHook ];
-  nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ apipkg ];
+  patches = [
+    (fetchpatch {
+      # Fix test compat with pytest 7.2.0
+      url = "https://github.com/pytest-dev/execnet/commit/c0459b92bc4a42b08281e69b8802d24c5d3415d4.patch";
+      hash = "sha256-AT2qr7AUpFXcPps525U63A7ARcEVmf0HM6ya73Z2vi0=";
+    })
+  ];
 
   # remove vbox tests
   postPatch = ''
@@ -29,14 +36,30 @@ buildPythonPackage rec {
     ${lib.optionalString isPyPy "rm -v testing/test_multi.py"}
   '';
 
-  pythonImportsCheck = [ "execnet" ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    apipkg
+  ];
+
+  checkInputs = [
+    py
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "execnet"
+  ];
 
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
+    changelog = "https://github.com/pytest-dev/execnet/blob/v${version}/CHANGELOG.rst";
     description = "Distributed Python deployment and communication";
-    license = licenses.mit;
     homepage = "https://execnet.readthedocs.io/";
+    license = licenses.mit;
     maintainers = with maintainers; [ ];
   };
 

--- a/pkgs/development/python-modules/flit-scm/default.nix
+++ b/pkgs/development/python-modules/flit-scm/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchFromGitLab
 , pythonOlder
-, git
 , flit-core
 , setuptools-scm
 , tomli
@@ -11,19 +10,37 @@
 buildPythonPackage rec {
   pname = "flit-scm";
   version = "1.7.0";
-
   format = "pyproject";
 
   src = fetchFromGitLab {
     owner = "WillDaSilva";
     repo = "flit_scm";
-    rev = version;
-    sha256 = "sha256-K5sH+oHgX/ftvhkY+vIg6wUokAP96YxrTWds3tnEtyg=";
-    leaveDotGit = true;
+    rev = "refs/tags/${version}";
+    hash = "sha256-K5sH+oHgX/ftvhkY+vIg6wUokAP96YxrTWds3tnEtyg=";
   };
 
-  nativeBuildInputs = [ flit-core setuptools-scm tomli git ];
-  propagatedBuildInputs = [ flit-core setuptools-scm ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    flit-core
+    setuptools-scm
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ];
+
+  propagatedBuildInputs = [
+    flit-core
+    setuptools-scm
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ];
+
+  pythonImportsCheck = [
+    "flit_scm"
+  ];
+
+
+  doCheck = false; # no tests
 
   meta = with lib; {
     description = "A PEP 518 build backend that uses setuptools_scm to generate a version file from your version control system, then flit to build the package.";

--- a/pkgs/development/python-modules/flit/default.nix
+++ b/pkgs/development/python-modules/flit/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "flit";
-  version = "3.7.1";
+  version = "3.8.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "takluyver";
     repo = "flit";
     rev = version;
-    sha256 = "sha256-zKgaeK3fskz2TuHvIWlxBrdZIWfIJHhaqopZ3+V36wY=";
+    hash = "sha256-iXf9K/xI4u+dDV0Zf6S08nbws4NqycrTEW0B8/qCjQc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "hypothesis";
-  version = "6.54.5";
+  version = "6.61.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "HypothesisWorks";
     repo = "hypothesis";
     rev = "hypothesis-python-${version}";
-    hash = "sha256-mr8ctmAzRgWNVpW+PZlOhaQ0l28P0U8PxvjoVjfHX78=";
+    hash = "sha256-gTcdJaOgP8Nc4fN8UH6+sLedivq5ZNxMRULajFOVnSo=";
   };
 
   postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";

--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
+, pythonAtLeast
 , pythonOlder
 , fetchFromGitHub
 , attrs
@@ -37,14 +38,17 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # Assertions mismatches with pytest>=6.0
-    "test_completion"
-
     # sensitive to platform, causes false negatives on darwin
     "test_import"
   ] ++ lib.optionals (stdenv.isAarch64 && pythonOlder "3.9") [
     # AssertionError: assert 'foo' in ['setup']
     "test_init_extension_module"
+  ] ++ lib.optionals (pythonAtLeast "3.11") [
+    # disabled until 3.11 is added to _SUPPORTED_PYTHONS in jedi/api/environment.py
+    "test_find_system_environments"
+
+    # disabled until https://github.com/davidhalter/jedi/issues/1858 is resolved
+    "test_interpreter"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "pip";
-  version = "22.2.2";
+  version = "22.3.1";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-SLjmxFUFmvgy8E8kxfc6lxxCRo+GN4L77pqkWkRR8aE=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-mrfd3VWqb4SgSjBJAxBhYegABdJa7pVXL7wA5uZtF/A=";
     name = "${pname}-${version}-source";
   };
 

--- a/pkgs/development/python-modules/pytest-forked/default.nix
+++ b/pkgs/development/python-modules/pytest-forked/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     description = "Run tests in isolated forked subprocesses";
     homepage = "https://github.com/pytest-dev/pytest-forked";

--- a/pkgs/development/python-modules/pytest-forked/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-forked/setup-hook.sh
@@ -1,0 +1,25 @@
+pytestForkedHook() {
+    pytestFlagsArray+=(
+        "--forked"
+    )
+
+    # Using --forked on darwin leads to crashes when fork safety is
+    # enabled. This often happens when urllib tries to request proxy
+    # settings on MacOS through `urllib.request.getproxies()`
+    # - https://github.com/python/cpython/issues/77906
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+    fi
+}
+
+# the flags should be added before pytestCheckHook runs so
+# until we have dependency mechanism in generic builder, we need to use this ugly hack.
+
+if [ -z "${dontUsePytestForked-}" ] && [ -z "${dontUsePytestCheck-}" ]; then
+    if [[ " ${preDistPhases:-} " =~ " pytestCheckPhase " ]]; then
+        preDistPhases+=" "
+        preDistPhases="${preDistPhases/ pytestCheckPhase / pytestForkedHook pytestCheckPhase }"
+    else
+        preDistPhases+=" pytestForkedHook"
+    fi
+fi

--- a/pkgs/development/python-modules/pytest-mock/default.nix
+++ b/pkgs/development/python-modules/pytest-mock/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
+, fetchpatch
 , pytest
 , pytest-asyncio
 , pytestCheckHook
@@ -10,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-mock";
-  version = "3.8.2";
+  version = "3.10.0";
 
   disabled = pythonOlder "3.7";
 
@@ -18,8 +19,16 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-d/A/RVQ5JVhwApXgWu0LEJaiDUpgpPPdzeWLDDHI/KI=";
+    hash = "sha256-+72whe98JSoyb9jNysCqOxMz2IEfExvcxwEALhvn7U8=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Remove unnecessary py.code import
+      url = "https://github.com/pytest-dev/pytest-mock/pull/328/commits/e2016928db1147a2a46de6ee9fa878ca0e9d8fc8.patch";
+      hash = "sha256-5Gpzi7h7Io1CMykmBCZR/upM8E9isc3jEItYgwjEOWA=";
+    })
+  ];
 
   nativeBuildInputs = [ setuptools-scm ];
 

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -7,32 +7,47 @@
 , filelock
 , execnet
 , pytest
-, pytest-forked
 , psutil
-, pexpect
+, setproctitle
 }:
 
 buildPythonPackage rec {
   pname = "pytest-xdist";
-  version = "2.5.0";
+  version = "3.1.0";
   disabled = pythonOlder "3.6";
+
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-RYDeyj/wTdsqxT66Oddstd1e3qwFDLb7x2iw3XErTt8=";
+    hash = "sha256-QP2481RJIcXfzUhqwIDOIocOcdgs7W0uePqXwq3dSAw=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
   buildInputs = [
     pytest
   ];
-  checkInputs = [ pytestCheckHook filelock pexpect ];
-  propagatedBuildInputs = [ execnet pytest-forked psutil ];
+
+  propagatedBuildInputs = [
+    execnet
+  ];
+
+  checkInputs = [
+    filelock
+    pytestCheckHook
+  ];
+
+  passthru.optional-dependencies = {
+    psutil = [ psutil ];
+    setproctitle = [ setproctitle ];
+  };
 
   pytestFlagsArray = [
     # pytest can already use xdist at this point
     "--numprocesses=$NIX_BUILD_CORES"
-    "--forked"
   ];
 
   # access file system

--- a/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
@@ -1,16 +1,7 @@
 pytestXdistHook() {
     pytestFlagsArray+=(
         "--numprocesses=$NIX_BUILD_CORES"
-        "--forked"
     )
-
-    # Using --forked on darwin leads to crashes when fork safety is
-    # enabled. This often happens when urllib tries to request proxy
-    # settings on MacOS through `urllib.request.getproxies()`
-    # - https://github.com/python/cpython/issues/77906
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-    fi
 }
 
 # the flags should be added before pytestCheckHook runs so

--- a/pkgs/development/python-modules/pytest-xprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-xprocess/default.nix
@@ -1,29 +1,40 @@
-{ lib, buildPythonPackage, fetchPypi
+{ lib
+, buildPythonPackage
+, fetchPypi
 , psutil
+, py
 , pytest
 , setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "pytest-xprocess";
-  version = "0.20.0";
+  version = "0.21.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-AhZ1IsTcdZ+RxKsZhUY5zR6fbgq/ynXhGWgrVB0b1j8=";
+    sha256 = "sha256-+UcL/PiE9ymetrgqQ9KYwxi45T7DFO5iTJh+DofBtEk=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
-
-  buildInputs = [ pytest ];
-
-  propagatedBuildInputs = [ psutil ];
-
-  # Remove test QoL package from install_requires
   postPatch = ''
+    # Remove test QoL package from install_requires
     substituteInPlace setup.py \
       --replace "'pytest-cache', " ""
   '';
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    psutil
+    py
+  ];
 
   # There's no tests in repo
   doCheck = false;

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -11,6 +11,7 @@
 
 # propagates
 , attrs
+, exceptiongroup
 , iniconfig
 , packaging
 , pluggy
@@ -20,12 +21,12 @@
 
 buildPythonPackage rec {
   pname = "pytest";
-  version = "7.1.3";
+  version = "7.2.0";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-TzZf7C3/nBFi+DTZ8YrxuhMGLbDHCL97lG+KXHYYDDk=";
+    hash = "sha256-xAFOtA4Q8R81WtTjwvssbG0ZGcc/O1pDPeRwggLK3lk=";
   };
 
   outputs = [
@@ -44,6 +45,8 @@ buildPythonPackage rec {
     pluggy
     py
     tomli
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    exceptiongroup
   ];
 
   postInstall = ''
@@ -69,7 +72,7 @@ buildPythonPackage rec {
     # - files are not needed after tests are finished
     pytestRemoveBytecodePhase () {
         # suffix is defined at:
-        #    https://github.com/pytest-dev/pytest/blob/7.1.3/src/_pytest/assertion/rewrite.py#L51-L53
+        #    https://github.com/pytest-dev/pytest/blob/7.2.0/src/_pytest/assertion/rewrite.py#L51-L53
         find $out -name "*-pytest-*.py[co]" -delete
     }
     preDistPhases+=" pytestRemoveBytecodePhase"

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -10,7 +10,7 @@
 
 let
   pname = "setuptools";
-  version = "65.3.0";
+  version = "65.6.3";
 
   # Create an sdist of setuptools
   sdist = stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ let
       owner = "pypa";
       repo = pname;
       rev = "refs/tags/v${version}";
-      hash = "sha256-LPguGVWvwEMZpJFuXWLVFzIlzw+/QSMjVi2oYh0cI0s=";
+      hash = "sha256-B/1MhH0RDW7/pUam2FHnIcUPN6NpvQYBjRyHIm+E9rI=";
       name = "${pname}-${version}-source";
     };
 

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -49,6 +49,9 @@ in buildPythonPackage {
   inherit (packages) version;
   format = "wheel";
 
+  # Python 3.11 still unsupported
+  disabled = pythonAtLeast "3.11";
+
   src = let
     pyVerNoDot = lib.strings.stringAsChars (x: if x == "." then "" else x) python.pythonVersion;
     platform = if stdenv.isDarwin then "mac" else "linux";

--- a/pkgs/development/python-modules/typing-extensions/default.nix
+++ b/pkgs/development/python-modules/typing-extensions/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "typing-extensions";
-  version = "4.3.0";
+  version = "4.4.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "typing_extensions";
     inherit version;
-    hash = "sha256-5tJnejL0f8frJ5XbHdFcHzTv9ha8ryz7Xpl/hU+hxKY=";
+    hash = "sha256-FRFDS7kr+N0ZjBKxzIEugA1Bgc/LhnZ04PgnnMkwh6o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16283,7 +16283,7 @@ with pkgs;
   python27Packages = python27.pkgs;
   python37Packages = python37.pkgs;
   python38Packages = python38.pkgs;
-  python39Packages = recurseIntoAttrs python39.pkgs;
+  python39Packages = python39.pkgs;
   python310Packages = recurseIntoAttrs python310.pkgs;
   python311Packages = python311.pkgs;
   python312Packages = python312.pkgs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16285,7 +16285,7 @@ with pkgs;
   python38Packages = python38.pkgs;
   python39Packages = python39.pkgs;
   python310Packages = recurseIntoAttrs python310.pkgs;
-  python311Packages = python311.pkgs;
+  python311Packages = recurseIntoAttrs python311.pkgs;
   python312Packages = python312.pkgs;
   pypyPackages = pypy.pkgs;
   pypy2Packages = pypy2.pkgs;


### PR DESCRIPTION
###### Description of changes

Disabling tests that fail in Python 3.11 until https://github.com/davidhalter/jedi/issues/1858 is resolved. We can also enable "test_completion" since it now passes in 0.18.2 (I believe it's due to https://github.com/davidhalter/jedi/commit/78a53bf005e45df295109d7a04da893bfa646eb6).

Needed by https://github.com/NixOS/nixpkgs/issues/198533#issuecomment-1296918471.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
