### PR TITLE
Opencv4 tests and blas provider

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -15,6 +15,7 @@
 , ocl-icd
 , buildPackages
 , qimgv
+, opencv4
 
 , enableJPEG ? true
 , libjpeg
@@ -74,6 +75,7 @@
 , CoreMedia
 , MediaToolbox
 , bzip2
+, callPackage
 }:
 
 let
@@ -91,6 +93,13 @@ let
     repo = "opencv_contrib";
     rev = version;
     sha256 = "sha256-meya0J3RdOIeMM46e/6IOVwrKn3t/c0rhwP2WQaybkE=";
+  };
+
+  testDataSrc = fetchFromGitHub {
+    owner = "opencv";
+    repo = "opencv_extra";
+    rev = version;
+    sha256 = "sha256-6hAdJdaUgtRGQanQKuY/q6fcXWXFZ3K/oLbGxvksry0=";
   };
 
   # Contrib must be built in order to enable Tesseract support:
@@ -171,10 +180,10 @@ let
   ade = rec {
     src = fetchurl {
       url = "https://github.com/opencv/ade/archive/${name}";
-      sha256 = "04n9na2bph706bdxnnqfcbga4cyj8kd9s9ni7qyvnpj5v98jwvlm";
+      sha256 = "sha256-TjLRbFbC7MDY9PxIy560ryviBI58cbQwqgc7A7uOHkg=";
     };
-    name = "v0.1.1f.zip";
-    md5 = "b624b995ec9c439cbc2e9e6ee940d3a2";
+    name = "v0.1.2a.zip";
+    md5 = "fa4b3e25167319cb0fa9432ef8281945";
     dst = ".cache/ade";
   };
 
@@ -208,12 +217,19 @@ let
 
   opencvFlag = name: enabled: "-DWITH_${name}=${printEnabled enabled}";
 
+  runAccuracyTests = true;
+  runPerformanceTests = false;
   printEnabled = enabled: if enabled then "ON" else "OFF";
 in
 
 stdenv.mkDerivation {
   pname = "opencv";
   inherit version src;
+
+  outputs = [
+    "out"
+    "package_tests"
+  ];
 
   postUnpack = lib.optionalString buildContrib ''
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/source/opencv_contrib"
@@ -263,7 +279,7 @@ stdenv.mkDerivation {
     ++ lib.optional enableFfmpeg ffmpeg
     ++ lib.optionals (enableFfmpeg && stdenv.isDarwin)
       [ VideoDecodeAcceleration bzip2 ]
-    ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base ])
+    ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good ])
     ++ lib.optional enableOvis ogre
     ++ lib.optional enableGPhoto2 libgphoto2
     ++ lib.optional enableDC1394 libdc1394
