### PR TITLE
devilutionx: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -42,8 +42,8 @@ let
     owner = "diasurgical";
     repo = "libzt";
     fetchSubmodules = true;
-    rev = "a34ba7f1cc2e41b05badd25d1b01fdc5fd2f4e02";
-    sha256 = "sha256-tyIPt+7OTi5W+5X/ixQP1puOKdhrqRZtpwXlWFBFpc8=";
+    rev = "37a2efb0b925df632299ef07dc78c0af5f6b4756";
+    sha256 = "sha256-+o4ZTVqh4MDZES9m7mkfkMRlRDMBytDBuA0QIlnp73U=";
   };
 
   # missing pkg-config and/or cmake file
@@ -55,21 +55,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "devilutionx";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "diasurgical";
     repo = "devilutionX";
     rev = version;
-    sha256 = "sha256-uuIPTdgGpHA8j1M8b+kfnBuiJ5mdS9rckvEfn2h7lmo=";
+    sha256 = "sha256-l0BhL+DXtkG2PdFqmkL0KJv41zl3N/AcuLmzw2j3jXY=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/diasurgical/devilutionX/commit/03b22352fc9e1ecb88b20a053c90c04a50717267.patch";
-      sha256 = "sha256-5aAwi1NV8P+nLLbEEnlwLGNQCQBb0nQkIVe5tR5Shsw=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace Source/init.cpp --replace "/usr/share/diasurgical/devilutionx/" "${placeholder "out"}/share/diasurgical/devilutionx/"


### PR DESCRIPTION
###### Description of changes

Removed SDL_AUDIOLIB patch as it is included in the 1.4.1 release (look for [33aab7e4b2eb4aa45b7549e86e4cd1831aaf7cc3](https://github.com/diasurgical/devilutionX/commits/1.4.1/3rdParty)), updated libzt dependency to match
https://github.com/diasurgical/devilutionX/commit/6bf474a6ba

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
