### PR TITLE
scala-cli: move assert to build time

### DIFF
--- a/pkgs/development/tools/build-managers/scala-cli/default.nix
+++ b/pkgs/development/tools/build-managers/scala-cli/default.nix
@@ -10,7 +10,6 @@
 , jre
 }:
 
-assert lib.versionAtLeast jre.version "17.0.0";
 let
   pname = "scala-cli";
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
@@ -22,7 +21,11 @@ stdenv.mkDerivation {
   inherit pname version;
   nativeBuildInputs = [ installShellFiles makeWrapper ]
     ++ lib.optional stdenv.isLinux autoPatchelfHook;
-  buildInputs = [ coreutils zlib stdenv.cc.cc ];
+  buildInputs =
+    assert lib.assertMsg (lib.versionAtLeast jre.version "17.0.0") ''
+      scala-cli requires Java 17 or newer, but ${jre.name} is ${jre.version}
+    '';
+    [ coreutils zlib stdenv.cc.cc ];
   src =
     let
       asset = assets."${stdenv.hostPlatform.system}" or (throw "Unsupported platform ${stdenv.hostPlatform.system}");


### PR DESCRIPTION
###### Description of changes

Moves the assert to an attribute inside the `mkDerivation` call.

This makes it possible to set a JRE with `pkgs.scala-cli.override { jre = pkgs.openjdk17; }` when you've already overwritten Nixpkgs's `jre` through an overlay. Otherwise, it would've failed at evaluation time.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
