### PR TITLE
oculante: init at 0.6.38

### DIFF
--- a/pkgs/applications/graphics/oculante/default.nix
+++ b/pkgs/applications/graphics/oculante/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, cmake
+, pkg-config
+, openssl
+, fontconfig
+, nasm
+, libX11
+, libXcursor
+, libXrandr
+, libXi
+, libGL
+, stdenv
+, gtk3
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "oculante";
+  version = "0.6.38";
+
+  src = fetchFromGitHub {
+    owner = "woelper";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-0msPeW0FoBzHBDfX2iFH4HzAknaGPNThuCLi2vhdK08=";
+  };
+
+  cargoSha256 = "sha256-eKRn8MC4/jjPRoajhwrtXsa8n9bGO5MAKjDuwHWs7Oc=";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    nasm
+  ];
+
+  checkFlagsArray = [ "--skip=tests::net" ]; # requires network access
+
+  buildInputs = [
+    openssl
+    fontconfig
+  ] ++ lib.optionals stdenv.isLinux [
+    libX11
+    libXcursor
+    libXi
+    libXrandr
+    libGL
+    gtk3
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.libobjc
+  ];
+
+  postFixup = lib.optionalString stdenv.isLinux ''
+    patchelf $out/bin/oculante --add-rpath ${lib.makeLibraryPath [ libGL ]}
+  '';
+
+  meta = with lib; {
+    broken = stdenv.isDarwin;
+    description = "A minimalistic crossplatform image viewer written in Rust";
+    homepage = "https://github.com/woelper/oculante";
+    changelog = "https://github.com/woelper/oculante/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31280,6 +31280,8 @@ with pkgs;
 
   octoprint = callPackage ../applications/misc/octoprint { };
 
+  oculante = callPackage ../applications/graphics/oculante { };
+
   ocr-a = callPackage ../data/fonts/ocr-a {};
 
   ocrad = callPackage ../applications/graphics/ocrad { };


### PR DESCRIPTION
###### Description of changes

Resolves #208177 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
