### PR TITLE
draft: per-dso .so resolution cache on glibc

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -184,6 +184,10 @@ rec {
               pulseSupport = false;
               smbdSupport = false;
               seccompSupport = false;
+              jackSupport = false;
+              alsaSupport = false;
+              libiscsiSupport = false;
+              docSupport = false;
               hostCpuTargets = [ "${final.qemuArch}-linux-user" ];
             };
             wine = (pkgs.winePackagesFor "wine${toString final.parsed.cpu.bits}").minimal;

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -34,6 +34,7 @@
                     else null)
 , nixosTestRunner ? false
 , doCheck ? false
+, docSupport ? true
 , qemu  # for passthru.tests
 }:
 
@@ -141,7 +142,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-strip" # We'll strip ourselves after separating debug info.
-    "--enable-docs"
     "--enable-tools"
     "--localstatedir=/var"
     "--sysconfdir=/etc"
@@ -168,7 +168,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional libiscsiSupport "--enable-libiscsi"
     ++ lib.optional smbdSupport "--smbd=${samba}/bin/smbd"
     ++ lib.optional uringSupport "--enable-linux-io-uring"
-    ++ lib.optional canokeySupport "--enable-canokey";
+    ++ lib.optional canokeySupport "--enable-canokey"
+    ++ lib.optional docSupport "--enable-docs";
 
   dontWrapGApps = true;
 

--- a/pkgs/build-support/setup-hooks/generate-ld-cache.sh
+++ b/pkgs/build-support/setup-hooks/generate-ld-cache.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+
+fixupOutputHooks+=('if [ -z "${dontGenerateLDCache-}" ]; then generateLDCache "$prefix"; fi')
+
+generateLDCache() {
+    local dir="$1"
+    [ -e "$dir" ] || return 0
+
+    echo "generating LD cache for ELF executables in $dir"
+
+    declare -a libDirs
+
+    local i
+    while IFS= read -r -d $'\0' i; do
+        if [[ "$i" =~ .build-id ]]; then continue; fi
+        if ! isELF "$i"; then continue; fi
+        echo "ld-caching $i"
+        patchelf --build-resolution-cache "$i" || true
+    done < <(find "$dir" -type f -print0)
+}

