### PR TITLE
python3Packages.fluids: init at 1.0.22, python3Packages.chemicals: init at 1.1.2, python3Packages.coolprop: init at 6.4.3, python3Packages.thermo: init at 0.2.23

### DIFF
--- a/pkgs/development/python-modules/chemicals/default.nix
+++ b/pkgs/development/python-modules/chemicals/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, pandas
+, scipy
+, fluids
+}:
+buildPythonPackage rec {
+  pname = "chemicals";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "CalebBell";
+    repo = "chemicals";
+    rev = "9b841f18accf87e97cc2c4bb73aea3ad1e198f67";
+    hash = "sha256-4JDmfIqE99XrCUtTAZ8Hnicc+6K42EmPpwx6tKYn6dQ=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    pandas
+    scipy
+    fluids
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/CalebBell/chemicals";
+    description = "An extensive compilation of pure component chemical data";
+    license = licenses.mit;
+    maintainers = with maintainers; [ larsr ];
+  };
+}

--- a/pkgs/development/python-modules/coolprop/default.nix
+++ b/pkgs/development/python-modules/coolprop/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, git
+, gcc
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, cython
+, requests
+, jinja2
+, pyyaml
+}:
+buildPythonPackage rec {
+  pname = "coolprop";
+  version = "6.4.3";
+  #format = "other";
+
+  src = fetchFromGitHub {
+    owner = "CoolProp";
+    repo = "CoolProp";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-VU8DEitcfEIIVAsfBc1XfZDh5tQOWAGtRAk5r9ln/hQ=";
+  };
+
+  nativeBuildInputs = [
+    cython
+    git
+    gcc
+  ];
+
+  propagatedBuildInputs = [
+    setuptools
+    wheel
+    requests
+    jinja2
+    pyyaml
+  ];
+
+  preBuild = ''
+    cd ./wrappers/Python
+  '';
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/CoolProp/CoolProp";
+    description = "Thermophysical properties for the masses";
+    license = licenses.mit;
+    maintainers = with maintainers; [ larsr ];
+  };
+}

--- a/pkgs/development/python-modules/fluids/default.nix
+++ b/pkgs/development/python-modules/fluids/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, scipy
+, pint
+}:
+
+buildPythonPackage rec {
+  pname = "fluids";
+  version = "1.0.22";
+
+  src = fetchFromGitHub {
+      owner = "CalebBell";
+      repo = "fluids";
+      rev = "refs/tags/${version}";
+      hash = "sha256-aMxnjFaWTnDCDnJrjlqInh/OH+EGxSCNIrHxE2MKIwU=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    pint
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/CalebBell/fluids";
+    description = "Software for engineers and technicians working in the fields of chemical, mechanical, or civil engineering.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ larsr ];
+  };
+}

--- a/pkgs/development/python-modules/thermo/default.nix
+++ b/pkgs/development/python-modules/thermo/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, pandas
+, scipy
+, fluids
+, chemicals
+, coolprop
+}:
+buildPythonPackage rec {
+  pname = "thermo";
+  version = "0.2.23";
+
+  src = fetchFromGitHub {
+    owner = "CalebBell";
+    repo = "thermo";
+    rev = "refs/tags/${version}";
+    hash = "sha256-n58EdLW9PGj3MWugvqd4/yS53ZdChqhG6K+0Oeb+rAc=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    pandas
+    scipy
+    coolprop
+    fluids
+    chemicals
+
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/CalebBell/thermo";
+    description = "Thermodynamics and Phase Equilibrium component of Chemical Engineering Design Library (ChEDL)";
+    license = licenses.mit;
+    maintainers = with maintainers; [ larsr ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3471,6 +3471,8 @@ self: super: with self; {
 
   flufl_lock = callPackage ../development/python-modules/flufl/lock.nix { };
 
+  fluids = callPackage ../development/python-modules/fluids { };
+
   flux-led = callPackage ../development/python-modules/flux-led { };
 
   flynt = callPackage ../development/python-modules/flynt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11173,6 +11173,8 @@ self: super: with self; {
     cudnnSupport = false;
   };
 
+  thermo = callPackage ../development/python-modules/thermo { };
+
   thermobeacon-ble = callPackage ../development/python-modules/thermobeacon-ble { };
 
   thermopro-ble = callPackage ../development/python-modules/thermopro-ble { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1681,6 +1681,8 @@ self: super: with self; {
 
   cheetah3 = callPackage ../development/python-modules/cheetah3 { };
 
+  chemicals = callPackage ../development/python-modules/chemicals { };
+
   cheroot = callPackage ../development/python-modules/cheroot { };
 
   cherrypy = callPackage ../development/python-modules/cherrypy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1981,6 +1981,8 @@ self: super: with self; {
 
   cookiecutter = callPackage ../development/python-modules/cookiecutter { };
 
+  coolprop = callPackage ../development/python-modules/coolprop { };
+
   cookies = callPackage ../development/python-modules/cookies { };
 
   coordinates = callPackage ../development/python-modules/coordinates { };


### PR DESCRIPTION
###### Description of changes

**fluids** Fluid dynamics component of Chemical Engineering Design Library (ChEDL)

**chemicals**: Chemical database of Chemical Engineering Design Library (ChEDL)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
