### PR TITLE
haskellPackages.git-brunch: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1779,7 +1779,6 @@ broken-packages:
   - GiST
   - git
   - git-all
-  - git-brunch
   - git-checklist
   - git-cuk
   - git-date


### PR DESCRIPTION
###### Description of changes

The package was indeed broken for GHC 9.2. I fixed it, and it now succesfully compiles. A [new version `1.6.0`](https://github.com/andys8/git-brunch/releases/tag/v1.6.0) is released. Also on [hackage](https://hackage.haskell.org/package/git-brunch-1.6.0.0).

I had a look at other pull requests and comments how to unbreak. They normally only remove the package from the broken list and run the regenerate list.

How is the process in this case though? I need to update the version to v1.6.0. It will change the hash and dependencies. Is this something I can do or will it be done with the next update of `haskell-updates`?

Here I would need some advice. Thanks in advance.


###### Update

I tried the instructions for [Initial haskell-updates PR](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/HACKING.md#initial-haskell-updates-pr)

And indeed the result would look better. So, should the PR stay as is and the next `haskell-updates` PR will result in a new version?

```
  "git-brunch" = callPackage
    ({ mkDerivation, base, brick, extra, hspec, microlens
     , microlens-mtl, mtl, optparse-applicative, process, text, vector
     , vty
     }:
     mkDerivation {
       pname = "git-brunch";
       version = "1.6.0.0";
       sha256 = "1crpcv68lpfl0cs6cxmi7mcd1vawmif6qz1n0j2in49ypr75qkdk";
       isLibrary = false;
       isExecutable = true;
       executableHaskellDepends = [
         base brick extra hspec microlens microlens-mtl mtl
         optparse-applicative process text vector vty
       ];
       testHaskellDepends = [
         base brick extra hspec microlens microlens-mtl mtl
         optparse-applicative process text vector vty
       ];
       description = "git checkout command-line tool";
       license = lib.licenses.bsd3;
       mainProgram = "git-brunch";
     }) {};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
