### PR TITLE
nixos/docs: add a ctags script for nixos options

### DIFF
--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -31,13 +31,14 @@ let
     prefix ? [],
     modules ? [],
     specialArgs ? {},
+    declarationLocations ? false,
   }:
   # NOTE: Regular NixOS currently does use this function! Don't break it!
   #       Ideally we don't diverge, unless we learn that we should.
   #       In other words, only the public interface of nixos.evalModules
   #       is experimental.
   lib.evalModules {
-    inherit prefix modules;
+    inherit prefix modules declarationLocations;
     class = "nixos";
     specialArgs = {
       modulesPath = builtins.toString ../modules;

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -32,6 +32,7 @@ evalConfigArgs@
 , lib ? import ../../lib
 , extraModules ? let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
                  in lib.optional (e != "") (import e)
+, declarationLocations ? false
 }:
 
 let pkgs_ = pkgs;
@@ -94,7 +95,7 @@ let
       locatedModules ++ legacyModules;
 
   noUserModules = evalModulesMinimal ({
-    inherit prefix specialArgs;
+    inherit prefix specialArgs declarationLocations;
     modules = baseModules ++ extraModules ++ [ pkgsModule modulesModule ];
   });
 

--- a/opts-tags.nix
+++ b/opts-tags.nix
@@ -20,6 +20,9 @@ let
             type = lib.types.int;
           };
         };
+        config = {
+          nya.nya = 2;
+        };
       })
     ];
   };
@@ -30,7 +33,7 @@ let
     let line = if loc ? line then loc.line else 1;
     in
     if loc != null then
-    "${name}\t${loc.file}\t${toString line}\n"
+      "${name}\t${loc.file}\t${toString line}\n"
     else "";
 
   toTags = acc0: struct: (builtins.foldl'
@@ -39,11 +42,12 @@ let
       if item ? _type && item._type == "option" then
         acc ++ builtins.map (locationToTagLine (builtins.toString item)) item.declarationsWithLocations
       else toTags acc item
-    ) acc0
+    )
+    acc0
     (builtins.attrNames struct));
 in
 {
   inherit nixos lib testEm;
-  tags = builtins.concatStringsSep "" (builtins.sort builtins.lessThan (toTags [] nixos.options));
+  tags = set: builtins.concatStringsSep "" (builtins.sort builtins.lessThan (toTags [ ] set.options));
   dl = lib.optionAttrSetToDocList nixos.options;
 }

--- a/opts-tags.nix
+++ b/opts-tags.nix
@@ -1,0 +1,49 @@
+let
+  lib = import ./lib;
+  nixos = import ./nixos/lib/eval-config.nix {
+    system = builtins.currentSystem;
+    modules = [ ];
+    declarationLocations = true;
+  };
+
+  testEm = lib.evalModules {
+    declarationLocations = true;
+    modules = [
+      ({ ... }: {
+        options = {
+          nya.nya = lib.mkOption {
+            description = "nya!";
+            type = lib.types.int;
+          };
+          nya.nyaaa = lib.mkOption {
+            description = "nyaaaaa!";
+            type = lib.types.int;
+          };
+        };
+      })
+    ];
+  };
+
+  locationToTagLine = name: loc:
+    # XXX: clearly we are getting some funny data for submodules.
+    # but i dont care. maybe it should be fixed.
+    let line = if loc ? line then loc.line else 1;
+    in
+    if loc != null then
+    "${name}\t${loc.file}\t${toString line}\n"
+    else "";
+
+  toTags = acc0: struct: (builtins.foldl'
+    (acc: name:
+      let item = struct.${name}; in
+      if item ? _type && item._type == "option" then
+        acc ++ builtins.map (locationToTagLine (builtins.toString item)) item.declarationsWithLocations
+      else toTags acc item
+    ) acc0
+    (builtins.attrNames struct));
+in
+{
+  inherit nixos lib testEm;
+  tags = builtins.concatStringsSep "" (builtins.sort builtins.lessThan (toTags [] nixos.options));
+  dl = lib.optionAttrSetToDocList nixos.options;
+}


### PR DESCRIPTION
###### Description of changes

This is basically the change made by https://github.com/NixOS/nixpkgs/pull/65024

This branch is very WIP and I'm frankly not sure when I'll get back to it. For instance, I'm not sure where to put the script in the tree right now as it's late and I'm tired.

to use it:

```
$ nix eval --raw --expr '(import ./opts-tags.nix).tags' --impure > opts-tags
```

then you can configure your editor, for instance with `'tags'` in vim, to load tags from that file (as well as [nix-doc](https://github.com/lf-/nix-doc) generated nix function ctags!)

output looks like this:
```
dev/nixpkgs - [nixos-tags●] » head opts-tags
_module.args    /home/jade/dev/nixpkgs/lib/modules.nix  157
_module.check   /home/jade/dev/nixpkgs/lib/modules.nix  221
_module.freeformType    /home/jade/dev/nixpkgs/lib/modules.nix       228
_module.specialArgs     /home/jade/dev/nixpkgs/lib/modules.nix       244
appstream.enable        /home/jade/dev/nixpkgs/nixos/modules/config/appstream.nix    6
assertions      /home/jade/dev/nixpkgs/nixos/modules/misc/assertions.nix     9
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
