### PR TITLE
git: set reasonable default features

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -12,7 +12,7 @@
 , withManual ? true
 , pythonSupport ? true
 , withpcre2 ? true
-, sendEmailSupport ? false
+, sendEmailSupport ? perlSupport
 , Security, CoreServices
 , nixosTests
 , withLibsecret ? false


### PR DESCRIPTION

###### Description of changes

Git should come with a reasonable set of baseline features. Arguable git-send-email is one of them. Development flows, such as those of Linux, depend on the tool being available.

The difference in closure size between this and the previous version is is negligible. There are no additional build-time dependencies pulled in and the runtime closure difference is about 1%.


```
Estimating rebuild amount by counting changed Hydra jobs (parallel=unset).
    470 x86_64-darwin
    493 x86_64-linux
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
