### PR TITLE
stdenv: bootstrap riscv64-musl

### DIFF
--- a/pkgs/development/compilers/rust/1_65.nix
+++ b/pkgs/development/compilers/rust/1_65.nix
@@ -52,6 +52,7 @@ import ./default.nix {
     aarch64-apple-darwin = "e1a37dc5991304716e260144311fd291d8fb514042e45c244c582b3454477038";
     powerpc64le-unknown-linux-gnu = "9d4591033eac22093d107991a68fffccea087b26bb54115d46cc544fbf5ef66c";
     riscv64gc-unknown-linux-gnu = "f63981d9c1057cb20cf30871757d42475a1cd0c187b3dcce5fabb0cce0f80c5b";
+    riscv64gc-unknown-linux-musl = "";
     mips64el-unknown-linux-gnuabi64 = "47488e4c53cca5c99b5837474a880f6c2368a7fe8368560dd8077bddb94959b5";
   };
 

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -19,6 +19,7 @@ PLATFORMS=(
   aarch64-apple-darwin
   powerpc64le-unknown-linux-gnu
   riscv64gc-unknown-linux-gnu
+  riscv64gc-unknown-linux-musl
   mips64el-unknown-linux-gnuabi64
 )
 BASEURL=https://static.rust-lang.org/dist

--- a/pkgs/stdenv/linux/bootstrap-files/riscv64-musl.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/riscv64-musl.nix
@@ -1,0 +1,12 @@
+{
+  busybox = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/riscv64/9bd3cf0063b80428bd85a286205adab4b6ffcbd6/busybox";
+    sha256 = "6f61912f94bc4ef287d1ff48a9521ed16bd07d8d8ec775e471f32c64d346583d";
+    executable = true;
+  };
+
+  bootstrapTools = import <nix/fetchurl.nix> {
+    url = "http://tarballs.nixos.org/stdenv-linux/riscv64/9bd3cf0063b80428bd85a286205adab4b6ffcbd6/bootstrap-tools.tar.xz";
+    sha256 = "5466b19288e980125fc62ebb864d09908ffe0bc50cebe52cfee89acff14d5b9f";
+  };
+}

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -4,42 +4,51 @@
 # compiler and linker that do not search in default locations,
 # ensuring purity of components produced by it.
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? []
+, localSystem
+, crossSystem
+, config
+, overlays
+, crossOverlays ? [ ]
 
