### PR TITLE
neovimUtils.makeNeovimConfig: add pathDependencies

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -51,6 +51,10 @@ let
 
   nvimAutoDisableWrap = makeNeovimConfig { };
 
+  neovimWithCyan = neovim.override {
+    configure.packages.all.start = [ vimPlugins.nvim-teal-maker ];
+  };
+
   wrapNeovim2 = suffix: config:
     wrapNeovimUnstable neovim-unwrapped (config // {
       extraName = suffix;
@@ -259,5 +263,10 @@ pkgs.recurseIntoAttrs rec {
   run_nvim_with_opt_plugin = runTest nvim_with_opt_plugin ''
     export HOME=$TMPDIR
     ${nvim_with_opt_plugin}/bin/nvim -i NONE +quit! -e
+  '';
+
+  pathDeps = runTest neovimWithCyan ''
+    export HOME=$(mktemp -d)
+    ${neovimWithCyan}/bin/nvim --headless -ei NONE '+!cyan version' +quit!
   '';
 }

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -69,6 +69,8 @@ let
         opt = map (x: x.plugin) pluginsPartitioned.right;
       };
 
+      pathDependencies = lib.concatMap (plugin: plugin.pathDependencies or [ ]) requiredPlugins;
+
       pluginPython3Packages = getDeps "python3Dependencies" requiredPlugins;
       python3Env = python3Packages.python.withPackages (ps:
         [ ps.pynvim ]
@@ -95,7 +97,9 @@ let
       # avoid double wrapping, see comment near finalMakeWrapperArgs
       makeWrapperArgs =
         let
-          binPath = lib.makeBinPath (lib.optionals withRuby [ rubyEnv ] ++ lib.optionals withNodeJs [ nodejs ]);
+          binPath = lib.makeBinPath (pathDependencies
+            ++ lib.optionals withRuby [ rubyEnv ]
+            ++ lib.optionals withNodeJs [ nodejs ]);
 
           hostProviderViml = lib.mapAttrsToList genProviderSettings hostprog_check_table;
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -674,10 +674,7 @@ self: super: {
   });
 
   nvim-teal-maker = super.nvim-teal-maker.overrideAttrs (old: {
-    postPatch = ''
-      substituteInPlace lua/tealmaker/init.lua \
-        --replace cyan ${luaPackages.cyan}/bin/cyan
-    '';
+    passthru.pathDependencies = [ luaPackages.cyan ];
     vimCommandCheck = "TealBuild";
   });
 


### PR DESCRIPTION
###### Description of changes

I couldn't figure how to do this for vim, so we can only adopt this for neovim plugins for now

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
