### PR TITLE
souffle: add darwin support

### DIFF
--- a/pkgs/development/compilers/souffle/default.nix
+++ b/pkgs/development/compilers/souffle/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , bash-completion, perl, ncurses, zlib, sqlite, libffi
 , mcpp, cmake, bison, flex, doxygen, graphviz
 , makeWrapper
@@ -19,6 +19,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wdTBSmyA2I+gaSV577NNKA2oY2fdVTGmvV7h15NY1tU=";
   };
 
+  patches = [ ./threads.patch ] ++ [
+    (fetchpatch {
+      name = "missing-override.patch";
+      url = "https://github.com/souffle-lang/souffle/commit/da2d778f0cca94f206686546fa56b9ffc738ad75.patch";
+      sha256 = "Oefm3vRRwOyom94oGSOK2w9m23gkbJ++9gcWrdLlkyk=";
+    })
+  ];
+
+  hardeningDisable = lib.optionals stdenv.isDarwin [ "strictoverflow" ];
+
   nativeBuildInputs = [ bison cmake flex mcpp doxygen graphviz makeWrapper perl ];
   buildInputs = [ bash-completion ncurses zlib sqlite libffi ];
   # these propagated inputs are needed for the compiled Souffle mode to work,
@@ -35,7 +45,6 @@ stdenv.mkDerivation rec {
   outputs = [ "out" ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "A translator of declarative Datalog programs into the C++ language";
     homepage    = "https://souffle-lang.github.io/";
     platforms   = platforms.unix;

--- a/pkgs/development/compilers/souffle/default.nix
+++ b/pkgs/development/compilers/souffle/default.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wdTBSmyA2I+gaSV577NNKA2oY2fdVTGmvV7h15NY1tU=";
   };
 
-  patches = [ ./threads.patch ] ++ [
+  patches = [
+    ./threads.patch
     (fetchpatch {
       name = "missing-override.patch";
       url = "https://github.com/souffle-lang/souffle/commit/da2d778f0cca94f206686546fa56b9ffc738ad75.patch";

--- a/pkgs/development/compilers/souffle/threads.patch
+++ b/pkgs/development/compilers/souffle/threads.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 73d5c3c84..e4b0dbfd1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -104,13 +104,6 @@ option(SOUFFLE_CUSTOM_GETOPTLONG "Enable/Disable custom getopt_long implementati
+ cmake_dependent_option(SOUFFLE_USE_LIBCPP "Link to libc++ instead of libstdc++" ON
+     "CMAKE_CXX_COMPILER_ID STREQUAL Clang" OFF)
+ 
+-# Using Clang? Likely want to use `lld` too.
+-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
+-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
+-endif()
+-
+ # Add aditional modules to CMake
+ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+ 
+@@ -247,7 +240,11 @@ endif()
+ # pthreads
+ # --------------------------------------------------
+ set(THREADS_PREFER_PTHREAD_FLAG ON)
+-find_package(Threads REQUIRED)
++set(CMAKE_THREAD_LIBS_INIT "-lpthread")
++set(CMAKE_HAVE_THREADS_LIBRARY 1)
++set(CMAKE_USE_WIN32_THREADS_INIT 0)
++set(CMAKE_USE_PTHREADS_INIT 1)
++set(THREADS_PREFER_PTHREAD_FLAG ON)
+ 
+ # --------------------------------------------------
+ # OpenMP


### PR DESCRIPTION
###### Description of changes

This PR fixes compilation error of souffle package for darwin. Currently is marked as broken.

###### Things done

After building the package in aarch64-darwin I was able to do a smoke test of the binary.

```
% ./result/bin/souffle --version
----------------------------------------------------------------------------
Version: 
----------------------------------------------------------------------------
Copyright (c) 2016-22 The Souffle Developers.
Copyright (c) 2013-16 Oracle and/or its affiliates.
All rights reserved.
============================================================================
```

I also run the https://souffle-lang.github.io/simple example successfully

```
% ./result/bin/souffle -F. -D. example.dl
```

I am surprised that the changes introduced by `missing-override.patch` and `hardeningDisable = lib.optionals stdenv.isDarwin [ "strictoverflow" ];` were not needed in linux already. 

The missing override patch is already present in upstream (See https://github.com/souffle-lang/souffle/pull/2279) but is not released in 2.3. So I am applying it on linux also.

The other patches were done by consulting https://github.com/alicevision/geogram/issues/2#issuecomment-536835320 and https://github.com/NixOS/nixpkgs/issues/39687#issuecomment-598607106

Without threads.patch I was getting:

```
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
CMake Error at /nix/store/4lqag9hdrzfcpsrb79ny90jlwnn5gckz-cmake-3.24.3/share/cmake-3.24/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Threads (missing: Threads_FOUND)
Call Stack (most recent call first):
  /nix/store/4lqag9hdrzfcpsrb79ny90jlwnn5gckz-cmake-3.24.3/share/cmake-3.24/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /nix/store/4lqag9hdrzfcpsrb79ny90jlwnn5gckz-cmake-3.24.3/share/cmake-3.24/Modules/FindThreads.cmake:230 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:251 (find_package)


-- Configuring incomplete, errors occurred!
See also "/tmp/nix-build-souffle-2.3.drv-0/source/build/CMakeFiles/CMakeOutput.log".
See also "/tmp/nix-build-souffle-2.3.drv-0/source/build/CMakeFiles/CMakeError.log".
```

Without disabling strictoverflow I was getting

```
make: *** [Makefile:136: all] Error 2
error: builder for '/nix/store/im01by48y5dlzj0asjljcy6b5qahx4xs-souffle-2.3.drv' failed with exit code 2;
       last 10 log lines:
       > clang-11: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]
       > clang-11: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]
       > make[2]: *** [src/CMakeFiles/libsouffle.dir/build.make:199: src/CMakeFiles/libsouffle.dir/ast/BooleanConstraint.cpp.o] Error 1
       > make[2]: *** [src/CMakeFiles/libsouffle.dir/build.make:171: src/CMakeFiles/libsouffle.dir/ast/Attribute.cpp.o] Error 1
       > make[2]: *** [src/CMakeFiles/libsouffle.dir/build.make:143: src/CMakeFiles/libsouffle.dir/ast/AliasType.cpp.o] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:104: src/CMakeFiles/libsouffle.dir/all] Error 2
       > make[1]: *** Waiting for unfinished jobs....
       > [ 10%] Linking CXX executable souffleprof
       > [ 10%] Built target souffleprof
       > make: *** [Makefile:136: all] Error 2
       For full logs, run 'nix log /nix/store/im01by48y5dlzj0asjljcy6b5qahx4xs-souffle-2.3.drv'.
```

Without missing-override.patch I was getting

```
error: builder for '/nix/store/2f1d014pnlw9d4m204ay8gh5dnz0415g-souffle-2.3.drv' failed with exit code 2;
       last 10 log lines:
       > /tmp/nix-build-souffle-2.3.drv-0/source/src/main.cpp:306:10: error: 'endInput' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
       >     bool endInput() {
       >          ^
       > /tmp/nix-build-souffle-2.3.drv-0/source/src/main.cpp:213:18: note: overridden virtual function is here
       >     virtual bool endInput() = 0;
       >                  ^
       > 1 error generated.
       > make[2]: *** [src/CMakeFiles/souffle.dir/build.make:76: src/CMakeFiles/souffle.dir/main.cpp.o] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:156: src/CMakeFiles/souffle.dir/all] Error 2
       > make: *** [Makefile:136: all] Error 2
       For full logs, run 'nix log /nix/store/2f1d014pnlw9d4m204ay8gh5dnz0415g-souffle-2.3.drv'.
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
