### PR TITLE
olaris-server: 0.4.0 -> unstable-2022-06-11

### DIFF
--- a/pkgs/servers/olaris/default.nix
+++ b/pkgs/servers/olaris/default.nix
@@ -1,14 +1,21 @@
-{ buildGoModule, fetchFromGitLab, fetchzip, installShellFiles, lib }:
+{ buildGoModule
+, fetchFromGitLab
+, fetchzip
+, ffmpeg
+, installShellFiles
+, lib
+, makeWrapper
+}:
 
 buildGoModule rec {
   pname = "olaris-server";
-  version = "0.4.0";
+  version = "unstable-2022-06-11";
 
   src = fetchFromGitLab {
-  owner = "olaris";
+    owner = "olaris";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-iworyQqyTabTI0NpZHTdUBGZSCaiC5Dhr69mRtsHLOs=";
+    rev = "bdb2aeb1595c941210249164a97c12404c1ae0d8";
+    hash = "sha256-Uhnh6GC85ORKnfHeYNtbSA40osuscxXDF5/kXJrF2Cs=";
   };
 
   preBuild = let
@@ -29,9 +36,9 @@ buildGoModule rec {
     "-X gitlab.com/olaris/olaris-server/helpers.Version=${version}"
   ];
 
-  vendorHash = "sha256-xWywDgw0LzJhPtVK0aGgT0TTanejJ39ZmGc50A3d68U=";
+  vendorHash = "sha256-bw8zvDGFBci9bELsxAD0otpNocBnO8aAcgyohLZ3Mv0=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   # integration tests require network access
   doCheck = false;
@@ -41,6 +48,7 @@ buildGoModule rec {
       --bash <($out/bin/olaris-server completion bash) \
       --fish <($out/bin/olaris-server completion fish) \
       --zsh <($out/bin/olaris-server completion zsh)
+      wrapProgram $out/bin/olaris-server --prefix PATH : ${lib.makeBinPath [ffmpeg]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION

###### Description of changes

As called out in the linked issue below, olaris-server has a runtime dependency on ffmpeg. Unfortunately, 0.4.0 requires a custom fork of ffmpeg. While we could fetch the upstream compiled artefact or build it ourselves, the former was unpalatable and the latter prohibitively difficult. As such, we have bumped to the, yet to be released, tip of the default branch, which has merged support for upstream ffmpeg.

Fixes #207877

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
