### PR TITLE
fishPlugins.puffer: init at unstable-2022-10-07

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -32,6 +32,8 @@ lib.makeScope newScope (self: with self; {
 
   pisces = callPackage ./pisces.nix { };
 
+  puffer = callPackage ./puffer.nix { };
+
   pure = callPackage ./pure.nix { };
 
   sponge = callPackage ./sponge.nix { };

--- a/pkgs/shells/fish/plugins/puffer.nix
+++ b/pkgs/shells/fish/plugins/puffer.nix
@@ -1,0 +1,20 @@
+{ lib, buildFishPlugin, fetchFromGitHub }:
+
+buildFishPlugin rec {
+  pname = "puffer";
+  version = "unstable-2022-10-07";
+
+  src = fetchFromGitHub {
+    owner = "nickeb96";
+    repo = "puffer-fish";
+    rev = "fd0a9c95da59512beffddb3df95e64221f894631";
+    hash = "sha256-aij48yQHeAKCoAD43rGhqW8X/qmEGGkg8B4jSeqjVU0=";
+  };
+
+  meta = with lib; {
+    description = "Text Expansions for Fish";
+    homepage = "https://github.com/nickeb96/puffer-fish";
+    license = licenses.mit;
+    maintainers = with maintainers; [ quantenzitrone ];
+  };
+}


### PR DESCRIPTION
###### Description of changes
added puffer-fish, a fish plugin for text expansion
closes #164764
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
