### PR TITLE
freenet: build01494 -> 01497

### DIFF
--- a/pkgs/applications/networking/p2p/freenet/default.nix
+++ b/pkgs/applications/networking/p2p/freenet/default.nix
@@ -1,60 +1,117 @@
-{ lib, stdenv, fetchurl, jdk, bash, coreutils, substituteAll, nixosTests, jna }:
+{ lib, stdenv, fetchurl, fetchFromGitHub, jdk, gradle, bash, coreutils
+, substituteAll, nixosTests, perl, fetchpatch, writeText }:
 
 let
-  version = "build01494";
+  version = "01497";
+
   freenet_ext = fetchurl {
-    url = "https://github.com/freenet/fred/releases/download/${version}/freenet-ext.jar";
+    url = "https://github.com/freenet/fred/releases/download/build01495/freenet-ext.jar";
     sha256 = "sha256-MvKz1r7t9UE36i+aPr72dmbXafCWawjNF/19tZuk158=";
   };
-  bcprov = fetchurl {
-    url = "https://github.com/freenet/fred/releases/download/${version}/bcprov-jdk15on-1.59.jar";
-    sha256 = "sha256-HDHkTjMdJeRtKTs+juLQcCimfbAR50yyRDKFrtHVnIU=";
-  };
+
   seednodes = fetchurl {
     url = "https://downloads.freenetproject.org/alpha/opennet/seednodes.fref";
     sha256 = "08awwr8n80b4cdzzb3y8hf2fzkr1f2ly4nlq779d6pvi5jymqdvv";
   };
 
-  freenet-jars = stdenv.mkDerivation {
-    pname = "freenet-jars";
-    inherit version;
+  patches = [
+    # gradle 7 support
+    (fetchpatch {
+      url = "https://github.com/freenet/fred/pull/827.patch";
+      sha256 = "sha256-T1zymxRTADVhhwp2TyB+BC/J4gZsT/CUuMrT4COlpTY=";
+    })
+  ];
 
-    src = fetchurl {
-      url = "https://github.com/freenet/fred/releases/download/${version}/freenet.jar";
-      sha256 = "sha256-1Pjc8Ob4EN7N05QkGTMKBn7z3myTDaQ98N48nNSLstg=";
-    };
+in stdenv.mkDerivation rec {
+  pname = "freenet";
+  inherit version patches;
 
-    dontUnpack = true;
-
-    installPhase = ''
-      mkdir -p $out/share/freenet
-      ln -s ${bcprov} $out/share/freenet/bcprov.jar
-      ln -s ${freenet_ext} $out/share/freenet/freenet-ext.jar
-      ln -s ${jna}/share/java/jna-platform.jar $out/share/freenet/jna_platform.jar
-      ln -s ${jna}/share/java/jna.jar $out/share/freenet/jna.jar
-      ln -s $src $out/share/freenet/freenet.jar
-    '';
+  src = fetchFromGitHub {
+    owner = "freenet";
+    repo = "fred";
+    rev = "refs/tags/build${version}";
+    hash = "sha256-pywNPekofF/QotNVF28McojqK7c1Zzucds5rWV0R7BQ=";
   };
 
-in stdenv.mkDerivation {
-  pname = "freenet";
-  inherit version;
+  postPatch = ''
+    rm gradle/verification-{keyring.keys,metadata.xml}
+  '';
 
-  src = substituteAll {
+  nativeBuildInputs = [ gradle jdk ];
+
+  wrapper = substituteAll {
     src = ./freenetWrapper;
     inherit bash coreutils jdk seednodes;
-    freenet = freenet-jars;
   };
 
-  dontUnpack = true;
+  # https://github.com/freenet/fred/blob/next/build-offline.sh
+  # fake build to pre-download deps into fixed-output derivation
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit src version patches;
 
-  passthru.tests = { inherit (nixosTests) freenet; };
+    nativeBuildInputs = [ gradle perl ];
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle --no-daemon build
+    '';
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/''${\($5 =~ s/okio-jvm/okio/r)}" #e' \
+        | sh
+    '';
+    # Don't move info to share/
+    forceShare = [ "dummy" ];
+    outputHashMode = "recursive";
+    # Downloaded jars differ by platform
+    outputHash = "sha256-CZf5M3lI7Lz9Pl8U/lNoQ6V6Jxbmkxau8L273XFFS2E=";
+    outputHashAlgo = "sha256";
+  };
+
+  # Point to our local deps repo
+  gradleInit = writeText "init.gradle" ''
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${deps}/'; metadataSources {mavenPom(); artifact()} }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${deps}/'; metadataSources {mavenPom(); artifact()} }
+        }
+      }
+    }
+
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          maven { url '${deps}/'; metadataSources {mavenPom(); artifact()} }
+        }
+      }
+    }
+  '';
+
+  buildPhase = ''
+    gradle jar -Dorg.gradle.java.home=${jdk} --offline --no-daemon --info --init-script $gradleInit
+  '';
 
   installPhase = ''
+    runHook preInstall
+    install -Dm444 build/libs/freenet.jar $out/share/freenet/freenet.jar
+    ln -s ${freenet_ext} $out/share/freenet/freenet-ext.jar
     mkdir -p $out/bin
-    install -Dm555 $src $out/bin/freenet
-    ln -s ${freenet-jars}/share $out/share
+    install -Dm555 ${wrapper} $out/bin/freenet
+    substituteInPlace $out/bin/freenet \
+      --subst-var-by outFreenet $out
+    ln -s ${deps} $out/deps
+    runHook postInstall
   '';
+
+  passthru.tests = { inherit (nixosTests) freenet; };
 
   meta = {
     description = "Decentralised and censorship-resistant network";

--- a/pkgs/applications/networking/p2p/freenet/freenetWrapper
+++ b/pkgs/applications/networking/p2p/freenet/freenetWrapper
@@ -1,7 +1,8 @@
 #! @bash@/bin/bash
 set -eo pipefail
 PATH=@coreutils@/bin:$PATH
-export CLASSPATH=@freenet@/share/freenet/bcprov.jar:@freenet@/share/freenet/freenet-ext.jar:@freenet@/share/freenet/jna_platform.jar:@freenet@/share/freenet/jna.jar:@freenet@/share/freenet/freenet.jar
+export CLASSPATH=$(find @outFreenet@/deps/ -name "*.jar"|grep -v bcprov-jdk15on-1.48.jar|tr $'\n' :)
+CLASSPATH=$CLASSPATH:@outFreenet@/share/freenet/freenet-ext.jar:@outFreenet@/share/freenet/freenet.jar
 
 export FREENET_HOME="$HOME/.local/share/freenet"
 if [ -n "$XDG_DATA_HOME" ] ; then


### PR DESCRIPTION
###### Description of changes

This builds freenet from source. I have copied the `deps` and `buildPhase` attributes from somewhere else. It might be worth extracting it to a hook or something.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
