### PR TITLE
openimageio2: 2.2.17.0 -> 2.4.6.1

### DIFF
--- a/pkgs/applications/graphics/openimageio/2.x.nix
+++ b/pkgs/applications/graphics/openimageio/2.x.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , boost
 , cmake
 , giflib
@@ -7,7 +8,7 @@
 , libjpeg
 , libpng
 , libtiff
-, opencolorio_1
+, opencolorio
 , openexr
 , robin-map
 , unzip
@@ -16,14 +17,22 @@
 
 stdenv.mkDerivation rec {
   pname = "openimageio";
-  version = "2.2.17.0";
+  version = "2.4.6.1";
 
   src = fetchFromGitHub {
     owner = "OpenImageIO";
     repo = "oiio";
-    rev = "Release-${version}";
-    sha256 = "0jqpb1zci911wdm928addsljxx8zsh0gzbhv9vbw6man4wi93h6h";
+    rev = "v${version}";
+    sha256 = "sha256-oBICukkborxXFHXyM2rIn5qSbCWECjwDQI9MUg13IRU=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "arm-fix-signed-unsigned-simd-mismatch.patch";
+      url = "https://github.com/OpenImageIO/oiio/commit/726c51181a2888b0bd1edbef5ac8451e9cc3f893.patch";
+      hash = "sha256-G4vexf0OHZ/sbcRob5X92tajkmAv72ok8rcVQtIE9XE=";
+    })
+  ];
 
   outputs = [ "bin" "out" "dev" "doc" ];
 
@@ -39,7 +48,7 @@ stdenv.mkDerivation rec {
     libjpeg
     libpng
     libtiff
-    opencolorio_1
+    opencolorio
     openexr
     robin-map
     fmt
@@ -58,7 +67,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://www.openimageio.org";
+    homepage = "https://openimageio.org";
     description = "A library and tools for reading and writing images";
     license = licenses.bsd3;
     maintainers = with maintainers; [ goibhniu ];

--- a/pkgs/development/libraries/minizip-ng/default.nix
+++ b/pkgs/development/libraries/minizip-ng/default.nix
@@ -51,13 +51,13 @@ stdenv.mkDerivation (finalAttrs: {
     "-DMZ_LIBCOMP=OFF"
   ];
 
-  postInstall = let
-    libext = if stdenv.hostPlatform.isStatic then ".a" else ".so";
-  in ''
+  postInstall = ''
     # make lib findable as libminizip-ng even if compat is enabled
-    if [ ! -e $out/lib/libminizip-ng${libext} ]; then
-      ln -s $out/lib/libminizip${libext} $out/lib/libminizip-ng${libext}
-    fi
+    for ext in so dylib a ; do
+      if [ -e $out/lib/libminizip.$ext ] && [ ! -e $out/lib/libminizip-ng.$ext ]; then
+        ln -s $out/lib/libminizip.$ext $out/lib/libminizip-ng.$ext
+      fi
+    done
     if [ ! -e $out/include/minizip-ng ]; then
       ln -s $out/include $out/include/minizip-ng
     fi

--- a/pkgs/development/libraries/opencolorio/default.nix
+++ b/pkgs/development/libraries/opencolorio/default.nix
@@ -8,6 +8,7 @@
 , ilmbase
 , pystring
 , imath
+, minizip-ng
 # Only required on Linux
 , glew
 , freeglut
@@ -21,19 +22,18 @@
 # Build apps
 , buildApps ? true # Utility applications
 , lcms2
-, openimageio2
-, openexr
+, openexr_3
 }:
 
 stdenv.mkDerivation rec {
   pname = "opencolorio";
-  version = "2.1.2";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "AcademySoftwareFoundation";
     repo = "OpenColorIO";
     rev = "v${version}";
-    sha256 = "sha256-e1PpWjjfSjtgN9Rs/+lsA45Z9S4y4T6nqrJ02DZ4vjs=";
+    sha256 = "sha256-l5UUysHdP/gb4Mn5A64XEoHOkthl6Mlb95CuI0l4vXQ=";
   };
 
   patches = [
@@ -43,7 +43,20 @@ stdenv.mkDerivation rec {
       revert = true;
       sha256 = "sha256-0DF+lwi2nfkUFG0wYvL3HYbhZS6SqGtPWoOabrFS1Eo=";
     })
+    (fetchpatch {
+      name = "pkg-config-absolute-path.patch";
+      url = "https://github.com/AcademySoftwareFoundation/OpenColorIO/commit/332462e7f5051b7e26ee3d8c22890cd5e71e7c30.patch";
+      sha256 = "sha256-7xHALhnOkKszgFBgPIbiZQaORnEJ+1M6RyoZdFgjElM=";
+    })
   ];
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    # these tests don't like being run headless on darwin. no builtin
+    # way of skipping tests so this is what we're reduced to.
+    substituteInPlace tests/cpu/Config_tests.cpp \
+      --replace 'OCIO_ADD_TEST(Config, virtual_display)' 'static void _skip_virtual_display()' \
+      --replace 'OCIO_ADD_TEST(Config, virtual_display_with_active_displays)' 'static void _skip_virtual_display_with_active_displays()'
+  '';
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
@@ -52,25 +65,24 @@ stdenv.mkDerivation rec {
     ilmbase
     pystring
     imath
+    minizip-ng
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [ glew freeglut ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ Carbon GLUT Cocoa ]
     ++ lib.optionals pythonBindings [ python3Packages.python python3Packages.pybind11 ]
-    ++ lib.optionals buildApps [ lcms2 openimageio2 openexr ];
+    ++ lib.optionals buildApps [
+      lcms2
+      openexr_3
+    ];
 
-    cmakeFlags = [
-      "-DOCIO_INSTALL_EXT_PACKAGES=NONE"
-    ] ++ lib.optional (!pythonBindings) "-DOCIO_BUILD_PYTHON=OFF"
-      ++ lib.optional (!buildApps) "-DOCIO_BUILD_APPS=OFF";
+  cmakeFlags = [
+    "-DOCIO_INSTALL_EXT_PACKAGES=NONE"
+    # GPU test fails with: freeglut (GPU tests): failed to open display ''
+    "-DOCIO_BUILD_GPU_TESTS=OFF"
+  ] ++ lib.optional (!pythonBindings) "-DOCIO_BUILD_PYTHON=OFF"
+    ++ lib.optional (!buildApps) "-DOCIO_BUILD_APPS=OFF";
 
-  # TODO Investigate this: Python and GPU tests fail to load libOpenColorIO.so.2.0
-  # doCheck = true;
-
-  # https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1649
-  postPatch = ''
-    substituteInPlace src/OpenColorIO/CMakeLists.txt \
-      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR} \
-      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR}
-  '';
+  # precision issues on non-x86
+  doCheck = stdenv.isx86_64;
 
   meta = with lib; {
     homepage = "https://opencolorio.org";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31361,7 +31361,7 @@ with pkgs;
     boost = boost175;
   };
 
