### PR TITLE
pythonPackages.sphinxcontrib-tikz: remove hard-coding executable dep paths

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-tikz/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-tikz/default.nix
@@ -2,8 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , sphinx
-, pdf2svg
-, texliveSmall
 }:
 
 buildPythonPackage rec {
@@ -15,12 +13,6 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-8f9FNx6WMopcqihUzNlQoPBGYoW2YkFi6W1iaFLD4qU=";
   };
-
-  postPatch = ''
-    substituteInPlace sphinxcontrib/tikz.py \
-      --replace "config.latex_engine" "'${texliveSmall.withPackages (ps: with ps; [ standalone pgfplots ])}/bin/pdflatex'" \
-      --replace "system(['pdf2svg'" "system(['${pdf2svg}/bin/pdf2svg'"
-  '';
 
   propagatedBuildInputs = [ sphinx ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I updated Python package sphinxcontrib-bayesnet and marked it non-broken.

However, I'm a bit confused by sphinxcontrib-tikz packagin in nixpkgs. For some reason, it hardcodes paths to pdflatex and pdf2svg. This makes it very difficult to:

- add new LaTeX/TikZ packages to the environment that is used to build the TikZ images
- add packages like sphinxcontrib-bayesnet that have sphinxcontrib-tikz as a Python dependency and would need more LaTeX/TikZ dependencies (in this case, tikz-bayesnet)

Why not let the user manage the LaTeX environment? They can use whatever packages they want. What's the problem with that? I think that's how people are Sphinx in other distros anyway.. Am I missing something? I just removed those hard-coded paths and let the user define them in the Sphinx config if needed.

Perhaps sphinxcontrib-tikz maintainer @costrouc has some insight?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
