### PR TITLE
shellcheck: add override for newer version

### DIFF
--- a/maintainers/scripts/haskell/update-stackage.sh
+++ b/maintainers/scripts/haskell/update-stackage.sh
@@ -62,10 +62,12 @@ sed -r \
     -e '/ lsp-types /d' \
     -e '/ lsp-test /d' \
     -e '/ hie-bios /d' \
+    -e '/ ShellCheck /d' \
     < "${tmpfile_new}" >> $stackage_config
 # Explanations:
 # cabal2nix, distribution-nixpkgs, jailbreak-cabal, language-nix: These are our packages and we know what we are doing.
 # lsp, lsp-types, lsp-test, hie-bios: These are tightly coupled to hls which is not in stackage. They have no rdeps in stackage.
+# ShellCheck: latest version of command-line dev tool.
 
 if [[ "${1:-}" == "--do-commit" ]]; then
 git add $stackage_config

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1814,6 +1814,7 @@ self: super: {
   ] super.haskell-ci).overrideScope (self: super: {
     Cabal = self.Cabal_3_6_3_0;
     cabal-install-parsers = self.cabal-install-parsers_0_4_5;
+    ShellCheck = self.ShellCheck_0_8_0;
   });
 
   large-hashable = lib.pipe (super.large-hashable.override {

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -157,6 +157,7 @@ extra-packages:
   - weeder == 2.2.*                     # 2022-02-21: preserve for GHC 8.10.7
   - weeder == 2.3.*                     # 2022-05-31: preserve for GHC 9.0.2
   - commonmark-extensions < 0.2.3.3     # 2022-12-17: required by emanote 1.0.0.0 (to avoid a bug in 0.2.3.3)
+  - ShellCheck == 0.8.0                 # 2022-12-28: required by haskell-ci 0.14.3
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -444,6 +444,8 @@ package-maintainers:
     - time-domain
   utdemir:
     - nix-tree
+  zowoq:
+    - ShellCheck
 
 unsupported-platforms:
   Allure:                                       [ platforms.darwin ]

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
@@ -2315,7 +2315,6 @@ default-package-overrides:
   - shakespeare ==2.0.30
   - shakespeare-text ==1.1.0
   - shared-memory ==0.2.0.0
-  - ShellCheck ==0.8.0
   - shell-conduit ==5.0.0
   - shell-escape ==0.2.0
   - shellmet ==0.0.4.1

--- a/pkgs/development/tools/shellcheck/default.nix
+++ b/pkgs/development/tools/shellcheck/default.nix
@@ -46,6 +46,6 @@ let
 
 in
   overrideMeta shellcheck (old: {
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    maintainers = with lib.maintainers; [ Profpatsch zowoq ];
     outputsToInstall = [ "bin" "man" "doc" ];
   })


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
