### PR TITLE
Reduce the closure size of various qt6 packages

### DIFF
--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -23,7 +23,7 @@ let
       install -Dm755 OpenBoardImporter $out/bin/OpenBoardImporter
     '';
   };
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation {
   pname = "openboard";
   version = "unstable-2022-11-28";
 
@@ -36,9 +36,9 @@ in stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace OpenBoard.pro \
-      --replace '/usr/include/quazip5' '${quazip}/include/QuaZip-Qt5-${quazip.version}/quazip' \
+      --replace '/usr/include/quazip5' '${lib.getDev quazip}/include/QuaZip-Qt5-${quazip.version}/quazip' \
       --replace '-lquazip5' '-lquazip1-qt5' \
-      --replace '/usr/include/poppler' '${poppler.dev}/include/poppler'
+      --replace '/usr/include/poppler' '${lib.getDev poppler}/include/poppler'
   '';
 
   nativeBuildInputs = [ qmake copyDesktopItems wrapQtAppsHook ];

--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     cp -a ${parts}/* parts/
   '';
 
-  NIX_CFLAGS_COMPILE = "-I${quazip}/include/QuaZip-Qt${lib.versions.major qtbase.version}-${quazip.version}/quazip";
+  NIX_CFLAGS_COMPILE = "-I${lib.getDev quazip}/include/QuaZip-Qt${lib.versions.major qtbase.version}-${quazip.version}/quazip";
 
   qmakeFlags = [
     "phoenix.pro"

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -31,7 +31,6 @@
 , libsepol
 , vulkan-headers
 , vulkan-loader
-, valgrind
 , libthai
 , libdrm
 , libdatrie
@@ -140,7 +139,6 @@ stdenv.mkDerivation rec {
     libthai
     libdrm
     libdatrie
-    valgrind
     udev
     # Text rendering
     fontconfig

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -271,6 +271,9 @@ stdenv.mkDerivation rec {
       -e "/^bindir=/ c bindir=$dev/bin"
 
     patchShebangs $out $dev
+
+    # QTEST_ASSERT and other macros keeps runtime reference to qtbase.dev
+    substituteInPlace "$dev/include/QtTest/qtestassert.h" --replace "__FILE__" "__BASE_FILE__"
   '';
 
   dontStrip = debugSymbols;

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative.nix
@@ -36,8 +36,4 @@ qtModule {
     "bin/qmlscene"
     "bin/qmltestrunner"
   ];
-
-  NIX_CFLAGS_COMPILE = [
-    "-fmacro-prefix-map=${qtbase.dev}=qtbase.dev"
-  ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtvirtualkeyboard.nix
@@ -11,5 +11,4 @@ qtModule {
   qtInputs = [ qtbase qtdeclarative qtsvg ];
   propagatedBuildInputs = [ hunspell ];
   nativeBuildInputs = [ pkg-config ];
-  outputs = [ "out" ];
 }

--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
+  outputs = [ "out" "dev" ];
+
   meta = with lib; {
     description = "Provides access to ZIP archives from Qt programs";
     license = licenses.lgpl21Plus;


### PR DESCRIPTION
###### Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/208246

I no longer see qtbase checking for valgrind in configurePhase, let's just remove it. This should not only reduce the runtime closure size, but also the build time closure size by a huge margin.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
