### PR TITLE
lib/types: make `either` expose submodules

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -869,9 +869,17 @@ rec {
   # option declarations in submodules have accurate position information.
   # TODO: Merge this into mergeOptionDecls
   fixupOptionType = loc: opt:
-    if opt.type.getSubModules or null == null
+    builtins.addErrorContext ''
+      while evaluating the type of option `${showOption loc}`
+
+      ====================================
+      A possible cause for the error is that `${showOption loc}` has a recursively
+      defined type that does not use `types.recursive`.
+      ====================================
+    ''
+    (if opt.type.getSubModules or null == null
     then opt // { type = opt.type or types.unspecified; }
-    else opt // { type = opt.type.substSubModules opt.options; options = []; };
+    else opt // { type = opt.type.substSubModules opt.options; options = []; });
 
 
   /* Properties. */

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -222,7 +222,7 @@ rec {
     concatMap (opt:
       let
         name = showOption opt.loc;
-        docOption = rec {
+        docOption = {
           loc = opt.loc;
           inherit name;
           description = opt.description or null;
@@ -256,6 +256,7 @@ rec {
       in
         # To find infinite recursion in NixOS option docs:
         # builtins.trace opt.loc
+        builtins.seq docOption.type # gives more useful traces
         [ docOption ] ++ optionals subOptionsVisible subOptions) (collect isOption options);
 
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -358,6 +358,9 @@ checkConfigOutput '^"The option `a\.b. defined in `.*/doRename-warnings\.nix. ha
   config.result \
   ./doRename-warnings.nix
 
+# Recursive types using `either` fail with an error mentioning `types.recursive`
+checkConfigError 'types\.recursive' docOptions ./declare-recursive-type.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/declare-recursive-type.nix
+++ b/lib/tests/modules/declare-recursive-type.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+
+{
+  options = {
+    value = lib.mkOption {
+      type = with lib.types; let
+        t = oneOf [ str (attrsOf t) ];
+      in t // {
+        description = "a recursive type";
+      };
+      description = "a value";
+    };
+  };
+}

--- a/lib/tests/modules/default.nix
+++ b/lib/tests/modules/default.nix
@@ -1,8 +1,11 @@
 { lib ? import ../.., modules ? [] }:
 
-{
+let
   inherit (lib.evalModules {
     inherit modules;
     specialArgs.modulesPath = ./.;
   }) config options;
+in {
+  inherit config options;
+  docOptions = lib.optionAttrSetToDocList options;
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -838,6 +838,17 @@ rec {
           else if all (x: t2.check x) defList
                then t2.merge loc defs
           else mergeOneOption loc defs;
+      getSubOptions = prefix: t2.getSubOptions prefix // t1.getSubOptions prefix;
+      getSubModules =
+        if t1.getSubModules == null && t2.getSubModules == null then null
+        else if t1.getSubModules == null then t2.getSubModules
+        # FIXME If both t1 and t2 have submodules, we should return the concatenation of both lists;
+        # however this causes "option is already defined" errors seemingly due to `fixupOptionType`
+        # for types of the form `either someSubmodule (listOf someSubmodule)`.
+        else t1.getSubModules;
+      substSubModules = let
+        maybeSubstModules = t: m: let t' = t.substSubModules m; in if t' == null then t else t';
+      in m: either (maybeSubstModules t1 m) (maybeSubstModules t2 m);
       typeMerge = f':
         let mt1 = t1.typeMerge (elemAt f'.wrapped 0).functor;
             mt2 = t2.typeMerge (elemAt f'.wrapped 1).functor;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -886,6 +886,16 @@ rec {
     # Augment the given type with an additional type check function.
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 
+    # A recursively defined type that doesn't trigger infinite recursions.
+    recursive = tf: let
+      base = tf (mkOptionType { name = "itself"; description = "itself"; descriptionClass = "noun"; });
+      type = tf type // {
+        description = "recursive type of ${optionDescriptionPhrase (class: class == "noun" || class == "composite") base}";
+        descriptionClass = "composite";
+        inherit (base) getSubOptions getSubModules substSubModules;
+      };
+    in type;
+
   };
 };
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -337,6 +337,16 @@ Composed types are types that take a type as parameter. `listOf
     value of type *`to`*. Can be used to preserve backwards compatibility
     of an option if its type was changed.
 
+`types.recursive` *`f`*
+
+:   A recursively defined type based on the fixed point of `f`.
+    As an example, you could define the type of boolean [rose trees](https://en.wikipedia.org/wiki/Rose_tree)
+    as `with types; recursive (t: either bool (listOf t))`. If you used
+    `lib.fix` instead of `recursive`, you would run into infinite recursions
+    as the module system tries to determine the description and suboptions of this type.
+
+    This is useful for defining recursive formats such as JSON.
+
 ## Submodule {#section-option-types-submodule}
 
 `submodule` is a very powerful type that defines a set of sub-options

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -698,6 +698,29 @@
           </para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term>
+          <literal>types.recursive</literal>
+          <emphasis><literal>f</literal></emphasis>
+        </term>
+        <listitem>
+          <para>
+            A recursively defined type based on the fixed point of
+            <literal>f</literal>. As an example, you could define the
+            type of boolean
+            <link xlink:href="https://en.wikipedia.org/wiki/Rose_tree">rose
+            trees</link> as
+            <literal>with types; recursive (t: either bool (listOf t))</literal>.
+            If you used <literal>lib.fix</literal> instead of
+            <literal>recursive</literal>, you would run into infinite
+            recursions as the module system tries to determine the
+            description and suboptions of this type.
+          </para>
+          <para>
+            This is useful for defining recursive formats such as JSON.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </section>
   <section xml:id="section-option-types-submodule">

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -53,7 +53,7 @@ in {
           desktop = mkOption {
             type = types.nullOr types.path;
             default = null;
-            description = lib.mkDoc ".desktop file to modify. Only necessary if it uses the absolute path to the executable.";
+            description = lib.mdDoc ".desktop file to modify. Only necessary if it uses the absolute path to the executable.";
             example = literalExpression ''"''${pkgs.firefox}/share/applications/firefox.desktop"'';
           };
           profile = mkOption {

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -106,7 +106,7 @@ in
                   '';
                 };
                 settings = mkOption {
-                  type = let t = types.attrsOf (types.either types.str (t // { description = "instances of this type recursively"; })); in t;
+                  type = types.recursive (t: types.attrsOf (types.either types.str t));
                   default = { };
                   example = {
                     snapshot_preserve_min = "2d";

--- a/nixos/modules/services/games/freeciv.nix
+++ b/nixos/modules/services/games/freeciv.nix
@@ -5,14 +5,13 @@ let
   inherit (config.users) groups;
   rootDir = "/run/freeciv";
   argsFormat = {
-    type = with lib.types; let
-      valueType = nullOr (oneOf [
+    type = with lib.types; recursive (t:
+      nullOr (oneOf [
         bool int float str
-        (listOf valueType)
-      ]) // {
+        (listOf t)
+      ])) // {
         description = "freeciv-server params";
       };
-    in valueType;
     generate = name: value:
       let mkParam = k: v:
             if v == null then []

--- a/nixos/modules/services/mail/davmail.nix
+++ b/nixos/modules/services/mail/davmail.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.davmail;
 
   configType = with types;
-    oneOf [ (attrsOf configType) str int bool ] // {
+    recursive (t: oneOf [ (attrsOf t) str int bool ]) // {
       description = "davmail config type (str, int, bool or attribute set thereof)";
     };
 

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -24,12 +24,14 @@ let
       };
       owner = mkOption {
         type = types.str;
-        default = "${cfg.user}";
+        default = cfg.user;
+        defaultText = lib.literalExpression "cfg.user";
         description = lib.mdDoc "Owner to set on unix socket";
       };
       group = mkOption {
         type = types.str;
-        default = "${cfg.group}";
+        default = cfg.group;
+        defaultText = lib.literalExpression "cfg.group";
         description = lib.mdDoc "Group to set on unix socket";
       };
       rawEntry = mkOption {

--- a/nixos/modules/services/network-filesystems/moosefs.nix
+++ b/nixos/modules/services/network-filesystems/moosefs.nix
@@ -17,9 +17,9 @@ let
 
     in {
       type = with types; let
-        valueType = oneOf ([
-          (listOf valueType)
-        ] ++ allowedTypes) // {
+        valueType = recursive (t: oneOf ([
+          (listOf t)
+        ] ++ allowedTypes)) // {
           description = "Flat key-value file";
         };
       in attrsOf valueType;

--- a/nixos/modules/services/networking/ncdns.nix
+++ b/nixos/modules/services/networking/ncdns.nix
@@ -12,7 +12,7 @@ let
   valueType = with types; oneOf [ int str bool path ]
     // { description = "setting type (integer, string, bool or path)"; };
 
-  configType = with types; attrsOf (nullOr (either valueType configType))
+  configType = with types; recursive (t: attrsOf (nullOr (either valueType t)))
     // { description = ''
           ncdns.conf configuration type. The format consists of an
           attribute set of settings. Each setting can be either `null`,

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -7,6 +7,8 @@ let
 
   cfg = config.services.searx;
 
+  settingsFormat = pkgs.formats.json {};
+
   settingsFile = pkgs.writeText "settings.yml"
     (builtins.toJSON cfg.settings);
 
@@ -24,12 +26,6 @@ let
       sed "s#@$n@#$v#g" -i settings.yml
     done
   '';
-
-  settingType = with types; (oneOf
-    [ bool int float str
-      (listOf settingType)
-      (attrsOf settingType)
-    ]) // { description = "JSON value"; };
 
 in
 
@@ -66,7 +62,7 @@ in
       };
 
       settings = mkOption {
-        type = types.attrsOf settingType;
+        type = types.attrsOf settingsFormat.type;
         default = { };
         example = literalExpression ''
           { server.port = 8080;

--- a/nixos/modules/services/networking/znc/default.nix
+++ b/nixos/modules/services/networking/znc/default.nix
@@ -61,16 +61,12 @@ let
     in
       concatStringsSep "\n" (toLines cfg.config);
 
-  semanticTypes = with types; rec {
+  zncConfType = with types; let
     zncAtom = nullOr (oneOf [ int bool str ]);
+  in recursive (zncConf: let
     zncAttr = attrsOf (nullOr zncConf);
-    zncAll = oneOf [ zncAtom (listOf zncAtom) zncAttr ];
-    zncConf = attrsOf (zncAll // {
-      # Since this is a recursive type and the description by default contains
-      # the description of its subtypes, infinite recursion would occur without
-      # explicitly breaking this cycle
-      description = "znc values (null, atoms (str, int, bool), list of atoms, or attrsets of znc values)";
-    });
+  in attrsOf (oneOf [ zncAtom (listOf zncAtom) zncAttr ])) // {
+    description = "znc values (null, atoms (str, int, bool), list of atoms, or attrsets of znc values)";
   };
 
 in
@@ -123,7 +119,7 @@ in
       };
 
       config = mkOption {
-        type = semanticTypes.zncConf;
+        type = zncConfType;
         default = {};
         example = literalExpression ''
           {

--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -118,7 +118,7 @@ in
           service = mkOption {
             type = nullOr str;
             default = null;
-            description = lib.mdDoc "The service on which to perform \<action\> after fetching.";
+            description = lib.mdDoc "The service on which to perform {option}`action` after fetching.";
           };
 
           action = mkOption {

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -64,6 +64,7 @@ let
   };
   optionPort = mkOption {
     type = with types; nullOr (oneOf [port (enum ["auto"])]);
+    description = lib.mdDoc (descriptionGeneric "");
     default = null;
   };
   optionPorts = optionName: mkOption {
@@ -78,8 +79,16 @@ let
         addr = optionAddress;
         port = optionPort;
         flags = optionFlags;
-        SessionGroup = mkOption { type = nullOr int; default = null; };
-      } // genAttrs isolateFlags (name: mkOption { type = types.bool; default = false; });
+        SessionGroup = mkOption {
+          type = nullOr int;
+          default = null;
+          description = lib.mdDoc (descriptionGeneric "SessionGroup");
+        };
+      } // genAttrs isolateFlags (name: mkOption {
+        type = types.bool;
+        description = lib.mdDoc (descriptionGeneric name);
+        default = false;
+      });
       config = {
         flags = filter (name: config.${name} == true) isolateFlags ++
                 optional (config.SessionGroup != null) "SessionGroup=${toString config.SessionGroup}";
@@ -113,8 +122,16 @@ let
           addr = optionAddress;
           port = optionPort;
           flags = optionFlags;
-          SessionGroup = mkOption { type = nullOr int; default = null; };
-        } // genAttrs flags (name: mkOption { type = types.bool; default = false; });
+          SessionGroup = mkOption {
+            type = nullOr int;
+            default = null;
+            description = lib.mdDoc (descriptionGeneric "SessionGroup");
+          };
+        } // genAttrs flags (name: mkOption {
+          type = types.bool;
+          description = lib.mdDoc (descriptionGeneric name);
+          default = false;
+        });
         config = mkIf doConfig { # Only add flags in SOCKSPort to avoid duplicates
           flags = filter (name: config.${name} == true) flags ++
                   optional (config.SessionGroup != null) "SessionGroup=${toString config.SessionGroup}";
@@ -123,6 +140,7 @@ let
     ];
   optionFlags = mkOption {
     type = with types; listOf str;
+    description = lib.mdDoc (descriptionGeneric "");
     default = [];
   };
   optionORPort = optionName: mkOption {
@@ -138,7 +156,11 @@ let
           addr = optionAddress;
           port = optionPort;
           flags = optionFlags;
-        } // genAttrs flags (name: mkOption { type = types.bool; default = false; });
+        } // genAttrs flags (name: mkOption {
+          type = types.bool;
+          description = lib.mdDoc (descriptionGeneric name);
+          default = false;
+        });
         config = {
           flags = filter (name: config.${name} == true) flags;
         };
@@ -475,6 +497,7 @@ in
                           port = optionPort;
                         };
                       }));
+                      description = lib.mdDoc "The HiddenServicePort's target.";
                     };
                   };
                 }))
@@ -595,7 +618,11 @@ in
                   flags = optionFlags;
                   addr = optionAddress;
                   port = optionPort;
-                } // genAttrs flags (name: mkOption { type = types.bool; default = false; });
+                } // genAttrs flags (name: mkOption {
+                  type = types.bool;
+                  description = lib.mdDoc (descriptionGeneric name);
+                  default = false;
+                });
                 config = {
                   flags = filter (name: config.${name} == true) flags;
                 };

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -39,12 +39,10 @@ let
     inherit (str) merge;
   };
 
-  elixirValue = let
-    elixirValue' = with types;
-      nullOr (oneOf [ bool int float str (attrsOf elixirValue') (listOf elixirValue') ]) // {
-        description = "Elixir value";
-      };
-  in elixirValue';
+  elixirValue = with types; recursive (t:
+    nullOr (oneOf [ bool int float str (attrsOf t) (listOf t) ])) // {
+      description = "Elixir value";
+    };
 
   frontend = {
     options = {

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -39,11 +39,6 @@ let
     inherit (str) merge;
   };
 
-  elixirValue = with types; recursive (t:
-    nullOr (oneOf [ bool int float str (attrsOf t) (listOf t) ])) // {
-      description = "Elixir value";
-    };
-
   frontend = {
     options = {
       package = mkOption {
@@ -633,7 +628,7 @@ in {
               };
 
               "Pleroma.Repo" = mkOption {
-                type = elixirValue;
+                type = format.valueType;
                 default = {
                   adapter = format.lib.mkRaw "Ecto.Adapters.Postgres";
                   socket_dir = "/run/postgresql";
@@ -761,7 +756,7 @@ in {
               };
 
               ":frontends" = mkOption {
-                type = elixirValue;
+                type = format.valueType;
                 default = mapAttrs
                   (key: val: format.lib.mkMap { name = val.name; ref = val.ref; })
                   cfg.frontends;
@@ -791,7 +786,7 @@ in {
                 ```
               '';
               type = types.submodule {
-                freeformType = elixirValue;
+                freeformType = format.valueType;
                 options = {
                   ":vapid_details" = {
                     subject = mkOption {
@@ -843,7 +838,7 @@ in {
 
             ":logger" = {
               ":backends" = mkOption {
-                type = types.listOf elixirValue;
+                type = types.listOf format.valueType;
                 visible = false;
                 default = with format.lib; [
                   (mkTuple [ (mkRaw "ExSyslogger") (mkAtom ":ex_syslogger") ])
@@ -875,7 +870,7 @@ in {
 
             ":tzdata" = {
               ":data_dir" = mkOption {
-                type = elixirValue;
+                type = format.valueType;
                 internal = true;
                 default = format.lib.mkRaw ''
                   Path.join(System.fetch_env!("CACHE_DIRECTORY"), "tzdata")

--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -14,7 +14,7 @@ let
 
   pkg = pkgs.limesurvey;
 
-  configType = with types; oneOf [ (attrsOf configType) str int bool ] // {
+  configType = with types; recursive (t: oneOf [ (attrsOf t) str int bool ]) // {
     description = "limesurvey config type (str, int, bool or attribute set thereof)";
   };
 

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -4,20 +4,18 @@ with lib;
 
 let
   cfg = config.services.traefik;
-  jsonValue = with types;
-    let
-      valueType = nullOr (oneOf [
-        bool
-        int
-        float
-        str
-        (lazyAttrsOf valueType)
-        (listOf valueType)
-      ]) // {
-        description = "JSON value";
-        emptyValue.value = { };
-      };
-    in valueType;
+  jsonValue = with types; recursive (t:
+    nullOr (oneOf [
+      bool
+      int
+      float
+      str
+      (lazyAttrsOf t)
+      (listOf t)
+    ])) // {
+      description = "JSON value";
+      emptyValue.value = { };
+    };
   dynamicConfigFile = if cfg.dynamicConfigFile == null then
     pkgs.runCommand "config.toml" {
       buildInputs = [ pkgs.remarshal ];

--- a/nixos/modules/services/web-servers/trafficserver/default.nix
+++ b/nixos/modules/services/web-servers/trafficserver/default.nix
@@ -140,12 +140,9 @@ in
     };
 
     records = mkOption {
-      type = with types;
-        let valueType = (attrsOf (oneOf [ int float str valueType ])) // {
-          description = "Traffic Server records value";
-        };
-        in
-        valueType;
+      type = with types; recursive (t: attrsOf (oneOf [ int float str t ])) // {
+        description = "Traffic Server records value";
+      };
       default = { };
       example = { proxy.config.proxy_name = "my_server"; };
       description = lib.mdDoc ''

--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -90,25 +90,24 @@ in {
       };
 
       instance = mkOption {
-        type =  with types; let
-          valueType = nullOr (oneOf [
+        type =  with types; recursive (t:
+          nullOr (oneOf [
             bool
             int
             float
             str
-            (lazyAttrsOf valueType)
-            (listOf valueType)
+            (lazyAttrsOf t)
+            (listOf t)
             (mkOptionType {
               name = "function";
               description = "function";
               check = x: isFunction x;
               merge = mergeOneOption;
             })
-          ]) // {
-            description = "Json value or lambda";
+          ])) // {
+            description = "JSON value or lambda";
             emptyValue.value = {};
           };
-        in valueType;
         default = {
           type = "normal";
         };

--- a/nixos/modules/services/x11/picom.nix
+++ b/nixos/modules/services/x11/picom.nix
@@ -231,7 +231,7 @@ in {
       scalar = oneOf [ bool int float str ]
         // { description = "scalar types"; };
 
-      libConfig = oneOf [ scalar (listOf libConfig) (attrsOf libConfig) ]
+      libConfig = recursive (t: oneOf [ scalar (listOf t) (attrsOf t) ])
         // { description = "libconfig type"; };
 
       topLevel = attrsOf libConfig

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -310,23 +310,23 @@ rec {
 
           ${concatStringsSep "\n" rootConfigs}
         '';
+
+      valueType = with lib.types; recursive (t: nullOr
+        (oneOf [
+          bool
+          int
+          float
+          str
+          (attrsOf t)
+          (listOf t)
+        ])) // {
+          description = "Elixir value";
+          descriptionClass = "noun";
+        };
     in
     {
-      type = with lib.types; let
-        valueType = recursive (t: nullOr
-          (oneOf [
-            bool
-            int
-            float
-            str
-            (attrsOf t)
-            (listOf t)
-          ])) // {
-            description = "Elixir value";
-            descriptionClass = "noun";
-          };
-      in
-      attrsOf (attrsOf (valueType));
+      inherit valueType;
+      type = with lib.types; attrsOf (attrsOf (valueType));
 
       lib =
         let

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -36,8 +36,8 @@ rec {
 
   json = {}: {
 
-    type = with lib.types; let
-      valueType = nullOr (oneOf [
+    type = with lib.types;
+      recursive (valueType: nullOr (oneOf [
         bool
         int
         float
@@ -45,10 +45,10 @@ rec {
         path
         (attrsOf valueType)
         (listOf valueType)
-      ]) // {
+      ])) // {
         description = "JSON value";
+        descriptionClass = "noun";
       };
-    in valueType;
 
     generate = name: value: pkgs.callPackage ({ runCommand, jq }: runCommand name {
       nativeBuildInputs = [ jq ];
@@ -70,8 +70,8 @@ rec {
       json2yaml "$valuePath" "$out"
     '') {};
 
-    type = with lib.types; let
-      valueType = nullOr (oneOf [
+    type = with lib.types;
+      recursive (valueType: nullOr (oneOf [
         bool
         int
         float
@@ -79,10 +79,10 @@ rec {
         path
         (attrsOf valueType)
         (listOf valueType)
-      ]) // {
+      ])) // {
         description = "YAML value";
+        descriptionClass = "noun";
       };
-    in valueType;
 
   };
 
@@ -106,6 +106,7 @@ rec {
         str
       ]) // {
         description = "INI atom (null, bool, int, float or string)";
+        descriptionClass = "noun";
       };
 
       iniAtom =
@@ -155,6 +156,7 @@ rec {
         str
       ]) // {
         description = "atom (null, bool, int, float or string)";
+        descriptionClass = "noun";
       };
 
       atom =
@@ -196,8 +198,8 @@ rec {
   };
 
   toml = {}: json {} // {
-    type = with lib.types; let
-      valueType = oneOf [
+    type = with lib.types;
+      recursive (valueType: oneOf [
         bool
         int
         float
@@ -205,10 +207,10 @@ rec {
         path
         (attrsOf valueType)
         (listOf valueType)
-      ] // {
+      ]) // {
         description = "TOML value";
+        descriptionClass = "noun";
       };
-    in valueType;
 
     generate = name: value: pkgs.callPackage ({ runCommand, remarshal }: runCommand name {
       nativeBuildInputs = [ remarshal ];
@@ -311,17 +313,18 @@ rec {
     in
     {
       type = with lib.types; let
-        valueType = nullOr
+        valueType = recursive (t: nullOr
           (oneOf [
             bool
             int
             float
             str
-            (attrsOf valueType)
-            (listOf valueType)
-          ]) // {
-          description = "Elixir value";
-        };
+            (attrsOf t)
+            (listOf t)
+          ])) // {
+            description = "Elixir value";
+            descriptionClass = "noun";
+          };
       in
       attrsOf (attrsOf (valueType));
 
@@ -376,6 +379,7 @@ rec {
             rawElixir = mkOptionType {
               name = "rawElixir";
               description = "raw elixir";
+              descriptionClass = "noun";
               check = isElixirType "raw";
             };
 
@@ -387,18 +391,21 @@ rec {
             atom = elixirOr (mkOptionType {
               name = "elixirAtom";
               description = "elixir atom";
+              descriptionClass = "noun";
               check = isElixirType "atom";
             });
 
             tuple = elixirOr (mkOptionType {
               name = "elixirTuple";
               description = "elixir tuple";
+              descriptionClass = "noun";
               check = isElixirType "tuple";
             });
 
             map = elixirOr (mkOptionType {
               name = "elixirMap";
               description = "elixir map";
+              descriptionClass = "noun";
               check = isElixirType "map";
             });
             # Wrap standard types, since anything in the Elixir configuration


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/207962, see commits

I'm sure the `getSubModules` bug has a simple fix but I am not able to think about it any more at the moment.