### PR TITLE
openvdb: 9.1.0 -> 10.0.1, refactor for split outputs

### DIFF
--- a/pkgs/development/libraries/openvdb/default.nix
+++ b/pkgs/development/libraries/openvdb/default.nix
@@ -5,6 +5,8 @@ stdenv.mkDerivation rec
   pname = "openvdb";
   version = "9.1.0";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "dreamworksanimation";
     repo = "openvdb";
@@ -15,6 +17,14 @@ stdenv.mkDerivation rec
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ openexr boost tbb jemalloc c-blosc ilmbase ];
+
+  cmakeFlags = [ "-DOPENVDB_CORE_STATIC=OFF" ];
+
+  postFixup = ''
+    substituteInPlace $dev/lib/cmake/OpenVDB/FindOpenVDB.cmake \
+      --replace \''${OPENVDB_LIBRARYDIR} $out/lib \
+      --replace \''${OPENVDB_INCLUDEDIR} $dev/include
+  '';
 
   meta = with lib; {
     description = "An open framework for voxel";

--- a/pkgs/development/libraries/openvdb/default.nix
+++ b/pkgs/development/libraries/openvdb/default.nix
@@ -3,15 +3,15 @@
 stdenv.mkDerivation rec
 {
   pname = "openvdb";
-  version = "9.1.0";
+  version = "10.0.1";
 
   outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
-    owner = "dreamworksanimation";
+    owner = "AcademySoftwareFoundation";
     repo = "openvdb";
     rev = "v${version}";
-    sha256 = "sha256-OP1xCR1YW60125mhhrW5+8/4uk+EBGIeoWGEU9OiIGY=";
+    sha256 = "sha256-kaf5gpGYVWinmnRwR/IafE1SJcwmP2psfe/UZdtH1Og=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Description of changes

Change `openvdb` to have a separate dev output, patch up the CMake module, and drop building the static lib. This slightly shrinks the size of the `blender` closure.

Before change:

```
$ nix path-info -rsSh nixpkgs#blender | tail -n1
/nix/store/1j0b0y65n9dlphj2vk0l8bxnsyaj854z-blender-3.3.1                        196.0M    1.4G
```

After change:

```
$ nix path-info -rsSh ~/nixpkgs#blender | tail -n1
warning: Git tree '/home/ciadmin/nixpkgs' is dirty
/nix/store/sw04xlgn6cz2r5w59gqa553dv34d1amr-blender-3.3.1                        196.0M    1.2G
```

After the bump to v10.0.1, size reduction remains:

```
$ nix path-info -rsSh ~/nixpkgs#blender | tail -n1
/nix/store/6jwm0yfqa14q7ngmz4irnrv401lmy7az-blender-3.3.1                        196.1M    1.2G
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).