### PR TITLE
gtk3: add missing libXdamage

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -145,6 +145,8 @@ stdenv.mkDerivation rec {
     libSM
     libXcomposite
     libXcursor
+    libXdamage
+    libXfixes
     libXi
     libXrandr
     libXrender


### PR DESCRIPTION
This fixes a regression introduced in this PR:

- https://github.com/NixOS/nixpkgs/pull/118479

[libXdamage is an optional dependency](https://gitlab.gnome.org/search?search=xdamage&project_id=665&group_id=8&search_code=true&repository_ref=gtk-3-24), however this is needed for XEmbed tray icons on MATE to work properly. This is already enabled in all other distributions ([1](https://salsa.debian.org/gnome-team/gtk3/-/blob/19ee51b8275b60e9f4c111ac99cb360598526858/debian/control#L39) [2](https://src.fedoraproject.org/rpms/gtk3/blob/041edbdb36900261950bb4444a35f9eebb304d53/f/gtk3.spec#_55) [3](https://github.com/archlinux/svntogit-packages/blob/580584efb898100f56ea4864cfdb9d7c8ea47643/trunk/PKGBUILD#L40) [4](https://code.opensuse.org/package/gtk3/blob/5b687ac35a0fb93b9b4c6240a2a844eaa84fc660/f/gtk3.spec#_87) [5](https://github.com/gentoo/gentoo/blob/3a8e29270689a0265e2a95d7382b37cf9a8983c9/x11-libs/gtk%2B/gtk%2B-3.24.36.ebuild#L54)) except us, this is also already required in gtk4.

- Fixes #122053
- Fixes https://github.com/mate-desktop/mate-panel/issues/1225

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).