### PR TITLE
wargus: remove download of data files

### DIFF
--- a/pkgs/games/wargus/default.nix
+++ b/pkgs/games/wargus/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, callPackage, fetchFromGitHub
-, fetchurl, runCommand, unzip, bchunk, p7zip
+, requireFile, runCommand, p7zip
 , cmake, pkg-config, makeWrapper
 , zlib, bzip2, libpng
 , dialog, python3, cdparanoia, ffmpeg
@@ -8,20 +8,19 @@
 let
   stratagus = callPackage ./stratagus.nix {};
 
-  dataDownload = fetchurl {
-    url = "https://archive.org/download/warcraft-ii-tides-of-darkness_202105/Warcess.zip";
-    sha256 = "0yxgvf8xpv1w2bjmny4a38pa3xcdgqckk9abj21ilkc5zqzqmm9b";
+  dataDownload = requireFile {
+    message = ''
+      Provide a Warcraft II CD-ROM image.
+    '';
+    name = "WC2BTDP01.iso";
+    sha256 = "0wc4wqb9afxykah8lq1jw0sl564j5gs1shrr67cflfsaiscr4qxm";
   };
 
   data = runCommand "warcraft2" {
-    buildInputs = [ unzip bchunk p7zip ];
+    buildInputs = [ p7zip ];
     meta.license = lib.licenses.unfree;
   } ''
-    unzip ${dataDownload} "Warcraft.II.Tides.of.Darkness/Warcraft II - Tides of Darkness (1995)/games/WarcrafD/cd/"{WC2BTDP.img,WC2BTDP.cue}
-    bchunk "Warcraft.II.Tides.of.Darkness/Warcraft II - Tides of Darkness (1995)/games/WarcrafD/cd/"{WC2BTDP.img,WC2BTDP.cue} WC2BTDP
-    rm -r Warcraft.II.Tides.of.Darkness
-    7z x WC2BTDP01.iso
-    rm WC2BTDP*.{iso,cdr}
+    7z x ${dataDownload}
     cp -r DATA $out
   '';
 

--- a/pkgs/games/wargus/default.nix
+++ b/pkgs/games/wargus/default.nix
@@ -2,7 +2,7 @@
 , requireFile, runCommand, p7zip
 , cmake, pkg-config, makeWrapper
 , zlib, bzip2, libpng
-, dialog, python3, cdparanoia, ffmpeg
+, ffmpeg
 }:
 
 let

--- a/pkgs/games/wargus/stratagus.nix
+++ b/pkgs/games/wargus/stratagus.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchFromGitHub
-, cmake, pkg-config, makeWrapper
-, zlib, bzip2, libpng, lua5_1, toluapp
+, cmake, pkg-config, zlib, bzip2, libpng, lua5_1, toluapp
 , SDL2, SDL2_mixer, SDL2_image, libGL
 }:
 


### PR DESCRIPTION
###### Description of changes

Resolves #208078

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
