### PR TITLE
emacs: allow overriding version argument

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -33,6 +33,7 @@
 , srcRepo ? true, autoreconfHook ? null, texinfo ? null
 , siteStart ? ./site-start.el
 , nativeComp ? true
+, version ? version
 , withAthena ? false
 , withToolkitScrollBars ? true
 , withPgtk ? false, gtk3 ? null

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -6,7 +6,7 @@
   , name ? "emacs-${version}${versionModifier}"
   , patches ? _: [ ]
   , macportVersion ? null
-}:
+}@outer:
 { stdenv, llvmPackages_6, lib, fetchurl, fetchpatch, substituteAll, ncurses, libXaw, libXpm
 , Xaw3d, libXcursor,  pkg-config, gettext, libXft, dbus, libpng, libjpeg, giflib
 , libtiff, librsvg, libwebp, gconf, libxml2, imagemagick, gnutls, libselinux
@@ -33,7 +33,7 @@
 , srcRepo ? true, autoreconfHook ? null, texinfo ? null
 , siteStart ? ./site-start.el
 , nativeComp ? true
-, version ? version
+, version ? outer.version
 , withAthena ? false
 , withToolkitScrollBars ? true
 , withPgtk ? false, gtk3 ? null


### PR DESCRIPTION

###### Description of changes
This allows one to use .override to change the version as it's being used in the derivation builder function, not just as a final derivation property (which would be .overrideAttrs). The version argument is used to determine other aspects of the final build, like which patches to apply: if you pass in a newer source (which you /can/ do using .overrideAttrs), the derivation builder won't know that and will still give you the patches for the older source.

Example of what you would want to do:

```nix
pkgs.emacs.overrideAttrs (_: {
  version = "30.0-git";
  src = latest-emacs-src-from-master;
})
```

That will override the ‘version’ property on the derivation (good) but it won't override the ‘version’ argument as used by the rest of the file, notably the patch selection's if-guard. So you'll end up with a failed patch.

Example of what you can do after this patch has been applied to nixpkgs:

```nix
pkgs.emacs.override ({
  version = "30.0-git";
}).overrideAttrs (_: {
  src = latest-emacs-src-from-master;
})
```

Edit: to clarify: you still can't do a single overrideAttrs, although as I understand it, you never can: that's for derivation attributes not function arguments. WIth this patch, at least you can override the function argument separately to achieve the same effect.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