--- a/pkgs/build-support/setup-hooks/generate-ld-cache.sh
+++ b/pkgs/build-support/setup-hooks/generate-ld-cache.sh
@@ -8,8 +8,6 @@ generateLDCache() {
 
     echo "generating LD cache for ELF executables in $dir"
 
-    declare -a libDirs
-
     local i
     while IFS= read -r -d $'\0' i; do
         if [[ "$i" =~ .build-id ]]; then continue; fi

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -88,6 +88,8 @@ stdenv.mkDerivation ({
       ./nix-nss-open-files.patch
 
       ./0001-Revert-Remove-all-usage-of-BASH-or-BASH-in-installed.patch
+
+      ./ldcache.patch
     ]
     ++ lib.optional stdenv.hostPlatform.isMusl ./fix-rpc-types-musl-conflicts.patch
     ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch;
@@ -163,6 +165,7 @@ stdenv.mkDerivation ({
   # out as the first output is an exception exclusive to glibc
   outputs = [ "out" "bin" "dev" "static" ];
 
+  dontStrip = true;
   strictDeps = true;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ bison python3Minimal ] ++ extraNativeBuildInputs;

--- a/pkgs/development/libraries/glibc/ldcache.patch
+++ b/pkgs/development/libraries/glibc/ldcache.patch
@@ -1,0 +1,136 @@
+diff --git a/elf/dl-load.c b/elf/dl-load.c
+index 5b0ff41ee1..fc507542fb 100644
+--- a/elf/dl-load.c
++++ b/elf/dl-load.c
+@@ -1999,6 +1999,80 @@ open_path (const char *name, size_t namelen, int mode,
+   return -1;
+ }
+ 
++static const char *
++_dl_find_nixos_cache(struct link_map *loader)
++{
++  const ElfW(Phdr) *phdr = loader->l_phdr, *pend = phdr + loader->l_phnum;
++  if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++    _dl_debug_printf("find nixos cache %lx -> %lx\n", (long) phdr, (long) pend);
++  for (; phdr != pend; phdr++) {
++    if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++      _dl_debug_printf("  try phdr %lx\n", (long) phdr);
++    if (phdr->p_type != PT_NOTE) continue;
++    const ElfW(Nhdr) *nhdr = (const void *) (phdr->p_vaddr + loader->l_addr);
++    size_t size = phdr->p_memsz;
++    if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++      _dl_debug_printf("    found notes %lx size %lx\n", (long) nhdr, (long) size);
++    while (size >= sizeof *nhdr) {
++      if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++        _dl_debug_printf("      check note namesz %x descsz %x\n", nhdr->n_namesz, nhdr->n_descsz);
++      const size_t noteSize = sizeof *nhdr + ALIGN_UP(nhdr->n_namesz, 4) + ALIGN_UP(nhdr->n_descsz, 4);
++      if (size < noteSize) break;
++      size -= noteSize;
++      const char *nname = (const char *) (nhdr + 1);
++      const char *desc = (const char *) (nhdr + 1) + ALIGN_UP(nhdr->n_namesz, 4);
++      if (nhdr->n_namesz == sizeof ELF_NOTE_NIXOS
++          && memcmp(nname, ELF_NOTE_NIXOS, sizeof ELF_NOTE_NIXOS) == 0
++          && nhdr->n_type == NT_NIXOS_LD_CACHE
++          && nhdr->n_descsz > 2
++          && desc[nhdr->n_descsz - 2] == '\0'
++          && desc[nhdr->n_descsz - 1] == '\0') {
++        if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++          _dl_debug_printf("      found!\n");
++        return desc;
++      }
++      nhdr = (const void *) nhdr + noteSize;
++    }
++  }
++
++  return NULL;
++}
++
++static int
++_dl_lookup_nixos_cache(struct link_map *loader, const char *name, char **realname)
++{
++  if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++    _dl_debug_printf("lookup from cache %s\n", name);
++  const char *entries = _dl_find_nixos_cache(loader);
++  if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++    _dl_debug_printf("  cache is %lx\n", (long) entries);
++  if (entries == NULL)
++    return 0;
++
++  while (entries[0] != '\0') {
++    const char *ename = entries;
++    const char *epath = ename + strlen(ename) + 1;
++    if (epath[0] == '\0') {
++      if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++        _dl_debug_printf("    broken cache\n");
++      return 0;
++    }
++    if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++      _dl_debug_printf("    match %s\n", ename);
++    if (strcmp(name, ename) == 0) {
++      if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++        _dl_debug_printf("    found: %s\n", epath);
++      *realname = strdup(epath);
++      return *realname != NULL;
++    }
++    entries = epath + strlen(epath) + 1;
++  }
++
++  if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
++    _dl_debug_printf("  not found\n");
++  return 0;
++}
++
+ /* Map in the shared object file NAME.  */
+ 
+ struct link_map *
+@@ -2142,6 +2216,22 @@ _dl_map_object (struct link_map *loader, const char *name,
+ 			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
+ 			LA_SER_LIBPATH, &found_other_class);
+ 
++      /* look at nixos resolution cache notes, if available. we'll only
++         check the loader itself (no fallbacks) because this is only a
++         cache, and on some architectures (eg armv7) neither loader nor
++         the GL(dl_ns)[x]._ns_loaded fallback are set during initial
++         load when running ld.so explicitly. loader *is* set when running
++         normally, so we'll always hit the cache if it exists. */
++      if (loader != NULL
++          && fd == -1
++          && _dl_lookup_nixos_cache(loader, name, &realname)) {
++        fd = open_verify (realname, fd, &fb, loader,
++                          LA_SER_RUNPATH, mode, &found_other_class,
++                          false);
++        if (fd == -1)
++          free(realname);
++      }
++
+       /* Look at the RUNPATH information for this binary.  */
+       if (fd == -1 && loader != NULL
+ 	  && cache_rpath (loader, &loader->l_runpath_dirs,
+diff --git a/elf/elf.h b/elf/elf.h
+index 0735f6b579..7b9b74a4bc 100644
+--- a/elf/elf.h
++++ b/elf/elf.h
+@@ -1261,12 +1261,23 @@ typedef struct
+ /* Note entries for freedesktop.org have this name.  */
+ #define ELF_NOTE_FDO		"FDO"
+ 
++/* Note entries for Nixpkgs/NixOS have this name.  */
++#define ELF_NOTE_NIXOS	"NixOS"
++
+ /* Defined types of notes for Solaris.  */
+ 
+ /* Value of descriptor (one word) is desired pagesize for the binary.  */
+ #define ELF_NOTE_PAGESIZE_HINT	1
+ 
+ 
++/* Defined note types for Nixpkgs/NixOS systems.  */
++
++/* Linker resolution cache. The descriptor consists of pairs of
++   null-terminated strings: (needed, libpath).
++   needed should match a DT_NEEDED entry, libpath provides the
++   search path for this single entry. */
++#define NT_NIXOS_LD_CACHE 0x63a86cb6
++
+ /* Defined note types for GNU systems.  */
+ 
+ /* ABI information.  The descriptor consists of words:

--- a/pkgs/development/libraries/glibc/ldcache.patch
+++ b/pkgs/development/libraries/glibc/ldcache.patch
@@ -1,8 +1,8 @@
 diff --git a/elf/dl-load.c b/elf/dl-load.c
-index 5b0ff41ee1..fc507542fb 100644
+index 5b0ff41ee1..f34758611d 100644
 --- a/elf/dl-load.c
 +++ b/elf/dl-load.c
-@@ -1999,6 +1999,80 @@ open_path (const char *name, size_t namelen, int mode,
+@@ -1999,6 +1999,62 @@ open_path (const char *name, size_t namelen, int mode,
    return -1;
  }
  
@@ -10,19 +10,11 @@ index 5b0ff41ee1..fc507542fb 100644
 +_dl_find_nixos_cache(struct link_map *loader)
 +{
 +  const ElfW(Phdr) *phdr = loader->l_phdr, *pend = phdr + loader->l_phnum;
-+  if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+    _dl_debug_printf("find nixos cache %lx -> %lx\n", (long) phdr, (long) pend);
-+  for (; phdr != pend; phdr++) {
-+    if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+      _dl_debug_printf("  try phdr %lx\n", (long) phdr);
++  for (; phdr != pend && loader->l_nixos_resolve_cache == NULL; phdr++) {
 +    if (phdr->p_type != PT_NOTE) continue;
 +    const ElfW(Nhdr) *nhdr = (const void *) (phdr->p_vaddr + loader->l_addr);
 +    size_t size = phdr->p_memsz;
-+    if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+      _dl_debug_printf("    found notes %lx size %lx\n", (long) nhdr, (long) size);
 +    while (size >= sizeof *nhdr) {
-+      if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+        _dl_debug_printf("      check note namesz %x descsz %x\n", nhdr->n_namesz, nhdr->n_descsz);
 +      const size_t noteSize = sizeof *nhdr + ALIGN_UP(nhdr->n_namesz, 4) + ALIGN_UP(nhdr->n_descsz, 4);
 +      if (size < noteSize) break;
 +      size -= noteSize;
@@ -34,73 +26,83 @@ index 5b0ff41ee1..fc507542fb 100644
 +          && nhdr->n_descsz > 2
 +          && desc[nhdr->n_descsz - 2] == '\0'
 +          && desc[nhdr->n_descsz - 1] == '\0') {
-+        if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+          _dl_debug_printf("      found!\n");
 +        return desc;
 +      }
 +      nhdr = (const void *) nhdr + noteSize;
 +    }
 +  }
 +
-+  return NULL;
++  return (void *) -1;
 +}
 +
 +static int
 +_dl_lookup_nixos_cache(struct link_map *loader, const char *name, char **realname)
 +{
-+  if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+    _dl_debug_printf("lookup from cache %s\n", name);
-+  const char *entries = _dl_find_nixos_cache(loader);
-+  if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+    _dl_debug_printf("  cache is %lx\n", (long) entries);
-+  if (entries == NULL)
++  if (loader->l_nixos_resolve_cache == NULL)
++    loader->l_nixos_resolve_cache = _dl_find_nixos_cache(loader);
++
++  if (loader->l_nixos_resolve_cache == (void *) -1)
 +    return 0;
 +
++  const char *entries = loader->l_nixos_resolve_cache;
 +  while (entries[0] != '\0') {
 +    const char *ename = entries;
 +    const char *epath = ename + strlen(ename) + 1;
 +    if (epath[0] == '\0') {
-+      if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+        _dl_debug_printf("    broken cache\n");
++      loader->l_nixos_resolve_cache = (void *) -1;
 +      return 0;
 +    }
-+    if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+      _dl_debug_printf("    match %s\n", ename);
 +    if (strcmp(name, ename) == 0) {
-+      if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+        _dl_debug_printf("    found: %s\n", epath);
 +      *realname = strdup(epath);
 +      return *realname != NULL;
 +    }
 +    entries = epath + strlen(epath) + 1;
 +  }
 +
-+  if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
-+    _dl_debug_printf("  not found\n");
 +  return 0;
 +}
 +
  /* Map in the shared object file NAME.  */
  
  struct link_map *
-@@ -2142,6 +2216,22 @@ _dl_map_object (struct link_map *loader, const char *name,
+@@ -2009,6 +2065,7 @@ _dl_map_object (struct link_map *loader, const char *name,
+   const char *origname = NULL;
+   char *realname;
+   char *name_copy;
++  char *rescache;
+   struct link_map *l;
+   struct filebuf fb;
+ 
+@@ -2142,6 +2199,34 @@ _dl_map_object (struct link_map *loader, const char *name,
  			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
  			LA_SER_LIBPATH, &found_other_class);
  
-+      /* look at nixos resolution cache notes, if available. we'll only
-+         check the loader itself (no fallbacks) because this is only a
-+         cache, and on some architectures (eg armv7) neither loader nor
-+         the GL(dl_ns)[x]._ns_loaded fallback are set during initial
-+         load when running ld.so explicitly. loader *is* set when running
-+         normally, so we'll always hit the cache if it exists. */
-+      if (loader != NULL
-+          && fd == -1
-+          && _dl_lookup_nixos_cache(loader, name, &realname)) {
-+        fd = open_verify (realname, fd, &fb, loader,
-+                          LA_SER_RUNPATH, mode, &found_other_class,
-+                          false);
-+        if (fd == -1)
-+          free(realname);
++      /* try the runpath resolution cache. */
++      if (fd == -1 && _dl_lookup_nixos_cache(loader, name, &rescache)) {
++	char* tmp = rescache, *iter;
++	while ((iter = strsep(&tmp, ":"))) {
++	  if (iter[0] == '?') {
++	    struct r_search_path_struct sp;
++	    if (decompose_rpath(&sp, iter + 1, loader, "RESCACHE")) {
++	      fd = open_path (name, namelen, mode,
++			      &sp, &realname, &fb, loader,
++			      LA_SER_RUNPATH, &found_other_class);
++	      if (sp.dirs != (void*) -1)
++		free(sp.dirs);
++	    }
++	  } else {
++	    realname = strdup(iter + 1);
++	    fd = open_verify (realname, fd,
++			      &fb, loader ?: GL(dl_ns)[nsid]._ns_loaded,
++			      LA_SER_RUNPATH, mode, &found_other_class,
++			      false);
++	    if (fd == -1)
++	      free(realname);
++	  }
++	  if (fd != -1)
++	    break;
++	}
++	free(rescache);
 +      }
 +
        /* Look at the RUNPATH information for this binary.  */
@@ -134,3 +136,16 @@ index 0735f6b579..7b9b74a4bc 100644
  /* Defined note types for GNU systems.  */
  
  /* ABI information.  The descriptor consists of words:
+diff --git a/include/link.h b/include/link.h
+index bef2820b40..b3dea3c5b1 100644
+--- a/include/link.h
++++ b/include/link.h
+@@ -349,6 +349,8 @@ struct link_map
+     size_t l_relro_size;
+ 
+     unsigned long long int l_serial;
++
++    const char *l_nixos_resolve_cache;
+   };
+ 
+ #include <dl-relocate-ld.h>

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  patches = [
+    ./ldcache.patch
+  ];
+
   setupHook = [ ./setup-hook.sh ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/tools/misc/patchelf/ldcache.patch
+++ b/pkgs/development/tools/misc/patchelf/ldcache.patch
@@ -1,0 +1,334 @@
+diff --git a/src/elf.h b/src/elf.h
+index 702f2e6..75c9020 100644
+--- a/src/elf.h
++++ b/src/elf.h
+@@ -1001,12 +1001,24 @@ typedef struct
+ #define ELF_NOTE_GNU		"GNU"
+ 
+ 
++/* Note entries for Nixpkgs/NixOS have this name.  */
++#define ELF_NOTE_NIXOS	"NixOS"
++
+ /* Defined types of notes for Solaris.  */
+ 
+ /* Value of descriptor (one word) is desired pagesize for the binary.  */
+ #define ELF_NOTE_PAGESIZE_HINT	1
+ 
+ 
++/* Defined note types for Nixpkgs/NixOS systems.  */
++
++/* Linker resolution cache. The descriptor consists of pairs of
++   null-terminated strings: (needed, libpath).
++   needed should match a DT_NEEDED entry, libpath provides the
++   search path for this single entry. */
++#define NT_NIXOS_LD_CACHE 0x63a86cb6
++
++
+ /* Defined note types for GNU systems.  */
+ 
+ /* ABI information.  The descriptor consists of words:
+diff --git a/src/patchelf.cc b/src/patchelf.cc
+index 49accae..eca68bb 100644
+--- a/src/patchelf.cc
++++ b/src/patchelf.cc
+@@ -20,6 +20,7 @@
+ #include <limits>
+ #include <map>
+ #include <memory>
++#include <numeric>
+ #include <set>
+ #include <sstream>
+ #include <stdexcept>
+@@ -295,7 +296,7 @@ ElfFile<ElfFileParamNames>::ElfFile(FileContents fContents)
+ 
+ 
+ template<ElfFileParams>
+-unsigned int ElfFile<ElfFileParamNames>::getPageSize() const
++Elf_Addr ElfFile<ElfFileParamNames>::getPageSize() const
+ {
+     if (forcedPageSize > 0)
+         return forcedPageSize;
+@@ -447,6 +448,26 @@ void ElfFile<ElfFileParamNames>::shiftFile(unsigned int extraPages, Elf_Addr sta
+         }
+     }
+ 
++    // try to extend an existing PT_LOAD segment backwards. not doing this confuses
++    // everything since elf sections need no longer be contained in a single segment.
++    for (auto & phdr : phdrs) {
++        if (rdi(phdr.p_type) != PT_LOAD) continue;
++        if (rdi(phdr.p_offset) != shift) continue;
++        assert(rdi(phdr.p_vaddr) > shift);
++        wri(phdr.p_offset, 0);
++        wri(phdr.p_vaddr, wri(phdr.p_paddr, startPage));
++        wri(phdr.p_filesz, rdi(phdr.p_filesz) + shift);
++        wri(phdr.p_memsz, rdi(phdr.p_memsz) + shift);
++        // FIXME also make this segment writable because we may later relocate writable
++        // sections into it
++        wri(phdr.p_flags, rdi(phdr.p_flags) | PF_R | PF_W);
++        // FIXME rewriteSectionsExecutable should not expect an extra phdr instead
++        phdrs.resize(rdi(hdr()->e_phnum) + 1);
++        wri(hdr()->e_phnum, rdi(hdr()->e_phnum) + 1);
++        wri(phdrs.back().p_type, PT_NULL);
++        return;
++    }
++
+     /* Add a segment that maps the new program/section headers and
+        PT_INTERP segment into memory.  Otherwise glibc will choke. */
+     phdrs.resize(rdi(hdr()->e_phnum) + 1);
+@@ -940,7 +961,6 @@ void ElfFile<ElfFileParamNames>::rewriteSections()
+     } else error("unknown ELF type");
+ }
+ 
+-
+ template<ElfFileParams>
+ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
+ {
+@@ -957,6 +977,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
+         }
+     }
+ 
++    assert(rdi(hdr()->e_phnum) == phdrs.size());
+     if (!noSort) {
+         sortPhdrs();
+     }
+@@ -1619,6 +1640,160 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
+     this->rewriteSections();
+ }
+ 
++template<ElfFileParams>
++void ElfFile<ElfFileParamNames>::buildResolutionCache()
++{
++    const auto shdrDynamic = findSectionHeader(".dynamic");
++    const auto shdrDynStr = findSectionHeader(".dynstr");
++    const char *strTab = (char *)fileContents->data() + rdi(shdrDynStr.sh_offset);
++    const Elf_Dyn *dyn = (Elf_Dyn *) (fileContents->data() + rdi(shdrDynamic.sh_offset));
++
++    std::vector<std::string> needed, runpath;
++    std::map<std::string, std::string> cache;
++
++    // TODO tests for:
++    //   - add note to {static,dynamic} {library,executable}
++    //   - update note
++    //   - set-interpreter with note in place (initramfs extra-utils)
++    //   - set-rpath with note in place (initramfs extra-utils)
++    for (; rdi(dyn->d_tag) != DT_NULL; dyn++) {
++        if (rdi(dyn->d_tag) == DT_NEEDED) {
++            needed.emplace_back(strTab + rdi(dyn->d_un.d_val));
++        } else if (rdi(dyn->d_tag) == DT_RUNPATH) {
++            runpath = splitColonDelimitedString(strTab + rdi(dyn->d_un.d_val));
++        }
++    }
++
++    // TODO remove old phdr
++    // TODO nuke/rebuild rescache when changing rpath
++    for (const auto &dir : runpath) {
++        // ignore directories with glibc-hwcaps subdirs. they're rare enough to
++        // not be worth handling, and fussy enough to stay away from for good measure.
++        if (access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0)
++            continue;
++        for (const auto &dep : needed) {
++            if (cache.count(dep) > 0)
++                continue;
++            if (access((dir + "/" + dep).c_str(), R_OK) == 0) {
++                cache.emplace(dep, dir + "/" + dep);
++            }
++        }
++    }
++
++    // leave the headers well enough alone if we can't resolve anything. this is
++    // especially important for glibc ld.so which indexes into its virtual memory
++    // using file offsets, but since it's static we don't want to touch it anyway.
++    if (cache.empty())
++        return;
++
++    for (const auto &[dep, dir] : cache)
++        debug("resolved %s to %s\n", dep.c_str(), dir.c_str());
++
++    const auto noteSize = std::accumulate(
++        cache.begin(), cache.end(), 1, // extra trailing '\0'
++        [](auto acc, const auto & p) { return acc + p.first.size() + p.second.size() + 2; });
++
++    static const char NOTE_NAME[] = ".note.nixos.ldcache";
++    const auto nameSize = roundUp(strlen(ELF_NOTE_NIXOS) + 1, 4);
++    const auto descSize = roundUp(noteSize, 4);
++    const auto cacheSectionSize = sizeof(Elf_Nhdr) + nameSize + descSize;
++
++    // ordinarily we could place our new note at the end of the current address space and end
++    // of file simultaneously, but qemu-user has a bug in its elf loader that'll detect an
++    // incorrect load base address (and thus phdrs table position) if n.p_offset < n.p_vaddr for
++    // the new PT_LOAD segment n covering the note and n.p_vaddr - n.p_offset < p.p_vaddr for
++    // the PT_PHDR segment p. for dynamic libraries this does not matter (because qemu does not
++    // load those), but executables will have to ensure that they do not cause such a condition.
++    // TODO add an assert to ensure we have the space for the note
++    const Elf_Addr noteAddr = [&] {
++        Elf_Addr addr = 0;
++        for (const auto & phdr : phdrs) {
++            if (rdi(phdr.p_type) != PT_LOAD) continue;
++            addr = std::max<Elf_Addr>(addr, rdi(phdr.p_vaddr) + rdi(phdr.p_memsz));
++        }
++        addr = roundUp(addr, getPageSize());
++
++        if (rdi(hdr()->e_type) == ET_EXEC) {
++            // find the smallest PT_LOAD p_vaddr - p_offset. note that this is *before*
++            // rewriteSections() adds a new PT_LOAD header that covers address space before
++            // the lowest current vaddr, but since rewriteSections() always adds these at the
++            // beginning of the file that offset will be even smaller and we may add more padding
++            // than is absolutely necessary, but never less.
++            Elf_Addr diff = ~0;
++            for (const auto & phdr : phdrs) {
++                if (rdi(phdr.p_type) != PT_LOAD) continue;
++                diff = std::min<Elf_Addr>(diff, rdi(phdr.p_vaddr) - rdi(phdr.p_offset));
++            }
++            addr += roundUp(diff, getPageSize());
++        }
++
++        return addr;
++    }();
++
++    const auto noteOffset = roundUp(fileContents->size(), getPageSize());
++    const auto shdrsOffset = roundUp(noteOffset + cacheSectionSize, sizeof(Elf_Shdr));
++    fileContents->resize(shdrsOffset + (shdrs.size() + 1) * sizeof(Elf_Shdr));
++
++    // HACK alloc new section header table because rewriting can't deal yet
++    wri(hdr()->e_shoff, shdrsOffset);
++
++    auto noteContents = fileContents->data() + noteOffset;
++    Elf_Nhdr &nhdr = *(Elf_Nhdr *) noteContents;
++    wri(nhdr.n_namesz, strlen(ELF_NOTE_NIXOS) + 1);
++    wri(nhdr.n_descsz, noteSize);
++    wri(nhdr.n_type, NT_NIXOS_LD_CACHE);
++    noteContents += sizeof(Elf_Nhdr);
++    memcpy(noteContents, ELF_NOTE_NIXOS, strlen(ELF_NOTE_NIXOS) + 1);
++    noteContents += nameSize;
++    for (const auto & [dep, dir] : cache) {
++        memcpy(noteContents, dep.data(), dep.size());
++        noteContents += dep.size() + 1;
++        memcpy(noteContents, dir.data(), dir.size());
++        noteContents += dir.size() + 1;
++    }
++
++    {
++        auto & loadPhdr = phdrs.emplace_back();
++        wri(loadPhdr.p_type, PT_LOAD);
++        wri(loadPhdr.p_offset, noteOffset);
++        wri(loadPhdr.p_vaddr, wri(loadPhdr.p_paddr, noteAddr));
++        wri(loadPhdr.p_filesz, wri(loadPhdr.p_memsz, cacheSectionSize));
++        wri(loadPhdr.p_flags, PF_R);
++        wri(loadPhdr.p_align, getPageSize());
++        wri(hdr()->e_phnum, rdi(hdr()->e_phnum) + 1);
++
++        auto & notePhdr = phdrs.emplace_back();
++        wri(notePhdr.p_type, PT_NOTE);
++        wri(notePhdr.p_offset, noteOffset);
++        wri(notePhdr.p_vaddr, wri(notePhdr.p_paddr, noteAddr));
++        wri(notePhdr.p_filesz, wri(notePhdr.p_memsz, cacheSectionSize));
++        wri(notePhdr.p_flags, PF_R);
++        wri(notePhdr.p_align, 4);
++        wri(hdr()->e_phnum, rdi(hdr()->e_phnum) + 1);
++
++        // this addition will let us replaceSection(.shstrtab), and thus rewriteSections()!
++        auto & noteShdr = shdrs.emplace_back();
++        wri(noteShdr.sh_name, sectionNames.size());
++        wri(noteShdr.sh_type, SHT_NOTE);
++        wri(noteShdr.sh_flags, SHF_ALLOC);
++        wri(noteShdr.sh_addr, noteAddr);
++        wri(noteShdr.sh_offset, noteOffset);
++        wri(noteShdr.sh_size, cacheSectionSize);
++        wri(noteShdr.sh_addralign, 4);
++        wri(hdr()->e_shnum, rdi(hdr()->e_shnum) + 1);
++    }
++
++    {
++        // .shstrtab is no longer the last section, so we can use replaceSection for this
++        sectionNames += NOTE_NAME;
++        sectionNames += '\0';
++        replaceSection(".shstrtab", sectionNames.size()) = sectionNames;
++    }
++
++    rewriteSections();
++    changed = true;
++}
++
+ template<ElfFileParams>
+ void ElfFile<ElfFileParamNames>::printNeededLibs() // const
+ {
+@@ -1749,6 +1924,7 @@ static bool removeRPath = false;
+ static bool setRPath = false;
+ static bool addRPath = false;
+ static bool addDebugTag = false;
++static bool buildResolutionCache = false;
+ static bool printRPath = false;
+ static std::string newRPath;
+ static std::set<std::string> neededLibsToRemove;
+@@ -1785,6 +1961,9 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, con
+     else if (addRPath)
+         elfFile.modifyRPath(elfFile.rpAdd, {}, newRPath);
+ 
++    if (buildResolutionCache)
++        elfFile.buildResolutionCache();
++
+     if (printNeeded) elfFile.printNeededLibs();
+ 
+     elfFile.removeNeeded(neededLibsToRemove);
+@@ -1817,9 +1996,9 @@ static void patchElf()
+         const std::string & outputFileName2 = outputFileName.empty() ? fileName : outputFileName;
+ 
+         if (getElfType(fileContents).is32Bit)
+-            patchElf2(ElfFile<Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Addr, Elf32_Off, Elf32_Dyn, Elf32_Sym, Elf32_Verneed, Elf32_Versym>(fileContents), fileContents, outputFileName2);
++            patchElf2(ElfFile<Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Nhdr, Elf32_Addr, Elf32_Off, Elf32_Dyn, Elf32_Sym, Elf32_Verneed, Elf32_Versym>(fileContents), fileContents, outputFileName2);
+         else
+-            patchElf2(ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Addr, Elf64_Off, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, Elf64_Versym>(fileContents), fileContents, outputFileName2);
++            patchElf2(ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Nhdr, Elf64_Addr, Elf64_Off, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, Elf64_Versym>(fileContents), fileContents, outputFileName2);
+     }
+ }
+ 
+@@ -1856,6 +2035,7 @@ void showHelp(const std::string & progName)
+   [--no-sort]\t\tDo not sort program+section headers; useful for debugging patchelf.\n\
+   [--clear-symbol-version SYMBOL]\n\
+   [--add-debug-tag]\n\
++  [--build-resolution-cache]\n\
+   [--output FILE]\n\
+   [--debug]\n\
+   [--version]\n\
+@@ -1970,6 +2150,9 @@ int mainWrapped(int argc, char * * argv)
+         else if (arg == "--add-debug-tag") {
+             addDebugTag = true;
+         }
++        else if (arg == "--build-resolution-cache") {
++            buildResolutionCache = true;
++        }
+         else if (arg == "--help" || arg == "-h" ) {
+             showHelp(argv[0]);
+             return 0;
+diff --git a/src/patchelf.h b/src/patchelf.h
+index 33ecfc3..620297c 100644
+--- a/src/patchelf.h
++++ b/src/patchelf.h
+@@ -1,7 +1,7 @@
+ using FileContents = std::shared_ptr<std::vector<unsigned char>>;
+ 
+-#define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed, class Elf_Versym
+-#define ElfFileParamNames Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym, Elf_Verneed, Elf_Versym
++#define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Nhdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed, class Elf_Versym
++#define ElfFileParamNames Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Nhdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym, Elf_Verneed, Elf_Versym
+ 
+ template<ElfFileParams>
+ class ElfFile
+@@ -73,7 +73,7 @@ private:
+ 
+     friend struct CompShdr;
+ 
+-    unsigned int getPageSize() const;
++    Elf_Addr getPageSize() const;
+ 
+     void sortShdrs();
+ 
+@@ -127,6 +127,8 @@ public:
+ 
+     void replaceNeeded(const std::map<std::string, std::string> & libs);
+ 
++    void buildResolutionCache();
++
+     void printNeededLibs() /* should be const */;
+ 
+     void noDefaultLib();

--- a/pkgs/development/tools/misc/patchelf/ldcache.patch
+++ b/pkgs/development/tools/misc/patchelf/ldcache.patch
@@ -28,7 +28,7 @@ index 702f2e6..75c9020 100644
  
  /* ABI information.  The descriptor consists of words:
 diff --git a/src/patchelf.cc b/src/patchelf.cc
-index 49accae..eca68bb 100644
+index 49accae..8d7ff52 100644
 --- a/src/patchelf.cc
 +++ b/src/patchelf.cc
 @@ -20,6 +20,7 @@
@@ -91,7 +91,7 @@ index 49accae..eca68bb 100644
      if (!noSort) {
          sortPhdrs();
      }
-@@ -1619,6 +1640,160 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
+@@ -1619,6 +1640,166 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
      this->rewriteSections();
  }
  
@@ -122,15 +122,21 @@ index 49accae..eca68bb 100644
 +    // TODO remove old phdr
 +    // TODO nuke/rebuild rescache when changing rpath
 +    for (const auto &dir : runpath) {
-+        // ignore directories with glibc-hwcaps subdirs. they're rare enough to
++        // treat everything that could be a variable as a raw path element for simplicity.
++        // this is correct in the vast majority of cases, in the others it just optimizes
++        // less.
++        const auto hasVar = dir.find("$") != std::string::npos;
++
++        // bail on directories with glibc-hwcaps subdirs. they're rare enough to
 +        // not be worth handling, and fussy enough to stay away from for good measure.
-+        if (access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0)
-+            continue;
++        const auto hasHwcaps = access((dir + "/glibc-hwcaps").c_str(), F_OK) == 0;
++
 +        for (const auto &dep : needed) {
-+            if (cache.count(dep) > 0)
-+                continue;
-+            if (access((dir + "/" + dep).c_str(), R_OK) == 0) {
-+                cache.emplace(dep, dir + "/" + dep);
++            const auto dpath = dir + "/" + dep;
++            if (hasVar || hasHwcaps || access(dpath.c_str(), R_OK) == 0) {
++                auto& cpath = cache[dep];
++                if (!cpath.empty()) cpath += ':';
++                cpath += hasVar || hasHwcaps ? "?" + dir : "=" + dpath;
 +            }
 +        }
 +    }
@@ -252,7 +258,7 @@ index 49accae..eca68bb 100644
  template<ElfFileParams>
  void ElfFile<ElfFileParamNames>::printNeededLibs() // const
  {
-@@ -1749,6 +1924,7 @@ static bool removeRPath = false;
+@@ -1749,6 +1930,7 @@ static bool removeRPath = false;
  static bool setRPath = false;
  static bool addRPath = false;
  static bool addDebugTag = false;
@@ -260,7 +266,7 @@ index 49accae..eca68bb 100644
  static bool printRPath = false;
  static std::string newRPath;
  static std::set<std::string> neededLibsToRemove;
-@@ -1785,6 +1961,9 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, con
+@@ -1785,6 +1967,9 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, con
      else if (addRPath)
          elfFile.modifyRPath(elfFile.rpAdd, {}, newRPath);
  
@@ -270,7 +276,7 @@ index 49accae..eca68bb 100644
      if (printNeeded) elfFile.printNeededLibs();
  
      elfFile.removeNeeded(neededLibsToRemove);
-@@ -1817,9 +1996,9 @@ static void patchElf()
+@@ -1817,9 +2002,9 @@ static void patchElf()
          const std::string & outputFileName2 = outputFileName.empty() ? fileName : outputFileName;
  
          if (getElfType(fileContents).is32Bit)
@@ -282,7 +288,7 @@ index 49accae..eca68bb 100644
      }
  }
  
-@@ -1856,6 +2035,7 @@ void showHelp(const std::string & progName)
+@@ -1856,6 +2041,7 @@ void showHelp(const std::string & progName)
    [--no-sort]\t\tDo not sort program+section headers; useful for debugging patchelf.\n\
    [--clear-symbol-version SYMBOL]\n\
    [--add-debug-tag]\n\
@@ -290,7 +296,7 @@ index 49accae..eca68bb 100644
    [--output FILE]\n\
    [--debug]\n\
    [--version]\n\
-@@ -1970,6 +2150,9 @@ int mainWrapped(int argc, char * * argv)
+@@ -1970,6 +2156,9 @@ int mainWrapped(int argc, char * * argv)
          else if (arg == "--add-debug-tag") {
              addDebugTag = true;
          }
@@ -300,6 +306,15 @@ index 49accae..eca68bb 100644
          else if (arg == "--help" || arg == "-h" ) {
              showHelp(argv[0]);
              return 0;
+@@ -1984,6 +2173,8 @@ int mainWrapped(int argc, char * * argv)
+     }
+ 
+     if (fileNames.empty()) error("missing filename");
++    if (forceRPath && buildResolutionCache)
++        error("resolution cache not available for RPATH");
+ 
+     if (!outputFileName.empty() && fileNames.size() != 1)
+         error("--output option only allowed with single input file");
 diff --git a/src/patchelf.h b/src/patchelf.h
 index 33ecfc3..620297c 100644
 --- a/src/patchelf.h

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -71,6 +71,8 @@ let
       ../../build-support/setup-hooks/reproducible-builds.sh
       ../../build-support/setup-hooks/set-source-date-epoch-to-latest.sh
       ../../build-support/setup-hooks/strip.sh
+    ] ++ lib.optionals (hostPlatform.isLinux && hostPlatform.isGnu) [
+      ../../build-support/setup-hooks/generate-ld-cache.sh
     ] ++ lib.optionals hasCC [ cc ];
 
   defaultBuildInputs = extraBuildInputs;


### PR DESCRIPTION
###### Description of changes

this is an alternative to #207061. to reduce stat storms and general slowness during application startup we save a resolution cache into each dso that maps DT_NEEDED entries to their corresponding path in the configured runpath. this should Just Work™.

we think this has many benefits over that, shrinkwrap, and other solutions:
- unlike shrinkwrap, dependencies can still be replaced with `LD_LIBRARY_PATH`
- unlike the guix approach it's in theory possible for a soname to resolve to two different paths in the same process (if that's possible at all in glibc, haven't actually checked. should be possible with multiple namespaces though)
- no new files in outputs are needed that could conflict when merging
- works when cross-compiling without qemu-user involvement

we've tested this on a cross-compiled armv7 system (in qemu-user, got bored of the board taking so long to load) running `strace -cf /run/current-system/bin/switch-to-configuration test`. unpatched nixos takes 44s to do this, with these patches that drops to 29s owing to almost 24000 failing `openat` and `stat` calls that are avoided by using the cache.

this is still very rough, full of debug code, tests are missing, and the patchelf code should be upstreamed (but is included here for ease of testing).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
