### PR TITLE
jumanpp: unbreak on aarch64-darwin

### DIFF
--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cmake, protobuf, libiconv }:
+{ lib, stdenv, fetchurl, fetchpatch, cmake, protobuf, libiconv }:
 
 stdenv.mkDerivation rec {
   pname = "jumanpp";
@@ -9,7 +9,25 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ASdr6qbkSe71M7QmuuwidCa4xQhDVoXBJ2XqvSY53pQ=";
   };
 
-  patches = [ ./0001-Exclude-all-tests-from-the-build.patch ];
+  patches = [
+    ./0001-Exclude-all-tests-from-the-build.patch
+    # https://github.com/ku-nlp/jumanpp/pull/132
+    (fetchpatch {
+      name = "fix-unused-warning.patch";
+      url = "https://github.com/ku-nlp/jumanpp/commit/cc0d555287c8b214e9d6f0279c449a4e035deee4.patch";
+      sha256 = "sha256-yRKwuUJ2UPXJcjxBGhSOmcQI/EOijiJDMmmmSRdNpX8=";
+    })
+    (fetchpatch {
+      name = "update-libs.patch";
+      url = "https://github.com/ku-nlp/jumanpp/commit/5e9068f56ae310ed7c1df185b14d49654ffe1ab6.patch";
+      sha256 = "sha256-X49/ZoLT0OGePLZYlgacNxA1dHM4WYdQ8I4LW3sW16E=";
+    })
+    (fetchpatch {
+      name = "fix-mmap-on-apple-m1.patch";
+      url = "https://github.com/ku-nlp/jumanpp/commit/0c22249f12928d0c962f03f229026661bf0c7921.patch";
+      sha256 = "sha256-g6CuruqyoMJxU/hlNoALx1QnFM8BlTsTd0pwlVrco3I=";
+    })
+  ];
   cmakeFlags = [ "-DJPP_ENABLE_TESTS=OFF" ];
 
   nativeBuildInputs = [ cmake ];
@@ -27,7 +45,5 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ mt-caret ];
     platforms = platforms.all;
-    # never built on aarch64-darwin since first introduction in nixpkgs
-    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
