### PR TITLE
tangram: 1.3.2 -> 1.4.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/tangram/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tangram/default.nix
@@ -1,21 +1,36 @@
-{ stdenv, lib, fetchFromGitHub, appstream-glib, desktop-file-utils, gdk-pixbuf
-, gettext, gjs, glib, gobject-introspection, gsettings-desktop-schemas, gtk3
-, hicolor-icon-theme, meson, ninja, pkg-config, python3, webkitgtk, wrapGAppsHook
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  appstream-glib,
+  desktop-file-utils,
+  gdk-pixbuf,
+  gettext,
+  gjs,
+  glib,
+  glib-networking,
+  gobject-introspection,
+  gsettings-desktop-schemas,
+  gtk4,
+  hicolor-icon-theme,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  webkitgtk,
+  wrapGAppsHook,
 }:
-
 stdenv.mkDerivation rec {
   pname = "tangram";
-  version = "1.3.2";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "sonnyp";
     repo = "Tangram";
     rev = "v${version}";
-    sha256 = "sha256-WI0H3bforQ6Jc/+TWFT1zUs4KRtWwvXY2/va+Fnd+iU=";
+    sha256 = "sha256-0KSmqDLp7+mmrzTlil8iXUdHmHUz91AoCcbc6YcHKbI=";
     fetchSubmodules = true;
   };
-
-  buildInputs = [ gdk-pixbuf gjs glib gsettings-desktop-schemas gtk3 webkitgtk ];
 
   nativeBuildInputs = [
     appstream-glib
@@ -30,12 +45,24 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
   ];
 
+  buildInputs = [
+    gdk-pixbuf
+    gjs
+    glib
+    glib-networking
+    gsettings-desktop-schemas
+    gtk4
+    webkitgtk
+  ];
+
+  dontPatchShebangs = true;
   dontWrapGApps = true;
 
   # Fixes https://github.com/NixOS/nixpkgs/issues/31168
   postPatch = ''
     chmod +x build-aux/meson/postinstall.py
     patchShebangs build-aux/meson/postinstall.py
+    substituteInPlace src/re.sonny.Tangram.in --replace "#!/usr/bin/env -S gjs -m" "#!/usr/bin/env -S ${gjs}/bin/gjs -m"
   '';
 
   postFixup = ''
@@ -51,6 +78,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/sonnyp/Tangram";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ austinbutler ];
+    maintainers = with maintainers; [austinbutler];
   };
 }


### PR DESCRIPTION
###### Description of changes

Upgrades to latest version and, thanks to https://github.com/NixOS/nixpkgs/pull/201219, actually works now.

https://github.com/sonnyp/Tangram/compare/v1.3.2...v1.4.2

Closes https://github.com/NixOS/nixpkgs/issues/190890.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
