### PR TITLE
repro-get: init at 0.2.1

### DIFF
--- a/pkgs/tools/package-management/repro-get/default.nix
+++ b/pkgs/tools/package-management/repro-get/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, testers
+, repro-get
+, cacert
+}:
+
+buildGoModule rec {
+  pname = "repro-get";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "reproducible-containers";
+    repo = "repro-get";
+    rev = "v${version}";
+    sha256 = "sha256-3cvKHwAyPYwR5VlhpPJH+3BK9Kw7dTGOPN1q2RnwsG0=";
+  };
+
+  vendorSha256 = "sha256-ebvtPc0QiP7fNiWYjd7iLG/4iH4DqWV/eaDHvmV/H3Y=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # The pkg/version test requires internet access, so disable it here and run it
+  # in passthru.pkg-version
+  preCheck = ''
+    rm -rf pkg/version
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/reproducible-containers/${pname}/pkg/version.Version=v${version}"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd repro-get \
+      --bash <($out/bin/repro-get completion bash) \
+      --fish <($out/bin/repro-get completion fish) \
+      --zsh <($out/bin/repro-get completion zsh)
+  '';
+
+  passthru.tests = {
+    "pkg-version" = repro-get.overrideAttrs (old: {
+      # see invalidateFetcherByDrvHash
+      name = "${repro-get.pname}-${builtins.unsafeDiscardStringContext (lib.substring 0 12 (baseNameOf repro-get.drvPath))}";
+      subPackages = [ "pkg/version" ];
+      installPhase = ''
+        rm -rf $out
+        touch $out
+      '';
+      preCheck = "";
+      outputHash = "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
+      outputHashAlgo = "sha256";
+      outputHashMode = "flat";
+      outputs = [ "out" ];
+      nativeBuildInputs = old.nativeBuildInputs ++ [ cacert ];
+    });
+    version = testers.testVersion {
+      package = repro-get;
+      command = "HOME=$(mktemp -d) repro-get -v";
+      inherit version;
+    };
+  };
+
+  meta = with lib; {
+    description = "Reproducible apt/dnf/apk/pacman, with content-addressing";
+    homepage = "https://github.com/reproducible-containers/repro-get";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24724,6 +24724,8 @@ with pkgs;
 
   reproxy = callPackage ../servers/reproxy { };
 
+  repro-get = callPackage ../tools/package-management/repro-get { };
+
   restic = callPackage ../tools/backup/restic { };
 
   restic-rest-server = callPackage ../tools/backup/restic/rest-server.nix { };


### PR DESCRIPTION
###### Description of changes

Adds `repro-get` as a package, a tool that could unlock a wider ecosystem of packages and could be useful as a fixed-output-derivation fetcher. This helps https://github.com/NixOS/nixpkgs/issues/207981

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
