### PR TITLE
boot.loader.raspberryPi.uboot: add Raspberry Pi 4 support

### DIFF
--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -117,8 +117,6 @@ in
 
           It is possible it already did not work like you expected.
 
-          It never worked on the Raspberry Pi 4 family.
-
           These options will be removed by NixOS 24.11.
         ''
       ];
@@ -130,8 +128,6 @@ in
           for years, and is now formally deprecated.
 
           It is possible it already did not work like you expected.
-
-          It never worked on the Raspberry Pi 4 family.
 
           These options will be removed by NixOS 24.11.
         ''

--- a/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.nix
@@ -15,8 +15,13 @@ let
         pkgs.ubootRaspberryPi3_64bit
       else
         pkgs.ubootRaspberryPi3_32bit
+    else if version == 4 then
+      if isAarch64 then
+        pkgs.ubootRaspberryPi4_64bit
+      else
+        pkgs.ubootRaspberryPi4_32bit
     else
-      throw "U-Boot is not yet supported on the raspberry pi 4.";
+      throw "Unsupported Raspberry Pi version: ${version}";
 
   extlinuxConfBuilder =
     import ../generic-extlinux-compatible/extlinux-conf-builder.nix {

--- a/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.sh
+++ b/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.sh
@@ -21,15 +21,24 @@ copyForced() {
 
 # Add the firmware files
 fwdir=@firmware@/share/raspberrypi/boot/
-copyForced $fwdir/bootcode.bin  $target/bootcode.bin
-copyForced $fwdir/fixup.dat     $target/fixup.dat
-copyForced $fwdir/fixup_cd.dat  $target/fixup_cd.dat
-copyForced $fwdir/fixup_db.dat  $target/fixup_db.dat
-copyForced $fwdir/fixup_x.dat   $target/fixup_x.dat
-copyForced $fwdir/start.elf     $target/start.elf
-copyForced $fwdir/start_cd.elf  $target/start_cd.elf
-copyForced $fwdir/start_db.elf  $target/start_db.elf
-copyForced $fwdir/start_x.elf   $target/start_x.elf
+copyForced $fwdir/bcm2711-rpi-4-b.dtb  $target/bcm2711-rpi-4-b.dtb
+copyForced $fwdir/bootcode.bin         $target/bootcode.bin
+copyForced $fwdir/fixup.dat            $target/fixup.dat
+copyForced $fwdir/fixup4.dat           $target/fixup4.dat
+copyForced $fwdir/fixup4cd.dat         $target/fixup4cd.dat
+copyForced $fwdir/fixup4db.dat         $target/fixup4db.dat
+copyForced $fwdir/fixup4x.dat          $target/fixup4x.dat
+copyForced $fwdir/fixup_cd.dat         $target/fixup_cd.dat
+copyForced $fwdir/fixup_db.dat         $target/fixup_db.dat
+copyForced $fwdir/fixup_x.dat          $target/fixup_x.dat
+copyForced $fwdir/start.elf            $target/start.elf
+copyForced $fwdir/start4.elf           $target/start4.elf
+copyForced $fwdir/start4cd.elf         $target/start4cd.elf
+copyForced $fwdir/start4db.elf         $target/start4db.elf
+copyForced $fwdir/start4x.elf          $target/start4x.elf
+copyForced $fwdir/start_cd.elf         $target/start_cd.elf
+copyForced $fwdir/start_db.elf         $target/start_db.elf
+copyForced $fwdir/start_x.elf          $target/start_x.elf
 
 # Add the uboot file
 copyForced @uboot@/u-boot.bin $target/u-boot-rpi.bin


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds uboot support for the Raspberry Pi 4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