-, bootstrapFiles ?
-  let table = {
-    glibc = {
-      i686-linux = import ./bootstrap-files/i686.nix;
-      x86_64-linux = import ./bootstrap-files/x86_64.nix;
-      armv5tel-linux = import ./bootstrap-files/armv5tel.nix;
-      armv6l-linux = import ./bootstrap-files/armv6l.nix;
-      armv7l-linux = import ./bootstrap-files/armv7l.nix;
-      aarch64-linux = import ./bootstrap-files/aarch64.nix;
-      mipsel-linux = import ./bootstrap-files/loongson2f.nix;
-      mips64el-linux = import ./bootstrap-files/mips64el.nix;
-      powerpc64le-linux = import ./bootstrap-files/powerpc64le.nix;
-      riscv64-linux = import ./bootstrap-files/riscv64.nix;
+, bootstrapFiles ? let
+    table = {
+      glibc = {
+        i686-linux = import ./bootstrap-files/i686.nix;
+        x86_64-linux = import ./bootstrap-files/x86_64.nix;
+        armv5tel-linux = import ./bootstrap-files/armv5tel.nix;
+        armv6l-linux = import ./bootstrap-files/armv6l.nix;
+        armv7l-linux = import ./bootstrap-files/armv7l.nix;
+        aarch64-linux = import ./bootstrap-files/aarch64.nix;
+        mipsel-linux = import ./bootstrap-files/loongson2f.nix;
+        mips64el-linux = import ./bootstrap-files/mips64el.nix;
+        powerpc64le-linux = import ./bootstrap-files/powerpc64le.nix;
+        riscv64-linux = import ./bootstrap-files/riscv64.nix;
+      };
+      musl = {
+        aarch64-linux = import ./bootstrap-files/aarch64-musl.nix;
+        armv6l-linux = import ./bootstrap-files/armv6l-musl.nix;
+        x86_64-linux = import ./bootstrap-files/x86_64-musl.nix;
+        riscv64-linux = import ./bootstrap-files/riscv64-musl.nix;
+      };
     };
-    musl = {
-      aarch64-linux = import ./bootstrap-files/aarch64-musl.nix;
-      armv6l-linux  = import ./bootstrap-files/armv6l-musl.nix;
-      x86_64-linux  = import ./bootstrap-files/x86_64-musl.nix;
-    };
-  };
 
-  # Try to find an architecture compatible with our current system. We
-  # just try every bootstrap we’ve got and test to see if it is
-  # compatible with or current architecture.
-  getCompatibleTools = lib.foldl (v: system:
-    if v != null then v
-    else if localSystem.canExecute (lib.systems.elaborate { inherit system; }) then archLookupTable.${system}
-    else null) null (lib.attrNames archLookupTable);
+    # Try to find an architecture compatible with our current system. We
+    # just try every bootstrap we’ve got and test to see if it is
+    # compatible with or current architecture.
+    getCompatibleTools = lib.foldl
+      (v: system:
+        if v != null then v
+        else if localSystem.canExecute (lib.systems.elaborate { inherit system; }) then archLookupTable.${system}
+        else null)
+      null
+      (lib.attrNames archLookupTable);
 
-  archLookupTable = table.${localSystem.libc}
-    or (abort "unsupported libc for the pure Linux stdenv");
-  files = archLookupTable.${localSystem.system} or (if getCompatibleTools != null then getCompatibleTools
+    archLookupTable = table.${localSystem.libc}
+      or (abort "unsupported libc for the pure Linux stdenv");
+    files = archLookupTable.${localSystem.system} or (if getCompatibleTools != null then getCompatibleTools
     else (abort "unsupported platform for the pure Linux stdenv"));
-  in files
+  in
+  files
 }:
 
 assert crossSystem == localSystem;
@@ -82,7 +91,7 @@ let
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
   stageFun = prevStage:
-    { name, overrides ? (self: super: {}), extraNativeBuildInputs ? [] }:
+    { name, overrides ? (self: super: { }), extraNativeBuildInputs ? [ ] }:
 
     let
 
@@ -100,34 +109,37 @@ let
             ${commonPreHook}
           '';
         shell = "${bootstrapTools}/bin/bash";
-        initialPath = [bootstrapTools];
+        initialPath = [ bootstrapTools ];
 
         fetchurlBoot = import ../../build-support/fetchurl/boot.nix {
           inherit system;
         };
 
-        cc = if prevStage.gcc-unwrapped == null
-             then null
-             else lib.makeOverridable (import ../../build-support/cc-wrapper) {
-          name = "${name}-gcc-wrapper";
-          nativeTools = false;
-          nativeLibc = false;
-          buildPackages = lib.optionalAttrs (prevStage ? stdenv) {
-            inherit (prevStage) stdenv;
-          };
-          cc = prevStage.gcc-unwrapped;
-          bintools = prevStage.binutils;
-          isGNU = true;
-          libc = getLibc prevStage;
-          inherit lib;
-          inherit (prevStage) coreutils gnugrep;
-          stdenvNoCC = prevStage.ccWrapperStdenv;
-        };
+        cc =
+          if prevStage.gcc-unwrapped == null
+          then null
+          else
+            lib.makeOverridable (import ../../build-support/cc-wrapper) {
+              name = "${name}-gcc-wrapper";
+              nativeTools = false;
+              nativeLibc = false;
+              buildPackages = lib.optionalAttrs (prevStage ? stdenv) {
+                inherit (prevStage) stdenv;
+              };
+              cc = prevStage.gcc-unwrapped;
+              bintools = prevStage.binutils;
+              isGNU = true;
+              libc = getLibc prevStage;
+              inherit lib;
+              inherit (prevStage) coreutils gnugrep;
+              stdenvNoCC = prevStage.ccWrapperStdenv;
+            };
 
         overrides = self: super: (overrides self super) // { fetchurl = thisStdenv.fetchurlBoot; };
       };
 
-    in {
+    in
+    {
       inherit config overlays;
       stdenv = thisStdenv;
     };
@@ -236,7 +248,7 @@ in
         ccWrapperStdenv
         gcc-unwrapped coreutils gnugrep
         perl gnum4 bison;
-      dejagnu = super.dejagnu.overrideAttrs (a: { doCheck = false; } );
+      dejagnu = super.dejagnu.overrideAttrs (a: { doCheck = false; });
 
       # We need libidn2 and its dependency libunistring as glibc dependency.
       # To avoid the cycle, we build against bootstrap libc, nuke references,
@@ -307,26 +319,27 @@ in
       ${localSystem.libc} = getLibc prevStage;
       gcc-unwrapped =
         let makeStaticLibrariesAndMark = pkg:
-              lib.makeOverridable (pkg.override { stdenv = self.makeStaticLibraries self.stdenv; })
-                .overrideAttrs (a: { pname = "${a.pname}-stage3"; });
-        in super.gcc-unwrapped.override {
-        # Link GCC statically against GMP etc.  This makes sense because
-        # these builds of the libraries are only used by GCC, so it
-        # reduces the size of the stdenv closure.
-        gmp = makeStaticLibrariesAndMark super.gmp;
-        mpfr = makeStaticLibrariesAndMark super.mpfr;
-        libmpc = makeStaticLibrariesAndMark super.libmpc;
-        isl = makeStaticLibrariesAndMark super.isl_0_20;
-        # Use a deterministically built compiler
-        # see https://github.com/NixOS/nixpkgs/issues/108475 for context
-        reproducibleBuild = true;
-        profiledCompiler = false;
-      };
+          lib.makeOverridable (pkg.override { stdenv = self.makeStaticLibraries self.stdenv; }).overrideAttrs
+            (a: { pname = "${a.pname}-stage3"; });
+        in
+        super.gcc-unwrapped.override {
+          # Link GCC statically against GMP etc.  This makes sense because
+          # these builds of the libraries are only used by GCC, so it
+          # reduces the size of the stdenv closure.
+          gmp = makeStaticLibrariesAndMark super.gmp;
+          mpfr = makeStaticLibrariesAndMark super.mpfr;
+          libmpc = makeStaticLibrariesAndMark super.libmpc;
+          isl = makeStaticLibrariesAndMark super.isl_0_20;
+          # Use a deterministically built compiler
+          # see https://github.com/NixOS/nixpkgs/issues/108475 for context
+          reproducibleBuild = true;
+          profiledCompiler = false;
+        };
     };
     extraNativeBuildInputs = [ prevStage.patchelf ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (!localSystem.isx86 || localSystem.libc == "musl")
-                   prevStage.updateAutotoolsGnuConfigScriptsHook;
+        prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
 
 
@@ -378,7 +391,7 @@ in
     extraNativeBuildInputs = [ prevStage.patchelf prevStage.xz ] ++
       # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
       lib.optional (!localSystem.isx86 || localSystem.libc == "musl")
-                   prevStage.updateAutotoolsGnuConfigScriptsHook;
+        prevStage.updateAutotoolsGnuConfigScriptsHook;
   })
 
   # Construct the final stdenv.  It uses the Glibc and GCC, and adds
