### PR TITLE
jami-*: 20221031.1308.130cc26 -> 20221220.0956.79e1207

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jami/client.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/client.nix
@@ -2,7 +2,6 @@
 , src
 , jami-meta
 , lib
-, fetchpatch
 , stdenv
 , pkg-config
 , cmake
@@ -30,14 +29,6 @@ stdenv.mkDerivation {
   inherit version src;
 
   sourceRoot = "source/client-qt";
-
-  patches = [
-    (fetchpatch {
-      name = "fix-build-without-webengine.patch";
-      url = "https://git.jami.net/savoirfairelinux/jami-client-qt/-/commit/9b2dbb64eaa9256f800dfa69d897545f4b0affd2.patch";
-      hash = "sha256-lgDlSlXIjtdymBa7xSe1PabSK9DnSG5KnJggOLWyn+A=";
-    })
-  ];
 
   preConfigure = ''
     echo 'const char VERSION_STRING[] = "${version}";' > src/app/version.h

--- a/pkgs/applications/networking/instant-messengers/jami/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/default.nix
@@ -3,7 +3,8 @@
 , callPackage
 , fetchFromGitHub
 , fetchzip
-, ffmpeg
+, fetchpatch
+, ffmpeg_5
 , pjsip
 , opendht
 , jack
@@ -40,7 +41,7 @@ let
   readLinesToList = with builtins; file: filter (s: isString s && stringLength s > 0) (split "\n" (readFile file));
 in
 rec {
-  ffmpeg-jami = (ffmpeg.override rec {
+  ffmpeg-jami = (ffmpeg_5.override rec {
     version = "5.0.1";
     branch = version;
     sha256 = "sha256-KN8z1AChwcGyDQepkZeAmjuI73ZfXwfcH/Bn+sZMWdY=";
@@ -50,7 +51,14 @@ rec {
       patch-src = src + "/daemon/contrib/src/ffmpeg/";
     in
     {
-      patches = old.patches ++ (map (x: patch-src + x) (readLinesToList ./config/ffmpeg_patches));
+      patches = old.patches ++ (map (x: patch-src + x) (readLinesToList ./config/ffmpeg_patches)) ++
+        # SDL2 recently changed their versioning
+        [
+          (fetchpatch {
+            url = "https://git.videolan.org/?p=ffmpeg.git;a=patch;h=e5163b1d34381a3319214a902ef1df923dd2eeba";
+            hash = "sha256-nLhP2+34cj5EgpnUrePZp60nYAxmbhZAEDfay4pBVk0=";
+          })
+        ];
       configureFlags = old.configureFlags
         ++ (readLinesToList ./config/ffmpeg_args_common)
         ++ lib.optionals stdenv.isLinux (readLinesToList ./config/ffmpeg_args_linux)
@@ -72,7 +80,20 @@ rec {
         sha256 = "sha256-N7jn4qen+PgFiVkTFi2HSWhx2QPHwAYMtnrpE/ptDVc=";
       };
 
-      patches = (map (x: patch-src + x) (readLinesToList ./config/pjsip_patches));
+      patches = (map (x: patch-src + x) (readLinesToList ./config/pjsip_patches)) ++ [
+        (fetchpatch {
+          name = "CVE-2022-23537.patch";
+          url = "https://github.com/pjsip/pjproject/commit/d8440f4d711a654b511f50f79c0445b26f9dd1e1.patch";
+          sha256 = "sha256-7ueQCHIiJ7MLaWtR4+GmBc/oKaP+jmEajVnEYqiwLRA=";
+        })
+        (fetchpatch {
+          name = "CVE-2022-23547.patch";
+          url = "https://github.com/pjsip/pjproject/commit/bc4812d31a67d5e2f973fbfaf950d6118226cf36.patch";
+          sha256 = "sha256-bpc8e8VAQpfyl5PX96G++6fzkFpw3Or1PJKNPKl7N5k=";
+        })
+      ];
+
+      patchFlags = [ "-p1" "-l" ];
 
       configureFlags = (readLinesToList ./config/pjsip_args_common)
         ++ lib.optionals stdenv.isLinux (readLinesToList ./config/pjsip_args_linux);
@@ -88,6 +109,6 @@ rec {
   };
 
   jami-client = qt6Packages.callPackage ./client.nix {
-    inherit version src jami-meta ffmpeg-jami;
+    inherit version src ffmpeg-jami jami-meta;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/jami/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jami/default.nix
@@ -12,11 +12,11 @@
 }:
 
 let
-  version = "20221031.1308.130cc26";
+  version = "20221220.0956.79e1207";
 
   src = fetchzip {
     url = "https://dl.jami.net/release/tarballs/jami_${version}.tar.gz";
-    hash = "sha256-+xpSoSsG+G+w8+g0FhXx+6Phroj83ijW8xWvYO+kdqY=";
+    hash = "sha256-AQgz2GqueFG+yK42zJ9MzvP4BddGt0BFb+cIoA6Fif8=";
 
     stripRoot = false;
     postFetch = ''


### PR DESCRIPTION
###### Description of changes
Closes #207667

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
