### PR TITLE
mdds: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/development/libraries/mdds/default.nix
+++ b/pkgs/development/libraries/mdds/default.nix
@@ -1,20 +1,21 @@
-{ lib, stdenv, fetchFromGitLab, autoreconfHook, boost, llvmPackages }:
+{ lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  boost,
+  llvmPackages,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mdds";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchFromGitLab {
     owner = "mdds";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-jCzF0REocpnP56LfY42zlGTXyKyz4GPovDshhrh4jyo=";
+    repo = "mdds";
+    rev = finalAttrs.version;
+    hash = "sha256-Y9uBJKM34UTEj/3c1w69QHhvwFcMNlAohEco0O0B+xI=";
   };
-
-  postInstall = ''
-    mkdir -p "$out/lib/pkgconfig"
-    cp "$out/share/pkgconfig/"* "$out/lib/pkgconfig"
-  '';
 
   nativeBuildInputs = [ autoreconfHook ];
 
@@ -22,11 +23,18 @@ stdenv.mkDerivation rec {
 
   checkInputs = [ boost ];
 
+  postInstall = ''
+    mkdir -p $out/lib/
+    mv $out/share/pkgconfig $out/lib/
+  '';
+
   meta = with lib; {
-    description = "A collection of multi-dimensional data structure and indexing algorithm";
     homepage = "https://gitlab.com/mdds/mdds";
-    maintainers = [];
+    description = "A collection of multi-dimensional data structure and indexing algorithms";
+    changelog = "https://gitlab.com/mdds/mdds/-/blob/${finalAttrs.version}/CHANGELOG";
     license = licenses.mit;
-    platforms = platforms.all;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.unix;
   };
-}
+})
+# TODO: multi-output


### PR DESCRIPTION
Also, adopting it

Closes https://github.com/NixOS/nixpkgs/pull/208432

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
