### PR TITLE
osu-lazer-bin: init at 2022.1228.0

### DIFF
--- a/pkgs/games/osu-lazer-bin/default.nix
+++ b/pkgs/games/osu-lazer-bin/default.nix
@@ -1,0 +1,35 @@
+{ appimageTools, lib, fetchurl }:
+
+appimageTools.wrapType2 rec {
+  pname = "osu-lazer-bin";
+  version = "2022.1228.0";
+
+  src = fetchurl {
+    url = "https://github.com/ppy/osu/releases/download/${version}/osu.AppImage";
+    sha256 = "sha256-KDJ6HrnGyM6Brtf66C0r+hbSt/stppe+srChtNSoQ9g=";
+  };
+
+  extraPkgs = pkgs: with pkgs; [ icu ];
+
+  extraInstallCommands =
+    let contents = appimageTools.extract { inherit pname version src; };
+    in ''
+      mv -v $out/bin/${pname}-${version} $out/bin/osu\!
+      install -m 444 -D ${contents}/osu\!.desktop -t $out/share/applications
+      for i in 16 32 48 64 96 128 256 512 1024; do
+        install -D ${contents}/osu\!.png $out/share/icons/hicolor/''${i}x$i/apps/osu\!.png
+      done
+    '';
+
+  meta = with lib; {
+    description = "Rhythm is just a *click* away (AppImage version for score submission and multiplayer)";
+    homepage = "https://osu.ppy.sh";
+    license = with licenses; [
+      mit
+      cc-by-nc-40
+      unfreeRedistributable # osu-framework contains libbass.so in repository
+    ];
+    maintainers = [ maintainers.delan ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34144,6 +34144,8 @@ with pkgs;
 
   osu-lazer = callPackage ../games/osu-lazer { };
 
+  osu-lazer-bin = callPackage ../games/osu-lazer-bin { };
+
   pro-office-calculator = libsForQt5.callPackage ../games/pro-office-calculator { };
 
   qgo = libsForQt5.callPackage ../games/qgo { };


### PR DESCRIPTION
###### Description of changes

osu! lazer is in nixpkgs (osu-lazer), but on Linux, only the official AppImage version is allowed to submit scores or play with others (see #208019). This patch adds an osu-lazer-bin using that AppImage, based on pkgs/applications/audio/cider.

The main executable (bin/osu!) runs for me on NixOS 22.05, and the desktop file works too. I use rofi though, so I have no way of knowing if I’ve installed the icons correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (**22.05 only**)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] ~~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
