### PR TITLE
verilog: bump tests, enable tests on darwin

### DIFF
--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -12,11 +12,14 @@
 }:
 
 let
+  # iverilog-test has been merged to the main iverilog main source tree
+  # in January 2022, so it won't be longer necessary.
+  # For now let's fetch it from the separate repo, since 11.0 was released in 2020.
   iverilog-test = fetchFromGitHub {
     owner  = "steveicarus";
     repo   = "ivtest";
-    rev    = "253609b89576355b3bef2f91e90db62223ecf2be";
-    sha256 = "18i7jlr2csp7mplcrwjhllwvb6w3v7x7mnx7vdw48nd3g5scrydx";
+    rev    = "a19e629a1879801ffcc6f2e6256ca435c20570f3";
+    sha256 = "sha256-3EkmrAXU0/mRxrxp5Hy7C3yWTVK16L+tPqqeEryY/r8=";
   };
 in
 stdenv.mkDerivation rec {
@@ -37,10 +40,6 @@ stdenv.mkDerivation rec {
   preConfigure = "sh autoconf.sh";
 
   enableParallelBuilding = true;
-
-  # tests try to access /proc/ which does not exist on darwin
-  # Cannot locate IVL modules : couldn't get command path from OS.
-  doCheck = !stdenv.isDarwin;
 
   installCheckInputs = [ perl ];
 


### PR DESCRIPTION
###### Description of changes

- $SUBJ 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
