### PR TITLE
Various fixes related to OCaml 5

### DIFF
--- a/pkgs/development/ocaml-modules/base64/default.nix
+++ b/pkgs/development/ocaml-modules/base64/default.nix
@@ -1,17 +1,17 @@
-{ lib, fetchurl, buildDunePackage, ocaml, alcotest, bos, rresult }:
+{ lib, fetchurl, buildDunePackage, ocaml, findlib, alcotest, bos, rresult }:
 
 buildDunePackage rec {
   pname = "base64";
   version = "3.5.0";
 
-  minimumOCamlVersion = "4.03";
-
-  useDune2 = true;
+  minimalOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-base64/releases/download/v${version}/base64-v${version}.tbz";
     sha256 = "sha256-WJ3pwAV46/54QZismBjTWGxHSyMWts0+HEbMsfYq46Q=";
   };
+
+  propagatedBuildInputs = [ findlib ];
 
   # otherwise fmt breaks evaluation
   doCheck = lib.versionAtLeast ocaml.version "4.08";

--- a/pkgs/development/ocaml-modules/mrmime/default.nix
+++ b/pkgs/development/ocaml-modules/mrmime/default.nix
@@ -6,6 +6,7 @@
 , bigarray-overlap
 , bigstringaf
 , buildDunePackage
+, cmdliner
 , emile
 , fetchzip
 , fmt
@@ -16,6 +17,7 @@
 , ke
 , lib
 , mirage-crypto-rng
+, ocaml
 , pecu
 , prettym
 , ptime
@@ -34,7 +36,9 @@ buildDunePackage rec {
     sha256 = "14k67v0b39b8jq3ny2ymi8g8sqx2gd81mlzsjphdzdqnlx6fk716";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
+
+  buildInputs = [ cmdliner hxd ];
 
   propagatedBuildInputs = [
     angstrom
@@ -60,10 +64,9 @@ buildDunePackage rec {
 
   checkInputs = [
     alcotest
-    hxd
     jsonm
   ];
-  doCheck = true;
+  doCheck = lib.versionOlder ocaml.version "5.0";
 
   meta = {
     description = "Parser and generator of mail in OCaml";

--- a/pkgs/development/ocaml-modules/piaf/default.nix
+++ b/pkgs/development/ocaml-modules/piaf/default.nix
@@ -1,5 +1,6 @@
 { alcotest-lwt
 , buildDunePackage
+, ocaml
 , dune-site
 , fetchzip
 , gluten-lwt-unix
@@ -13,6 +14,9 @@
 , ssl
 , uri
 }:
+
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "piaf is not available for OCaml ${ocaml.version}"
 
 buildDunePackage rec {
   pname = "piaf";

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchurl
 , buildDunePackage
+, ocaml
 , cppo
 , ppxlib
 , ppx_derivers
@@ -51,7 +52,7 @@ buildDunePackage rec {
     result
   ];
 
-  doCheck = true;
+  doCheck = lib.versionOlder ocaml.version "5.0";
   checkInputs = [
     (if lib.versionAtLeast version "5.2" then ounit2 else ounit)
   ];


### PR DESCRIPTION
###### Description of changes

Fix build when possible; disable broken stuff otherwise.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
