### PR TITLE
bsnes-hd: unbreak on x86_64-darwin

### DIFF
--- a/pkgs/applications/emulators/bsnes/bsnes-hd/default.nix
+++ b/pkgs/applications/emulators/bsnes/bsnes-hd/default.nix
@@ -6,9 +6,12 @@
 , SDL2
 , gtk3, gtksourceview3
 , alsa-lib, libao, openal, libpulseaudio
-, libicns, Cocoa, OpenAL
+, libicns, makeWrapper, darwin
 }:
 
+let
+  inherit (darwin.apple_sdk_11_0.frameworks) Cocoa OpenAL;
+in
 stdenv.mkDerivation {
   pname = "bsnes-hd";
   version = "10.6-beta";
@@ -35,8 +38,9 @@ stdenv.mkDerivation {
     ./macos-copy-app-to-prefix.patch
   ];
 
-  nativeBuildInputs = [ pkg-config wrapGAppsHook ]
-    ++ lib.optionals stdenv.isDarwin [ libicns ];
+  nativeBuildInputs = [ pkg-config ]
+    ++ lib.optionals stdenv.isLinux [ wrapGAppsHook ]
+    ++ lib.optionals stdenv.isDarwin [ libicns makeWrapper ];
 
   buildInputs = [ SDL2 libao ]
     ++ lib.optionals stdenv.isLinux [ libX11 libXv udev gtk3 gtksourceview3 alsa-lib openal libpulseaudio ]
@@ -44,10 +48,17 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  makeFlags = [ "-C" "bsnes" "hiro=gtk3" "prefix=$(out)" ];
+  makeFlags = [ "-C" "bsnes" "prefix=$(out)" ]
+    ++ lib.optionals stdenv.isLinux [ "hiro=gtk3" ]
+    ++ lib.optionals stdenv.isDarwin [ "hiro=cocoa" ];
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/bin
+    makeWrapper $out/{Applications/bsnes.app/Contents/MacOS,bin}/bsnes
+  '';
 
   # https://github.com/bsnes-emu/bsnes/issues/107
-  preFixup = ''
+  preFixup = lib.optionalString stdenv.isLinux ''
     gappsWrapperArgs+=(
       --prefix GDK_BACKEND : x11
     )
@@ -59,9 +70,6 @@ stdenv.mkDerivation {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ stevebob ];
     platforms = platforms.unix;
-    # ../nall/traits.hpp:19:14: error: no member named 'is_floating_point_v' in namespace 'std'; did you mean 'is_floating_point'?
-    #   using std::is_floating_point_v;
-    broken = (stdenv.isDarwin && stdenv.isx86_64);
     mainProgram = "bsnes";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2175,9 +2175,7 @@ with pkgs;
 
   ares = darwin.apple_sdk_11_0.callPackage ../applications/emulators/bsnes/ares { };
 
-  bsnes-hd = callPackage ../applications/emulators/bsnes/bsnes-hd {
-    inherit (darwin.apple_sdk.frameworks) Cocoa OpenAL;
-  };
+  bsnes-hd = darwin.apple_sdk_11_0.callPackage ../applications/emulators/bsnes/bsnes-hd { };
 
   higan = callPackage ../applications/emulators/bsnes/higan { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
