### PR TITLE
`types.path`: Do not allow lists of strings

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -96,14 +96,16 @@ let
       concatImapStringsSep makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
-      escapeShellArg escapeShellArgs isValidPosixName toShellVar toShellVars
+      escapeShellArg escapeShellArgs
+      isStorePath isStringLike
+      isValidPosixName toShellVar toShellVars
       escapeRegex escapeXML replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
       getName getVersion
       mesonOption mesonBool mesonEnable
       nameFromURL enableFeature enableFeatureAs withFeature
-      withFeatureAs fixedWidthString fixedWidthNumber isStorePath
+      withFeatureAs fixedWidthString fixedWidthNumber
       toInt toIntBase10 readPathsFromFile fileContents;
     inherit (self.stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -63,7 +63,7 @@ let
 
     inherit (builtins) add addErrorContext attrNames concatLists
       deepSeq elem elemAt filter genericClosure genList getAttr
-      hasAttr head isAttrs isBool isInt isList isString length
+      hasAttr head isAttrs isBool isInt isList isPath isString length
       lessThan listToAttrs pathExists readFile replaceStrings seq
       stringLength sub substring tail trace;
     inherit (self.trivial) id const pipe concat or and bitAnd bitOr bitXor

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -18,6 +18,7 @@ rec {
     isInt
     isList
     isAttrs
+    isPath
     isString
     match
     parseDrvName
@@ -821,7 +822,8 @@ rec {
      string interpolations and in most functions that expect a string.
    */
   isStringLike = x:
-    elem (typeOf x) [ "path" "string" ] ||
+    isString x ||
+    isPath x ||
     x ? outPath ||
     x ? __toString;
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -810,10 +810,9 @@ rec {
      null, bool, list of similarly coercible values.
   */
   isConvertibleWithToString = x:
-    elem (typeOf x) [ "path" "string" "null" "int" "float" "bool" ] ||
-    (isList x && lib.all isConvertibleWithToString x) ||
-    x ? outPath ||
-    x ? __toString;
+    isStringLike x ||
+    elem (typeOf x) [ "null" "int" "float" "bool" ] ||
+    (isList x && lib.all isConvertibleWithToString x);
 
   /* Check whether a value can be coerced to a string.
      The value must be a string, path, or attribute set.

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -810,7 +810,7 @@ rec {
   */
   isMoreCoercibleToString = x:
     elem (typeOf x) [ "path" "string" "null" "int" "float" "bool" ] ||
-    (isList x && lib.all isCoercibleToString x) ||
+    (isList x && lib.all isMoreCoercibleToString x) ||
     x ? outPath ||
     x ? __toString;
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -829,7 +829,7 @@ rec {
        => false
   */
   isStorePath = x:
-    if !(isList x) && isCoercibleToString x then
+    if isSimpleCoercibleToString x then
       let str = toString x; in
       substring 0 1 str == "/"
       && dirOf str == storeDir

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -798,19 +798,20 @@ rec {
   in lib.warnIf (!precise) "Imprecise conversion from float to string ${result}"
     result;
 
-  /* Soft-deprecated name for isMoreCoercibleToString */
+  /* Soft-deprecated function. While the original implementation is available as
+     isConvertibleWithToString, consider using isStringLike instead, if suitable. */
   isCoercibleToString = lib.warnIf (lib.isInOldestRelease 2305)
-    "lib.strings.isCoercibleToString is deprecated in favor of either isStringLike or isMoreCoercibleString. Only use the latter if it needs to return true for null, numbers, booleans and list of similarly coercibles."
-    isMoreCoercibleToString;
+    "lib.strings.isCoercibleToString is deprecated in favor of either isStringLike or isConvertibleWithToString. Only use the latter if it needs to return true for null, numbers, booleans and list of similarly coercibles."
+    isConvertibleWithToString;
 
   /* Check whether a list or other value can be passed to toString.
 
      Many types of value are coercible to string this way, including int, float,
      null, bool, list of similarly coercible values.
   */
-  isMoreCoercibleToString = x:
+  isConvertibleWithToString = x:
     elem (typeOf x) [ "path" "string" "null" "int" "float" "bool" ] ||
-    (isList x && lib.all isMoreCoercibleToString x) ||
+    (isList x && lib.all isConvertibleWithToString x) ||
     x ? outPath ||
     x ? __toString;
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -805,6 +805,17 @@ rec {
     x ? outPath ||
     x ? __toString;
 
+  /* Check whether a value can be coerced to a string,
+     The value must be a string, path, or attribute set.
+
+     This follows Nix's internal coerceToString(coerceMore = false) logic,
+     except for external types, for which we return false.
+   */
+  isSimpleCoercibleToString = x:
+    elem (typeOf x) [ "path" "string" ] ||
+    x ? outPath ||
+    x ? __toString;
+
   /* Check whether a value is a store path.
 
      Example:

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -798,8 +798,17 @@ rec {
   in lib.warnIf (!precise) "Imprecise conversion from float to string ${result}"
     result;
 
-  /* Check whether a value can be coerced to a string */
-  isCoercibleToString = x:
+  /* Soft-deprecated name for isMoreCoercibleToString */
+  isCoercibleToString = lib.warnIf (lib.isInOldestRelease 2305)
+    "lib.strings.isCoercibleToString is deprecated in favor of either isSimpleCoercibleToString or isMoreCoercibleString. Only use the latter if it needs to return true for null, numbers, booleans and list of similarly coercibles."
+    isMoreCoercibleToString;
+
+  /* Check whether a list or other value can be passed to toString.
+
+     Many types of value are coercible to string this way, including int, float,
+     null, bool, list of similarly coercible values.
+  */
+  isMoreCoercibleToString = x:
     elem (typeOf x) [ "path" "string" "null" "int" "float" "bool" ] ||
     (isList x && lib.all isCoercibleToString x) ||
     x ? outPath ||

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -395,7 +395,7 @@ rec {
   */
   toShellVar = name: value:
     lib.throwIfNot (isValidPosixName name) "toShellVar: ${name} is not a valid shell variable name" (
-    if isAttrs value && ! isCoercibleToString value then
+    if isAttrs value && ! isSimpleCoercibleToString value then
       "declare -A ${name}=(${
         concatStringsSep " " (lib.mapAttrsToList (n: v:
           "[${escapeShellArg n}]=${escapeShellArg v}"

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -55,6 +55,7 @@ let
     escapeNixString
     hasInfix
     isCoercibleToString
+    isSimpleCoercibleToString
     ;
   inherit (lib.trivial)
     boolToString
@@ -227,7 +228,7 @@ rec {
       merge = loc: defs:
         let
           getType = value:
-            if isAttrs value && isCoercibleToString value
+            if isAttrs value && isSimpleCoercibleToString value
             then "stringCoercibleSet"
             else builtins.typeOf value;
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -54,7 +54,6 @@ let
     concatStringsSep
     escapeNixString
     hasInfix
-    isMoreCoercibleToString
     isSimpleCoercibleToString
     ;
   inherit (lib.trivial)
@@ -480,7 +479,7 @@ rec {
     path = mkOptionType {
       name = "path";
       descriptionClass = "noun";
-      check = x: isMoreCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
+      check = x: isSimpleCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
       merge = mergeEqualOption;
     };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -54,7 +54,7 @@ let
     concatStringsSep
     escapeNixString
     hasInfix
-    isCoercibleToString
+    isMoreCoercibleToString
     isSimpleCoercibleToString
     ;
   inherit (lib.trivial)
@@ -480,7 +480,7 @@ rec {
     path = mkOptionType {
       name = "path";
       descriptionClass = "noun";
-      check = x: isCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
+      check = x: isMoreCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
       merge = mergeEqualOption;
     };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -54,7 +54,7 @@ let
     concatStringsSep
     escapeNixString
     hasInfix
-    isSimpleCoercibleToString
+    isStringLike
     ;
   inherit (lib.trivial)
     boolToString
@@ -227,7 +227,7 @@ rec {
       merge = loc: defs:
         let
           getType = value:
-            if isAttrs value && isSimpleCoercibleToString value
+            if isAttrs value && isStringLike value
             then "stringCoercibleSet"
             else builtins.typeOf value;
 
@@ -479,7 +479,7 @@ rec {
     path = mkOptionType {
       name = "path";
       descriptionClass = "noun";
-      check = x: isSimpleCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
+      check = x: isStringLike x && builtins.substring 0 1 (toString x) == "/";
       merge = mergeEqualOption;
     };
 

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -42,7 +42,7 @@ let
         else if isDerivation v then toString v
         else if builtins.isPath v then toString v
         else if isString v then v
-        else if strings.isCoercibleToString v then toString v
+        else if strings.isMoreCoercibleToString v then toString v
         else abort "The nix conf value: ${toPretty {} v} can not be encoded";
 
       mkKeyValue = k: v: "${escape [ "=" ] k} = ${mkValueString v}";

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -42,7 +42,7 @@ let
         else if isDerivation v then toString v
         else if builtins.isPath v then toString v
         else if isString v then v
-        else if strings.isMoreCoercibleToString v then toString v
+        else if strings.isConvertibleWithToString v then toString v
         else abort "The nix conf value: ${toPretty {} v} can not be encoded";
 
       mkKeyValue = k: v: "${escape [ "=" ] k} = ${mkValueString v}";

--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -18,7 +18,7 @@ let
     in
     lib.concatStrings (lib.mapAttrsToList toArg args);
 
-  isPathType = x: lib.strings.isCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
+  isPathType = x: lib.strings.isMoreCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
 
 in
 {

--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -18,7 +18,7 @@ let
     in
     lib.concatStrings (lib.mapAttrsToList toArg args);
 
-  isPathType = x: lib.strings.isMoreCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
+  isPathType = x: lib.types.path.check x;
 
 in
 {


### PR DESCRIPTION
###### Description of changes

Explains https://github.com/NixOS/nixpkgs/issues/208044

`types.path` used to allow lists of strings, because they are coercible to strings when `more = true` in Nix. However, lists of stringlike values are rarely intended to be actual paths, because spaces in paths are quite rare, and better represented by actual spaces. Therefore I believe the old behavior to be a bug, and expect this change to fix more things than it breaks.

This PR further improves `lib.strings` by renaming `lib.strings.isCoercibleToString` and deprecating it after 23.05, in order to make the `more = true | false` setting explicit.

`listOf path` will behave as before, unless individual list items were in turn lists of paths.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] ~Tested, as applicable~ compared to the Nix C++ code
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
