### PR TITLE
python3Packages.datatable: 0.11.0 -> unstable-2022-12-15

### DIFF
--- a/pkgs/development/python-modules/datatable/default.nix
+++ b/pkgs/development/python-modules/datatable/default.nix
@@ -1,25 +1,29 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, pythonOlder
-, pipInstallHook, writeText
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pipInstallHook
+, writeText
 , blessed
 , docutils
 , libcxx
 , llvm
 , pytestCheckHook
 , typesentry
-, isPy310
 }:
 
 buildPythonPackage rec {
   pname = "datatable";
-  version = "0.11.0";
-  disabled = pythonOlder "3.5";
+  # python 3.10+ support is not in the 1.0.0 release
+  version = "unstable-2022-12-15";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "19c602711e00f72e9ae296d8fa742d46da037c2d3a2d254bdf68f817a8da76bb";
+  src = fetchFromGitHub {
+    owner = "h2oai";
+    repo = pname;
+    rev = "9522f0833d3e965656396de4fffebd882d39c25d";
+    hash = "sha256-lEXQwhx2msnJkkRrTkAwYttlYTISyH/Z7dSalqRrOhI=";
   };
-  # authors seem to have created their own build system
-  format = "other";
 
   postPatch = ''
     # tarball doesn't appear to have been shipped totally ready-to-build
@@ -27,16 +31,13 @@ buildPythonPackage rec {
       --replace \
         'shell_cmd(["git"' \
         '"0000000000000000000000000000000000000000" or shell_cmd(["git"'
-    echo '${version}' > VERSION.txt
+    # TODO revert back to use ${version} when bumping to the next stable release
+    echo '1.0' > VERSION.txt
 
     # don't make assumptions about architecture
     sed -i '/-m64/d' ci/ext.py
   '';
   DT_RELEASE = "1";
-
-  buildPhase = ''
-    python ci/ext.py wheel
-  '';
 
   propagatedBuildInputs = [ typesentry blessed ];
   buildInputs = [ llvm pipInstallHook ];
@@ -62,8 +63,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/h2oai/datatable";
     license = licenses.mpl20;
     maintainers = with maintainers; [ abbradar ];
-    # uses custom build system and adds -Wunused-variable -Werror
-    # warning: ‘dt::expr::doc_first’ defined but not used [-Wunused-variable]
-    broken = isPy310;
   };
 }


### PR DESCRIPTION
This fixes the packages for python 3.10+.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
