### PR TITLE
clipboard-jh: init at 0.3.2

### DIFF
--- a/pkgs/tools/misc/clipboard-jh/default.nix
+++ b/pkgs/tools/misc/clipboard-jh/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, libffi
+, pkg-config
+, wayland-protocols
+, wayland
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clipboard-jh";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "Slackadays";
+    repo = "clipboard";
+    rev = version;
+    sha256 = "sha256-xdogl2WDuQXeLFuBY1u7PSpaoVI9HKScOdxHZ3+whIg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libffi
+    wayland-protocols
+    wayland
+    xorg.libX11
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE='MinSizeRel'"
+    "-Wno-dev"
+    "-DINSTALL_PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "Cut, copy, and paste anything, anywhere, all from the terminal";
+    homepage = "https://github.com/Slackadays/clipboard";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ dit7ya ];
+    mainProgram = "clipboard";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13237,6 +13237,8 @@ with pkgs;
 
   clipnotify = callPackage ../tools/misc/clipnotify { };
 
+  clipboard-jh = callPackage ../tools/misc/clipboard-jh { };
+
   clipbuzz = callPackage ../tools/misc/clipbuzz { };
 
   xclip = callPackage ../tools/misc/xclip { };


### PR DESCRIPTION
###### Description of changes

[Slackadays/Clipboard: 📋 Cut, copy, and paste anything, anywhere, all from the terminal.](https://github.com/Slackadays/Clipboard)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
