### PR TITLE
freesweep: small cleanup

### DIFF
--- a/pkgs/games/freesweep/default.nix
+++ b/pkgs/games/freesweep/default.nix
@@ -1,5 +1,5 @@
-{ fetchFromGitHub, fetchpatch, ncurses, lib, stdenv,
-  updateAutotoolsGnuConfigScriptsHook }:
+{ fetchFromGitHub, fetchpatch, ncurses, lib, stdenv
+, updateAutotoolsGnuConfigScriptsHook, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "freesweep";
@@ -12,12 +12,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-iuu81yHbNrjdPsimBrPK58PJ0d8i3ySM7rFUG/d8NJM";
   };
 
-  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
+  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook installShellFiles ];
   buildInputs = [ ncurses ];
 
-  preConfigure = ''
-    configureFlags="$configureFlags --with-prefsdir=$out/share"
-  '';
+  configureFlags = [ "--with-prefsdir=$out/share" ];
 
   enableParallelBuilding = true;
 
@@ -25,7 +23,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
     install -D -m 0555 freesweep $out/bin/freesweep
     install -D -m 0444 sweeprc $out/share/sweeprc
-    install -D -m 0444 freesweep.6 $out/share/man/man6/freesweep.6
+    installManPage freesweep.6
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Description of changes



###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).