### PR TITLE
fxload: updated to newer version from libusb1’s examples

### DIFF
--- a/pkgs/os-specific/linux/fxload/default.nix
+++ b/pkgs/os-specific/linux/fxload/default.nix
@@ -1,37 +1,31 @@
-{lib, stdenv, fetchurl}:
+{ lib
+, stdenv
+, libusb1
+}:
 
 stdenv.mkDerivation rec {
   pname = "fxload";
-  version = "2002.04.11";
+  version = libusb1.version;
+  dontUnpack = true;
+  dontBuild = true;
+  dontConfigure = true;
+  dontInstall = true;
+  dontPatch = true;
+  dontPatchELF = true;
 
-  src = fetchurl {
-    url = "mirror://sourceforge/linux-hotplug/fxload-${lib.replaceStrings ["."] ["_"] version}.tar.gz";
-    sha256 = "1hql93bp3dxrv1p67nc63xsbqwljyynm997ysldrc3n9ifi6s48m";
-  };
-
-  patches = [
-    # Will be needed after linux-headers is updated to >= 2.6.21.
-    (fetchurl {
-      url = "http://sources.gentoo.org/viewcvs.py/*checkout*/gentoo-x86/sys-apps/fxload/files/fxload-20020411-linux-headers-2.6.21.patch?rev=1.1";
-      sha256 = "0ij0c8nr1rbyl5wmyv1cklhkxglvsqz32h21cjw4bjm151kgmk7p";
-    })
-  ];
-
-  preBuild = ''
-    substituteInPlace Makefile --replace /usr /
-    makeFlagsArray=(INSTALL=install prefix=$out)
-  '';
-
-  preInstall = ''
+  # fxload binary exist inside the `examples/bin` directory of `libusb1`
+  postFixup = ''
     mkdir -p $out/sbin
-    mkdir -p $out/share/man/man8
-    mkdir -p $out/share/usb
+    ln -s ${passthru.libusb}/examples/bin/fxload $out/sbin/fxload
   '';
+
+  passthru.libusb = libusb1.override { withExamples = true; };
 
   meta = with lib; {
-    homepage = "http://linux-hotplug.sourceforge.net/?selected=usb";
-    description = "Tool to upload firmware to Cypress EZ-USB microcontrollers";
-    license = licenses.gpl2;
+    homepage = "https://github.com/libusb/libusb";
+    description = "Tool to upload firmware to into an21, fx, fx2, fx2lp and fx3 ez-usb devices";
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ realsnick ];
   };
 }


### PR DESCRIPTION
the previous version used was quite old and not supporting USB3. This one is using an updated `fxload` binary from `libusb1`’s examples. 

libusb1 approved PR: https://github.com/NixOS/nixpkgs/pull/207880