### PR TITLE
jquake: 1.8.1 -> 1.8.4

### DIFF
--- a/pkgs/applications/misc/jquake/default.nix
+++ b/pkgs/applications/misc/jquake/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "jquake";
-  version = "1.8.1";
+  version = "1.8.4";
 
   src = fetchurl {
-    url = "https://fleneindre.github.io/downloads/JQuake_${version}_linux.zip";
-    sha256 = "sha256-fIxCcqpv0KAXUBbyinTXr/fkAcufVtpr9FUTJkXSgTs=";
+    url = "https://github.com/fleneindre/fleneindre.github.io/raw/master/downloads/JQuake_${version}_linux.zip";
+    sha256 = "sha256-oIYkYmI8uG4zjnm1Jq1mzIcSwRlKbWJqvACygQyp9sA=";
   };
 
   nativeBuildInputs = [ unzip copyDesktopItems ];
@@ -58,8 +58,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Real-time earthquake map of Japan";
     homepage = "https://jquake.net";
-    downloadPage = "https://jquake.net/?down";
-    changelog = "https://jquake.net/?docu";
+    downloadPage = "https://jquake.net/en/terms.html?os=linux&arch=any";
+    changelog = "https://jquake.net/en/changelog.html";
     maintainers = with maintainers; [ nessdoor ];
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;


### PR DESCRIPTION
###### Description of changes
Updated base package and links to download page and changelog.
Backport requested because download URL has changed, breaking builds for the new 22.11 release.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).