### PR TITLE
gnirehtet: patch for recent rust versions

### DIFF
--- a/pkgs/tools/networking/gnirehtet/default.nix
+++ b/pkgs/tools/networking/gnirehtet/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, fetchzip, androidenv, makeWrapper }:
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, fetchpatch
+, fetchzip
+, androidenv
+, makeWrapper
+}:
 let
 version = "2.5";
 apk = stdenv.mkDerivation {
@@ -6,7 +14,7 @@ apk = stdenv.mkDerivation {
   inherit version;
   src = fetchzip {
     url = "https://github.com/Genymobile/gnirehtet/releases/download/v${version}/gnirehtet-rust-linux64-v${version}.zip";
-    sha256 = "1db0gkg5z8lighhkyqfsr9jiacrck89zmfnmp74vj865hhxgjzgq";
+    hash = "sha256-+H35OoTFILnJudW6+hOaLDMVZcraYT8hfJGiX958YLU=";
   };
   installPhase = ''
     mkdir $out
@@ -19,13 +27,38 @@ rustPlatform.buildRustPackage {
   inherit version;
 
   src = fetchFromGitHub {
-      owner = "Genymobile";
-      repo = "gnirehtet";
-      rev = "v${version}";
-      sha256 = "0wk6n082gnj9xk46n542h1012h8gyhldca23bs7vl73g0534g878";
+    owner = "Genymobile";
+    repo = "gnirehtet";
+    rev = "v${version}";
+    hash = "sha256-6KBHRgFvHLqPXkMo1ij0D0ERQICCFGvI7EnaJxCwZnI=";
   };
+
   sourceRoot = "source/relay-rust";
-  cargoSha256 = "03r8ivsvmhi5f32gj4yacbyzanziymszya18dani53bq9zis9z31";
+
+  cargoPatches = [
+    (fetchpatch {
+      name = "fix-trailing-semicolon-in-macro.patch";
+      url = "https://github.com/Genymobile/gnirehtet/commit/537b3d87344a456e1310f10dcef37592063f4e54.patch";
+      hash = "sha256-6U4ZEcqyXcXrfLRtynepS7gp+Uh5sujRyHVLXbWvpq8=";
+      stripLen = 1;
+    })
+    # Updates Cargo.lock and is needed to apply the subsequent patch
+    (fetchpatch {
+      name = "prefix-unused-field-with-underscore.patch";
+      url = "https://github.com/Genymobile/gnirehtet/commit/2f695503dd80519ce73a80c5aa360b08a97c029d.patch";
+      hash = "sha256-YVd1B2PVLRGpJNkKb7gpUQWmccfvYaeAmayOmWg8D+Y=";
+      stripLen = 1;
+    })
+    # https://github.com/Genymobile/gnirehtet/pull/478
+    (fetchpatch {
+      name = "fix-for-rust-1.64.patch";
+      url = "https://github.com/Genymobile/gnirehtet/commit/8eeed2084d0d1e2f83056bd11622beaa1fa61281.patch";
+      hash = "sha256-Wwc+4vG48/qpusGjlE+mSJvvarYq2mQ2CkDkrtKHAwo=";
+      stripLen = 1;
+    })
+  ];
+
+  cargoHash = "sha256-3iYOeHIQHwxmh8b8vKUf5fQS2fXP2g3orLquvLXzZwE=";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
###### Description of changes

Pull in a few patches (including https://github.com/Genymobile/gnirehtet/pull/478) that resolve https://github.com/Genymobile/gnirehtet/issues/475.

I cannot test this myself, but perhaps this will fix https://github.com/NixOS/nixpkgs/issues/207750.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
