### PR TITLE
hypr: unbreak on darwin

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hypr/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hypr/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cairo
 , cmake
 , glib
@@ -15,6 +16,7 @@
 , xcbutilcursor
 , xcbutilkeysyms
 , xcbutilwm
+, xcbutil
 , xmodmap
 }:
 
@@ -31,6 +33,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./000-dont-set-compiler.diff
+    # TODO: remove on next release
+    (fetchpatch {
+      url = "https://github.com/hyprwm/Hypr/commit/08d6af2caf882247943f0e8518ad782f35d1aba4.patch";
+      sha256 = "sha256-WjR12ZH8CE+l9xSeQUAPYW5r5HzoPpod5YqDPJTdTY8=";
+    })
+    (fetchpatch {
+      url = "https://github.com/hyprwm/Hypr/commit/7512a3ab91865b1e11b8c4a9dfdffb25c2b153de.patch";
+      sha256 = "sha256-0Hq5n115z0U44op7A1FO9tUOeMEPV0QgD5E5zcmend0=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -51,7 +62,11 @@ stdenv.mkDerivation (finalAttrs: {
     xcbutilcursor
     xcbutilkeysyms
     xcbutilwm
+    xcbutil
   ];
+
+  # src/ewmh/ewmh.cpp:67:28: error: non-constant-expression cannot be narrowed from type 'int' to 'uint32_t' (aka 'unsigned int') in initializer list
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-Wno-c++11-narrowing";
 
   installPhase = ''
     runHook preInstall
@@ -71,7 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsd3;
     maintainers = with maintainers; [ AndersonTorres ];
     inherit (libX11.meta) platforms;
-    broken = stdenv.isDarwin; # xcb/xcb_atom.h not found
     mainProgram = "Hypr";
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4764,7 +4764,9 @@ with pkgs;
 
   hunt = callPackage ../tools/misc/hunt { };
 
-  hypr = callPackage ../applications/window-managers/hyprwm/hypr { };
+  hypr = callPackage ../applications/window-managers/hyprwm/hypr {
+    cairo = cairo.override { xcbSupport = true; };
+  };
 
   hyprland = callPackage ../applications/window-managers/hyprwm/hyprland {
     stdenv = gcc11Stdenv;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
