### PR TITLE
yubioath-flutter: slight refactor and cleanup

### DIFF
--- a/pkgs/applications/misc/yubioath-flutter/default.nix
+++ b/pkgs/applications/misc/yubioath-flutter/default.nix
@@ -5,20 +5,60 @@
 , stdenv
 , pcre2
 }:
-
 let
   vendorHashes = {
     x86_64-linux = "sha256-BwhWA8N0S55XkljDKPNkDhsj0QSpmJJ5MwEnrPjymS8=";
     aarch64-linux = "sha256-T1aGz3+2Sls+rkUVDUo39Ky2igg+dxGSUaf3qpV7ovQ=";
   };
-
+in
+flutter.mkFlutterApp rec {
+  pname = "yubioath-flutter";
   version = "6.0.2";
+
   src = fetchFromGitHub {
     owner = "Yubico";
     repo = "yubioath-flutter";
     rev = version;
     sha256 = "13nh5qpq02c6azfdh4cbzhlrq0hs9is45q5z5cnxg84hrx26hd4k";
   };
+
+  passthru.helper = python3.pkgs.callPackage ./helper.nix { inherit src version meta; };
+
+  vendorHash = vendorHashes.${stdenv.system};
+
+  postPatch = ''
+    substituteInPlace linux/CMakeLists.txt \
+      --replace "../build/linux/helper" "${passthru.helper}/libexec/helper"
+  '';
+
+  preInstall = ''
+    # Make sure we have permission to delete things CMake has copied in to our build directory from elsewhere.
+    chmod -R +w build
+  '';
+
+  postInstall = ''
+    # Swap the authenticator-helper symlink with the correct symlink.
+    ln -fs "${passthru.helper}/bin/authenticator-helper" "$out/app/helper/authenticator-helper"
+
+    # Cleanup.
+    rm -rf \
+      "$out/app/README.adoc" \
+      "$out/app/desktop_integration.sh" \
+      "$out/app/linux_support" \
+      $out/bin/* # We will repopulate this directory later.
+
+    # Symlink binary.
+    ln -sf "$out/app/authenticator" "$out/bin/yubioath-flutter"
+
+    # Set the correct path to the binary in desktop file.
+    substituteInPlace "$out/share/applications/com.yubico.authenticator.desktop" \
+      --replace "@EXEC_PATH/authenticator" "$out/bin/yubioath-flutter"
+  '';
+
+  buildInputs = [
+    pcre2
+  ];
+
   meta = with lib; {
     description = "Yubico Authenticator for Desktop";
     homepage = "https://github.com/Yubico/yubioath-flutter";
@@ -26,32 +66,4 @@ let
     maintainers = with maintainers; [ lukegb ];
     platforms = builtins.attrNames vendorHashes;
   };
-
-  helper = python3.pkgs.callPackage ./helper.nix { inherit src version meta; };
-in
-flutter.mkFlutterApp rec {
-  pname = "yubioath-flutter";
-  inherit src version meta;
-
-  passthru.helper = helper;
-
-  vendorHash = vendorHashes."${stdenv.system}";
-
-  postPatch = ''
-    substituteInPlace linux/CMakeLists.txt \
-      --replace "../build/linux/helper" "${helper}/libexec/helper"
-  '';
-
-  preInstall = ''
-    # Make sure we have permission to delete things CMake has copied in to our build directory from elsewhere.
-    chmod -R +w build/
-  '';
-  postInstall = ''
-    # Swap the authenticator-helper symlink with the correct symlink.
-    ln -fs "${helper}/bin/authenticator-helper" "$out/app/helper/authenticator-helper"
-  '';
-
-  buildInputs = [
-    pcre2
-  ];
 }

--- a/pkgs/applications/misc/yubioath-flutter/default.nix
+++ b/pkgs/applications/misc/yubioath-flutter/default.nix
@@ -40,6 +40,10 @@ flutter.mkFlutterApp rec {
     # Swap the authenticator-helper symlink with the correct symlink.
     ln -fs "${passthru.helper}/bin/authenticator-helper" "$out/app/helper/authenticator-helper"
 
+    # Move the icon.
+    mkdir $out/share/icons
+    mv $out/app/linux_support/com.yubico.yubioath.png $out/share/icons
+
     # Cleanup.
     rm -rf \
       "$out/app/README.adoc" \
@@ -52,7 +56,8 @@ flutter.mkFlutterApp rec {
 
     # Set the correct path to the binary in desktop file.
     substituteInPlace "$out/share/applications/com.yubico.authenticator.desktop" \
-      --replace "@EXEC_PATH/authenticator" "$out/bin/yubioath-flutter"
+      --replace "@EXEC_PATH/authenticator" "$out/bin/yubioath-flutter" \
+      --replace "@EXEC_PATH/linux_support/com.yubico.yubioath.png" "$out/share/icons/com.yubico.yubioath.png"
   '';
 
   buildInputs = [

--- a/pkgs/applications/misc/yubioath-flutter/helper.nix
+++ b/pkgs/applications/misc/yubioath-flutter/helper.nix
@@ -12,7 +12,7 @@
 , meta
 }:
 
-buildPythonApplication rec {
+buildPythonApplication {
   pname = "yubioath-flutter-helper";
   inherit src version meta;
 


### PR DESCRIPTION
###### Description of changes

- .desktop file now works properly
- the binary no longer has the generic name "authenticator"
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
