### PR TITLE
vitables: init at 3.0.2

### DIFF
--- a/pkgs/tools/misc/vitables/default.nix
+++ b/pkgs/tools/misc/vitables/default.nix
@@ -1,0 +1,47 @@
+{ lib, pkgs, fetchFromGitHub, buildPythonPackage, python3Packages, hatchling, qt6, ... }:
+
+buildPythonPackage rec {
+  pname = "vitables";
+  version = "3.0.3";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    inherit version;
+    owner = "uvemas";
+    repo = "ViTables";
+    rev = "8ab92d1142579ea8df72737beb6696733cf8b510";
+    sha256 = "sha256-tnf0qjjxyyVywPs6XicIS2VneYRiZ4f5WK0fUz42zAQ=";
+  };
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    qt6.qtbase
+  ] ++ (with python3Packages; [
+    numexpr
+    numpy
+    pyqt6
+    qtpy
+    tables
+  ]);
+
+  # Tests segfault and largely depend on GUIs
+  doCheck = false;
+
+  preFixup = ''
+    wrapQtApp "$out/bin/vitables"
+  '';
+
+  meta = {
+    description = ''
+      A graphical tool for browsing and editing files in both PyTables and HDF5
+      format
+    '';
+    homepage = "https://vitables.org";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ williamvds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14287,6 +14287,8 @@ with pkgs;
 
   vit = callPackage ../applications/misc/vit { };
 
+  vitables = python3Packages.callPackage ../tools/misc/vitables { };
+
   viu = callPackage ../tools/graphics/viu { };
 
   vix = callPackage ../tools/misc/vix { };


### PR DESCRIPTION
https://github.com/uvemas/ViTables/releases/tag/v3.0.2

###### Description of changes

Added the ViTables tool, which is a visualiser and editor for HDF5 files.

Most tests are disabled because they run GUIs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
