### PR TITLE
Python pyside2/shiboken2: fix build issue for older python versions using libxcrypt

### DIFF
--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -1,5 +1,13 @@
-{ python, fetchurl, lib, stdenv,
-  cmake, ninja, qt5, shiboken2 }:
+{ python
+, fetchurl
+, lib
+, stdenv
+, cmake
+, libxcrypt
+, ninja
+, qt5
+, shiboken2
+}:
 
 stdenv.mkDerivation rec {
   pname = "pyside2";
@@ -26,12 +34,29 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${qt5.qtdeclarative.dev}/include/QtQuick/${qt5.qtdeclarative.version}/QtQuick";
 
   nativeBuildInputs = [ cmake ninja qt5.qmake python ];
+
   buildInputs = (with qt5; [
-    qtbase qtxmlpatterns qtmultimedia qttools qtx11extras qtlocation qtscript
-    qtwebsockets qtwebengine qtwebchannel qtcharts qtsensors qtsvg
-  ]) ++ [
-    python.pkgs.setuptools
-  ];
+    qtbase
+    qtxmlpatterns
+    qtmultimedia
+    qttools
+    qtx11extras
+    qtlocation
+    qtscript
+    qtwebsockets
+    qtwebengine
+    qtwebchannel
+    qtcharts
+    qtsensors
+    qtsvg
+  ]) ++ (with python.pkgs; [
+    setuptools
+  ]) ++ (lib.optionals (python.pythonOlder "3.9") [
+    # see similar issue: 202262
+    # libxcrypt is required for crypt.h for building older python modules
+    libxcrypt
+  ]);
+
   propagatedBuildInputs = [ shiboken2 ];
 
   dontWrapQtApps = true;

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -1,5 +1,12 @@
-{ python, lib, stdenv, pyside2
-, cmake, qt5, llvmPackages }:
+{ python
+, lib
+, stdenv
+, pyside2
+, cmake
+, qt5
+, libxcrypt
+, llvmPackages
+}:
 
 stdenv.mkDerivation {
   pname = "shiboken2";
@@ -17,7 +24,18 @@ stdenv.mkDerivation {
   CLANG_INSTALL_DIR = llvmPackages.libclang.out;
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvmPackages.libclang python python.pkgs.setuptools qt5.qtbase qt5.qtxmlpatterns ];
+
+  buildInputs = [
+    llvmPackages.libclang
+    python
+    python.pkgs.setuptools
+    qt5.qtbase
+    qt5.qtxmlpatterns
+  ] ++ (lib.optionals (python.pythonOlder "3.9") [
+    # see similar issue: 202262
+    # libxcrypt is required for crypt.h for building older python modules
+    libxcrypt
+  ]);
 
   cmakeFlags = [
     "-DBUILD_TESTS=OFF"


### PR DESCRIPTION
###### Description of changes

Building python.pkgs.pyside2|shiboken2 fails for python version older than 3.9, due to crypt.h header issue related to older glibc (#202262).

A similar issue can be found at #202262. 

The fix is to use libxrypto for these older python versions.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
