### PR TITLE
python3Packages.notion-client: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/notion-client/default.nix
+++ b/pkgs/development/python-modules/notion-client/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, anyio
+, httpx
+, pytest-asyncio
+, pytest-vcr
+}:
+
+buildPythonPackage rec {
+  pname = "notion-client";
+  version = "2.0.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ramnes";
+    repo = "notion-sdk-py";
+    rev = version;
+    sha256 = "sha256-zfG1OgH/2ytDUC+ogIY9/nP+xkgjiMt9+HVcWEMXoj8=";
+  };
+
+  propagatedBuildInputs = [
+    httpx
+  ];
+
+  # disable coverage options as they don't provide us value, and they break the defalt pytestCheckHook
+  preCheck = ''
+    sed -i '/addopts/d' ./setup.cfg
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    anyio
+    pytest-asyncio
+    pytest-vcr
+  ];
+
+  pythonImportsCheck = [
+    "notion_client"
+  ];
+
+  meta = with lib; {
+    description = "Python client for the official Notion API";
+    homepage = "https://github.com/ramnes/notion-sdk-py";
+    changelog = "https://github.com/ramnes/notion-sdk-py/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6331,6 +6331,8 @@ self: super: with self; {
 
   notify2 = callPackage ../development/python-modules/notify2 { };
 
+  notion-client = callPackage ../development/python-modules/notion-client { };
+
   notmuch = callPackage ../development/python-modules/notmuch {
     inherit (pkgs) notmuch;
   };


### PR DESCRIPTION
###### Description of changes

I would like to be able to use the `notion-client` [python library](https://github.com/ramnes/notion-sdk-py) to interact with [Notion](https://www.notion.so/) from within nixpkgs!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
