### PR TITLE
godot_4: 4.0-beta3 -> 4.0-beta10

### DIFF
--- a/pkgs/development/tools/godot/4/default.nix
+++ b/pkgs/development/tools/godot/4/default.nix
@@ -9,11 +9,11 @@
 , libX11
 , libXcursor
 , libXinerama
-, libXi
-, libXrandr
 , libXext
+, libXrandr
+, libXrender
+, libXi
 , libXfixes
-, libGLU
 , freetype
 , alsa-lib
 , libpulseaudio
@@ -21,6 +21,9 @@
 , speechd
 , fontconfig
 , udev
+, withPlatform ? "linuxbsd"
+, withTarget ? "editor"
+, withPrecision ? "single"
 , withPulseaudio ? false
 , withDbus ? true
 , withSpeechd ? false
@@ -29,9 +32,16 @@
 , withTouch ? true
 }:
 
+assert lib.asserts.assertOneOf "withPrecision" withPrecision [ "single" "double" ];
+
 let
-  # Options from godot/platform/linuxbsd/detect.py
   options = {
+    # Options from 'godot/SConstruct'
+    platform = withPlatform;
+    target = withTarget;
+    precision = withPrecision; # Floating-point precision level
+
+    # Options from 'godot/platform/linuxbsd/detect.py'
     pulseaudio = withPulseaudio;
     dbus = withDbus; # Use D-Bus to handle screensaver and portal desktop settings
     speechd = withSpeechd; # Use Speech Dispatcher for Text-to-Speech support
@@ -42,13 +52,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "godot";
-  version = "4.0-beta3";
+  version = "4.0-beta10";
 
   src = fetchFromGitHub {
     owner = "godotengine";
     repo = "godot";
-    rev = "01ae26d31befb6679ecd92cd3c73aa5a76162e95";
-    sha256 = "sha256-Q+zMviGevezjcQKJPOm7zAu4liJ5z8Rl73TYmjRR3MY=";
+    rev = "d0398f62f08ce0cfba80990b21c6af4181f93fe9";
+    sha256 = "sha256-h4DpK7YC7/qMc6GAD2nvNVmrlGjKT5d7OK+1NcuZCMg=";
   };
 
   nativeBuildInputs = [
@@ -59,27 +69,26 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     scons
-    libGLU
+  ]
+  ++ runtimeDependencies;
+
+  runtimeDependencies = [
     libX11
     libXcursor
     libXinerama
-    libXi
-    libXrandr
     libXext
+    libXrandr
+    libXrender
+    libXi
     libXfixes
-  ]
-  ++ runtimeDependencies
-  # Necessary to make godot see fontconfig.lib and dbus.lib
-  ++ lib.optional withFontconfig fontconfig
-  ++ lib.optional withDbus dbus;
-
-  runtimeDependencies = [
-    vulkan-loader
     alsa-lib
+    vulkan-loader
   ]
   ++ lib.optional withPulseaudio libpulseaudio
+  ++ lib.optional withDbus dbus
   ++ lib.optional withDbus dbus.lib
   ++ lib.optional withSpeechd speechd
+  ++ lib.optional withFontconfig fontconfig
   ++ lib.optional withFontconfig fontconfig.lib
   ++ lib.optional withUdev udev;
 
@@ -91,7 +100,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  sconsFlags = [ "platform=linuxbsd target=editor production=true" ];
+  # Options from 'godot/SConstruct' and 'godot/platform/linuxbsd/detect.py'
+  sconsFlags = [ "production=true" ];
   preConfigure = ''
     sconsFlags+=" ${
       lib.concatStringsSep " "

--- a/pkgs/development/tools/godot/4/xfixes.patch
+++ b/pkgs/development/tools/godot/4/xfixes.patch
@@ -1,12 +1,12 @@
 diff --git a/platform/linuxbsd/detect.py b/platform/linuxbsd/detect.py
-index ac69f3806b..14acbf5c58 100644
+index 844b15e9fb..0c8bee1757 100644
 --- a/platform/linuxbsd/detect.py
 +++ b/platform/linuxbsd/detect.py
-@@ -191,6 +191,7 @@ def configure(env: "Environment"):
-         env.ParseConfig("pkg-config xrandr --cflags --libs")
-         env.ParseConfig("pkg-config xrender --cflags --libs")
-         env.ParseConfig("pkg-config xi --cflags --libs")
-+        env.ParseConfig("pkg-config xfixes --cflags --libs")
+@@ -192,6 +192,7 @@ def configure(env: "Environment"):
+         env.ParseConfig("pkg-config xrandr --cflags")
+         env.ParseConfig("pkg-config xrender --cflags")
+         env.ParseConfig("pkg-config xi --cflags")
++        env.ParseConfig("pkg-config xfixes --cflags")
  
      if env["touch"]:
          env.Append(CPPDEFINES=["TOUCH_ENABLED"])


### PR DESCRIPTION
###### Description of changes

Update to [Godot 4.0 beta 10](https://godotengine.org/article/dev-snapshot-godot-4-0-beta-10)

In case of driver errors, give a try with: `godot --rendering-driver vulkan` (or `opengl3`)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
