### PR TITLE
cutecom: enable on darwin

### DIFF
--- a/pkgs/tools/misc/cutecom/default.nix
+++ b/pkgs/tools/misc/cutecom/default.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, lib, fetchFromGitLab, qtbase, qtserialport, cmake }:
+{ stdenv, lib, fetchFromGitLab, qtserialport, cmake, wrapQtAppsHook }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "cutecom";
   version = "0.51.0+patch";
 
@@ -11,10 +11,17 @@ mkDerivation rec {
     sha256 = "X8jeESt+x5PxK3rTNC1h1Tpvue2WH09QRnG2g1eMoEE=";
   };
 
-  buildInputs = [ qtbase qtserialport ];
-  nativeBuildInputs = [ cmake ];
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "/Applications" "$out/Applications"
+  '';
 
-  postInstall = ''
+  buildInputs = [ qtserialport ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+
+  postInstall = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+  '' else ''
     cd ..
     mkdir -p "$out"/share/{applications,icons/hicolor/scalable/apps,man/man1}
     cp cutecom.desktop "$out/share/applications"
@@ -25,8 +32,8 @@ mkDerivation rec {
   meta = with lib; {
     description = "A graphical serial terminal";
     homepage = "https://gitlab.com/cutecom/cutecom/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ bennofs ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
