### PR TITLE
process-cpp: init at unstable-2021-05-11

### DIFF
--- a/pkgs/development/libraries/process-cpp/default.nix
+++ b/pkgs/development/libraries/process-cpp/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, boost
+, properties-cpp
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "process-cpp";
+  version = "unstable-2021-05-11";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "ubports";
+    repo = "development/core/lib-cpp/process-cpp";
+    rev = "ee6d99a3278343f5fdcec7ed3dad38763e257310";
+    sha256 = "sha256-jDYXKCzrg/ZGFC2xpyfkn/f7J3t0cdOwHK2mLlYWNN0=";
+  };
+
+  postPatch = ''
+    # Excludes tests from tainting nativeBuildInputs with their dependencies when not being run
+    # Tests fail upon verifying OOM score adjustment via /proc/<pid>/oom_score
+    # [ RUN      ] LinuxProcess.adjusting_proc_oom_score_adj_works
+    # /build/source/tests/linux_process_test.cpp:83: Failure
+    # Value of: is_approximately_equal(oom_score.value, core::posix::linux::proc::process::OomScoreAdj::max_value())
+    #   Actual: false (333 > 10)
+    # Expected: true
+    sed -i '/tests/d' CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    properties-cpp
+  ];
+
+  meta = with lib; {
+    description = "A simple convenience library for handling processes in C++11";
+    homepage = "https://gitlab.com/ubports/development/core/lib-cpp/process-cpp";
+    license = with licenses; [ gpl3Only lgpl3Only ];
+    maintainers = with maintainers; [ onny ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31669,6 +31669,8 @@ with pkgs;
 
   premid = callPackage ../applications/misc/premid { };
 
+  process-cpp = callPackage ../development/libraries/process-cpp { };
+
   processing = callPackage ../applications/graphics/processing {
     jdk = oraclejdk8;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
