### PR TITLE
libsForQt5.libopenshot-audio: unbreak on aarch64-darwin

### DIFF
--- a/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-XtwTZsj/L/sw/28E7Qr5UyghGlBFFXvbmZLGXBB8vg0=";
   };
 
+  # https://github.com/OpenShot/libopenshot-audio/issues/112
+  postPatch = ''
+    substituteInPlace JuceLibraryCode/modules/juce_core/native/juce_osx_ObjCHelpers.h \
+      --replace "#if ! JUCE_IOS" "#if ! JUCE_IOS && ! JUCE_ARM"
+  '';
+
   nativeBuildInputs = [
     cmake
     doxygen
@@ -63,7 +69,5 @@ stdenv.mkDerivation rec {
     license = with licenses; gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; unix;
-    # never built on aarch64-darwin since first introduction in nixpkgs
-    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , alsa-lib
 , cmake
 , doxygen
@@ -28,11 +29,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-XtwTZsj/L/sw/28E7Qr5UyghGlBFFXvbmZLGXBB8vg0=";
   };
 
-  # https://github.com/OpenShot/libopenshot-audio/issues/112
-  postPatch = ''
-    substituteInPlace JuceLibraryCode/modules/juce_core/native/juce_osx_ObjCHelpers.h \
-      --replace "#if ! JUCE_IOS" "#if ! JUCE_IOS && ! JUCE_ARM"
-  '';
+  patches = [
+    # https://forum.juce.com/t/juce-and-macos-11-arm/40285/24
+    ./undef-fpret-on-aarch64-darwin.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -35,8 +35,9 @@ stdenv.mkDerivation rec {
     export _REL_PYTHON_MODULE_PATH=$(toPythonPath $out)
   '';
 
-  nativeBuildInputs = [
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
     alsa-lib
+  ] ++ [
     cmake
     doxygen
     pkg-config

--- a/pkgs/applications/video/openshot-qt/undef-fpret-on-aarch64-darwin.patch
+++ b/pkgs/applications/video/openshot-qt/undef-fpret-on-aarch64-darwin.patch
@@ -1,0 +1,13 @@
+diff --git a/JuceLibraryCode/modules/juce_core/native/juce_osx_ObjCHelpers.h b/JuceLibraryCode/modules/juce_core/native/juce_osx_ObjCHelpers.h
+index 2593790..0b5983d 100644
+--- a/JuceLibraryCode/modules/juce_core/native/juce_osx_ObjCHelpers.h
++++ b/JuceLibraryCode/modules/juce_core/native/juce_osx_ObjCHelpers.h
+@@ -209,7 +209,7 @@ static inline ReturnValue ObjCMsgSendSuper (struct objc_super* s, SEL sel, Param
+ typedef id (*MsgSendSuperFn) (struct objc_super*, SEL, ...);
+ static inline MsgSendSuperFn getMsgSendSuperFn() noexcept   { return (MsgSendSuperFn) (void*) objc_msgSendSuper; }
+ 
+-#if ! JUCE_IOS
++#if JUCE_INTEL && ! JUCE_IOS
+ typedef double (*MsgSendFPRetFn) (id, SEL op, ...);
+ static inline MsgSendFPRetFn getMsgSendFPRetFn() noexcept   { return (MsgSendFPRetFn) (void*) objc_msgSend_fpret; }
+ #endif


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
