### PR TITLE
mopidy-notify: init at 0.2.0

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -27,6 +27,8 @@ lib.makeScope newScope (self: with self; {
 
   mopidy-musicbox-webclient = callPackage ./musicbox-webclient.nix { };
 
+  mopidy-notify = callPackage ./notify.nix { };
+
   mopidy-podcast = callPackage ./podcast.nix { };
 
   mopidy-scrobbler = callPackage ./scrobbler.nix { };

--- a/pkgs/applications/audio/mopidy/notify.nix
+++ b/pkgs/applications/audio/mopidy/notify.nix
@@ -1,0 +1,29 @@
+{ lib, pythonPackages, mopidy }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "Mopidy-Notify";
+  version = "0.2.0";
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-lzZupjlS0kbNvsn18serOoMfu0sRb0nRwpowvOPvt/g=";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+    pythonPackages.pydbus
+  ];
+
+  nativeBuildInputs = [
+    pythonPackages.pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "mopidy_notify" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/phijor/mopidy-notify";
+    description = "Mopidy extension for showing desktop notifications on track change";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lilyinstarlight ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30764,6 +30764,7 @@ with pkgs;
     mopidy-mpris
     mopidy-muse
     mopidy-musicbox-webclient
+    mopidy-notify
     mopidy-podcast
     mopidy-scrobbler
     mopidy-somafm


### PR DESCRIPTION
###### Description of changes

This PR adds a new Mopidy extension, [mopidy-notify](https://github.com/phijor/mopidy-notify)

I've added it to my local mopidy managed by home-manager under `extensionPackages` and it functions correctly without anything special needed

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).