### PR TITLE
nanosaur2: init at 2.1.0, nanosaur: fix build

### DIFF
--- a/pkgs/games/nanosaur/default.nix
+++ b/pkgs/games/nanosaur/default.nix
@@ -38,9 +38,7 @@ stdenv.mkDerivation rec {
       And you get to shoot at T-Rexes with nukes.
     '';
     homepage = "https://github.com/jorio/Nanosaur";
-    license = with licenses; [
-      cc-by-sa-40
-    ];
+    license = licenses.cc-by-sa-40;
     maintainers = with maintainers; [ lux ];
     platforms = platforms.linux;
   };

--- a/pkgs/games/nanosaur/default.nix
+++ b/pkgs/games/nanosaur/default.nix
@@ -12,22 +12,31 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake makeWrapper ];
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
   buildInputs = [
     SDL2
   ];
 
   configurePhase = ''
+    runHook preConfigure
     cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+    runHook postConfigure
   '';
 
   buildPhase = ''
+    runHook preBuild
     cmake --build build
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     mv build $out
     makeWrapper $out/Nanosaur $out/bin/Nanosaur --chdir "$out"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/games/nanosaur2/default.nix
+++ b/pkgs/games/nanosaur2/default.nix
@@ -47,9 +47,7 @@ stdenv.mkDerivation rec {
       Is a continuation of the original Nanosaur storyline, only this time you get to fly a pterodactyl who’s loaded with hi-tech weaponry.
     '';
     homepage = "https://github.com/jorio/Nanosaur2";
-    license = with licenses; [
-      cc-by-sa-40
-    ];
+    license = licenses.cc-by-sa-40;
     maintainers = with maintainers; [ lux ];
     platforms = platforms.linux;
   };

--- a/pkgs/games/nanosaur2/default.nix
+++ b/pkgs/games/nanosaur2/default.nix
@@ -1,0 +1,56 @@
+{ lib, stdenv, fetchFromGitHub, SDL2, cmake, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "nanosaur2";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jorio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-UY+fyn8BA/HfCd2LCj5cfGmQACKUICH6CDCW4q6YDkg=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+  buildInputs = [
+    SDL2
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    cmake --build build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mv build $out
+    makeWrapper $out/Nanosaur2 $out/bin/Nanosaur2 --chdir "$out"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A port of Nanosaur2, a 2004 Macintosh game by Pangea Software, for modern operating systems";
+    longDescription = ''
+      Nanosaur is a 2004 Macintosh game by Pangea Software.
+
+      Is a continuation of the original Nanosaur storyline, only this time you get to fly a pterodactyl who’s loaded with hi-tech weaponry.
+    '';
+    homepage = "https://github.com/jorio/Nanosaur2";
+    license = with licenses; [
+      cc-by-sa-40
+    ];
+    maintainers = with maintainers; [ lux ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/otto-matic/default.nix
+++ b/pkgs/games/otto-matic/default.nix
@@ -35,9 +35,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A port of Otto Matic, a 2001 Macintosh game by Pangea Software, for modern operating systems";
     homepage = "https://github.com/jorio/OttoMatic";
-    license = with licenses; [
-      cc-by-sa-40
-    ];
+    license = licenses.cc-by-sa-40;
     maintainers = with maintainers; [ lux ];
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34690,6 +34690,8 @@ with pkgs;
 
   nanosaur = callPackage ../games/nanosaur { };
 
+  nanosaur2 = callPackage ../games/nanosaur2 { };
+
   nethack = callPackage ../games/nethack { };
 
   nethack-qt = callPackage ../games/nethack {


### PR DESCRIPTION
###### Description of changes

Add [Nanosaur 2](https://github.com/jorio/Nanosaur2) package. (We already have nanosaur1, this is 99% identical).
Also we change the Nanosaur package to be identical.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