@@ -401,12 +414,12 @@ in
       preHook = commonPreHook;
 
       initialPath =
-        ((import ../generic/common-path.nix) {pkgs = prevStage;});
+        ((import ../generic/common-path.nix) { pkgs = prevStage; });
 
       extraNativeBuildInputs = [ prevStage.patchelf ] ++
         # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
         lib.optional (!localSystem.isx86 || localSystem.libc == "musl")
-        prevStage.updateAutotoolsGnuConfigScriptsHook;
+          prevStage.updateAutotoolsGnuConfigScriptsHook;
 
       cc = prevStage.gcc;
 
@@ -425,21 +438,43 @@ in
       allowedRequisites = with prevStage; with lib;
         # Simple executable tools
         concatMap (p: [ (getBin p) (getLib p) ]) [
-            gzip bzip2 xz bash binutils.bintools coreutils diffutils findutils
-            gawk gmp gnumake gnused gnutar gnugrep gnupatch patchelf ed file
-          ]
+          gzip
+          bzip2
+          xz
+          bash
+          binutils.bintools
+          coreutils
+          diffutils
+          findutils
+          gawk
+          gmp
+          gnumake
+          gnused
+          gnutar
+          gnugrep
+          gnupatch
+          patchelf
+          ed
+          file
+        ]
         # Library dependencies
         ++ map getLib (
-            [ attr acl zlib pcre libidn2 libunistring ]
-            ++ lib.optional (gawk.libsigsegv != null) gawk.libsigsegv
-          )
+          [ attr acl zlib pcre libidn2 libunistring ]
+          ++ lib.optional (gawk.libsigsegv != null) gawk.libsigsegv
+        )
         # More complicated cases
-        ++ (map (x: getOutput x (getLibc prevStage)) [ "out" "dev" "bin" ] )
-        ++  [ /*propagated from .dev*/ linuxHeaders
-            binutils gcc gcc.cc gcc.cc.lib gcc.expand-response-params
-          ]
-          ++ lib.optionals (!localSystem.isx86 || localSystem.libc == "musl")
-            [ prevStage.updateAutotoolsGnuConfigScriptsHook prevStage.gnu-config ];
+        ++ (map (x: getOutput x (getLibc prevStage)) [ "out" "dev" "bin" ])
+        ++ [
+          /*propagated from .dev*/
+          linuxHeaders
+          binutils
+          gcc
+          gcc.cc
+          gcc.cc.lib
+          gcc.expand-response-params
+        ]
+        ++ lib.optionals (!localSystem.isx86 || localSystem.libc == "musl")
+          [ prevStage.updateAutotoolsGnuConfigScriptsHook prevStage.gnu-config ];
 
       overrides = self: super: {
         inherit (prevStage)

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -21,6 +21,7 @@ in lib.mapAttrs (n: make) (with lib.systems.examples; {
   armv6l-musl  = muslpi;
   aarch64-musl = aarch64-multiplatform-musl;
   riscv64 = riscv64;
+  riscv64-musl = riscv64-musl;
   mips64el-linux-gnuabin32 = mips64el-linux-gnuabin32;
   mips64el-linux-gnuabi64  = mips64el-linux-gnuabi64;
   mipsel-linux-gnu         = mipsel-linux-gnu;


### PR DESCRIPTION
###### Description of changes

Per [the changelog](http://musl.libc.org/releases.html), musl has had RISC-V support since 1.1.23. We currently have 1.2.3, so it's time to build `pkgsMusl` for RISC-V!

This does not currently work, because there is no supported release of the Rust compiler for the `riscv64gc-unknown-linux-musl` platform: https://doc.rust-lang.org/rustc/platform-support.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
