### PR TITLE
webfontkitgenerator: init at 1.0.3

### DIFF
--- a/pkgs/applications/misc/webfontkitgenerator/default.nix
+++ b/pkgs/applications/misc/webfontkitgenerator/default.nix
@@ -1,0 +1,61 @@
+{ appstream-glib
+, desktop-file-utils
+, fetchFromGitHub
+, gettext
+, glib-networking
+, gobject-introspection
+, gtk4
+, gtksourceview5
+, lib
+, libadwaita
+, libsoup_3
+, meson
+, ninja
+, pkg-config
+, python3
+, stdenv
+, wrapGAppsHook4
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "webfont-kit-generator";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "rafaelmardojai";
+    repo = "webfont-kit-generator";
+    rev = finalAttrs.version;
+    hash = "sha256-aD/1moWIiU4zpLTW+VHH9n/sj10vCZ8UzB2ey3mR0/k=";
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gettext
+    gobject-introspection
+    gtk4 # For gtk4-update-icon-cache
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib-networking
+    gtk4
+    gtksourceview5
+    libadwaita
+    libsoup_3
+    (python3.withPackages (ps: with ps; [
+      fonttools
+      pygobject3
+    ]))
+  ];
+
+  meta = with lib; {
+    description = "Webfont Kit Generator is a simple utility that allows you to generate woff, woff2 and the necessary CSS boilerplate from non-web font formats (otf & ttf)";
+    homepage = "https://apps.gnome.org/app/com.rafaelmardojai.WebfontKitGenerator";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ benediktbroich ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2229,6 +2229,8 @@ with pkgs;
 
   citations = callPackage ../applications/misc/citations { };
 
+  webfontkitgenerator = callPackage ../applications/misc/webfontkitgenerator { };
+
   citra-canary = callPackage ../applications/emulators/citra {
     branch = "canary";
   };


### PR DESCRIPTION
###### Description of changes
Add new package [webfont-kit-generator](https://flathub.org/apps/details/com.rafaelmardojai.WebfontKitGenerator).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

For some reason 

> webfont-kit-generator --help

Returns:
> Call:
 >  .webfontkitgenerator-wrapped [OPTION …]

It thinks its name is ".webfont-kit-generator-wrapped". Maybe this can be changed. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
