### PR TITLE
.editorconfig: disallow trailing whitespace for markdown again

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,10 +55,13 @@ trim_trailing_whitespace = unset
 [*.lock]
 indent_size = unset
 
-# trailing whitespace is an actual syntax element of classic Markdown/
-# CommonMark to enforce a line break
+# Although Markdown/CommonMark allows using two trailing spaces to denote
+# a hard line break, we do not use that feature in nixpkgs since
+# it forces the surrounding paragraph to become a <literallayout> which
+# does not wrap reasonably.
+# Instead of a hard line break, start a new paragraph by inserting a blank line.
 [*.md]
-trim_trailing_whitespace = unset
+trim_trailing_whitespace = true
 
 # binaries
 [*.nib]

--- a/doc/builders/images/makediskimage.section.md
+++ b/doc/builders/images/makediskimage.section.md
@@ -20,7 +20,7 @@ Features are separated in various sections depending on if you opt for a Nix-sto
 ### Common
 
 - arbitrary NixOS configuration
-- automatic or bound disk size: `diskSize` parameter, `additionalSpace` can be set when `diskSize` is `auto` to add a constant of disk space 
+- automatic or bound disk size: `diskSize` parameter, `additionalSpace` can be set when `diskSize` is `auto` to add a constant of disk space
 - multiple partition table layouts: EFI, legacy, legacy + GPT, hybrid, none through `partitionTableType` parameter
 - OVMF or EFI firmwares and variables templates can be customized
 - root filesystem `fsType` can be customized to whatever `mkfs.${fsType}` exist during operations

