### PR TITLE
python3Packages.pytest-tap: init at 3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3019,6 +3019,15 @@
     githubId = 16950437;
     name = "cwyc";
   };
+  cynerd = {
+    name = "Karel Kočí";
+    email = "cynerd@email.cz";
+    github = "Cynerd";
+    githubId = 3811900;
+    keys = [{
+      fingerprint = "2B1F 70F9 5F1B 48DA 2265 A7FA A6BC 8B8C EB31 659B";
+    }];
+  };
   cyounkins = {
     name = "Craig Younkins";
     email = "cyounkins@gmail.com";

--- a/pkgs/development/python-modules/pytest-tap/default.nix
+++ b/pkgs/development/python-modules/pytest-tap/default.nix
@@ -10,6 +10,8 @@
 buildPythonPackage rec {
   pname = "pytest-tap";
   version = "3.3";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
@@ -19,13 +21,25 @@ buildPythonPackage rec {
     sha256 = "R0RSdKTyJYGq+x0+ut4pJEywTGNgGp/ps36ZaH5dyY4=";
   };
 
-  buildInputs = [ pytest ];
-  propagatedBuildInputs = [ tappy ];
+  buildInputs = [
+    pytest
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  propagatedBuildInputs = [
+    tappy
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   disabledTests = [
     # Fixed in 4ed0138bf659c348b6dfb8bb701ae1989625d3d8 and hopefully in next release
     "test_unittest_expected_failure"
+  ];
+
+  pythonImportsCheck = 
+    "pytest_tap"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pytest-tap/default.nix
+++ b/pkgs/development/python-modules/pytest-tap/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     "test_unittest_expected_failure"
   ];
 
-  pythonImportsCheck = 
+  pythonImportsCheck = [
     "pytest_tap"
   ];
 

--- a/pkgs/development/python-modules/pytest-tap/default.nix
+++ b/pkgs/development/python-modules/pytest-tap/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytest
+, tappy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-tap";
+  version = "3.3";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "python-tap";
+    repo = "pytest-tap";
+    rev = "v${version}";
+    sha256 = "R0RSdKTyJYGq+x0+ut4pJEywTGNgGp/ps36ZaH5dyY4=";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ tappy ];
+
+  checkInputs = [ pytestCheckHook ];
+  disabledTests = [
+    # Fixed in 4ed0138bf659c348b6dfb8bb701ae1989625d3d8 and hopefully in next release
+    "test_unittest_expected_failure"
+  ];
+
+  meta = with lib; {
+    description = "Test Anything Protocol (TAP) reporting plugin for pytest";
+    homepage = "https://github.com/python-tap/pytest-tap";
+    changelog = "https://github.com/python-tap/pytest-tap/blob/v${version}/docs/releases.rst";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ cynerd ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8982,6 +8982,8 @@ self: super: with self; {
 
   pytest-sugar = callPackage ../development/python-modules/pytest-sugar { };
 
+  pytest-tap = callPackage ../development/python-modules/pytest-tap { };
+
   pytest-test-utils = callPackage ../development/python-modules/pytest-test-utils { };
 
   pytest-testmon = callPackage ../development/python-modules/pytest-testmon { };


### PR DESCRIPTION
###### Description of changes

https://pypi.org/project/pytest-tap

The handy extension if pytest driven tests are included alongside other test frameworks and TAP is used as a standard output for all of them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
