### PR TITLE
gmsh: Enable dynamic linking and Python bindings

### DIFF
--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     xorg.libICE
   ];
 
+  # N.B. the shared object is used by bindings
+  cmakeFlags = [
+    "-DENABLE_BUILD_SHARED=ON"
+    "-DENABLE_BUILD_DYNAMIC=ON"
+  ];
+
   nativeBuildInputs = [ cmake gfortran ];
 
   doCheck = true;

--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -5,11 +5,11 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "gmsh";
-  version = "4.11.0";
+  version = "4.11.1";
 
   src = fetchurl {
     url = "https://gmsh.info/src/gmsh-${version}-source.tgz";
-    sha256 = "sha256-PPLyRFXuCSUsmeZNTmRilW5o8P8fN7rKC3jICdbMVXo=";
+    sha256 = "sha256-xf4bfL1AOIioFJKfL9D11p4nYAIioYx4bbW3boAFs2U=";
   };
 
   buildInputs = [

--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     xorg.libICE
   ];
 
+  enableParallelBuilding = true;
+
   # N.B. the shared object is used by bindings
   cmakeFlags = [
     "-DENABLE_BUILD_SHARED=ON"

--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DENABLE_BUILD_SHARED=ON"
     "-DENABLE_BUILD_DYNAMIC=ON"
+    "-DENABLE_OPENMP=ON"
   ];
 
   nativeBuildInputs = [ cmake gfortran ];

--- a/pkgs/applications/science/math/gmsh/fix-python.patch
+++ b/pkgs/applications/science/math/gmsh/fix-python.patch
@@ -1,0 +1,50 @@
+diff --git a/api/gmsh.py b/api/gmsh.py
+index 747acb203..02004da5d 100644
+--- a/api/gmsh.py
++++ b/api/gmsh.py
+@@ -44,44 +44,7 @@ moduledir = os.path.dirname(os.path.realpath(__file__))
+ parentdir1 = os.path.dirname(moduledir)
+ parentdir2 = os.path.dirname(parentdir1)
+ 
+-if platform.system() == "Windows":
+-    libname = "gmsh-4.11.dll"
+-elif platform.system() == "Darwin":
+-    libname = "libgmsh.4.11.dylib"
+-else:
+-    libname = "libgmsh.so.4.11"
+-
+-# check if the library is in the same directory as the module...
+-libpath = os.path.join(moduledir, libname)
+-
+-# ... or in the parent directory or its lib or Lib subdirectory
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir1, libname)
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir1, "lib", libname)
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir1, "Lib", libname)
+-
+-# ... or in the parent of the parent directory or its lib or Lib subdirectory
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir2, libname)
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir2, "lib", libname)
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir2, "Lib", libname)
+-
+-# if we couldn't find it, use ctype's find_library utility...
+-if not os.path.exists(libpath):
+-    if platform.system() == "Windows":
+-        libpath = find_library("gmsh-4.11")
+-        if not libpath:
+-            libpath = find_library("gmsh")
+-    else:
+-        libpath = find_library("gmsh")
+-
+-# ... and print a warning if everything failed
+-if not os.path.exists(libpath):
+-    print("Warning: could not find Gmsh shared library " + libname)
++libpath = "@LIBPATH@"
+ 
+ lib = CDLL(libpath)
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3807,6 +3807,10 @@ self: super: with self; {
 
   gmpy = callPackage ../development/python-modules/gmpy { };
 
+  gmsh = toPythonModule (callPackage ../applications/science/math/gmsh {
+    enablePython = true;
+  });
+
   gntp = callPackage ../development/python-modules/gntp { };
 
   gnureadline = callPackage ../development/python-modules/gnureadline { };


### PR DESCRIPTION
###### Description of changes

In addition to its GUI interface, gmsh is also usable from a variety of languages with in-tree and out-of-tree bindings. However, these require that the shared library `libgmsh.so` is produced. To avoid on-disk duplication, we also enable dynamic linking of the executable.

Also bump to 4.11.1 and enable OpenMP support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
