### PR TITLE
ocamlPackages.inotify: 2.3 → 2.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/inotify/default.nix
+++ b/pkgs/development/ocaml-modules/inotify/default.nix
@@ -1,42 +1,26 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, ocaml, findlib, ocamlbuild
-, ocaml_lwt # optional lwt support
-, ounit, fileutils # only for tests
+{ lib, fetchFromGitHub, buildDunePackage
+, lwt # optional lwt support
+, ounit2, fileutils # only for tests
 }:
 
-stdenv.mkDerivation rec {
-  version = "2.3";
-  pname = "ocaml${ocaml.version}-inotify";
+buildDunePackage rec {
+  version = "2.4.1";
+  pname = "inotify";
 
   src = fetchFromGitHub {
     owner = "whitequark";
     repo = "ocaml-inotify";
     rev = "v${version}";
-    sha256 = "1s6vmqpx19hxzsi30jvp3h7p56rqnxfhfddpcls4nz8sqca1cz5y";
+    hash = "sha256-2ATFF3HeATjhWgW4dG4jheQ9m1oE8xTQ7mpMT/1Jdp8=";
   };
 
-  patches = [ (fetchpatch {
-    url = "https://github.com/whitequark/ocaml-inotify/commit/716c8002cc1652f58eb0c400ae92e04003cba8c9.patch";
-    sha256 = "04lfxrrsmk2mc704kaln8jqx93jc4bkxhijmfy2d4cmk1cim7r6k";
-  }) ];
-
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ ocaml_lwt ];
-  checkInputs = [ ounit fileutils ];
+  buildInputs = [ lwt ];
+  checkInputs = [ ounit2 fileutils ];
 
   # Otherwise checkInputs can't be found
   strictDeps = false;
 
-  configureFlags = [ "--enable-lwt"
-    (lib.optionalString doCheck "--enable-tests") ];
-
-  postConfigure = lib.optionalString doCheck ''
-    echo '<lib_test/test_inotify_lwt.*>: pkg_threads' | tee -a _tags
-  '';
-
   doCheck = true;
-  checkTarget = "test";
-
-  createFindlibDestdir = true;
 
   meta = {
     description = "Bindings for Linux’s filesystem monitoring interface, inotify";

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -2,9 +2,8 @@
 , gnutls, nettle
 }:
 
-if lib.versionOlder ocaml.version "4.02"
-then throw "ocamlnet is not available for OCaml ${ocaml.version}"
-else
+lib.throwIf (lib.versionOlder ocaml.version "4.02" || lib.versionAtLeast ocaml.version "5.0")
+  "ocamlnet is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-ocamlnet";

--- a/pkgs/development/ocaml-modules/xml-light/default.nix
+++ b/pkgs/development/ocaml-modules/xml-light/default.nix
@@ -1,5 +1,8 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, gitUpdater }:
 
+lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
+  "xml-light is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-xml-light";
   version = "2.4";


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
