### PR TITLE
dt-schema: 2022.1 -> 2022.12

### DIFF
--- a/pkgs/development/python-modules/dtschema/default.nix
+++ b/pkgs/development/python-modules/dtschema/default.nix
@@ -6,11 +6,12 @@
 , rfc3987
 , ruamel-yaml
 , setuptools-scm
+, libfdt
 }:
 
 buildPythonPackage rec {
   pname = "dtschema";
-  version = "2022.01";
+  version = "2022.12";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,8 +20,13 @@ buildPythonPackage rec {
     owner = "devicetree-org";
     repo = "dt-schema";
     rev = "refs/tags/v${version}";
-    hash = "sha256-wwlXIM/eO3dII/qQpkAGLT3/15rBLi7ZiNtqYFf7Li4=";
+    sha256 = "sha256-+wF6WdonZrkZEnlq/P6QeT3X7CMinxbapLa7q0t2zUc=";
   };
+
+  patches = [
+    # Change name of pylibfdt to libfdt
+    ./fix_libfdt_name.patch
+  ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
@@ -32,6 +38,7 @@ buildPythonPackage rec {
     jsonschema
     rfc3987
     ruamel-yaml
+    libfdt
   ];
 
   # Module has no tests

--- a/pkgs/development/python-modules/dtschema/fix_libfdt_name.patch
+++ b/pkgs/development/python-modules/dtschema/fix_libfdt_name.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 62db8af..4a980c1 100755
+--- a/setup.py
++++ b/setup.py
+@@ -52,7 +52,7 @@ setuptools.setup(
+         'ruamel.yaml>0.15.69',
+         'jsonschema>=4.1.2',
+         'rfc3987',
+-        'pylibfdt',
++        'libfdt',
+     ],
+ 
+     classifiers=[


### PR DESCRIPTION
###### Description of changes
- Update dt-schema to 2022.12
- Add a patch for fixing the name of a new dependency `pylibfdt`. Nixos already have `libfdt` wich is the same just not the same name found on [Pypi](https://pypi.org/project/pylibfdt/)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Fixes #207837

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
