### PR TITLE
nixos/services/backup/syncoid: add per-command user option

### DIFF
--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -208,6 +208,7 @@ in
             description = lib.mdDoc ''
               The local user for this transfer command, overriding {option}`services.syncoid.user`.
               With privilege delegation (i.e. with a user other than `root`), and when multiple commands involve the same dataset, it is important to use a different local user for each of those commands, as otherwise permissions can get removed when one command finishes, but the others are still in progress.
+              If different users are to use the same SSH key file, then that file has to be owned and readable by a group that the users have in common, but not be owned by any of the users, or OpenSSH will refuse to use the key as that user (e.g. `users.users.backup-to-''${target}.group = "backup"` and {command}`chown root:backup $sshKey ; chmod 640 $sshKey`).
             '';
           };
 

--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -21,7 +21,7 @@ let
   # delegating permissions, if it doesn't exist we delegate it to the parent
   # dataset (if it exists). This should solve the case of provisoning new
   # datasets.
-  buildAllowCommand = permissions: dataset: (
+  buildAllowCommand = permissions: user: dataset: (
     "-+${pkgs.writeShellScript "zfs-allow-${dataset}" ''
       # Here we explicitly use the booted system to guarantee the stable API needed by ZFS
 
@@ -34,7 +34,7 @@ let
         ${lib.escapeShellArgs [
           "/run/booted-system/sw/bin/zfs"
           "allow"
-          cfg.user
+          user
           (concatStringsSep "," permissions)
           dataset
         ]}
@@ -43,7 +43,7 @@ let
           ${lib.escapeShellArgs [
             "/run/booted-system/sw/bin/zfs"
             "allow"
-            cfg.user
+            user
             (concatStringsSep "," permissions)
             # Remove the last part of the path
             (builtins.dirOf dataset)
@@ -59,20 +59,20 @@ let
   # knowing if the allow command did execute on the parent dataset or
   # not in the pre-hook. We can't run the same if in the post hook
   # since the dataset should have been created at this point.
-  buildUnallowCommand = permissions: dataset: (
+  buildUnallowCommand = permissions: user: dataset: (
     "-+${pkgs.writeShellScript "zfs-unallow-${dataset}" ''
       # Here we explicitly use the booted system to guarantee the stable API needed by ZFS
       ${lib.escapeShellArgs [
         "/run/booted-system/sw/bin/zfs"
         "unallow"
-        cfg.user
+        user
         (concatStringsSep "," permissions)
         dataset
       ]}
       ${lib.optionalString ((builtins.dirOf dataset) != ".") (lib.escapeShellArgs [
         "/run/booted-system/sw/bin/zfs"
         "unallow"
-        cfg.user
+        user
         (concatStringsSep "," permissions)
         # Remove the last part of the path
         (builtins.dirOf dataset)
@@ -202,6 +202,15 @@ in
 
           recursive = mkEnableOption (lib.mdDoc ''the transfer of child datasets'');
 
+          user = mkOption {
+            type = types.str;
+            example = "backup-to-\${target}";
+            description = lib.mdDoc ''
+              The local user for this transfer command, overriding {option}`services.syncoid.user`.
+              With privilege delegation (i.e. with a user other than `root`), and when multiple commands involve the same dataset, it is important to use a different local user for each of those commands, as otherwise permissions can get removed when one command finishes, but the others are still in progress.
+            '';
+          };
+
           sshKey = mkOption {
             type = types.nullOr types.path;
             # Prevent key from being copied to store
@@ -281,6 +290,7 @@ in
         };
         config = {
           source = mkDefault name;
+          user = mkDefault cfg.user;
           sshKey = mkDefault cfg.sshKey;
           localSourceAllow = mkDefault cfg.localSourceAllow;
           localTargetAllow = mkDefault cfg.localTargetAllow;
@@ -326,11 +336,11 @@ in
             path = [ "/run/booted-system/sw/bin/" ];
             serviceConfig = {
               ExecStartPre =
-                (map (buildAllowCommand c.localSourceAllow) (localDatasetName c.source)) ++
-                (map (buildAllowCommand c.localTargetAllow) (localDatasetName c.target));
+                (map (buildAllowCommand c.localSourceAllow c.user) (localDatasetName c.source)) ++
+                (map (buildAllowCommand c.localTargetAllow c.user) (localDatasetName c.target));
               ExecStopPost =
-                (map (buildUnallowCommand c.localSourceAllow) (localDatasetName c.source)) ++
-                (map (buildUnallowCommand c.localTargetAllow) (localDatasetName c.target));
+                (map (buildUnallowCommand c.localSourceAllow c.user) (localDatasetName c.source)) ++
+                (map (buildUnallowCommand c.localTargetAllow c.user) (localDatasetName c.target));
               ExecStart = lib.escapeShellArgs ([ "${pkgs.sanoid}/bin/syncoid" ]
                 ++ optionals c.useCommonArgs cfg.commonArgs
                 ++ optional c.recursive "-r"
@@ -345,7 +355,7 @@ in
                 c.source
                 c.target
               ]);
-              User = cfg.user;
+              User = c.user;
               Group = cfg.group;
               StateDirectory = [ "syncoid" ];
               StateDirectoryMode = "700";


### PR DESCRIPTION
Allow specifying a different user for each `config.services.syncoid.commands`.

With privilege delegation (i.e. with a user other than `root`), and when multiple commands involve the same dataset, it is important to use a different local user for each of those commands, as otherwise permissions can get removed when one command finishes, but the others are still in progress.

This was one of the things I needed to do to make my backups reliable (the others are quite setup-specific).
I have a setup where all hosts push encrypted snapshots to one server, which then forwards them to two other servers. Especially when one of those was down, that one failing (and the service exiting, removing the permissions) kept making the other one fail as well.

I guess this is a regression of ecd32b8104e6cca16fe1b2cfb89f39a8c7c01731 (not blaming). @etu, thoughts?

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
