### PR TITLE
nixos/zfs: mitigate data loss issues when resuming from hibernate

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -607,7 +607,7 @@ in
             $out/bin/zfs --help >/dev/null 2>&1
             $out/bin/zpool --help >/dev/null 2>&1
           '';
-        postDeviceCommands = mkIf (!config.boot.initrd.systemd.enable) (concatStringsSep "\n" ([''
+        postResumeCommands = mkIf (!config.boot.initrd.systemd.enable) (concatStringsSep "\n" ([''
             ZFS_FORCE="${optionalString cfgZfs.forceImportRoot "-f"}"
           ''] ++ [(importLib {
             # See comments at importLib definition.


### PR DESCRIPTION
###### Description of changes

There are occasional data corruption issues when resuming from hibernate on ZFS.  The upstream issue is here: https://github.com/openzfs/zfs/issues/260.  The nixpkgs attempt to address this is here: https://github.com/NixOS/nixpkgs/pull/171680.

Particularly relevant is this comment by @bryanasdev000:

> ZFS corruption seem caused by either using swap on ZFS (which is not a good idea, see https://github.com/openzfs/zfs/issues/7734) or hibernating and importing a pool before resume/swap (https://github.com/openzfs/zfs/issues/12842#issue-1077802751 https://github.com/openzfs/zfs/issues/12842#issuecomment-1030760929).

The nixos stage1 boot script is prone to the second failure case, because it imports ZFS pools in the postDeviceCommands step, which is run before attempting to resume from suspend.  @infinisil made a patch to the stage1 script here which moves postDeviceCommands to after the attempt to resume: https://github.com/infinisil/nixpkgs2/commit/448fe5db58cddfcc9258a71ca0c4c11d19ca1ecb

This certainly fixes the problem, but I'm unsure of how general of a fix it is.  postDeviceCommands is used (afaics) to load some other filesystem containers (for lack of a better word...) such as luks and btrfs.  It's valid to resume from a swap file in one of those containers.  So, I think the correct fix is to move only the ZFS imports to after the resume step.  That's what this PR accomplishes, by introducing a new postResumeCommands step that ZFS can hook into.

This is my first nixpkgs PR and I hope these changes will be more or less suitable to incorporate as is -- but if there's further exploration or discussion that's needed then I will be happy with that outcome too! :slightly_smiling_face: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
