### PR TITLE
paperless-ngx: Support automatic classifier

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -12,6 +12,7 @@
 , unpaper
 , liberation_ttf
 , fetchFromGitHub
+, fetchpatch
 }:
 
 let
@@ -136,6 +137,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     langdetect
     lxml
     msgpack
+    nltk
     numpy
     ocrmypdf
     pathvalidate
@@ -192,6 +194,14 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
   postBuild = ''
     ${python.interpreter} -OO -m compileall src
   '';
+
+  patches = [
+    (fetchpatch {
+      name = "Bakes-the-NLTK-data-into-the-image-60mb.patch";
+      url = "https://github.com/paperless-ngx/paperless-ngx/commit/8da3ae2c539266d96c8885964f07bf34c69d73c4.patch";
+      hash = "sha256-MFOAfZkcyx0teLvGZ9lrG5YlroYljv6GgAlCoaH8S/A=";
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/lib


### PR DESCRIPTION
###### Description of changes

`nltk` was added as a dependency in 1.10[^1] but was not added in #206835. The patch from upstream is applied to allow for proper passing of the nltk data (due to restricted networking the automatic download of this data at runtime would fail).

[^1]: https://github.com/paperless-ngx/paperless-ngx/commit/d856e480455f611c0094179a8e0441144816de53

In regards to actually using the classifier on NixOS: You still need to obtain the required nltk datasets. Since I (a) was not sure where they could be placed within nixpkgs and (b) in terms of licenses they appear to be a poorly documented mess. However, here is a working example on how the classifier will work in NixOS:

```nix
{ pkgs, config, lib, ...}:

{
services.paperless = let
  nltkDatasets = {
    # Raw data is licensed in most parts as BSD-3 clause with one CC-BY-SA 3 dataset
    # BSD-3: https://github.com/snowballstem/snowball-data/commit/0fe3da19bb818461548f4780815ab323fea606bb
    # CC-BY-SA dataset addition: https://github.com/snowballstem/snowball-data/commit/35999218ecdd19c82fc87f791179d00657007814
    "stemmers/snowball_data" = pkgs.fetchzip { # Roughly 35M in closure size
      pname = "snowball_data";
      version = "2015-02-10";
      url = "https://raw.githubusercontent.com/nltk/nltk_data/ebd75b7b05637d6b70828a15fc458fd9e76a70d0/packages/stemmers/snowball_data.zip";
      hash = "sha256-CjMftTNwAQksVzIom0M7nlAroD5w8Fk64blBNSgZX5k=";
      meta.license = with lib.licenses; [ bsd3 cc-by-nc-sa-30 ];
    };
    # License unclear. Some parts seem to (in part?) originate from https://pypi.org/project/stop-words/
    "corpora/stopwords" = pkgs.fetchzip { # Roughly 85K in final closure size
      pname = "stopwords";
      version = "2016-08-20";
      url = "https://raw.githubusercontent.com/nltk/nltk_data/7d5849ea69b31fe13f03903756835fa2f867a187/packages/corpora/stopwords.zip";
      hash = "sha256-zQf9RnK0yWI1bIEjNEm2hmGubHGeDQN0supIBQGww6c= ";
    };
    # Unable to spot a license for this
    "tokenizers/punkt" = pkgs.fetchzip { # Roughly 35M in closure size
      pname = "punkt";
      version = "2022-07-14";
      url = "https://raw.githubusercontent.com/nltk/nltk_data/1d3c34b4cfd6059986bf4bc604e5929335ab92ff/packages/tokenizers/punkt.zip";
      hash = "sha256-SKZu26K17qMUg7iCFZey0GTECUZ+sTTrF/pqeEgJCos=";
    };
  };
in {
    enable = true;
    # ...
    extraConfig.PAPERLESS_NLTK_DIR = pkgs.linkFarm "nltk_data" nltkDatasets;
    # ...
};
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
