### PR TITLE
wgnord: init at 0.1.10

### DIFF
--- a/pkgs/applications/networking/wgnord/default.nix
+++ b/pkgs/applications/networking/wgnord/default.nix
@@ -1,0 +1,65 @@
+{ bash
+, coreutils
+, curl
+, fetchFromGitHub
+, gnugrep
+, gnused
+, iproute2
+, jq
+, lib
+, resholve
+, wireguard-tools
+}:
+
+resholve.mkDerivation rec {
+  pname = "wgnord";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "phirecc";
+    repo = pname;
+    rev = version;
+    hash = "sha256-T7dAEgi4tGvrzBABGLzKHhpCx0bxSCtTVI5iJJqJGlE=";
+  };
+
+  postPatch = ''
+    substituteInPlace wgnord \
+      --replace '$conf_dir/countries.txt' "$out/share/countries.txt" \
+      --replace '$conf_dir/countries_iso31662.txt' "$out/share/countries_iso31662.txt"
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm 755 wgnord -t $out/bin/
+    install -Dm 644 countries.txt -t $out/share/
+    install -Dm 644 countries_iso31662.txt -t $out/share/
+  '';
+
+  solutions.default = {
+    scripts = [ "bin/wgnord" ];
+    interpreter = "${bash}/bin/sh";
+    inputs = [
+      coreutils
+      curl
+      gnugrep
+      gnused
+      iproute2
+      jq
+      wireguard-tools
+    ];
+    fix.aliases = true; # curl command in an alias
+    execer = [
+      "cannot:${iproute2}/bin/ip"
+      "cannot:${wireguard-tools}/bin/wg-quick"
+    ];
+  };
+
+  meta = with lib; {
+    description = "A NordVPN Wireguard (NordLynx) client in POSIX shell";
+    homepage = "https://github.com/phirecc/wgnord";
+    changelog = "https://github.com/phirecc/wgnord/releases/tag/v${version}";
+    maintainers = with lib.maintainers; [ urandom ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33327,6 +33327,8 @@ with pkgs;
 
   weston = callPackage ../applications/window-managers/weston { };
 
+  wgnord = callPackage ../applications/networking/wgnord/default.nix {};
+
   whalebird = callPackage ../applications/misc/whalebird {
     electron = electron_19;
   };


### PR DESCRIPTION


###### Description of changes

Fixes #201573

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
