### PR TITLE
nixos/fwupd: allow customization of uefi_capsule.conf.

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -19,10 +19,11 @@ let
       };
     };
     "fwupd/uefi_capsule.conf" = {
-      source = pkgs.writeText "uefi_capsule.conf" ''
-        [uefi_capsule]
-        OverrideESPMountPoint=${config.boot.loader.efi.efiSysMountPoint}
-      '';
+      source = format.generate "uefi_capsule.conf" {
+        uefi_capsule = {
+          OverrideESPMountPoint = config.boot.loader.efi.efiSysMountPoint;
+        } // cfg.uefiCapsuleSettings;
+      };
     };
   };
 
@@ -133,6 +134,12 @@ in {
         description = lib.mdDoc ''
           Configurations for the fwupd daemon.
         '';
+      };
+
+      uefiCapsuleSettings = mkOption {
+        type = format.type.nestedTypes.elemType;
+        default = {};
+        description = lib.mdDoc "Settings for uefi_capsule.conf";
       };
     };
   };


### PR DESCRIPTION
Signed-off-by: David Anderson <dave@natulte.net>

###### Description of changes

The Framework laptop ships firmware through LVFS, but because of some weirdness of their bios images, you have to set `DisableCapsuleUpdateOnDisk=true` in /etc/fwupd/uefi_capsule.conf for the updates to work.

From https://discourse.nixos.org/t/how-to-disablecapsuleupdateondisk-in-etc-fwupd-uefi-capsule-conf/23751/4 , currently the only way to do that is to mkForce the entire config file with a replacement.

There's already structured config support in place for daemon.conf, this PR extends it to support uefi_capsule.conf as well. No specific options are defined, because really nobody but nixos-hardware should be grubbing around this low-level, and if you are you already know what setting you want.

This PR doesn't extend this to support structured config for all of fwupd's other files, because that requires building an ini file _reader_ to pull the upstream files out of the package and into structured form, so that we can apply user overrides and re-serialize out to disk. I haven't figured out a clean way to do that yet. However, the upstream uefi_capsule.conf is already being completely overridden by the module's config, so similar to daemon.conf that one file is trivial to translate into structured config.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
