### PR TITLE
blender: 3.3.1 -> 3.4.1

### DIFF
--- a/pkgs/applications/misc/blender/darwin.patch
+++ b/pkgs/applications/misc/blender/darwin.patch
@@ -1,27 +1,29 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7a621b8..decec9e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1894,7 +1894,7 @@ if(WITH_COMPILER_SHORT_FILE_MACRO)
-   ADD_CHECK_CXX_COMPILER_FLAG(CXX_PREFIX_MAP_FLAGS CXX_MACRO_PREFIX_MAP -fmacro-prefix-map=foo=bar)
+@@ -1731,7 +1731,7 @@ if(WITH_COMPILER_SHORT_FILE_MACRO)
+   add_check_cxx_compiler_flag(CXX_PREFIX_MAP_FLAGS CXX_MACRO_PREFIX_MAP -fmacro-prefix-map=foo=bar)
    if(C_MACRO_PREFIX_MAP AND CXX_MACRO_PREFIX_MAP)
      if(APPLE)
 -      if(XCODE AND ${XCODE_VERSION} VERSION_LESS 12.0)
 +      if(FALSE)
        # Developers may have say LLVM Clang-10.0.1 toolchain (which supports the flag)
        # with Xcode-11 (the Clang of which doesn't support the flag).
-         message(WARNING
+         message(
 diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake/platform/platform_apple.cmake
+index c5fe3c9..8e1ef96 100644
 --- a/build_files/cmake/platform/platform_apple.cmake
 +++ b/build_files/cmake/platform/platform_apple.cmake
-@@ -60,7 +60,6 @@ else()
+@@ -68,7 +68,6 @@ else()
    message(STATUS "Using pre-compiled LIBDIR: ${LIBDIR}")
  endif()
  if(NOT EXISTS "${LIBDIR}/")
 -  message(FATAL_ERROR "Mac OSX requires pre-compiled libs at: '${LIBDIR}'")
  endif()
  
- # Prefer lib directory paths
-@@ -98,10 +97,6 @@ if(WITH_CODEC_SNDFILE)
+ # Avoid searching for headers since this would otherwise override our lib
+@@ -111,10 +110,6 @@ if(WITH_CODEC_SNDFILE)
    find_library(_sndfile_VORBIS_LIBRARY NAMES vorbis HINTS ${LIBDIR}/ffmpeg/lib)
    find_library(_sndfile_VORBISENC_LIBRARY NAMES vorbisenc HINTS ${LIBDIR}/ffmpeg/lib)
    list(APPEND LIBSNDFILE_LIBRARIES
@@ -32,16 +34,7 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
    )
  
    print_found_status("SndFile libraries" "${LIBSNDFILE_LIBRARIES}")
-@@ -118,7 +113,7 @@ if(WITH_PYTHON)
-     # Normally cached but not since we include them with blender.
-     set(PYTHON_INCLUDE_DIR "${LIBDIR}/python/include/python${PYTHON_VERSION}")
-     set(PYTHON_EXECUTABLE "${LIBDIR}/python/bin/python${PYTHON_VERSION}")
--    set(PYTHON_LIBRARY ${LIBDIR}/python/lib/libpython${PYTHON_VERSION}.a)
-+    set(PYTHON_LIBRARY ${LIBDIR}/python/lib/libpython${PYTHON_VERSION}.dylib)
-     set(PYTHON_LIBPATH "${LIBDIR}/python/lib/python${PYTHON_VERSION}")
-   else()
-     # Module must be compiled against Python framework.
-@@ -147,7 +142,7 @@ endif()
+@@ -134,7 +129,7 @@ endif()
  
  # FreeType compiled with Brotli compression for woff2.
  find_package(Freetype REQUIRED)
@@ -50,7 +43,7 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
    ${LIBDIR}/brotli/lib/libbrotlicommon-static.a
    ${LIBDIR}/brotli/lib/libbrotlidec-static.a)
  
-@@ -159,9 +154,7 @@ if(WITH_CODEC_FFMPEG)
+@@ -146,9 +141,7 @@ if(WITH_CODEC_FFMPEG)
    set(FFMPEG_ROOT_DIR ${LIBDIR}/ffmpeg)
    set(FFMPEG_FIND_COMPONENTS
      avcodec avdevice avformat avutil
@@ -61,7 +54,7 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
    if(EXISTS ${LIBDIR}/ffmpeg/lib/libaom.a)
      list(APPEND FFMPEG_FIND_COMPONENTS aom)
    endif()
-@@ -273,7 +266,6 @@ if(WITH_BOOST)
+@@ -250,7 +243,6 @@ if(WITH_BOOST)
  endif()
  
  if(WITH_INTERNATIONAL OR WITH_CODEC_FFMPEG)
@@ -69,7 +62,7 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
  endif()
  
  if(WITH_PUGIXML)
-@@ -402,7 +394,7 @@ endif()
+@@ -337,7 +329,7 @@ endif()
  
  # CMake FindOpenMP doesn't know about AppleClang before 3.12, so provide custom flags.
  if(WITH_OPENMP)

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -28,11 +28,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "blender";
-  version = "3.3.1";
+  version = "3.4.1";
 
   src = fetchurl {
     url = "https://download.blender.org/source/${pname}-${version}.tar.xz";
-    hash = "sha256-KtpI8L+KDKgCuYfXV0UgEuH48krPTSNFOwnC1ZURjMo=";
+    hash = "sha256-JHxMEignDJAQ9HIcmFy1tiirUKvPnyZ4Ywc3FC7rkcM=";
   };
 
   patches = lib.optional stdenv.isDarwin ./darwin.patch;

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -97,6 +97,7 @@ stdenv.mkDerivation rec {
   cmakeFlags =
     [
       "-DWITH_ALEMBIC=ON"
+      "-DWITH_USD=ON"
       "-DWITH_MOD_OCEANSIM=ON"
       "-DWITH_CODEC_FFMPEG=ON"
       "-DWITH_CODEC_SNDFILE=ON"

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -1,5 +1,5 @@
 { config, stdenv, lib, fetchurl, fetchzip, boost, cmake, ffmpeg, gettext, glew
-, ilmbase, libXi, libX11, libXext, libXrender
+, ilmbase, libepoxy, libXi, libX11, libXext, libXrender
 , libjpeg, libpng, libsamplerate, libsndfile
 , libtiff, libwebp, libGLU, libGL, openal, opencolorio, openexr, openimagedenoise, openimageio2, openjpeg, python310Packages
 , openvdb, libXxf86vm, tbb, alembic
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
       pugixml
       potrace
       libharu
+      libepoxy
     ]
     ++ (if (!stdenv.isDarwin) then [
       libXi libX11 libXext libXrender


### PR DESCRIPTION
This is based on #207284 and thus targeted at staging. I included the commit from #207284 here for easier testing.

Caveat:
On my machine blender wouldn't start because of:
![image](https://user-images.githubusercontent.com/1544760/210119635-422808e9-4bf6-4aea-8f4a-ef748618f455.png)

Hopefully this is an issue on my machine only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
