### PR TITLE
ocamlPackages.parany: 12.1.2 → {12.2.2, 13.0.1}

### DIFF
--- a/pkgs/development/ocaml-modules/domainslib/default.nix
+++ b/pkgs/development/ocaml-modules/domainslib/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchurl, buildDunePackage
+, lockfree
+, mirage-clock-unix
+}:
+
+buildDunePackage rec {
+  pname = "domainslib";
+  version = "0.5.0";
+
+  duneVersion = "3";
+  minimalOCamlVersion = "5.0";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/domainslib/releases/download/v${version}/domainslib-${version}.tbz";
+    hash = "sha256-rty+9DUhTUEcN7BPl8G6Q/G/MJ6z/UAn0RPkG8hACwA=";
+  };
+
+  propagatedBuildInputs = [ lockfree ];
+
+  doCheck = true;
+  checkInputs = [ mirage-clock-unix ];
+
+  meta = {
+    homepage = "https://github.com/ocaml-multicore/domainslib";
+    description = "Nested-parallel programming";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/dscheck/default.nix
+++ b/pkgs/development/ocaml-modules/dscheck/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchurl, buildDunePackage
+, containers
+, oseq
+}:
+
+buildDunePackage rec {
+  pname = "dscheck";
+  version = "0.1.0";
+
+  minimalOCamlVersion = "5.0";
+  duneVersion = "3";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/dscheck/releases/download/${version}/dscheck-${version}.tbz";
+    hash = "sha256-zoouFZJcUp71yeluVb1xLUIMcFv99OpkcQQCHkPTKcI=";
+  };
+
+  propagatedBuildInputs = [ containers oseq ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Traced atomics";
+    homepage = "https://github.com/ocaml-multicore/dscheck";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/lockfree/default.nix
+++ b/pkgs/development/ocaml-modules/lockfree/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchurl, buildDunePackage
+, dscheck
+, qcheck, qcheck-alcotest
+}:
+
+buildDunePackage rec {
+  pname = "lockfree";
+  version = "0.3.0";
+
+  minimalOCamlVersion = "5.0";
+  duneVersion = "3";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/lockfree/releases/download/${version}/lockfree-${version}.tbz";
+    hash = "sha256-XdJR5ojFsA7bJ4aZ5rh10NjopE0NjfqQ9KitOLMh3Jo=";
+  };
+
+  propagatedBuildInputs = [ dscheck ];
+
+  doCheck = true;
+  checkInputs = [ qcheck qcheck-alcotest ];
+
+  meta = {
+    description = "Lock-free data structures for multicore OCaml";
+    homepage = "https://github.com/ocaml-multicore/lockfree";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/oseq/default.nix
+++ b/pkgs/development/ocaml-modules/oseq/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, seq
+, containers, qcheck
+}:
+
+buildDunePackage rec {
+  version = "0.4";
+  pname = "oseq";
+
+  src = fetchFromGitHub {
+    owner = "c-cube";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-FoCBvvPwa/dUCrgDEd0clEKAO7EcpedjaO4v+yUO874=";
+  };
+
+  propagatedBuildInputs = [ seq ];
+
+  duneVersion = "3";
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    qcheck
+  ];
+
+  meta = {
+    homepage = "https://c-cube.github.io/oseq/";
+    description = "Purely functional iterators compatible with standard `seq`";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/parany/default.nix
+++ b/pkgs/development/ocaml-modules/parany/default.nix
@@ -1,20 +1,32 @@
-{ lib, buildDunePackage, fetchFromGitHub, ocamlnet, cpu }:
+{ lib, buildDunePackage, fetchFromGitHub, ocaml, cpu, domainslib }:
+
+let params =
+  if lib.versionAtLeast ocaml.version "5.00" then {
+    version = "13.0.1";
+    hash = "sha256-OYa0uLsDyzjmXZgWcYUxLhqco4Kp/icfDamNe3En5JQ=";
+    propagatedBuildInputs = [ domainslib ];
+  } else {
+    version = "12.2.2";
+    hash = "sha256-woZ4XJqqoRr/7mDurXYvTbSUUcLBEylzVYBQp1BAOqc=";
+    propagatedBuildInputs = [ cpu ];
+  }
+; in
 
 buildDunePackage rec {
   pname = "parany";
-  version = "12.1.2";
+  inherit (params) version;
 
-  useDune2 = true;
-  minimumOCamlVersion = "4.03.0";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "UnixJunkie";
     repo = pname;
     rev = "v${version}";
-    sha256 = "yOeJzb2Wr6jA4efI9/fuqDCl/Tza3zxT3YjAiJmhHHg=";
+    inherit (params) hash;
   };
 
-  propagatedBuildInputs = [ ocamlnet cpu ];
+  inherit (params) propagatedBuildInputs;
 
   meta = with lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/tools/comby/default.nix
+++ b/pkgs/development/tools/comby/default.nix
@@ -15,8 +15,8 @@ let
     ocamlPackages.buildDunePackage rec {
       inherit pname preBuild;
       version = "1.8.1";
-      useDune2 = true;
-      minimumOcamlVersion = "4.08.1";
+      duneVersion = "3";
+      minimalOcamlVersion = "4.08.1";
       doCheck = true;
 
       src = fetchFromGitHub {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -737,6 +737,8 @@ let
 
     lo = callPackage ../development/ocaml-modules/lo { };
 
+    lockfree = callPackage ../development/ocaml-modules/lockfree { };
+
     logs = callPackage ../development/ocaml-modules/logs { };
 
     lru = callPackage ../development/ocaml-modules/lru { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1114,6 +1114,8 @@ let
 
     ordering = callPackage ../development/ocaml-modules/ordering { };
 
+    oseq = callPackage ../development/ocaml-modules/oseq { };
+
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
     otoml = callPackage ../development/ocaml-modules/otoml { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -328,6 +328,8 @@ let
 
     domain-name = callPackage ../development/ocaml-modules/domain-name { };
 
+    domainslib = callPackage ../development/ocaml-modules/domainslib { };
+
     dose3 = callPackage ../development/ocaml-modules/dose3 { };
 
     dscheck = callPackage ../development/ocaml-modules/dscheck { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -330,6 +330,8 @@ let
 
     dose3 = callPackage ../development/ocaml-modules/dose3 { };
 
+    dscheck = callPackage ../development/ocaml-modules/dscheck { };
+
     dssi = callPackage ../development/ocaml-modules/dssi { };
 
     dtoa = callPackage ../development/ocaml-modules/dtoa { };


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
