### PR TITLE
alice-tools: init at 0.12.1

### DIFF
--- a/pkgs/tools/games/alice-tools/default.nix
+++ b/pkgs/tools/games/alice-tools/default.nix
@@ -1,0 +1,106 @@
+{ stdenv
+, lib
+, gitUpdater
+, fetchFromGitHub
+, fetchpatch
+, meson
+, ninja
+, pkg-config
+, bison
+, flex
+, libiconv
+, libpng
+, libjpeg
+, libwebp
+, zlib
+, withGUI ? true
+, qtbase ? null
+, wrapQtAppsHook ? null
+}:
+
+assert withGUI -> qtbase != null && wrapQtAppsHook != null;
+
+stdenv.mkDerivation rec {
+  pname = "alice-tools";
+  version = "0.12.1";
+
+  src = fetchFromGitHub {
+    owner = "nunuhara";
+    repo = "alice-tools";
+    rev = version;
+    fetchSubmodules = true;
+    hash = "sha256-uXiNNneAOTDupgc+ZvaeRNbEQFJBv4ppdEc3kZeUsg8=";
+  };
+
+  patches = [
+    # These two patches (one to alice-tools, one to a subproject) improve DCF & PCF parsing
+    # Remove them when version > 0.12.1
+    (fetchpatch {
+      url = "https://github.com/nunuhara/alice-tools/commit/c800e85b37998d7a47060f5da4b1782d7201a042.patch";
+      excludes = [ "subprojects/libsys4" ];
+      hash = "sha256-R5ckFHqUWHdAPkFa53UbVeLgxJg/8qGLTQWwj5YRJc4=";
+    })
+    (fetchpatch {
+      url = "https://github.com/nunuhara/libsys4/commit/cff2b826d1618fb17616cdd288ab0c50f35e8032.patch";
+      stripLen = 1;
+      extraPrefix = "subprojects/libsys4/";
+      hash = "sha256-CmetiVP2kGL+MwuE9OoEDrDFxzwWvv1TtZuq1li1uIw=";
+    })
+  ];
+
+  postPatch = lib.optionalString (withGUI && lib.versionAtLeast qtbase.version "6.0") ''
+    substituteInPlace src/meson.build \
+      --replace qt5 qt6
+  '';
+
+  mesonFlags = lib.optionals (withGUI && lib.versionAtLeast qtbase.version "6.0") [
+    # Qt6 requires at least C++17, project uses compiler's default, default too old on Darwin & aarch64-linux
+    "-Dcpp_std=c++17"
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    bison
+    flex
+  ] ++ lib.optionals withGUI [
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libiconv
+    libpng
+    libjpeg
+    libwebp
+    zlib
+  ] ++ lib.optionals withGUI [
+    qtbase
+  ];
+
+  dontWrapQtApps = true;
+
+  # Default install step only installs a static library of a build dependency
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 src/alice $out/bin/alice
+  '' + lib.optionalString withGUI ''
+    install -Dm755 src/galice $out/bin/galice
+    wrapQtApp $out/bin/galice
+  '' + ''
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "Tools for extracting/editing files from AliceSoft games";
+    homepage = "https://github.com/nunuhara/alice-tools";
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ OPNA2608 ];
+    mainProgram = if withGUI then "galice" else "alice";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1361,6 +1361,14 @@ with pkgs;
 
   albert = libsForQt5.callPackage ../applications/misc/albert {};
 
+  alice-tools = callPackage ../tools/games/alice-tools {
+    withGUI = false;
+  };
+
+  alice-tools-qt5 = libsForQt5.callPackage ../tools/games/alice-tools { };
+
+  alice-tools-qt6 = qt6Packages.callPackage ../tools/games/alice-tools { };
+
   allure = callPackage ../development/tools/allure {};
 
   aquosctl = callPackage ../tools/misc/aquosctl { };


### PR DESCRIPTION
###### Description of changes

Packages [alice-tools](https://github.com/nunuhara/alice-tools), a collection of tools for viewing and converting file formats used in AliceSoft games.

![image](https://user-images.githubusercontent.com/23431373/211100421-b94c3a7d-9ead-445c-b649-1e1814ca1ad3.png)

I have checked CLI/Qt5/Qt6 variants on x86_64-linux & aarch64-linux, and CLI/Qt5 variants on x86_64-darwin. My macOS version is seemingly too old for Qt6 so trying to use those binaries just errors on my end. I have checked the builds by opening the graphics-containing archive from one of my games, browsing through its contents and extracting some of the assets into png & webp formats.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
