### PR TITLE
neovim: make the build reproducible

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, gettext, msgpack, libtermkey, libiconv
+, fetchpatch
 , libuv, lua, ncurses, pkg-config
 , unibilium, gperf
 , libvterm-neovim
@@ -19,6 +20,16 @@ let
         nvim-client luv coxpcall busted luafilesystem penlight inspect
       ]
     ));
+  codegenLua =
+    if lua.pkgs.isLuaJIT
+      then
+        let deterministicLuajit =
+          lua.override {
+            deterministicStringIds = true;
+            self = deterministicLuajit;
+          };
+        in deterministicLuajit.withPackages(ps: [ ps.mpack ps.lpeg ])
+      else lua;
 
   pyEnv = python3.withPackages(ps: with ps; [ pynvim msgpack ]);
 in
@@ -38,6 +49,13 @@ in
       # necessary so that nix can handle `UpdateRemotePlugins` for the plugins
       # it installs. See https://github.com/neovim/neovim/issues/9413.
       ./system_rplugin_manifest.patch
+      # make the build reproducible, rebased version of
+      # https://github.com/neovim/neovim/pull/21586
+      (fetchpatch {
+        name = "neovim-build-make-generated-source-files-reproducible.patch";
+        url = "https://github.com/raboof/neovim/commit/485dd2af3efbfd174163583c46e0bb2a01ff04f1.patch";
+        hash = "sha256-9aRVK4lDkL/W4RVjeKptrZFY7rYYBx6/RGR4bQSbCsM=";
+      })
     ];
 
     dontFixCmake = true;
@@ -89,7 +107,7 @@ in
       substituteInPlace src/nvim/version.c --replace NVIM_VERSION_CFLAGS "";
     '';
     # check that the above patching actually works
-    disallowedReferences = [ stdenv.cc ];
+    disallowedReferences = [ stdenv.cc ] ++ lib.optional (lua != codegenLua) codegenLua;
 
     cmakeFlags = [
       # Don't use downloaded dependencies. At the end of the configurePhase one
@@ -101,7 +119,12 @@ in
     ++ lib.optional (!lua.pkgs.isLuaJIT) "-DPREFER_LUA=ON"
     ;
 
-    preConfigure = lib.optionalString stdenv.isDarwin ''
+    preConfigure = lib.optionalString lua.pkgs.isLuaJIT ''
+      cmakeFlagsArray+=(
+        "-DLUAC_PRG=${codegenLua}/bin/luajit -b -s %s -"
+        "-DLUA_GEN_PRG=${codegenLua}/bin/luajit"
+      )
+    '' + lib.optionalString stdenv.isDarwin ''
       substituteInPlace src/nvim/CMakeLists.txt --replace "    util" ""
     '';
 

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -26,6 +26,12 @@
 , enableAPICheck ? false
 , enableVMAssertions ? false
 , useSystemMalloc ? false
+# Upstream generates randomized string id's by default for security reasons
+# https://github.com/LuaJIT/LuaJIT/issues/626. Deterministic string id's should
+# never be needed for correctness (that should be fixed in the lua code),
+# but may be helpful when you want to embed jit-compiled raw lua blobs in
+# binaries that you want to be reproducible.
+, deterministicStringIds ? false
 , luaAttr ? "luajit_${lib.versions.major version}_${lib.versions.minor version}"
 } @ inputs:
 assert enableJITDebugModule -> enableJIT;
@@ -45,6 +51,7 @@ let
     ++ optional enableGDBJITSupport "-DLUAJIT_USE_GDBJIT"
     ++ optional enableAPICheck "-DLUAJIT_USE_APICHECK"
     ++ optional enableVMAssertions "-DLUAJIT_USE_ASSERT"
+    ++ optional deterministicStringIds "-DLUAJIT_SECURITY_STRID=0"
   ;
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Description of changes

This introduces a patch that improves binary reproducibility since changes in ordering of the generated code indeed cause changes in the compiled code.

Additionally, since neovim embeds luajit-compiled bytecode into the nvim binary, we are impacted by https://github.com/LuaJIT/LuaJIT/issues/626 . It is possible to switch to lua 5.1, but that'd be a regression (luajit has much better performance and some plugins depend on it, like for example Noice and Lazy). Disabling `COMPILE_LUA` at build time would cause a runtime penalty each time neovim starts. Instead, we run luagit with those security settings disabled for the build-time code generation.
    
(Note to self: for a minimized testcase this seemed to help at 975ec13f5d5aefcac1dbb15fa867e660e07c93a1 but no longer at 03080b795aa3496ed62d4a0697c9f4767e7ca7e5 of luajit, which is surprising since that commit doesn't look super relevant. _Also_ surprisingly it does seem to work in the context of the neovim code generation, though, so that might be good enough...)
    
Fixes #207841

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
