### PR TITLE
dvc: remove anthonyroussel from maintainers

### DIFF
--- a/pkgs/applications/version-management/dvc/default.nix
+++ b/pkgs/applications/version-management/dvc/default.nix
@@ -97,6 +97,6 @@ python3.pkgs.buildPythonApplication rec {
     description = "Version Control System for Machine Learning Projects";
     homepage = "https://dvc.org";
     license = licenses.asl20;
-    maintainers = with maintainers; [ cmcdragonkai fab anthonyroussel ];
+    maintainers = with maintainers; [ cmcdragonkai fab ];
   };
 }

--- a/pkgs/development/python-modules/dvc-render/default.nix
+++ b/pkgs/development/python-modules/dvc-render/default.nix
@@ -58,6 +58,6 @@ buildPythonPackage rec {
     description = "Library for rendering DVC plots";
     homepage = "https://github.com/iterative/dvc-render";
     license = licenses.asl20;
-    maintainers = with maintainers; [ fab anthonyroussel ];
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/dvc-task/default.nix
+++ b/pkgs/development/python-modules/dvc-task/default.nix
@@ -55,6 +55,6 @@ buildPythonPackage rec {
     description = "Celery task queue used in DVC";
     homepage = "https://github.com/iterative/dvc-task";
     license = licenses.asl20;
-    maintainers = with maintainers; [ anthonyroussel ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Since dvc >2.17, DVC is becoming more and more complex to package with its "micro-repository" architecture that requires creating (at least) 11 new Python packages in Nix: dvc-http, dvc-oss, dvc-hdfs, dvc-gs, dvc-gdrive, dvc-azure, dvc-ssh, dvc-s3, dvc-webdav, dvc-webhdfs, iterative-telemetry, sshfs

And because

* I have not used this software for a few months
* I don't like with their new telemetry system: https://github.com/iterative/iterative-telemetry
* I don't like the new way this application should be packaged:
  * Too many repositories & packages for only one software
  * Manage cyclic dependencies between DVC libraries and DVC himself (dvc-ssh depends on dvc which depends on dvc-ssh, same for dvc-webdav & dvc-webhdfs)
 
I would like to be removed from the Nix package maintainers of dvc.
Sorry!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
