### PR TITLE
[22.11] python310Packages.statmake: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/statmake/default.nix
+++ b/pkgs/development/python-modules/statmake/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "statmake";
-  version = "0.5.1";
+  version = "0.6.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "daltonmaag";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-BpxjAr65ZQEJ0PSUIPtS78UvJbMG91qkV8py2K/+W2E=";
+    hash = "sha256-3BZ71JVvj7GCojM8ycu160viPj8BLJ1SiW86Df2fzsw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

statmake 0.5.1 is currently broken in NixOS 22.11:

```
E                   ValueError: Not enough values in [200] to structure as typing.Tuple[float, float]
/nix/store/jaqjh73hy0hs58756mq08wxs240cm3fp-python3.10-cattrs-22.2.0/lib/python3.10/site-packages/cattrs/converters.py:655: ValueError
=========================== short test summary info ============================
FAILED tests/test_make_stat.py::test_load_stylespace_broken_range - ValueErro...
========================= 1 failed, 28 passed in 1.64s =========================
```

You can reproduce this using: `nix-build -A pkgs.python310Packages.statmake`

This is unfortunate, because it is a dependency of `pkgs.cantarell-fonts`, which is included by default in at least the GNOME desktop.

So why did no one notice? cantarell-fonts is a fixed output derivation and comes from the cache. This means only people that end up rebuilding cantarell-fonts actually run into this problem right now.

Resolve this by backporting the statmake update from unstable (b06eba978ee1445345e47a5a46a391069b63cb09), which fixes its tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
