### PR TITLE
forgejo: init at 1.18.0-rc1-1

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -6,18 +6,19 @@ gitea.overrideAttrs (old: rec {
 
   src = fetchurl {
     name = "${pname}-src-${version}.tar.gz";
+    # see https://codeberg.org/forgejo/forgejo/releases
     url = "https://codeberg.org/attachments/976c426a-3e04-49ff-9762-47fab50624a3";
     hash = "sha256-kreBMHlMVB1UeG67zMbszGrgjaROateCRswH7GrKnEw=";
   };
 
-  postInstall = old.postInstall + ''
+  postInstall = old.postInstall or "" + ''
     mv $out/bin/{${old.pname},${pname}}
   '';
 
   meta = with lib; {
     description = "A self-hosted lightweight software forge";
     homepage = "https://forgejo.org";
-    changelog = "https://codeberg.org/${pname}/${pname}/releases/tag/v${version}";
+    changelog = "https://codeberg.org/forgejo/forgejo/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ urandom ];
   };

--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -1,0 +1,24 @@
+{ fetchurl, gitea, lib }:
+
+gitea.overrideAttrs (old: rec {
+  pname = "forgejo";
+  version = "1.18.0-rc1-1";
+
+  src = fetchurl {
+    name = "${pname}-src-${version}.tar.gz";
+    url = "https://codeberg.org/attachments/976c426a-3e04-49ff-9762-47fab50624a3";
+    hash = "sha256-kreBMHlMVB1UeG67zMbszGrgjaROateCRswH7GrKnEw=";
+  };
+
+  postInstall = old.postInstall + ''
+    mv $out/bin/{${old.pname},${pname}}
+  '';
+
+  meta = with lib; {
+    description = "A self-hosted lightweight software forge";
+    homepage = "https://forgejo.org";
+    changelog = "https://codeberg.org/${pname}/${pname}/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ urandom ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7469,6 +7469,8 @@ with pkgs;
 
   gitea = callPackage ../applications/version-management/gitea { };
 
+  forgejo = callPackage ../applications/version-management/forgejo {};
+
   gokart = callPackage ../development/tools/gokart { };
 
   gl2ps = callPackage ../development/libraries/gl2ps { };


### PR DESCRIPTION

###### Description of changes

As we are packaging a self described, soft fork, it seems apt to reuse
the existing gitea build infrastructure. It works, so we have just used
overrideAttrs to inject a different pname, version, src, meta, and fixup
the binary name.

Fixes #207601
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
