### PR TITLE
git-bug-migration: init at 0.3.4

### DIFF
--- a/pkgs/applications/version-management/git-bug-migration/default.nix
+++ b/pkgs/applications/version-management/git-bug-migration/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "git-bug-migration";
+  version = "v0.3.4"; # the `rev` below pins the version of the source to get
+  rev = "e8931156bcbdef8515470d1e18c12391335a235a";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "MichaelMure";
+    repo = "git-bug-migration";
+    sha256 = "1m2dbmxm7ijibsa3vsr3al776hi8c0ajsz8cvg1r3lf29nnn1q10";
+  };
+
+  vendorSha256 = "sha256-Hid9OK91LNjLmDHam0ZlrVQopVOsqbZ+BH2rfQi5lS0=";
+
+  doCheck = false;
+
+  ldflags = [
+    "-X github.com/MichaelMure/git-bug-migration/commands.GitCommit=${rev}"
+    "-X github.com/MichaelMure/git-bug-migration/commands.GitLastTag=${version}"
+    "-X github.com/MichaelMure/git-bug-migration/commands.GitExactTag=${version}"
+  ];
+
+  postInstall = ''
+  '';
+
+  meta = with lib; {
+    description = "Migration tool for git-bug, to break things and move forward";
+    homepage = "https://github.com/MichaelMure/git-bug-migration";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ royneary ];
+  };
+}

--- a/pkgs/applications/version-management/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-bug/default.nix
@@ -16,6 +16,14 @@ buildGoModule rec {
 
   doCheck = false;
 
+  postUnpack = ''
+     pwd
+     grep -rl "please use https://github.com/MichaelMure/git-bug-migration to upgrade" \
+     | xargs \
+       sed -r -i \
+           -e 's@(please use https://github.com/MichaelMure/git-bug-migration to upgrade[^"]*)"@\1 (hint: install nixpkgs#git-bug-migration)"@'
+  '';
+
   ldflags = [
     "-X github.com/MichaelMure/git-bug/commands.GitCommit=${rev}"
     "-X github.com/MichaelMure/git-bug/commands.GitLastTag=${version}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1682,6 +1682,8 @@ with pkgs;
 
   git-bug = callPackage ../applications/version-management/git-bug { };
 
+  git-bug-migration = callPackage ../applications/version-management/git-bug-migration { };
+
   git-chglog = callPackage ../applications/version-management/git-chglog { };
 
   git-cinnabar = callPackage ../applications/version-management/git-cinnabar {


### PR DESCRIPTION
###### Description of changes

This PR adds git-bug-migration to the nixpkgs repository.

This tool is required since the git-bug storage format is not forward compatible.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
