### PR TITLE
tuifimanager: init at 2.3.4

### DIFF
--- a/pkgs/applications/file-managers/tuifimanager/default.nix
+++ b/pkgs/applications/file-managers/tuifimanager/default.nix
@@ -1,0 +1,38 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "tuifimanager";
+  version = "2.3.4";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "GiorgosXou";
+    rev = "v.${version}";
+    hash = "sha256-KJYPpeBALyg6Gd1GQgJbvGdJbAT47qO9FnSH7GhO4oQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "Send2Trash == 1.8.0" "Send2Trash >= 1.8.0"
+  '';
+
+  propagatedBuildInputs = with python3Packages; [ unicurses send2trash ];
+  pythonImportsCheck = [ "TUIFIManager" ];
+
+  # Tests currently cause build to fail
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A cross-platform terminal-based termux-oriented file manager";
+    longDescription = ''
+      A cross-platform terminal-based termux-oriented file manager (and component),
+      meant to be used with a Uni-Curses project or as is. This project is mainly an
+      attempt to get more attention to the Uni-Curses project.
+    '';
+    homepage = "https://github.com/GiorgosXou/TUIFIManager";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ michaelBelsanti ];
+    mainProgram = "tuifi";
+  };
+}

--- a/pkgs/development/python-modules/unicurses/default.nix
+++ b/pkgs/development/python-modules/unicurses/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, ncurses, x256 }:
+
+buildPythonPackage rec {
+  pname = "unicurses";
+  version = "2.1.3";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "Uni-Curses";
+    hash = "sha256-uzSiF0jAZzI0iZngM/GuJ60o+UbLQ5XQzycTPito34w=";
+  };
+
+  propagatedBuildInputs = [ x256 ];
+
+  # Necessary because ctypes.util.find_library does not find the ncurses libraries
+  postPatch = ''
+    substituteInPlace './unicurses/__init__.py' \
+      --replace "find_library('ncursesw')" '"${ncurses}/lib/libncursesw.so.6"' \
+      --replace "find_library('panelw')" '"${ncurses}/lib/libpanelw.so.6"'
+  '';
+
+  pythonImportsCheck = [ "unicurses" ];
+
+  meta = with lib; {
+    description = "Unified Curses Wrapper for Python";
+    homepage = "https://github.com/unicurses/unicurses";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ michaelBelsanti ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2268,6 +2268,8 @@ with pkgs;
 
   spaceFM = callPackage ../applications/file-managers/spacefm { };
 
+  tuifimanager = callPackage ../applications/file-managers/tuifimanager { };
+
   vifm = callPackage ../applications/file-managers/vifm { };
 
   vifm-full = vifm.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11585,6 +11585,8 @@ self: super: with self; {
     unicorn-emu = pkgs.unicorn;
   };
 
+  unicurses = callPackage ../development/python-modules/unicurses { };
+
   unicrypto = callPackage ../development/python-modules/unicrypto { };
 
   unidecode = callPackage ../development/python-modules/unidecode { };


### PR DESCRIPTION
###### Description of changes
Packaged TUIFIManager and Unicurses
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
