### PR TITLE
public-inbox: 1.8.0 -> 1.9.0

### DIFF
--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -275,9 +275,8 @@ in
           default = {};
           description = lib.mdDoc "public inboxes";
           type = types.submodule {
-            # Keeping in line with the tradition of unnecessarily specific types, allow users to set
-            # freeform settings either globally under the `publicinbox` section, or for specific
-            # inboxes through additional nesting.
+            # Support both global options like `services.public-inbox.settings.publicinbox.imapserver`
+            # and inbox specific options like `services.public-inbox.settings.publicinbox.foo.address`.
             freeformType = with types; attrsOf (oneOf [ iniAtom (attrsOf iniAtom) ]);
 
             options.css = mkOption {
@@ -285,11 +284,23 @@ in
               default = [];
               description = lib.mdDoc "The local path name of a CSS file for the PSGI web interface.";
             };
+            options.imapserver = mkOption {
+              type = with types; listOf str;
+              default = [];
+              example = [ "imap.public-inbox.org" ];
+              description = lib.mdDoc "IMAP URLs to this public-inbox instance";
+            };
             options.nntpserver = mkOption {
               type = with types; listOf str;
               default = [];
               example = [ "nntp://news.public-inbox.org" "nntps://news.public-inbox.org" ];
               description = lib.mdDoc "NNTP URLs to this public-inbox instance";
+            };
+            options.pop3server = mkOption {
+              type = with types; listOf str;
+              default = [];
+              example = [ "pop.public-inbox.org" ];
+              description = lib.mdDoc "POP3 URLs to this public-inbox instance";
             };
             options.wwwlisting = mkOption {
               type = with types; enum [ "all" "404" "match=domain" ];

--- a/nixos/tests/public-inbox.nix
+++ b/nixos/tests/public-inbox.nix
@@ -14,7 +14,7 @@ in
 
   meta.maintainers = with pkgs.lib.maintainers; [ julm ];
 
-  machine = { config, pkgs, nodes, ... }: let
+  nodes.machine = { config, pkgs, nodes, ... }: let
     inherit (config.services) gitolite public-inbox;
     # Git repositories paths in Gitolite.
     # Only their baseNameOf is used for configuring public-inbox.
@@ -221,7 +221,7 @@ in
     # Delete a mail.
     # Note that the use of an extension not listed in the addresses
     # require to use --all
-    machine.succeed("curl -L https://machine.example.localdomain/inbox/repo1/repo1@root-1/raw | sudo -u public-inbox public-inbox-learn rm --all")
-    machine.fail("curl -L https://machine.example.localdomain/inbox/repo1/repo1@root-1/T/#u | grep 'This is a testing mail.'")
+    machine.succeed("curl -L https://machine.${domain}/inbox/repo1/repo1@root-1/raw | sudo -u public-inbox public-inbox-learn rm --all")
+    machine.fail("curl -L https://machine.${domain}/inbox/repo1/repo1@root-1/T/#u | grep 'This is a testing mail.'")
   '';
 })

--- a/pkgs/servers/mail/public-inbox/default.nix
+++ b/pkgs/servers/mail/public-inbox/default.nix
@@ -6,6 +6,7 @@
 , gnumake
 , highlight
 , libgit2
+, libxcrypt
 , man
 , openssl
 , pkg-config
@@ -137,12 +138,14 @@ buildPerlPackage rec {
   installTargets = [ "install" ];
   postInstall = ''
     for prog in $out/bin/*; do
-        wrapProgram $prog --prefix PATH : ${lib.makeBinPath [
-          git
-          /* for InlineC */
-          gnumake
-          stdenv.cc.cc
-        ]}
+        wrapProgram $prog \
+            --set NIX_CFLAGS_COMPILE_${stdenv.cc.suffixSalt} -I${lib.getDev libxcrypt}/include \
+            --prefix PATH : ${lib.makeBinPath [
+              git
+              /* for InlineC */
+              gnumake
+              stdenv.cc
+            ]}
     done
 
     mv sa_config $sa_config