@@ -299,8 +315,9 @@ stdenv.mkDerivation {
     "-DProtobuf_PROTOC_EXECUTABLE=${lib.getExe buildPackages.protobuf}"
     "-DPROTOBUF_UPDATE_FILES=ON"
     "-DOPENCV_ENABLE_NONFREE=${printEnabled enableUnfree}"
-    "-DBUILD_TESTS=OFF"
-    "-DBUILD_PERF_TESTS=OFF"
+    "-DBUILD_TESTS=${printEnabled runAccuracyTests}"
+    "-DBUILD_PERF_TESTS=${printEnabled runPerformanceTests}"
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
     "-DBUILD_DOCS=${printEnabled enableDocs}"
     # "OpenCV disables pkg-config to avoid using of host libraries. Consider using PKG_CONFIG_LIBDIR to specify target SYSROOT"
     # but we have proper separation of build and host libs :), fixes cross
@@ -333,6 +350,14 @@ stdenv.mkDerivation {
   postBuild = lib.optionalString enableDocs ''
     make doxygen
   '';
+
+  preInstall =
+    lib.optionalString (runAccuracyTests || runPerformanceTests) ''
+    mkdir $package_tests
+    cp -R $src/samples $package_tests/
+    ''
+    + lib.optionalString runAccuracyTests "mv ./bin/*test* $package_tests/ \n"
+    + lib.optionalString runPerformanceTests "mv ./bin/*perf* $package_tests/";
 
   # By default $out/lib/pkgconfig/opencv4.pc looks something like this:
   #
@@ -368,16 +393,23 @@ stdenv.mkDerivation {
 
   passthru = {
     tests = {
-      inherit qimgv;
       inherit (gst_all_1) gst-plugins-bad;
-    } // lib.optionalAttrs (!enablePython) { pythonEnabled = pythonPackages.opencv4; };
+    }
+    // lib.optionalAttrs (!stdenv.isDarwin) { inherit qimgv; }
+    // lib.optionalAttrs (!enablePython) { pythonEnabled = pythonPackages.opencv4; }
+    // lib.optionalAttrs (stdenv.buildPlatform != "x86_64-darwin") {
+      opencv4-tests = callPackage ./tests.nix {
+        inherit enableGStreamer enableGtk2 enableGtk3 runAccuracyTests runPerformanceTests testDataSrc;
+        inherit opencv4;
+        };
+      };
   } // lib.optionalAttrs enablePython { pythonPath = [ ]; };
 
   meta = with lib; {
     description = "Open Computer Vision Library with more than 500 algorithms";
     homepage = "https://opencv.org/";
     license = with licenses; if enableUnfree then unfree else bsd3;
-    maintainers = with maintainers; [ mdaiter basvandijk ];
+    maintainers = with maintainers; [ basvandijk ];
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/opencv/tests.nix
+++ b/pkgs/development/libraries/opencv/tests.nix
@@ -1,0 +1,70 @@
+{ opencv4
+, testDataSrc
+, stdenv
+, lib
+, runCommand
+, gst_all_1
+, runAccuracyTests
+, runPerformanceTests
+, enableGStreamer
+, enableGtk2
+, enableGtk3
+, xvfb-run
+}:
+let
+  testNames = [
+    "calib3d"
+    "core"
+    "features2d"
+    "flann"
+    "imgcodecs"
+    "imgproc"
+    "ml"
+    "objdetect"
+    "photo"
+    "stitching"
+    "video"
+    #"videoio" # - a lot of GStreamer warnings and failed tests
+    #"dnn" #- some caffe tests failed, probably because github workflow also downloads additional models
+  ] ++ lib.optionals (!stdenv.isAarch64 && enableGStreamer) [ "gapi" ]
+  ++ lib.optionals (enableGtk2 || enableGtk3) [ "highgui" ];
+  perfTestNames = [
+    "calib3d"
+    "core"
+    "features2d"
+    "imgcodecs"
+    "imgproc"
+    "objdetect"
+    "photo"
+    "stitching"
+    "video"
+  ] ++ lib.optionals (!stdenv.isAarch64 && enableGStreamer) [ "gapi" ];
+  testRunner = if stdenv.isDarwin then "" else "${lib.getExe xvfb-run} -a ";
+  testsPreparation = ''
+    touch $out
+    # several tests want a write access, so we have to copy files
+    tmpPath="$(mktemp -d "/tmp/opencv_extra_XXXXXX")"
+    cp -R ${testDataSrc} $tmpPath/opencv_extra
+    chmod -R +w $tmpPath/opencv_extra
+    export OPENCV_TEST_DATA_PATH="$tmpPath/opencv_extra/testdata"
+    export OPENCV_SAMPLES_DATA_PATH="${opencv4.package_tests}/samples/data"
+
+    #ignored tests because of gtest error - "Test code is not available due to compilation error with GCC 11"
+    export GTEST_FILTER="-AsyncAPICancelation/cancel*"
+  '';
+  accuracyTests = lib.optionalString runAccuracyTests ''
+    ${ builtins.concatStringsSep "\n"
+      (map (test: "${testRunner}${opencv4.package_tests}/opencv_test_${test} --test_threads=$NIX_BUILD_CORES --gtest_filter=$GTEST_FILTER" ) testNames)
+    }
+  '';
+  perfomanceTests = lib.optionalString runPerformanceTests ''
+    ${ builtins.concatStringsSep "\n"
+      (map (test: "${testRunner}${opencv4.package_tests}/opencv_perf_${test} --perf_impl=plain --perf_min_samples=10 --perf_force_samples=10 --perf_verify_sanity --skip_unstable=1 --gtest_filter=$GTEST_FILTER") perfTestNames)
+    }
+  '';
+in
+runCommand "opencv4-tests"
+{
+  nativeBuildInputs = lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good ]);
+}
+  (testsPreparation + accuracyTests + perfomanceTests)


### PR DESCRIPTION
###### Description of changes
This PR is derived from my attempt to fix #196653 . I've figured out that by default blas provider uses openblas under the hood, so the change was trivial albeit a little ugly because of  `blas.provider.pname` check. Everything seemed fine, but I decided to throw in some unit tests just to be sure I didn't break anything. Initially for testing I overrided blas.provider with mkl, ran tests with it and managed to enable 80% of the opencv's tests. After that I switched blas.provider to openblas, ran tests and ... they broke, hung indefinitely, to be precise :expressionless: . I tried to set --test_threads=1 , turned off several test groups from `testNames` but different tests hung anyway. Ok, I've tried to ran tests without my blas.provider changes - result was the same :exploding_head: . Then I saw `singleThreaded` in openblas, and soon found [link to the openblas docs](https://github.com/xianyi/OpenBLAS/wiki/Faq/4bded95e8dc8aadc70ce65267d1093ca7bdefc4c#multi-threaded) and matched it with `-DWITH_OPENMP=ON` flag we use here. I've made experiments with this two flags, and results are quite logical - you can either use singleThreaded openblas, or build opencv with WITH_OPENMP=OFF, and then tests pass. So, I've figured out we have 3 options:

1. Delete tests and just use blas.provider. Nobody had any complaints so far, right? :see_no_evil:
2. Use singleThreaded openblas
3. build opencv with WITH_OPENMP=OFF

I've ruled out 1st option, because concurrency bugs could be really hard to spot and reproduce, but when they finally hit you it could cause you a lot of headache. Between 2nd and 3rd option I've intuitively inclined toward 2nd option, because I think that linear algebra calculations should be only a small part of what opencv does. Moreover, it seems that blas support was initially added to fix perfomance bottlenecks, but later optimizations were applied and [the need has vanished](https://github.com/opencv/opencv/wiki/ChangeLog#version33). But anyway, I decided to enable perf tests as well and compare both variants - in my unscientific benchmark (6C 12T i5-11400F + 32Gb)  difference of total time between two versions was negligible. So, I decided that 2nd option is "good enough" (however, documentation on multithreading support of opencv and openblas contain hints to other possible approaches with pluggable MT backends, if anyone interested to dig this rabbit hole even more)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
