### PR TITLE
nixos/systemd-boot: skip EFI update to 252.1

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -16,6 +16,7 @@ import datetime
 import glob
 import os.path
 from typing import NamedTuple, List, Optional
+from packaging import version
 
 class SystemIdentifier(NamedTuple):
     profile: Optional[str]
@@ -258,12 +259,18 @@ def main() -> None:
         if available_match is None:
             raise Exception("could not determine systemd-boot version")
 
-        installed_version = installed_match.group(1)
-        available_version = available_match.group(1)
+        installed_version = version.parse(installed_match.group(1))
+        available_version = version.parse(available_match.group(1))
 
+        # systemd 252 has a regression that leaves some machines unbootable, so we skip that update.
+        # The fix is in 252.2
+        # See https://github.com/systemd/systemd/issues/25363 and https://github.com/NixOS/nixpkgs/pull/201558#issuecomment-1348603263
         if installed_version < available_version:
-            print("updating systemd-boot from %s to %s" % (installed_version, available_version))
-            subprocess.check_call(["@systemd@/bin/bootctl", "--esp-path=@efiSysMountPoint@", "update"])
+            if version.parse('252') <= available_version < version.parse('252.2'):
+                print("skipping systemd-boot update to %s because of known regression" % available_version)
+            else:
+                print("updating systemd-boot from %s to %s" % (installed_version, available_version))
+                subprocess.check_call(["@systemd@/bin/bootctl", "--esp-path=@efiSysMountPoint@", "update"])
 
     mkdir_p("@efiSysMountPoint@/efi/nixos")
     mkdir_p("@efiSysMountPoint@/loader/entries")

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -7,12 +7,14 @@ let
 
   efi = config.boot.loader.efi;
 
+  python3 = pkgs.python3.withPackages (ps: [ ps.packaging ]);
+
   systemdBootBuilder = pkgs.substituteAll {
     src = ./systemd-boot-builder.py;
 
     isExecutable = true;
 
-    inherit (pkgs) python3;
+    inherit python3;
 
     systemd = config.systemd.package;
 
@@ -48,7 +50,7 @@ let
   };
 
   checkedSystemdBootBuilder = pkgs.runCommand "systemd-boot" {
-    nativeBuildInputs = [ pkgs.mypy ];
+    nativeBuildInputs = [ pkgs.mypy python3 ];
   } ''
     install -m755 ${systemdBootBuilder} $out
     mypy \


### PR DESCRIPTION
That version has a regression that leaves some machines unbootable. While we wait for the fix to land in master, this is a workaround that should save people some pain.

See https://github.com/NixOS/nixpkgs/pull/205946#issuecomment-1366083167

This can be immediately reverted in `staging` (or `staging-next`) since the systemd update is already there.