### PR TITLE
molsketch: init at 0.7.3

### DIFF
--- a/pkgs/applications/editors/molsketch/default.nix
+++ b/pkgs/applications/editors/molsketch/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, mkDerivation
+, fetchurl
+, cmake
+, pkg-config
+, hicolor-icon-theme
+, openbabel
+, desktop-file-utils
+, qttranslations
+}:
+
+mkDerivation rec {
+  pname = "molsketch";
+  version = "0.7.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/molsketch/Molsketch-${version}-src.tar.gz";
+    hash = "sha256-82iNJRiXqESwidjifKBf0+ljcqbFD1WehsXI8VUgrwQ=";
+  };
+
+  preConfigure = ''
+    cmakeFlags="$cmakeFlags -DMSK_PREFIX=$out"
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    hicolor-icon-theme
+    openbabel
+    desktop-file-utils
+    qttranslations
+  ];
+
+  meta = with lib; {
+    description = "2D molecule editor";
+    homepage = "https://sourceforge.net/projects/molsketch/";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.fortuneteller2k ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29285,6 +29285,8 @@ with pkgs;
 
   moe =  callPackage ../applications/editors/moe { };
 
+  molsketch = libsForQt5.callPackage ../applications/editors/molsketch { };
+
   pattypan = callPackage ../applications/misc/pattypan {};
 
   praat = callPackage ../applications/audio/praat { };


### PR DESCRIPTION
###### Description of changes
2d molecule editor

![image](https://user-images.githubusercontent.com/20619776/210079097-5bffc640-ce8b-49e3-9637-311da45ffec7.png)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
