### PR TITLE
libusb1: add option to build with examples

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11436,6 +11436,12 @@
     githubId = 1973389;
     name = "Reuben D'Netto";
   };
+  realsnick = {
+    name = "Ido Samuelson";
+    email = "ido.samuelson@gmail.com";
+    github = "realsnick";
+    githubId = 1440852;
+  };
   redbaron = {
     email = "ivanov.maxim@gmail.com";
     github = "redbaron";


### PR DESCRIPTION
recreate PR on `staging` branch

added withExamples to build all examples into examples/bin.

since the fxload package is outdated and source code moved to libusb's examples. I believe it is better to build fxload here and have it install to /sbin similarly to how fxload package does it.

this version of fxload supports USB3 devices.

Previous PR: https://github.com/NixOS/nixpkgs/pull/207513
Issue:: https://github.com/NixOS/nixpkgs/issues/207381
