### PR TITLE
netflix: allow passing flags to google-chrome

### DIFF
--- a/pkgs/applications/video/netflix/default.nix
+++ b/pkgs/applications/video/netflix/default.nix
@@ -5,6 +5,9 @@
 , runtimeShell
 , symlinkJoin
 , writeScriptBin
+
+  # command line arguments which are always set e.g "--disable-gpu"
+, commandLineArgs ? [ ]
 }:
 
 let
@@ -43,9 +46,12 @@ let
 
   script = writeScriptBin name ''
     #!${runtimeShell}
-    exec ${google-chrome}/bin/${google-chrome.meta.mainProgram} \
+    exec ${google-chrome}/bin/${google-chrome.meta.mainProgram} ${lib.escapeShellArgs commandLineArgs} \
       --app=https://netflix.com \
-      --no-first-run --no-default-browser-check --no-crash-upload
+      --no-first-run \
+      --no-default-browser-check \
+      --no-crash-upload \
+      "$@"
   '';
 
 in


### PR DESCRIPTION
###### Description of changes

Allow google-chrome to receive additional command line flags either via the script or via override similar to the google-chrome package. `--disable-gpu-sandbox` can be used as a test flag as it results in a warning banner at startup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
