### PR TITLE
blueprint-compiler: refactor

### DIFF
--- a/pkgs/development/compilers/blueprint/default.nix
+++ b/pkgs/development/compilers/blueprint/default.nix
@@ -1,14 +1,13 @@
-{ gtk4
-, python3
-, stdenv
-, fetchFromGitLab
+{ fetchFromGitLab
 , gobject-introspection
+, gtk4
 , lib
 , meson
 , ninja
+, python3
+, stdenv
 , testers
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "blueprint-compiler";
   version = "0.6.0";
@@ -21,31 +20,27 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-L6EGterkZ8EB6xSnJDZ3IMuOumpTpEGnU74X3UgC7k0=";
   };
 
-  doCheck = true;
-
   nativeBuildInputs = [
     meson
     ninja
   ];
 
   buildInputs = [
-    python3
-    gtk4
-  ] ++ (with python3.pkgs; [
-    pygobject3
-    wrapPython
-  ]);
+    (python3.withPackages (ps: with ps; [
+      pygobject3
+    ]))
+  ];
 
   propagatedBuildInputs = [
+    # For setup hook, so that the compiler can find typelib files
     gobject-introspection
   ];
 
-  postFixup = ''
-    makeWrapperArgs="\
-      --prefix GI_TYPELIB_PATH : $GI_TYPELIB_PATH \
-      --prefix PYTHONPATH : \"$(toPythonPath $out):$(toPythonPath ${python3.pkgs.pygobject3})\""
-    wrapPythonPrograms
-  '';
+  doCheck = true;
+
+  checkInputs = [
+    gtk4
+  ];
 
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;


### PR DESCRIPTION
Some improvements discussed [here](https://github.com/NixOS/nixpkgs/pull/208157) after the merge of 0.6.0.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
