### PR TITLE
mopidy-musicbox-webclient: Slightly refactor

### DIFF
--- a/pkgs/applications/audio/mopidy/musicbox-webclient.nix
+++ b/pkgs/applications/audio/mopidy/musicbox-webclient.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+{ lib
+, fetchFromGitHub
+, pythonPackages
+, mopidy
+}:
 
 pythonPackages.buildPythonApplication rec {
   pname = "mopidy-musicbox-webclient";
@@ -11,14 +15,17 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1lzarazq67gciyn6r8cdms0f7j0ayyfwhpf28z93ydb280mfrrb9";
   };
 
-  propagatedBuildInputs = [ mopidy ];
+  propagatedBuildInputs = [
+    mopidy
+  ];
 
   doCheck = false;
 
   meta = with lib; {
     description = "A Mopidy frontend extension and web client with additional features for Pi MusicBox";
     homepage = "https://github.com/pimusicbox/mopidy-musicbox-webclient";
+    changelog = "https://github.com/pimusicbox/mopidy-musicbox-webclient/blob/v${version}/CHANGELOG.rst";
     license = licenses.asl20;
-    maintainers = [ maintainers.spwhitt ];
+    maintainers = with maintainers; [ spwhitt ];
   };
 }

--- a/pkgs/applications/audio/mopidy/musicbox-webclient.nix
+++ b/pkgs/applications/audio/mopidy/musicbox-webclient.nix
@@ -6,7 +6,7 @@ pythonPackages.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "pimusicbox";
-    repo = "mopidy-musicbox-webclient";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1lzarazq67gciyn6r8cdms0f7j0ayyfwhpf28z93ydb280mfrrb9";
   };
@@ -16,8 +16,9 @@ pythonPackages.buildPythonApplication rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Mopidy extension for playing music from SoundCloud";
-    license = licenses.mit;
+    description = "A Mopidy frontend extension and web client with additional features for Pi MusicBox";
+    homepage = "https://github.com/pimusicbox/mopidy-musicbox-webclient";
+    license = licenses.asl20;
     maintainers = [ maintainers.spwhitt ];
   };
 }


### PR DESCRIPTION
###### Description of changes

The provided description seems intended for the `mopidy-soundcloud` extension rather than the provided, and the license is incorrect. Rectified these and provided the project homepage.

Additionally, used the recursive nature of the attrset to slightly deduplicate information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Does not result in any package changes, but will make it easier to find and more license-compliant.