--- a/doc/builders/testers.chapter.md
+++ b/doc/builders/testers.chapter.md
@@ -62,7 +62,7 @@ runCommand "example" {
 '';
 ```
 
-While `testBuildFailure` is designed to keep changes to the original builder's 
+While `testBuildFailure` is designed to keep changes to the original builder's
 environment to a minimum, some small changes are inevitable.
 
  - The file `$TMPDIR/testBuildFailure.log` is present. It should not be deleted.

--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -16,7 +16,8 @@ In the following is an example expression using `buildGoModule`, the following a
   `vendorHash` can also be set to `null`.
   In that case, rather than fetching the dependencies and vendoring them, the dependencies vendored in the source repo will be used.
 
-  To avoid updating this field when dependencies change, run `go mod vendor` in your source repo and set `vendorHash = null;`  
+  To avoid updating this field when dependencies change, run `go mod vendor` in your source repo and set `vendorHash = null;`
+
   To obtain the actual hash, set `vendorHash = lib.fakeSha256;` and run the build ([more details here](#sec-source-hashes)).
 - `proxyVendor`: Fetches (go mod download) and proxies the vendor directory. This is useful if your code depends on c code and go mod tidy does not include the needed sources to build or if any dependency has case-insensitive conflicts which will produce platform dependant `vendorHash` checksums.
 

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -16,8 +16,20 @@
     </para>
     <itemizedlist>
       <listitem>
-<literallayout>Nix has been updated from 2.3 to 2.8. This mainly brings experimental support for Flakes, but also marks the <literal>nix</literal> command as experimental which now has to be enabled via the configuration explicitly. For more information and instructions for upgrades, see the relase notes for <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.4.html">nix-2.4</link>,
-<link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.5.html">nix-2.5</link>, <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.6.html">nix-2.6</link>, <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.7.html">nix-2.7</link> and <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.8.html">nix-2.8</link></literallayout>
+        <para>
+          Nix has been updated from 2.3 to 2.8. This mainly brings
+          experimental support for Flakes, but also marks the
+          <literal>nix</literal> command as experimental which now has
+          to be enabled via the configuration explicitly. For more
+          information and instructions for upgrades, see the relase
+          notes for
+          <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.4.html">nix-2.4</link>,
+          <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.5.html">nix-2.5</link>,
+          <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.6.html">nix-2.6</link>,
+          <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.7.html">nix-2.7</link>
+          and
+          <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-2.8.html">nix-2.8</link>
+        </para>
       </listitem>
       <listitem>
         <para>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -9,8 +9,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - Nix has been updated from 2.3 to 2.8. This mainly brings experimental support
   for Flakes, but also marks the `nix` command as experimental which now has to
   be enabled via the configuration explicitly. For more information and
-  instructions for upgrades, see the 
-  relase notes for [nix-2.4](https://nixos.org/manual/nix/stable/release-notes/rl-2.4.html),  
+  instructions for upgrades, see the
+  relase notes for [nix-2.4](https://nixos.org/manual/nix/stable/release-notes/rl-2.4.html),
   [nix-2.5](https://nixos.org/manual/nix/stable/release-notes/rl-2.5.html),
   [nix-2.6](https://nixos.org/manual/nix/stable/release-notes/rl-2.6.html),
   [nix-2.7](https://nixos.org/manual/nix/stable/release-notes/rl-2.7.html) and
@@ -30,7 +30,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - Systemd has been upgraded to the version 250.
 
-- Pulseaudio has been updated to version 15.0 and now optionally 
+- Pulseaudio has been updated to version 15.0 and now optionally
   [supports additional Bluetooth audio codecs](https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/15.0/#supportforldacandaptxbluetoothcodecsplussbcxqsbcwithhigher-qualityparameters)
   such as aptX or LDAC, with codec switching available in `pavucontrol`. This
   feature is disabled by default, but can be enabled with the option
@@ -50,7 +50,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   settings for many certificates at once. This also opens up the option to use
   DNS-01 validation when using `enableACME` web server virtual hosts (e.g.
   `services.nginx.virtualHosts.*.enableACME`).
-  
+
 ## New Services {#sec-release-22.05-new-services}
 
 - [1password](https://1password.com/), command-lines and graphic interface for 1Password. Available as [programs._1password](#opt-programs._1password.enable) and [programs._1password-gui](#opt-programs._1password.enable).
@@ -743,11 +743,11 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The configuration portion of the `nix-daemon` module has been reworked and exposed as [nix.settings](options.html#opt-nix-settings):
   * Legacy options have been mapped to the corresponding options under under [nix.settings](options.html#opt-nix.settings) and will be deprecated when NixOS 21.11 reaches end of life.
   * [nix.buildMachines.publicHostKey](options.html#opt-nix.buildMachines.publicHostKey) has been added.
-  
+
 - [`kops`](https://kops.sigs.k8s.io) defaults to 1.23.2, which will enable [Instance Metadata Service Version 2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) and require tokens on new clusters with Kubernetes >= 1.22. This will increase security by default, but may break some types of workloads. The default behaviour for `spec.kubeDNS.nodeLocalDNS.forwardToKubeDNS` has changed from `true` to `false`. Cilium now has `disable-cnp-status-updates: true` by default. Set this to false if you rely on the CiliumNetworkPolicy status fields. Support for Kubernetes 1.17, the Lyft CNI, Weave CNI on Kubernetes >= 1.23, CentOS 7 and 8, Debian 9, RHEL 7, and Ubuntu 16.05 (Xenial) has been removed. See the [1.22 release notes](https://kops.sigs.k8s.io/releases/1.22-notes/) and [1.23 release notes](https://kops.sigs.k8s.io/releases/1.23-notes/) for more details, including other significant changes.
 
 - Mattermost has been upgraded to extended support version 6.3 as the previously
-  packaged extended support version 5.37 is [reaching end of life](https://docs.mattermost.com/upgrade/extended-support-release.html). 
+  packaged extended support version 5.37 is [reaching end of life](https://docs.mattermost.com/upgrade/extended-support-release.html).
   Migration may take some time, see the [changelog](https://docs.mattermost.com/install/self-managed-changelog.html#release-v6-3-extended-support-release)
   and [important upgrade notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
 
@@ -762,14 +762,14 @@ In addition to numerous new and upgraded packages, this release has the followin
   By default auto-upgrade will now run immediately if it would have been triggered at least
   once during the time when the timer was inactive.
 
-- Mastodon now uses `services.redis.servers` to start a new redis server, instead of using a global redis server. 
+- Mastodon now uses `services.redis.servers` to start a new redis server, instead of using a global redis server.
   This improves compatibility with other services that use redis.
-  
-  Note that this will recreate the redis database, although according to the [Mastodon docs](https://docs.joinmastodon.org/admin/backups/), 
+
+  Note that this will recreate the redis database, although according to the [Mastodon docs](https://docs.joinmastodon.org/admin/backups/),
   this is almost harmless:
-  > Losing the Redis database is almost harmless: The only irrecoverable data will be the contents of the Sidekiq queues and scheduled retries of previously failed jobs. 
+  > Losing the Redis database is almost harmless: The only irrecoverable data will be the contents of the Sidekiq queues and scheduled retries of previously failed jobs.
   >  The home and list feeds are stored in Redis, but can be regenerated with tootctl.
-  
+
   If you do want to save the redis database, you can use the following commands:
   ```bash
   redis-cli save
@@ -980,7 +980,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   or `wl*` with priority 99 (which means that it doesn't have any effect if such an interface is matched
   by a `.network-`unit with a lower priority). In case of scripted networking, no behavior
   was changed.
-  
+
 - The new [`postgresqlTestHook`](https://nixos.org/manual/nixpkgs/stable/#sec-postgresqlTestHook) runs a PostgreSQL server for the duration of package checks.
 
 - `zfs` was updated from 2.1.4 to 2.1.5, enabling it to be used with Linux kernel 5.18.

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -34,7 +34,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `carnix` and `cratesIO` has been removed due to being unmaintained, use alternatives such as [naersk](https://github.com/nix-community/naersk) and [crate2nix](https://github.com/kolloch/crate2nix) instead.
 
-- `borgbackup` module now has an option for inhibiting system sleep while backups are running, defaulting to off (not inhibiting sleep), available as [`services.borgbackup.jobs.<name>.inhibitsSleep`](#opt-services.borgbackup.jobs._name_.inhibitsSleep). 
+- `borgbackup` module now has an option for inhibiting system sleep while backups are running, defaulting to off (not inhibiting sleep), available as [`services.borgbackup.jobs.<name>.inhibitsSleep`](#opt-services.borgbackup.jobs._name_.inhibitsSleep).
 
 - The EC2 image module no longer fetches instance metadata in stage-1. This results in a significantly smaller initramfs, since network drivers no longer need to be included, and faster boots, since metadata fetching can happen in parallel with startup of other services.
   This breaks services which rely on metadata being present by the time stage-2 is entered. Anything which reads EC2 metadata from `/etc/ec2-metadata` should now have an `after` dependency on `fetch-ec2-metadata.service`

--- a/pkgs/servers/nextcloud/packages/README.md
+++ b/pkgs/servers/nextcloud/packages/README.md
@@ -13,9 +13,9 @@ for example `breezedark` for the app with the url
 
 To regenerate the nixpkgs nextcloudPackages set, run:
 
-``` 
+```
 ./generate.sh
-``` 
+```
 
 After that you can commit and submit the changes.
 

--- a/pkgs/servers/web-apps/wordpress/packages/README.md
+++ b/pkgs/servers/web-apps/wordpress/packages/README.md
@@ -18,9 +18,9 @@ For available translations and language codes see [upstream translation reposito
 
 To regenerate the nixpkgs wordpressPackages set, run:
 
-``` 
+```
 ./generate.sh
-``` 
+```
 
 After that you can commit and submit the changes.
 
@@ -29,7 +29,7 @@ After that you can commit and submit the changes.
 The plugins will be available in the namespace `wordpressPackages.plugins`.
 Using it together with the Wordpress module could look like this:
 
-``` 
+```
 services.wordpress = {
   sites."blog.${config.networking.domain}" = {
     plugins = with pkgs.wordpressPackages.plugins; [


### PR DESCRIPTION
Although trailing whitespace is significant in Markdown, there's no good reason to use that (mis)feature.

Using two trailing spaces to insert a line break makes Pandoc generate a `<literallayout>` instead of a `<para>`, which messes up the wrapping. Instead, you can always just start a new paragraph.

cc @schmittlauch for https://github.com/NixOS/nixpkgs/pull/168012#issuecomment-1104511719 and @adisbladis for https://github.com/NixOS/nixpkgs/pull/171344