-  openimageio2 = callPackage ../applications/graphics/openimageio/2.x.nix { };
+  openimageio2 = darwin.apple_sdk_11_0.callPackage ../applications/graphics/openimageio/2.x.nix { };
 
   openjump = callPackage ../applications/misc/openjump { };
 


### PR DESCRIPTION
###### Description of changes

This was surprisingly painful.

https://nvd.nist.gov/vuln/detail/CVE-2022-36354
https://nvd.nist.gov/vuln/detail/CVE-2022-38143
https://nvd.nist.gov/vuln/detail/CVE-2022-41639
https://nvd.nist.gov/vuln/detail/CVE-2022-41649
https://nvd.nist.gov/vuln/detail/CVE-2022-41684
https://nvd.nist.gov/vuln/detail/CVE-2022-41794
https://nvd.nist.gov/vuln/detail/CVE-2022-41837
https://nvd.nist.gov/vuln/detail/CVE-2022-41838
https://nvd.nist.gov/vuln/detail/CVE-2022-41977
https://nvd.nist.gov/vuln/detail/CVE-2022-41981
https://nvd.nist.gov/vuln/detail/CVE-2022-41988
https://nvd.nist.gov/vuln/detail/CVE-2022-41999
https://nvd.nist.gov/vuln/detail/CVE-2022-43592
https://nvd.nist.gov/vuln/detail/CVE-2022-43593
https://nvd.nist.gov/vuln/detail/CVE-2022-43594
https://nvd.nist.gov/vuln/detail/CVE-2022-43595
https://nvd.nist.gov/vuln/detail/CVE-2022-43596
https://nvd.nist.gov/vuln/detail/CVE-2022-43597
https://nvd.nist.gov/vuln/detail/CVE-2022-43598
https://nvd.nist.gov/vuln/detail/CVE-2022-43599
https://nvd.nist.gov/vuln/detail/CVE-2022-43600
https://nvd.nist.gov/vuln/detail/CVE-2022-43601
https://nvd.nist.gov/vuln/detail/CVE-2022-43602
https://nvd.nist.gov/vuln/detail/CVE-2022-43603

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