--- a/pkgs/servers/mail/public-inbox/default.nix
+++ b/pkgs/servers/mail/public-inbox/default.nix
@@ -18,30 +18,33 @@
 , EmailAddressXS
 , EmailMIME
 , IOSocketSSL
+# FIXME: to be packaged
+#, IOSocketSocks
 , IPCRun
 , Inline
 , InlineC
 , LinuxInotify2
 , MailIMAPClient
+# FIXME: to be packaged
+#, NetNetrc
+# FIXME: to be packaged
+#, NetNNTP
 , ParseRecDescent
 , Plack
 , PlackMiddlewareReverseProxy
+, PlackTestExternalServer
 , SearchXapian
+, TestSimple13
 , TimeDate
 , URI
+, XMLTreePP
 }:
 
 let
 
   skippedTests = [
-    # These tests would fail, and produce "Operation not permitted"
-    # errors from git, because they use git init --shared.  This tries
-    # to set the setgid bit, which isn't permitted inside build
-    # sandboxes.
-    #
-    # These tests were indentified with
-    #     grep -r shared t/
-    "convert-compact" "search" "v2writable" "www_listing"
+    # fatal: Could not make /tmp/pi-search-9188-DGZM/a.git/branches/ writable by group
+    "search"
     # perl5.32.0-public-inbox> t/eml.t ...................... 1/? Cannot parse parameter '=?ISO-8859-1?Q?=20charset=3D=1BOF?=' at t/eml.t line 270.
     # perl5.32.0-public-inbox> #   Failed test 'got wide character by assuming utf-8'
     # perl5.32.0-public-inbox> #   at t/eml.t line 272.
@@ -68,6 +71,8 @@ let
     #   expected: anything else
     # waiting for child to reap grandchild...
     "spawn"
+    # Failed to connect to 127.0.0.1
+    "v2mirror"
   ];
 
   testConditions = with lib;
@@ -77,11 +82,11 @@ in
 
 buildPerlPackage rec {
   pname = "public-inbox";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchurl {
     url = "https://public-inbox.org/public-inbox.git/snapshot/public-inbox-${version}.tar.gz";
-    sha256 = "sha256-laJOOCk5NecIGWesv4D30cLGfijQHVkeo55eNqNKzew=";
+    sha256 = "sha256-ENnT2YK7rpODII9TqiEYSCp5mpWOnxskeSuAf8Ilqro=";
   };
 
   outputs = [ "out" "devdoc" "sa_config" ];
@@ -100,12 +105,15 @@ buildPerlPackage rec {
     DBDSQLite
     DBI
     EmailAddressXS
-    EmailMIME
     highlight
     IOSocketSSL
+    #IOSocketSocks
     IPCRun
     Inline
     InlineC
+    MailIMAPClient
+    #NetNetrc
+    #NetNNTP
     ParseRecDescent
     Plack
     PlackMiddlewareReverseProxy
@@ -118,13 +126,16 @@ buildPerlPackage rec {
 
   doCheck = !stdenv.isDarwin;
   nativeCheckInputs = [
-    MailIMAPClient
     curl
     git
     openssl
     pkg-config
     sqlite
     xapian
+    EmailMIME
+    PlackTestExternalServer
+    TestSimple13
+    XMLTreePP
   ] ++ lib.optionals stdenv.isLinux [
     LinuxInotify2
   ];


### PR DESCRIPTION
###### Description of changes

- [X] Update to [public-inbox 1.9.0](https://public-inbox.org/meta/2022-08-21T023659Z-public-inbox-1.9.0-rele@sed/)
- [X] Fix git make tests fail (TODO: reenable those tests once Git 2.39 is available in Nixpkgs)
- [X] Fix `InlineC` support by correctly including `stdenv.cc` instead of `stdenv.cc.cc` in `public-inbox`'s environment.
- [ ] Support the new `public-inbox-netd` superserver?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
