### PR TITLE
firefox: fix desktop file and icon for variants

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -31,7 +31,7 @@ let
       (lib.toUpper (lib.substring 0 1 applicationName) + lib.substring 1 (-1) applicationName)
     , nameSuffix ? ""
     , icon ? applicationName
-    , wmClass ? null
+    , wmClass ? applicationName
     , extraNativeMessagingHosts ? []
     , pkcs11Modules ? []
     , useGlvnd ? true
@@ -61,7 +61,7 @@ let
       smartcardSupport = cfg.smartcardSupport or false;
 
       nativeMessagingHosts =
-        ([ ]
+        [ ]
           ++ lib.optional (cfg.enableBrowserpass or false) (lib.getBin browserpass)
           ++ lib.optional (cfg.enableBukubrow or false) bukubrow
           ++ lib.optional (cfg.enableTridactylNative or false) tridactyl-native
@@ -70,7 +70,7 @@ let
           ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma5Packages.plasma-browser-integration
           ++ lib.optional (cfg.enableFXCastBridge or false) fx_cast_bridge
           ++ extraNativeMessagingHosts
-        );
+        ;
       libs =   lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver cups pciutils ]
             ++ lib.optional pipewireSupport pipewire
             ++ lib.optional ffmpegSupport ffmpeg_5
@@ -168,10 +168,10 @@ let
       inherit pname version;
 
       desktopItem = makeDesktopItem ({
-        name = applicationName;
-        exec = "${launcherName} %U";
+        name = launcherName;
+        exec = "${launcherName} --name ${wmClass} %U";
         inherit icon;
-        desktopName = "${desktopName}${nameSuffix}";
+        inherit desktopName;
         startupNotify = true;
         startupWMClass = wmClass;
         terminal = false;
@@ -403,7 +403,7 @@ let
       disallowedRequisites = [ stdenv.cc ];
 
       meta = browser.meta // {
-        description = browser.meta.description;
+        inherit (browser.meta) description;
         hydraPlatforms = [];
         priority = (browser.meta.priority or 0) - 1; # prefer wrapper over the package
       };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29788,6 +29788,7 @@ with pkgs;
   firefox-beta-bin = res.wrapFirefox firefox-beta-bin-unwrapped {
     pname = "firefox-beta-bin";
     desktopName = "Firefox Beta";
+    wmClass = "firefox-beta";
   };
 
   firefox-devedition-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
@@ -29800,6 +29801,7 @@ with pkgs;
     nameSuffix = "-devedition";
     pname = "firefox-devedition-bin";
     desktopName = "Firefox DevEdition";
+    wmClass = "firefox-devedition";
   };
 
   librewolf-unwrapped = callPackage ../applications/networking/browsers/librewolf {};


### PR DESCRIPTION
###### Description of changes

Using a Firefox variant such as `firefox-devedition-bin` currently results in weirdness with the icons and descriptions (at least on Gnome).

![image](https://user-images.githubusercontent.com/354741/210033153-30c7e804-50a2-4773-8d0c-0b0662168d70.png)

![image](https://user-images.githubusercontent.com/354741/210033143-21c8c74a-215b-439b-a68b-d46b2c853c1c.png)

This fixes that. The resulting desktop file becomes `firefox-devedition.desktop` in this example.

Here's what it looks like after:
![image](https://user-images.githubusercontent.com/354741/210033561-c0fadb35-405e-46b9-a6fc-5ad5eee366d1.png)

Comparison of the desktop file on `master` and this branch:

```diff
 [Desktop Entry]
 Actions=new-private-window;new-window;profile-manager-window
 Categories=Network;WebBrowser
-Exec=firefox-devedition %U
+Exec=firefox-devedition --name firefox-devedition %U
 GenericName=Web Browser
 Icon=firefox
 MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;x-scheme-handler/http;x-scheme-handler/https
-Name=Firefox DevEdition-devedition
+Name=Firefox DevEdition
 StartupNotify=true
+StartupWMClass=firefox-devedition
 Terminal=false
 Type=Application
 Version=1.4

 [Desktop Action new-private-window]
-Exec=firefox-devedition --private-window %U
+Exec=firefox-devedition --private-window --name firefox-devedition %U
 Name=New Private Window

 [Desktop Action new-window]
-Exec=firefox-devedition --new-window %U
+Exec=firefox-devedition --new-window --name firefox-devedition %U
 Name=New Window

 [Desktop Action profile-manager-window]
-Exec=firefox-devedition --ProfileManager
+Exec=firefox-devedition --ProfileManager --name firefox-devedition
 Name=Profile Manager
```

Comparison of the desktop file for `firefox` between `master` and this branch:
```diff
 [Desktop Entry]
 Actions=new-private-window;new-window;profile-manager-window
 Categories=Network;WebBrowser
-Exec=firefox %U
+Exec=firefox --name firefox %U
 GenericName=Web Browser
 Icon=firefox
 MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;x-scheme-handler/http;x-scheme-handler/https
 Name=Firefox
 StartupNotify=true
+StartupWMClass=firefox
 Terminal=false
 Type=Application
 Version=1.4

 [Desktop Action new-private-window]
-Exec=firefox --private-window %U
+Exec=firefox --private-window --name firefox %U
 Name=New Private Window

 [Desktop Action new-window]
-Exec=firefox --new-window %U
+Exec=firefox --new-window --name firefox %U
 Name=New Window

 [Desktop Action profile-manager-window]
-Exec=firefox --ProfileManager
+Exec=firefox --ProfileManager --name firefox
 Name=Profile Manager
```

Note I'm no expert on these various settings, just played around and found what works.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).