### PR TITLE
Revert "treewide: use nativeBuildInputs with runCommand instead of inlining"

### DIFF
--- a/nixos/modules/installer/tools/nixos-build-vms/build-vms.nix
+++ b/nixos/modules/installer/tools/nixos-build-vms/build-vms.nix
@@ -18,9 +18,8 @@ let
   interactiveDriver = (testing.makeTest { inherit nodes; name = "network"; testScript = "start_all(); join_all();"; }).test.driverInteractive;
 in
 
-  pkgs.runCommandLocal "nixos-build-vms" {
-    nativeBuildInputs = [ pkgs.makeWrapper ];
-  } ''
+
+pkgs.runCommand "nixos-build-vms" { nativeBuildInputs = [ pkgs.makeWrapper ]; } ''
   mkdir -p $out/bin
   ln -s ${interactiveDriver}/bin/nixos-test-driver $out/bin/nixos-test-driver
   ln -s ${interactiveDriver}/bin/nixos-test-driver $out/bin/nixos-run-vms

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -77,11 +77,10 @@ let
           pkgsLibPath = filter (pkgs.path + "/pkgs/pkgs-lib");
           nixosPath = filter (pkgs.path + "/nixos");
           modules = map (p: ''"${removePrefix "${modulesPath}/" (toString p)}"'') docModules.lazy;
-          nativeBuildInputs = with pkgs; [ nix ];
         } ''
           export NIX_STORE_DIR=$TMPDIR/store
           export NIX_STATE_DIR=$TMPDIR/state
-          nix-instantiate \
+          ${pkgs.buildPackages.nix}/bin/nix-instantiate \
             --show-trace \
             --eval --json --strict \
             --argstr libPath "$libPath" \

--- a/nixos/modules/virtualisation/brightbox-image.nix
+++ b/nixos/modules/virtualisation/brightbox-image.nix
@@ -27,21 +27,21 @@ in
               popd
             '';
           diskImageBase = "nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.raw";
-          nativeBuildInputs = with pkgs; [ e2fsprogs parted ];
-          buildInputs = with pkgs; [ util-linux perl ];
-          exportReferencesGraph = [ "closure" config.system.build.toplevel ];
+          buildInputs = [ pkgs.util-linux pkgs.perl ];
+          exportReferencesGraph =
+            [ "closure" config.system.build.toplevel ];
         }
         ''
           # Create partition table
-          parted --script /dev/vda mklabel msdos
-          parted --script /dev/vda mkpart primary ext4 1 ${diskSize}
-          parted --script /dev/vda print
+          ${pkgs.parted}/sbin/parted --script /dev/vda mklabel msdos
+          ${pkgs.parted}/sbin/parted --script /dev/vda mkpart primary ext4 1 ${diskSize}
+          ${pkgs.parted}/sbin/parted --script /dev/vda print
           . /sys/class/block/vda1/uevent
           mknod /dev/vda1 b $MAJOR $MINOR
 
           # Create an empty filesystem and mount it.
-          mkfs.ext4 -L nixos /dev/vda1
-          tune2fs -c 0 -i 0 /dev/vda1
+          ${pkgs.e2fsprogs}/sbin/mkfs.ext4 -L nixos /dev/vda1
+          ${pkgs.e2fsprogs}/sbin/tune2fs -c 0 -i 0 /dev/vda1
 
           mkdir /mnt
           mount /dev/vda1 /mnt

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -218,8 +218,7 @@ let
                 chmod 0644 $efiVars
               '' else ""}
             '';
-          nativeBuildInputs = with pkgs; [ dosfstools gptfdisk kmod mtools ];
-          buildInputs = with pkgs; [ util-linux ];
+          buildInputs = [ pkgs.util-linux ];
           QEMU_OPTS = "-nographic -serial stdio -monitor none"
                       + lib.optionalString cfg.useEFIBoot (
                         " -drive if=pflash,format=raw,unit=0,readonly=on,file=${cfg.efi.firmware}"
@@ -227,7 +226,7 @@ let
         }
         ''
           # Create a /boot EFI partition with 60M and arbitrary but fixed GUIDs for reproducibility
-          sgdisk \
+          ${pkgs.gptfdisk}/bin/sgdisk \
             --set-alignment=1 --new=1:34:2047 --change-name=1:BIOSBootPartition --typecode=1:ef02 \
             --set-alignment=512 --largest-new=2 --change-name=2:EFISystem --typecode=2:ef00 \
             --attributes=1:set:1 \
@@ -250,16 +249,16 @@ let
             ''
           }
 
-          mkfs.fat -F16 /dev/vda2
+          ${pkgs.dosfstools}/bin/mkfs.fat -F16 /dev/vda2
           export MTOOLS_SKIP_CHECK=1
-          mlabel -i /dev/vda2 ::boot
+          ${pkgs.mtools}/bin/mlabel -i /dev/vda2 ::boot
 
           # Mount /boot; load necessary modules first.
-          insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_cp437.ko.xz || true
-          insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_iso8859-1.ko.xz || true
-          insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/fat.ko.xz || true
-          insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/vfat.ko.xz || true
-          insmod ${pkgs.linux}/lib/modules/*/kernel/fs/efivarfs/efivarfs.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_cp437.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_iso8859-1.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/fat.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/vfat.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/efivarfs/efivarfs.ko.xz || true
           mkdir /boot
           mount /dev/vda2 /boot
 

--- a/nixos/tests/step-ca.nix
+++ b/nixos/tests/step-ca.nix
@@ -1,13 +1,11 @@
 import ./make-test-python.nix ({ pkgs, ... }:
   let
-    test-certificates = pkgs.runCommandLocal "test-certificates" {
-      nativeBuildInputs = with pkgs; [ step-cli ];
-    } ''
+    test-certificates = pkgs.runCommandLocal "test-certificates" { } ''
       mkdir -p $out
       echo insecure-root-password > $out/root-password-file
       echo insecure-intermediate-password > $out/intermediate-password-file
-      step certificate create "Example Root CA" $out/root_ca.crt $out/root_ca.key --password-file=$out/root-password-file --profile root-ca
-      step certificate create "Example Intermediate CA 1" $out/intermediate_ca.crt $out/intermediate_ca.key --password-file=$out/intermediate-password-file --ca-password-file=$out/root-password-file --profile intermediate-ca --ca $out/root_ca.crt --ca-key $out/root_ca.key
+      ${pkgs.step-cli}/bin/step certificate create "Example Root CA" $out/root_ca.crt $out/root_ca.key --password-file=$out/root-password-file --profile root-ca
+      ${pkgs.step-cli}/bin/step certificate create "Example Intermediate CA 1" $out/intermediate_ca.crt $out/intermediate_ca.key --password-file=$out/intermediate-password-file --ca-password-file=$out/root-password-file --profile intermediate-ca --ca $out/root_ca.crt --ca-key $out/root_ca.key
     '';
   in
   {


### PR DESCRIPTION
Reverts NixOS/nixpkgs#206775

Breaks installer tests, see https://hydra.nixos.org/build/203100465/nixlog/47

Don't see an obvious fix so let's just revert for now and figure it out later.

CC @SuperSandro2000 