### PR TITLE
qFlipper: Add wrapGAppsHook to build inputs

### DIFF
--- a/pkgs/tools/misc/qflipper/default.nix
+++ b/pkgs/tools/misc/qflipper/default.nix
@@ -6,6 +6,7 @@
 , libusb1
 , libGL
 , qmake
+, wrapGAppsHook
 , wrapQtAppsHook
 , mkDerivation
 
@@ -44,6 +45,7 @@ mkDerivation {
     pkg-config
     qmake
     qttools
+    wrapGAppsHook
     wrapQtAppsHook
   ];
 
@@ -68,6 +70,8 @@ mkDerivation {
     "DEFINES+=DISABLE_APPLICATION_UPDATES"
     "CONFIG+=qtquickcompiler"
   ];
+
+  dontWrapGApps = true;
 
   postPatch = ''
     substituteInPlace qflipper_common.pri \
@@ -98,5 +102,4 @@ mkDerivation {
     maintainers = with maintainers; [ cab404 ];
     platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]; # qtbase doesn't build yet on aarch64-darwin
   };
-
 }


### PR DESCRIPTION
###### Description of changes

I'm on NixOS 22.11 (Raccoon, gnome DE) and when using qFlipper it runs into an error while attempting to select a file from  my system.

```
(qFlipper:187584): GLib-GIO-ERROR **: 17:27:29.657: Settings schema 'org.gtk.Settings.FileChooser' is not installed
```

This was resolved by adding `wrapGAppsHook`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
