### PR TITLE
code-maat: init at 1.0.3

### DIFF
--- a/pkgs/development/tools/code-maat/default.nix
+++ b/pkgs/development/tools/code-maat/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, makeBinaryWrapper
+, jre
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "code-maat";
+  version = "1.0.3";
+
+  src = fetchurl {
+    url = "https://github.com/adamtornhill/code-maat/releases/download/v${finalAttrs.version}/code-maat-${finalAttrs.version}-standalone.jar";
+    hash = "sha256-cAaGX9BX27Z2GN583YmhagWsBIygVc0ZDkzbspM9OJw=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  installPhase =
+    let
+      jar = "$out/libexec/code-maat/code-maat.jar";
+    in
+    ''
+      runHook preInstall
+
+      install -D ${finalAttrs.src} ${jar}
+      mkdir -p "$out/bin"
+      makeWrapper "${jre}/bin/java" "$out/bin/code-maat" \
+          --add-flags "-jar ${jar}"
+
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    description = "A command line tool to mine and analyze data from version-control systems";
+    homepage = "https://github.com/adamtornhill/code-maat";
+    platforms = platforms.unix;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ sir4ur0n ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -42302,4 +42302,6 @@ with pkgs;
   yazi = callPackage ../applications/file-managers/yazi { inherit (darwin.apple_sdk.frameworks) Foundation; };
 
   ssl-proxy = callPackage ../tools/networking/ssl-proxy { };
+
+  code-maat = callPackage ../development/tools/code-maat {};
 }


### PR DESCRIPTION
* the JAR is provided in ./libexec/code-maat (e.g. to reuse as a JAR dependency in a Java project)
* the JAR is wrapped as an executable in ./bin/code-maat

Closes https://github.com/NixOS/nixpkgs/issues/208339

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
